### PR TITLE
Fix to skip for traverse when empty text node converts to an empty node list.

### DIFF
--- a/packages/@markuplint/pug-parser/src/index.spec.ts
+++ b/packages/@markuplint/pug-parser/src/index.spec.ts
@@ -285,4 +285,18 @@ else
 			'[5:12]>[6:4](54,58)#text: ⏎→→→',
 		]);
 	});
+
+	it('tag interpolation (Issue #58)', () => {
+		const doc = parse(`p
+	| lorem #[span ipsum]`);
+		const map = nodeListToDebugMaps(doc.nodeList);
+		// console.log(map);
+		expect(doc.parseError).toBeUndefined();
+		expect(map).toStrictEqual([
+			'[1:1]>[1:2](0,1)p: p',
+			'[2:4]>[2:10](5,11)#text: lorem␣',
+			'[2:12]>[2:16](13,17)span: span',
+			'[2:17]>[2:22](18,23)#text: ipsum',
+		]);
+	});
 });

--- a/packages/@markuplint/pug-parser/src/parse.ts
+++ b/packages/@markuplint/pug-parser/src/parse.ts
@@ -56,7 +56,7 @@ class Parser {
 		let prevNode: MLASTNode | null = null;
 		for (const astNode of astNodes) {
 			const nodes = this.nodeize(astNode, prevNode, parentNode);
-			if (!nodes) {
+			if (!nodes || (Array.isArray(nodes) && nodes.length === 0)) {
 				continue;
 			}
 

--- a/packages/@markuplint/pug-parser/src/pug-parser/index.spec.ts
+++ b/packages/@markuplint/pug-parser/src/pug-parser/index.spec.ts
@@ -1588,10 +1588,9 @@ mixin link(href, name)
 		});
 	});
 
-	it.only('tag interpolation (Issue #58)', () => {
+	it('tag interpolation (Issue #58)', () => {
 		const ast = pugParse(`p
 	| lorem #[span ipsum]`);
-		console.log(JSON.stringify(ast));
 		expect(ast).toStrictEqual({
 			type: 'Block',
 			nodes: [

--- a/packages/@markuplint/pug-parser/src/pug-parser/index.spec.ts
+++ b/packages/@markuplint/pug-parser/src/pug-parser/index.spec.ts
@@ -1587,4 +1587,83 @@ mixin link(href, name)
 			line: 0,
 		});
 	});
+
+	it.only('tag interpolation (Issue #58)', () => {
+		const ast = pugParse(`p
+	| lorem #[span ipsum]`);
+		console.log(JSON.stringify(ast));
+		expect(ast).toStrictEqual({
+			type: 'Block',
+			nodes: [
+				{
+					type: 'Tag',
+					name: 'p',
+					raw: 'p',
+					offset: 0,
+					endOffset: 1,
+					line: 1,
+					endLine: 1,
+					column: 1,
+					endColumn: 2,
+					block: {
+						type: 'Block',
+						nodes: [
+							{
+								type: 'Text',
+								raw: 'lorem ',
+								offset: 5,
+								endOffset: 11,
+								line: 2,
+								endLine: 2,
+								column: 4,
+								endColumn: 10,
+							},
+							{
+								type: 'Tag',
+								name: 'span',
+								raw: 'span',
+								offset: 13,
+								endOffset: 17,
+								line: 2,
+								endLine: 2,
+								column: 12,
+								endColumn: 16,
+								block: {
+									type: 'Block',
+									nodes: [
+										{
+											type: 'Text',
+											raw: 'ipsum',
+											offset: 18,
+											endOffset: 23,
+											line: 2,
+											endLine: 2,
+											column: 17,
+											endColumn: 22,
+										},
+									],
+									line: 2,
+								},
+								attrs: [],
+							},
+							// A cause of issue #58
+							{
+								type: 'Text',
+								raw: '',
+								offset: 24,
+								endOffset: 24,
+								line: 2,
+								endLine: 2,
+								column: 23,
+								endColumn: 23,
+							},
+						],
+						line: 1,
+					},
+					attrs: [],
+				},
+			],
+			line: 0,
+		});
+	});
 });


### PR DESCRIPTION
Fix for #58 