### PR TITLE
Add dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:14.11
+
+COPY . /markuplint
+
+WORKDIR /markuplint
+RUN npm install yarn
+RUN npx yarn install
+RUN npx yarn run bootstrap
+RUN npx yarn run build
+RUN cd /usr/bin && ln -s /markuplint/packages/markuplint/bin/markuplint
+
+ENTRYPOINT ["markuplint"]


### PR DESCRIPTION
To more convenient, I add Dockerfile to exec markuplint using docker.

Exec like below.
In this PoC, I tagged the sample image to `markuplint`, but I
think it's preferable to properly tag each version and deploy it
to DockerHub.

```
$ docker build -t markuplint .
$ docker run markuplint --help

  A Linter for All Markup Languages.

  Usage
  	$ markuplint <HTML file pathes (glob format)>
  	$ <stdout> | markuplint

  Options
  	--config-file,  -c FILE_PATH  Ruleset file path.
  	--fix,                        Fix HTML.
  	--format,       -f FORMAT     Output format. Support "JSON", "Simple" and "Standard". Default: "Standard".
  	--no-color,                   Output no color.
  	--problem-only, -p            Output only problems, without passeds.
  	--verbose                     Output with detailed information.

  	--help,         -h            Show help.
  	--version,      -v            Show version.

  Examples
  	$ markuplint verifyee.html --ruleset path/to/.markuplintrc
  	$ cat verifyee.html | markuplint
```

```
$ docker run markuplint test/fixture/002.html
<markuplint> warning: Attribute value is must quote on double quotation mark (attr-value-quotes) /markuplint/test/fixture/002.html:2:7
   1: <!DOCTYPE•html>
   2: <html•lang=en>
   3: <head>
<markuplint> warning: Attribute value is must quote on double quotation mark (attr-value-quotes) /markuplint/test/fixture/002.html:4:8
   3: <head>
   4: →   <meta•charset=UTF-8>
   5: →   <meta•name=viewport•content='width=device-width,•initial-scale=1.0'>
<markuplint> warning: Attribute value is must quote on double quotation mark (attr-value-quotes) /markuplint/test/fixture/002.html:5:8
   4: →   <meta•charset=UTF-8>
   5: →   <meta•name=viewport•content='width=device-width,•initial-scale=1.0'>
   6: →   <meta•http-equiv=X-UA-Compatible•content=ie=edge>
<markuplint> warning: Attribute value is must quote on double quotation mark (attr-value-quotes) /markuplint/test/fixture/002.html:5:22
   4: →   <meta•charset=UTF-8>
   5: →   <meta•name=viewport•content='width=device-width, initial-scale=1.0'>
   6: →   <meta•http-equiv=X-UA-Compatible•content=ie=edge>
<markuplint> warning: Attribute value is must quote on double quotation mark (attr-value-quotes) /markuplint/test/fixture/002.html:6:8
   5: →   <meta•name=viewport•content='width=device-width,•initial-scale=1.0'>
   6: →   <meta•http-equiv=X-UA-Compatible•content=ie=edge>
   7: →   <title>Document</title>
<markuplint> warning: Attribute value is must quote on double quotation mark (attr-value-quotes) /markuplint/test/fixture/002.html:6:35
   5: →   <meta•name=viewport•content='width=device-width,•initial-scale=1.0'>
   6: →   <meta•http-equiv=X-UA-Compatible•content=ie=edge>
   7: →   <title>Document</title>
<markuplint> error: Missing the h1 element (required-h1) /markuplint/test/fixture/002.html:1:1
   1: <!DOCTYPE•html>
   2: <html•lang=en>
```