### PR TITLE
ci: improve GitHub Actions workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,15 +22,31 @@ jobs:
                 node: [12]
 
         steps:
-            - uses: actions/checkout@v1
+            - uses: actions/checkout@v2
+
+            - name: Get yarn cache directory path
+              id: yarn-cache-dir-path
+              run: echo "::set-output name=dir::$(yarn cache dir)"
+
+            - uses: actions/cache@v2
+              id: cache
+              with:
+                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                    ${{ runner.os }}-yarn-
+
             - name: Use Node.js ${{ matrix.node }}
               uses: actions/setup-node@v1
               with:
                   node-version: ${{ matrix.node }}
-            - name: npm install, build, and test
-              run: |
-                  yarn install
-                  yarn build
-                  yarn test
-              env:
-                  CI: true
+
+            - name: Install dependencies
+              if: steps.cache.outputs.cache-hit != 'true'
+              run: yarn install
+
+            - name: Build
+              run: yarn build
+
+            - name: Test
+              run: yarn test


### PR DESCRIPTION
- remove `env: CI`
  - This setting now defaults.  https://github.blog/changelog/2020-04-15-github-actions-sets-the-ci-environment-variable-to-true/

- use cache
  - https://github.com/actions/cache/blob/main/examples.md#node---yarn