### PR TITLE
fix docs

### DIFF
--- a/website/src/pages/setting-for-other-languages.mdx
+++ b/website/src/pages/setting-for-other-languages.mdx
@@ -55,7 +55,7 @@ If you use React.
 ```json
 {
 	"parser": {
-		".vue$": "@markuplint/jsx-parser"
+		".jsx$": "@markuplint/jsx-parser"
 	},
 	"specs": ["@markuplint/react-spec"]
 }


### PR DESCRIPTION
Hi!
I was looking at the markuplint site and thought I might have the wrong extension for jsx.

Here is the page.
https://markuplint.dev/setting-for-other-languages#Set%20to%20the%20configuration%20file

![スクリーンショット 2021-05-21 23 42 22](https://user-images.githubusercontent.com/13248811/119155507-3ad39800-ba8e-11eb-87f7-5d638fef4d68.png)

The extension is `.vue`.

This fix will make it look like the image.

![スクリーンショット 2021-05-21 23 36 58](https://user-images.githubusercontent.com/13248811/119154809-7b7ee180-ba8d-11eb-9925-77482e48c0a6.png)

I hope I can be of some help to you 😃 