### PR TITLE
Fix not to warn the HTML native attribute in the component.

### DIFF
--- a/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
@@ -538,16 +538,7 @@ test('React Component', async () => {
 		'en',
 	);
 
-	expect(r).toStrictEqual([
-		{
-			ruleId: 'invalid-attr',
-			severity: 'error',
-			line: 1,
-			col: 42,
-			message: 'The "tabindex" attribute is not allowed. Did you mean "tabIndex"?',
-			raw: 'tabindex',
-		},
-	]);
+	expect(r).toStrictEqual([]);
 });
 
 test('React HTML', async () => {

--- a/packages/@markuplint/rules/src/invalid-attr/index.ts
+++ b/packages/@markuplint/rules/src/invalid-attr/index.ts
@@ -38,7 +38,7 @@ export default createRule<true, Option>({
 				const attrName = attr.getName();
 				const name = attrName.potential;
 
-				if (attr.attrType === 'html-attr' && attr.isInvalid) {
+				if (!node.isCustomElement && attr.attrType === 'html-attr' && attr.isInvalid) {
 					const candidate = attr.candidate;
 					const message =
 						`The "${attrName.raw}" attribute is not allowed.` +


### PR DESCRIPTION
Fix not to warn the HTML native attribute that is camel-cased name mapped by JSX in the component because it is unrelate and definable freely.

