### PR TITLE
fix link setting-for-other-languages.mdx

### DIFF
--- a/website/src/pages/setting-for-other-languages.mdx
+++ b/website/src/pages/setting-for-other-languages.mdx
@@ -34,7 +34,7 @@ $ yarn add -D @markuplint/vue-parser @markuplint/vue-spec
 | Lang                                                                                   | Parser                        | Spec                     |
 | -------------------------------------------------------------------------------------- | ----------------------------- | ------------------------ |
 | [_Pug_](https://pugjs.org/)                                                            | `@markuplint/pug-parser`      | -                        |
-| [_JSX_](https://vuejs.org/) (React etc...)                                             | `@markuplint/jsx-parser`      | `@markuplint/react-spec` |
+| [_JSX_](https://reactjs.org/docs/introducing-jsx.html) (React etc...                   | `@markuplint/jsx-parser`      | `@markuplint/react-spec` |
 | [_Vue_](https://vuejs.org/)                                                            | `@markuplint/vue-parser`      | `@markuplint/vue-spec`   |
 | [_Svelte_](https://svelte.dev/)                                                        | `@markuplint/svelte-parser`   | -                        |
 | [_Astro_](https://astro.build/)                                                        | `@markuplint/astro-parser`    | -                        |


### PR DESCRIPTION
## 修正提案

JSXのリンクがVue.jsになっていたので修正PRを投げました。