### PR TITLE
Add the `no-hard-code-id` rule

### DIFF
--- a/packages/@markuplint/create-rule-helper/scaffold/core/README.md
+++ b/packages/@markuplint/create-rule-helper/scaffold/core/README.md
@@ -1,4 +1,10 @@
-# The `{{name}}` rule
+---
+title: 'TODO: Title'
+id: '{{ name }}'
+category: 'TODO category'
+---
+
+# TODO: Title
 
 TODO: Write a description
 

--- a/packages/@markuplint/i18n/$schema.json
+++ b/packages/@markuplint/i18n/$schema.json
@@ -42,6 +42,7 @@
 				"c:deprecated": { "type": "string" },
 				"c:disallowed": { "type": "string" },
 				"c:duplicated": { "type": "string" },
+				"c:hard-coded": { "type": "string" },
 				"c:ineffective": { "type": "string" },
 				"c:invalid": { "type": "string" },
 				"c:non-standard": { "type": "string" },

--- a/packages/@markuplint/i18n/locales/ja.json
+++ b/packages/@markuplint/i18n/locales/ja.json
@@ -30,6 +30,7 @@
 		"c:deprecated": "は非推奨です",
 		"c:disallowed": "は許可されていません",
 		"c:duplicated": "が重複しています",
+		"c:hard-coded": "ハードコーディングされています",
 		"c:ineffective": "は効果がありません",
 		"c:invalid": "は妥当ではありません",
 		"c:non-standard": "は非標準です",

--- a/packages/@markuplint/pug-parser/src/attr-tokenizer.ts
+++ b/packages/@markuplint/pug-parser/src/attr-tokenizer.ts
@@ -4,7 +4,7 @@ import type { MLASTAttr } from '@markuplint/ml-ast';
 import { tokenizer, uuid } from '@markuplint/parser-utils';
 
 export default function attrTokenizer(attr: ASTAttr): MLASTAttr {
-	if (/^[#.]/.test(attr.raw)) {
+	if (attr.raw[0] === '#' || attr.raw[0] === '.') {
 		let value = '';
 		if (typeof attr.val === 'string') {
 			[, , value] = attr.val.match(/(['"`]?)([^\1]+)(\1)/) || ['', '', ''];
@@ -23,7 +23,7 @@ export default function attrTokenizer(attr: ASTAttr): MLASTAttr {
 			endCol: attr.endColumn,
 			potentialName: attr.name,
 			potentialValue: value,
-			valueType: !attr.mustEscape ? 'code' : typeof attr.val === 'boolean' ? 'boolean' : 'string',
+			valueType: 'string',
 			isDuplicatable: attr.raw[0] === '.',
 		};
 	}

--- a/packages/@markuplint/rules/schema.json
+++ b/packages/@markuplint/rules/schema.json
@@ -57,6 +57,9 @@
 				"no-boolean-attr-value": {
 					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/no-boolean-attr-value/schema.json"
 				},
+				"no-hard-code-id": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/no-hard-code-id/schema.json"
+				},
 				"no-use-event-handler-attr": {
 					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/no-use-event-handler-attr/schema.json"
 				},

--- a/packages/@markuplint/rules/src/index.ts
+++ b/packages/@markuplint/rules/src/index.ts
@@ -16,6 +16,7 @@ import IneffectiveAttr from './ineffective-attr';
 import InvalidAttr from './invalid-attr';
 import LandmarkRoles from './landmark-roles';
 import NoBooleanAttrValue from './no-boolean-attr-value';
+import NoHardCodeId from './no-hard-code-id';
 import NoUseEventHandlerAttr from './no-use-event-handler-attr';
 import PermittedContents from './permitted-contents';
 import RequiredAttr from './required-attr';
@@ -41,6 +42,7 @@ export default {
 	'invalid-attr': InvalidAttr,
 	'landmark-roles': LandmarkRoles,
 	'no-boolean-attr-value': NoBooleanAttrValue,
+	'no-hard-code-id': NoHardCodeId,
 	'no-use-event-handler-attr': NoUseEventHandlerAttr,
 	'permitted-contents': PermittedContents,
 	'required-attr': RequiredAttr,

--- a/packages/@markuplint/rules/src/no-hard-code-id/README.ja.md
+++ b/packages/@markuplint/rules/src/no-hard-code-id/README.ja.md
@@ -1,0 +1,31 @@
+# id 属性値のハードコーディング禁止(`no-hard-code-id`)
+
+コードが HTML の断片の場合、id 属性値をハードコーディングすると警告します。
+
+## ルールの詳細
+
+👎 間違ったコード例
+
+```jsx
+<div id="foo"></div>
+```
+
+👍 正しいコード例
+
+```jsx
+const id = uid();
+<div id={id}></div>;
+```
+
+```jsx
+const Component = ({ id }) => <div id={id}></div>;
+```
+
+### 設定値
+
+-   型: `boolean`
+-   デフォルト値: `true`
+
+### デフォルトの警告の厳しさ
+
+`warning`

--- a/packages/@markuplint/rules/src/no-hard-code-id/README.md
+++ b/packages/@markuplint/rules/src/no-hard-code-id/README.md
@@ -1,0 +1,37 @@
+---
+title: Disallow hard-code the id attribute
+id: no-hard-code-id
+category: maintenability
+---
+
+# Disallow hard-code the id attribute
+
+Warn it hard-coded the value of the id attribute when the element is a fragment.
+
+## Rule Details
+
+👎 Examples of **incorrect** code for this rule
+
+```jsx
+<div id="foo"></div>
+```
+
+👍 Examples of **correct** code for this rule
+
+```jsx
+const id = uid();
+<div id={id}></div>;
+```
+
+```jsx
+const Component = ({ id }) => <div id={id}></div>;
+```
+
+### Interface
+
+-   Type: `boolean`
+-   Deafult Value: `true`
+
+### Default severity
+
+`warning`

--- a/packages/@markuplint/rules/src/no-hard-code-id/index.spec.ts
+++ b/packages/@markuplint/rules/src/no-hard-code-id/index.spec.ts
@@ -1,0 +1,90 @@
+import { mlRuleTest } from 'markuplint';
+
+import rule from './';
+
+it('is hard-coeded', async () => {
+	const { violations } = await mlRuleTest(rule, '<div id="foo"></div>');
+	expect(violations).toStrictEqual([
+		{
+			severity: 'warning',
+			line: 1,
+			col: 6,
+			raw: 'id="foo"',
+			message: 'It is hard-coded',
+		},
+	]);
+});
+
+it('is hard-coeded', async () => {
+	const { violations } = await mlRuleTest(rule, 'div#foo', {
+		parser: {
+			'/.*/': '@markuplint/pug-parser',
+		},
+	});
+	expect(violations).toStrictEqual([
+		{
+			severity: 'warning',
+			line: 1,
+			col: 4,
+			raw: '#foo',
+			message: 'It is hard-coded',
+		},
+	]);
+});
+
+it('is hard-coeded', async () => {
+	const { violations } = await mlRuleTest(rule, 'div(id="foo")', {
+		parser: {
+			'/.*/': '@markuplint/pug-parser',
+		},
+	});
+	expect(violations).toStrictEqual([
+		{
+			severity: 'warning',
+			line: 1,
+			col: 5,
+			raw: 'id="foo"',
+			message: 'It is hard-coded',
+		},
+	]);
+});
+
+it('is hard-coeded', async () => {
+	const { violations } = await mlRuleTest(rule, '<div id="foo"></div>', {
+		parser: {
+			'.*': '@markuplint/jsx-parser',
+		},
+	});
+	expect(violations).toStrictEqual([
+		{
+			severity: 'warning',
+			line: 1,
+			col: 6,
+			raw: 'id="foo"',
+			message: 'It is hard-coded',
+		},
+	]);
+});
+
+it('is no hard-coeded', async () => {
+	const { violations } = await mlRuleTest(rule, 'div(id=foo)', {
+		parser: {
+			'/.*/': '@markuplint/pug-parser',
+		},
+	});
+	expect(violations.length).toBe(0);
+});
+
+it('is no hard-coeded', async () => {
+	const { violations } = await mlRuleTest(rule, '<div id={foo}></div>', {
+		parser: {
+			'/.*/': '@markuplint/jsx-parser',
+		},
+	});
+	expect(violations.length).toBe(0);
+});
+
+it('is no fragment', async () => {
+	const { violations } = await mlRuleTest(rule, '<html><body><div id="foo"></div></body></html>');
+	expect(violations.length).toBe(0);
+});

--- a/packages/@markuplint/rules/src/no-hard-code-id/index.ts
+++ b/packages/@markuplint/rules/src/no-hard-code-id/index.ts
@@ -1,0 +1,30 @@
+import { createRule } from '@markuplint/ml-core';
+
+export default createRule<boolean, null>({
+	defaultServerity: 'warning',
+	defaultValue: true,
+	defaultOptions: null,
+	async verify({ document, report, t }) {
+		if (!document.isFragment) {
+			return;
+		}
+		document.walkOn('Element', el => {
+			for (const attr of el.attributes) {
+				if (
+					(attr.attrType === 'html-attr' && !attr.isDynamicValue) ||
+					(attr.attrType === 'ps-attr' &&
+						attr.potentialName.toLowerCase() === 'id' &&
+						attr.valueType !== 'code')
+				) {
+					report({
+						scope: el,
+						line: attr.startLine,
+						col: attr.startCol,
+						raw: attr.raw,
+						message: t('It is {0:c}', 'hard-coded'),
+					});
+				}
+			}
+		});
+	},
+});

--- a/packages/markuplint/src/testing-tool/index.ts
+++ b/packages/markuplint/src/testing-tool/index.ts
@@ -43,6 +43,10 @@ export async function mlRuleTest<T extends RuleConfigValue, O = null>(
 				? {
 						'<current-rule>': config.rule,
 				  }
+				: config.rule === undefined && config.nodeRule === undefined && config.childNodeRule === undefined
+				? {
+						'<current-rule>': true,
+				  }
 				: undefined,
 		nodeRules:
 			config.nodeRule !== undefined

--- a/website/src/pages/rules/index.mdx
+++ b/website/src/pages/rules/index.mdx
@@ -25,6 +25,11 @@ title: Rules
 
 - [`class-naming`](/rules/class-naming)
 
+## Maintenability
+
+- [`no-hard-code-id`](/rules/no-hard-code-id)
+- [`no-use-event-handler-attr`](/rules/no-use-event-handler-attr)
+
 ## Style
 
 - [`attr-equal-space-after`](/rules/attr-equal-space-after)


### PR DESCRIPTION
Warn it hard-coded the value of the id attribute when the element is a fragment.

👎 Examples of **incorrect** code for this rule

```jsx
<div id="foo"></div>
```

👍 Examples of **correct** code for this rule

```jsx
const id = uid();
<div id={id}></div>;
```

```jsx
const Component = ({ id }) => <div id={id}></div>;
```