### PR TITLE
Fix to catch the error on `vue-parser`

### DIFF
--- a/packages/@markuplint/vue-parser/src/index.spec.ts
+++ b/packages/@markuplint/vue-parser/src/index.spec.ts
@@ -5,7 +5,25 @@ import { nodeListToDebugMaps } from '@markuplint/parser-utils';
 import { parse } from './';
 
 describe('parser', () => {
-	it('empty code', () => {
+	it('empty', () => {
+		const doc = parse('');
+		expect(doc.nodeList).toStrictEqual([]);
+		expect(doc.nodeList.length).toBe(0);
+	});
+
+	it('syntax error', () => {
+		expect(() => {
+			parse('"');
+		}).toThrow('Unterminated string constant');
+	});
+
+	it('silent syntax error', () => {
+		const doc = parse('<!--');
+		expect(doc.nodeList).toStrictEqual([]);
+		expect(doc.nodeList.length).toBe(0);
+	});
+
+	it('template empty', () => {
 		const doc = parse('<template></template>');
 		expect(doc.nodeList).toStrictEqual([]);
 		expect(doc.nodeList.length).toBe(0);

--- a/packages/@markuplint/vue-parser/src/vue-parser/index.ts
+++ b/packages/@markuplint/vue-parser/src/vue-parser/index.ts
@@ -1,6 +1,8 @@
 import * as VueESLintParser from 'vue-eslint-parser';
 
-export default function vueParse(vueTemplate: string): VueESLintParser.AST.ESLintProgram {
+export type VueTokens = VueESLintParser.AST.ESLintProgram;
+
+export default function vueParse(vueTemplate: string): VueTokens {
 	const ast = VueESLintParser.parse(vueTemplate, { parser: false });
 	return ast;
 }


### PR DESCRIPTION
```vue
"
<template></template>
```

The double quotation that started causes the syntax error on `espree`.