### PR TITLE
Allow custom parser for html files

### DIFF
--- a/packages/@markuplint/file-resolver/src/resolve-parser.ts
+++ b/packages/@markuplint/file-resolver/src/resolve-parser.ts
@@ -10,8 +10,8 @@ const parsers = new Map<string, MLMarkupLanguageParser>();
 
 export async function resolveParser(file: MLFile, parserConfig?: ParserConfig, parserOptions?: ParserOptions) {
 	parserConfig = {
-		...parserConfig,
 		'/\\.html?$/i': '@markuplint/html-parser',
+		...parserConfig,
 	};
 	parserOptions = parserOptions || {};
 


### PR DESCRIPTION
# Problem

Parser option for "/\\.html?$/i" is currently overridden as "@markuplint/html-parser." This makes it impossible to use custom parser for html files. This means Angular users cannot use custom parser since Angular uses html files for creating components. 

# How to fix
Prioritize user option instead of overriding it with default option.