### PR TITLE
add nunjucks-comment

### DIFF
--- a/packages/@markuplint/nunjucks-parser/src/index.spec.ts
+++ b/packages/@markuplint/nunjucks-parser/src/index.spec.ts
@@ -8,4 +8,8 @@ describe('Tags', () => {
 	it('nunjucks-output', () => {
 		expect(parse('{{ any }}').nodeList[0].nodeName).toBe('#ps:nunjucks-output');
 	});
+
+	it('nunjucks-comment', () => {
+		expect(parse('{# any #}').nodeList[0].nodeName).toBe('#ps:nunjucks-comment');
+	});
 });

--- a/packages/@markuplint/nunjucks-parser/src/parse.ts
+++ b/packages/@markuplint/nunjucks-parser/src/parse.ts
@@ -15,6 +15,11 @@ export const parse: Parse = rawCode => {
 			start: /{{/,
 			end: /}}/,
 		},
+		{
+			type: 'nunjucks-comment',
+			start: /{#/,
+			end: /#}/,
+		},
 	]);
 	const doc = htmlParse(blocks.replaced);
 	doc.nodeList = restoreNode(doc.nodeList, blocks);


### PR DESCRIPTION
#429 を解決するため、Nunjucksのコメントの構文を扱えるように記述を追加しました。

Nunjucks ドキュメント：
https://mozilla.github.io/nunjucks/templating.html#comments