### PR TITLE
fix required defer

### DIFF
--- a/packages/@markuplint/ml-core/markuplint-recommended.json
+++ b/packages/@markuplint/ml-core/markuplint-recommended.json
@@ -92,7 +92,7 @@
 			}
 		},
 		{
-			"selector": ":where(script[src])",
+			"selector": ":where(script[src]:not([type=module]))",
 			"rules": {
 				"required-attr": ["defer"]
 			}


### PR DESCRIPTION
 #438 を修正しました。

`defer` を強制する `script` タグを、`type="module"` の場合以外に制限しています。