### PR TITLE
Fix to catch the error when passing an invalid locale string to `toLocaleString` method.

### DIFF
--- a/packages/@markuplint/i18n/src/translator.ts
+++ b/packages/@markuplint/i18n/src/translator.ts
@@ -84,8 +84,23 @@ function toString(value: Primitive, locale = 'en') {
 		case 'string':
 			return value;
 		case 'number':
-			return value.toLocaleString(locale);
+			return toLocaleString(value, locale);
 		case 'boolean':
 			return `${value}`;
 	}
+}
+
+function toLocaleString(value: number, locale: string) {
+	try {
+		return value.toLocaleString(locale);
+	} catch (e: unknown) {
+		if (e instanceof RangeError) {
+			try {
+				return value.toLocaleString('en');
+			} catch (_) {
+				// void
+			}
+		}
+	}
+	return value.toString(10);
 }


### PR DESCRIPTION
```
<markuplint> error: RangeError: Incorrect locale information provided
    at Number.toLocaleString (<anonymous>)
    at toString (/xxxx/node_modules/@markuplint/i18n/lib/translator.js:84:26)
```