### PR TITLE
Includes filePath to violations when outputs JSON format.

### DIFF
--- a/packages/markuplint/src/cli/output.ts
+++ b/packages/markuplint/src/cli/output.ts
@@ -10,7 +10,16 @@ export function output(results: MLResultInfo, options: CLIOptions) {
 	let out: string[];
 	switch (format.toLowerCase()) {
 		case 'json': {
-			process.stdout.write(JSON.stringify(results.violations, null, 2));
+			process.stdout.write(
+				JSON.stringify(
+					results.violations.map(v => ({
+						...v,
+						filePath: results.filePath,
+					})),
+					null,
+					2,
+				),
+			);
 			return;
 		}
 		case 'simple': {


### PR DESCRIPTION
Fix #498 