### PR TITLE
Fix to no warning the `require-accessible-name` rule on an element has `aria-hidden`

### DIFF
--- a/packages/@markuplint/rules/src/require-accessible-name/index.spec.ts
+++ b/packages/@markuplint/rules/src/require-accessible-name/index.spec.ts
@@ -223,3 +223,21 @@ test('The accessible name may be mutable', async () => {
 		).violations,
 	).toStrictEqual([]);
 });
+
+describe('Issues', () => {
+	// https://github.com/markuplint/markuplint/issues/536
+	test('#536', async () => {
+		expect(
+			(await mlRuleTest(rule, '<h2 id="h">Heading</h2><div role="region" aria-labelledby="h">...</div>'))
+				.violations,
+		).toStrictEqual([]);
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					'<h2 id="h">Heading</h2><div role="region" aria-labelledby="h" aria-hidden="true">...</div>',
+				)
+			).violations,
+		).toStrictEqual([]);
+	});
+});

--- a/packages/@markuplint/rules/src/require-accessible-name/index.ts
+++ b/packages/@markuplint/rules/src/require-accessible-name/index.ts
@@ -9,6 +9,12 @@ export default createRule<boolean, null>({
 				return;
 			}
 
+			// **SHORT TERM SOLUTION**
+			// In v3.x, it will be resolved by https://github.com/markuplint/markuplint/pull/540
+			if (el.getAttribute('aria-hidden') === 'true') {
+				return;
+			}
+
 			const role = getComputedRole(document.specs, el);
 			if (!role) {
 				return;


### PR DESCRIPTION
Fix #536 