### PR TITLE
Add supporting for `importmap` with the type attribute of the script element

### DIFF
--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -27874,7 +27874,7 @@
 					"type": [
 						"MIMEType",
 						{
-							"enum": ["module"],
+							"enum": ["module", "importmap"],
 							"caseInsensitive": true
 						}
 					]

--- a/packages/@markuplint/html-spec/src/spec.script.json
+++ b/packages/@markuplint/html-spec/src/spec.script.json
@@ -31,7 +31,7 @@
 			"type": [
 				"MIMEType",
 				{
-					"enum": ["module"],
+					"enum": ["module", "importmap"],
 					"caseInsensitive": true
 				}
 			]


### PR DESCRIPTION
Fix #537 