### PR TITLE
Fix test failures on Windows

### DIFF
--- a/packages/@markuplint/config-presets/build.mjs
+++ b/packages/@markuplint/config-presets/build.mjs
@@ -14,7 +14,7 @@ const srcDir = path.resolve(dirname, 'src');
 const currents = await asyncGlob('preset.*.json,!preset.___json');
 await Promise.all(currents.map(current => rm(current)));
 
-const files = await asyncGlob(path.resolve(srcDir, '*.json'));
+const files = await asyncGlob('*.json', { cwd: srcDir });
 const md = await readFile(path.resolve(srcDir, 'README.md'), { encoding: 'utf-8' });
 
 const presets = [];
@@ -23,7 +23,7 @@ const extended = {};
 
 for (const file of files) {
 	const filename = path.basename(file);
-	const code = await readFile(path.resolve(dirname, 'src', filename), { encoding: 'utf-8' });
+	const code = await readFile(path.resolve(srcDir, filename), { encoding: 'utf-8' });
 	const json = JSON.parse(stripComments(code));
 	const compressed = JSON.stringify(json);
 	await writeFile(path.resolve(dirname, filename), compressed, { encoding: 'utf-8' });

--- a/packages/markuplint/src/cli/index.spec.ts
+++ b/packages/markuplint/src/cli/index.spec.ts
@@ -6,7 +6,7 @@ import { cli } from './bootstrap';
 
 const entryFilePath = path.resolve(__dirname, '../../bin/markuplint');
 
-const escape = (path: string) => path.replaceAll('\\', '\\\\'); // For Windows
+const escape = (path: string) => path.replace(/\\/g, '\\\\'); // For Windows
 
 describe('STDOUT Test', () => {
 	it('empty', async () => {

--- a/packages/markuplint/src/cli/index.spec.ts
+++ b/packages/markuplint/src/cli/index.spec.ts
@@ -6,6 +6,8 @@ import { cli } from './bootstrap';
 
 const entryFilePath = path.resolve(__dirname, '../../bin/markuplint');
 
+const escape = (path: string) => path.replaceAll('\\', '\\\\'); // For Windows
+
 describe('STDOUT Test', () => {
 	it('empty', async () => {
 		const resultPromise = execa(entryFilePath, []);
@@ -30,20 +32,20 @@ describe('STDOUT Test', () => {
 
 	it('verify', async () => {
 		const targetFilePath = path.resolve(__dirname, '../../../../test/fixture/001.html');
-		const { stdout, exitCode } = await execa(entryFilePath, ['--no-color', targetFilePath]);
+		const { stdout, exitCode } = await execa(entryFilePath, ['--no-color', escape(targetFilePath)]);
 		expect(stdout).toBe(`<markuplint> passed ${targetFilePath}`);
 		expect(exitCode).toBe(0);
 	});
 
 	it('verify --problem-only', async () => {
 		const targetFilePath = path.resolve(__dirname, '../../../../test/fixture/001.html');
-		const { stdout } = await execa(entryFilePath, ['--problem-only', targetFilePath]);
+		const { stdout } = await execa(entryFilePath, ['--problem-only', escape(targetFilePath)]);
 		expect(stdout).toBe('');
 	});
 
 	it('verify and failure', async () => {
 		const targetFilePath = path.resolve(__dirname, '../../../../test/fixture/002.html');
-		const { stdout, stderr, exitCode } = await execa(entryFilePath, ['--no-color', targetFilePath], {
+		const { stdout, stderr, exitCode } = await execa(entryFilePath, ['--no-color', escape(targetFilePath)], {
 			reject: false,
 		});
 		expect(stdout).toBe('');
@@ -53,7 +55,7 @@ describe('STDOUT Test', () => {
 
 	it('format', async () => {
 		const targetFilePath = path.resolve(__dirname, '../../../../test/fixture/001.html');
-		const { stdout } = await execa(entryFilePath, ['--format', 'JSON', targetFilePath]);
+		const { stdout } = await execa(entryFilePath, ['--format', 'JSON', escape(targetFilePath)]);
 		expect(stdout).toBe('[]');
 	});
 });

--- a/website/prebuild.mjs
+++ b/website/prebuild.mjs
@@ -116,7 +116,6 @@ async function createRuleDoc(path, value, option) {
 
   const { data: frontMatter, content } = matter(doc);
 
-  // NOTE: `glob` returns `/` separated paths, even on Windows.
   frontMatter.custom_edit_url = `${editUrlBase}/${RULES_DIR}/${name}/README.md`;
   let rewrote = matter.stringify(content.replace(/\(https:\/\/markuplint\.dev\//g, '(/'), frontMatter);
 


### PR DESCRIPTION

## What is the purpose of this PR?

- [ ] Fix bug
- [ ] Fix typo
- [ ] Update specs
- [ ] Add new rule
- [ ] Add new parser
- [ ] Improve or refactor rules
- [ ] Add a new core feature
- [ ] Improve or refactor core features
- [ ] Update documents
- [x] Others

### Description

Tests failed on only Windows, I fixed it.
https://github.com/markuplint/markuplint/actions/runs/3607777519/jobs/6080005176

- `glob` accepts only `/` (forward-slash) separated pattern even on Windows.
https://github.com/isaacs/node-glob#windows
but, `path.resolve` returns path separated by `\` (back-slash).
- when pass the file path to `execa`, it seems that we need to escape the back-slash

and,

- glob is no longer used in website/prebuild.mjs, so deleted the comment