### PR TITLE
[website] Fix can't use `.md` or `.mdx` in pages folder

### DIFF
--- a/website/src/theme/MDXContent/index.js
+++ b/website/src/theme/MDXContent/index.js
@@ -1,15 +1,11 @@
-import { useDoc } from '@docusaurus/theme-common/internal';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import MDXContent from '@theme-original/MDXContent';
 import Admonition from '@theme/Admonition';
 import React from 'react';
 
 export default function MDXContentWrapper(props) {
-  const {
-    metadata: { source },
-  } = useDoc();
   const { i18n } = useDocusaurusContext();
-
+  const source = props.children.type.metadata.source;
   return (
     <>
       {i18n.currentLocale === 'ja' && !source.startsWith('@site/i18n') && (


### PR DESCRIPTION

## What is the purpose of this PR?

- [ ] Fix bug
- [ ] Fix typo
- [ ] Update specs
- [ ] Add new rule
- [ ] Add new parser
- [ ] Improve or refactor rules
- [ ] Add a new core feature
- [ ] Improve or refactor core features
- [ ] Update documents
- [x] Others

### Description

I added the feature to show ”このページはまだ翻訳が用意されていないため、英語版を表示しています。" when the page have no translation, but it worked only with `docs`. 
 `website/src/pages/something.md` occured an error.

Now, we can use `.md` or `.mdx` in the `website/src/pages` directory.