### PR TITLE
Fix to add the hint about `aria-busy`

### DIFF
--- a/packages/@markuplint/rules/src/permitted-contents/index.spec.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/index.spec.ts
@@ -1249,4 +1249,29 @@ describe('Issues', () => {
 			},
 		]);
 	});
+
+	test('#606', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					`<dl>
+					<template>
+						<dt></dt>
+						<dd></dd>
+					</template>
+				</dl>`,
+				)
+			).violations,
+		).toStrictEqual([
+			// https://github.com/markuplint/markuplint/issues/606#issuecomment-1345446732
+			{
+				severity: 'error',
+				line: 1,
+				col: 1,
+				message: 'Require one or more elements. (Need "dt")',
+				raw: '<dl>',
+			},
+		]);
+	});
 });

--- a/packages/@markuplint/rules/src/wai-aria/checkings/required-owned-elements.ts
+++ b/packages/@markuplint/rules/src/wai-aria/checkings/required-owned-elements.ts
@@ -45,22 +45,6 @@ export const checkingRequiredOwnedElements: ElementChecker<
 
 		// TODO: Needs to resolve `aria-own`
 
-		if (el.isEmpty()) {
-			return {
-				scope: el,
-				message: t(
-					'{0}. Or, {1}',
-					t(
-						'require {0}',
-						role.requiredOwnedElements.length === 1
-							? t('the "{0*}" {1}', role.requiredOwnedElements[0], 'role')
-							: t('the {0}', 'roles') + `: ${t(role.requiredOwnedElements)}`,
-					),
-					t('require {0}', 'aria-busy="true"'),
-				),
-			};
-		}
-
 		const children: OwnedElement[] = Array.from(el.childNodes).map<OwnedElement>(child => {
 			if (child.is(child.ELEMENT_NODE)) {
 				const computedChild = getComputedRole(child.ownerMLDocument.specs, child, child.rule.options.version);
@@ -114,6 +98,22 @@ export const checkingRequiredOwnedElements: ElementChecker<
 			return;
 		}
 
+		if (mayBeBeforeCreated(el)) {
+			return {
+				scope: el,
+				message: t(
+					'{0}. Or, {1}',
+					t(
+						'require {0}',
+						role.requiredOwnedElements.length === 1
+							? t('the "{0*}" {1}', role.requiredOwnedElements[0], 'role')
+							: t('the {0}', 'roles') + `: ${t(role.requiredOwnedElements)}`,
+					),
+					t('require {0}', 'aria-busy="true"'),
+				),
+			};
+		}
+
 		return {
 			scope: el,
 			message: t(
@@ -125,3 +125,13 @@ export const checkingRequiredOwnedElements: ElementChecker<
 			),
 		};
 	};
+
+function mayBeBeforeCreated(el: Element<boolean, Options>) {
+	if (el.isEmpty()) {
+		return true;
+	}
+
+	return Array.from(el.children).every(child => {
+		return ['script', 'template'].includes(child.localName);
+	});
+}

--- a/packages/@markuplint/rules/src/wai-aria/index.spec.ts
+++ b/packages/@markuplint/rules/src/wai-aria/index.spec.ts
@@ -988,5 +988,76 @@ describe('Issues', () => {
 				)
 			).violations,
 		).toStrictEqual([]);
+
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					`<table>
+						<caption>
+							text
+						</caption>
+						<tbody>
+							<template>
+								<tr>
+									<td></td>
+								</tr>
+							</template>
+						</tbody>
+					</table>`,
+				)
+			).violations,
+		).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 1,
+				message: 'The "table" role expects the roles: "row", "rowgroup > row"',
+				raw: '<table>',
+			},
+			{
+				severity: 'error',
+				line: 5,
+				col: 7,
+				message: 'Require the "row" role. Or, require aria-busy="true"',
+				raw: '<tbody>',
+			},
+		]);
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					`<table>
+						<caption>
+							text
+						</caption>
+						<tbody>
+							<tr>
+								<td></td>
+							</tr>
+						</tbody>
+					</table>`,
+				)
+			).violations,
+		).toStrictEqual([]);
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					`<table>
+						<caption>
+							text
+						</caption>
+						<tbody aria-busy="true">
+							<template>
+								<tr>
+									<td></td>
+								</tr>
+							</template>
+						</tbody>
+					</table>`,
+				)
+			).violations,
+		).toStrictEqual([]);
 	});
 });

--- a/packages/@markuplint/rules/src/wai-aria/index.spec.ts
+++ b/packages/@markuplint/rules/src/wai-aria/index.spec.ts
@@ -925,4 +925,68 @@ describe('Issues', () => {
 			expect(violations).toStrictEqual([]);
 		}
 	});
+
+	test('#606', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					`<ul>
+						<template>
+							<li></li>
+						</template>
+					</ul>`,
+				)
+			).violations,
+		).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 1,
+				message: 'Require the "listitem" role. Or, require aria-busy="true"',
+				raw: '<ul>',
+			},
+		]);
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					`<ul aria-busy="true">
+						<template>
+							<li></li>
+						</template>
+					</ul>`,
+				)
+			).violations,
+		).toStrictEqual([]);
+
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					`<ul>
+						<!-- -->
+					</ul>`,
+				)
+			).violations,
+		).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 1,
+				message: 'Require the "listitem" role. Or, require aria-busy="true"',
+				raw: '<ul>',
+			},
+		]);
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					`<ul aria-busy="true">
+						<!-- -->
+					</ul>`,
+				)
+			).violations,
+		).toStrictEqual([]);
+	});
 });


### PR DESCRIPTION
Fixes #606 

## What is the purpose of this PR?

- [x] Fix bug
- [ ] Fix typo
- [ ] Update specs
- [ ] Add new rule
- [ ] Add new parser
- [ ] Improve or refactor rules
- [ ] Add a new core feature
- [ ] Improve or refactor core features
- [ ] Update documents
- [ ] Others

### Description

When warning about [**Required Owned Elements**](https://w3c.github.io/aria/#mustContain) on `wai-aria` rule, it adds about requiring `aria-busy` to the warning message if it needs.

## Checklist

Fill out the checks for the applicable purpose.

- [x] Fix bug
  - [x] Add the test that can check whether resolved the issue.
- [ ] Update specs
  - [ ] Element
    - [ ] Update **[global attributes](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/html-spec/src/spec-common.attributes.json)**
    - [ ] Update **[content models](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/html-spec/src/spec-common.contents.json)**
    - [ ] Add also ARIA that you explored **ARIA in HTML [Recommendation](https://www.w3.org/TR/html-aria/) and [Editor's draft](https://w3c.github.io/html-aria/)**
  - [ ] Attribute
    - [ ] Update **[global attributes](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/html-spec/src/spec-common.attributes.json)**
    - [ ] Update **[IDL attribute](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/parser-utils/src/idl-attributes.ts)**
- [ ] Add new rule
  - [ ] Add a test
  - [ ] Add a README document
    - [ ] Create an issue that requests translating the doc if you want.
  - [ ] Add to [index](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/rules/src/index.ts)
  - [ ] Add JSON schema to [schema.json](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/rules/schema.json)
  - [ ] Add to [initializer](https://github.com/markuplint/markuplint/blob/main/packages/markuplint/src/cli/init/index.ts)
  - [ ] Add to [`@markuplint/config-presets`](https://github.com/markuplint/markuplint/tree/main/packages/%40markuplint/config-presets)
- [ ] Add new parser
  - [ ] Add a test
    - [ ] Do a test with some parser.
  - [ ] Add to [initializer](https://github.com/markuplint/markuplint/blob/main/packages/markuplint/src/cli/init/index.ts)
