### PR TITLE
Fix to replace the masked node with the restored node at `nextNode` and `prevNode`

### DIFF
--- a/packages/@markuplint/ejs-parser/src/index.spec.ts
+++ b/packages/@markuplint/ejs-parser/src/index.spec.ts
@@ -158,3 +158,11 @@ describe('Tags', () => {
 		expect(parse('<%% any %>').nodeList[0].nodeName).toBe('#text');
 	});
 });
+
+describe('Issues', () => {
+	test('#607', () => {
+		const ast = parse('<% %><div></div>');
+		expect(ast.nodeList.length).toBe(3);
+		expect(ast.nodeList[1].prevNode?.uuid).toBe(ast.nodeList[0].uuid);
+	});
+});

--- a/packages/@markuplint/ml-core/src/ml-dom/index.spec.ts
+++ b/packages/@markuplint/ml-core/src/ml-dom/index.spec.ts
@@ -612,3 +612,15 @@ describe('Rule', () => {
 		expect(pugRules).toStrictEqual(['x-a:global', 'x-b:a', 'x-c:b']);
 	});
 });
+
+describe('Issues', () => {
+	test('#607', () => {
+		const dom = createTestDocument('<% %><div></div>', {
+			config: {
+				nodeRules: [{ selector: '* ~ div', rules: {} }],
+			},
+			parser: require('@markuplint/ejs-parser'),
+		});
+		expect(dom.nodeList[0].nodeName).toBe('#ml-block');
+	});
+});

--- a/packages/@markuplint/parser-utils/src/ignore-block.spec.ts
+++ b/packages/@markuplint/parser-utils/src/ignore-block.spec.ts
@@ -269,3 +269,14 @@ describe('restoreNode', () => {
 		expect(restoredAst).toStrictEqual([]);
 	});
 });
+
+describe('Issues', () => {
+	test('#607', () => {
+		const code = '<div><% %><img/></div>';
+		const masked = ignoreBlock(code, tags);
+		const ast = parse(masked.replaced);
+		const restoredAst = restoreNode(ast.nodeList, masked);
+		expect(restoredAst[2].parentNode?.uuid).toBe(restoredAst[0].uuid);
+		expect(restoredAst[2].prevNode?.uuid).toBe(restoredAst[1].uuid);
+	});
+});

--- a/packages/@markuplint/parser-utils/src/ignore-block.ts
+++ b/packages/@markuplint/parser-utils/src/ignore-block.ts
@@ -118,6 +118,12 @@ export function restoreNode(nodeList: MLASTNode[], ignoreBlock: IgnoreBlock) {
 							startCol,
 							endCol,
 						};
+						if (node.prevNode?.nextNode) {
+							node.prevNode.nextNode = textNode;
+						}
+						if (node.nextNode?.prevNode) {
+							node.nextNode.prevNode = textNode;
+						}
 						insertList.push(textNode);
 					}
 					if (body) {
@@ -144,6 +150,12 @@ export function restoreNode(nodeList: MLASTNode[], ignoreBlock: IgnoreBlock) {
 							startCol,
 							endCol,
 						};
+						if (node.prevNode?.nextNode) {
+							node.prevNode.nextNode = bodyNode;
+						}
+						if (node.nextNode?.prevNode) {
+							node.nextNode.prevNode = bodyNode;
+						}
 						insertList.push(bodyNode);
 					}
 					text = below;


### PR DESCRIPTION
Fixes #607

## What is the purpose of this PR?

- [x] Fix bug
- [ ] Fix typo
- [ ] Update specs
- [ ] Add new rule
- [ ] Add new parser
- [ ] Improve or refactor rules
- [ ] Add a new core feature
- [ ] Improve or refactor core features
- [ ] Update documents
- [ ] Others

### Description

- There was a problem when using a parser.
- It reproduces using together the sibling selector if it refers to the prev node, which is a processor-specific block node.
- The restore function of parser-utils had the bug that exposes an invalid UUID if `prevNode` or `nextNode` is a processor-specific block node because it forgot to replace those nodes.

## Checklist

Fill out the checks for the applicable purpose.

- [x] Fix bug
  - [x] Add the test that can check whether resolved the issue.
- [ ] Update specs
  - [ ] Element
    - [ ] Update **[global attributes](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/html-spec/src/spec-common.attributes.json)**
    - [ ] Update **[content models](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/html-spec/src/spec-common.contents.json)**
    - [ ] Add also ARIA that you explored **ARIA in HTML [Recommendation](https://www.w3.org/TR/html-aria/) and [Editor's draft](https://w3c.github.io/html-aria/)**
  - [ ] Attribute
    - [ ] Update **[global attributes](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/html-spec/src/spec-common.attributes.json)**
    - [ ] Update **[IDL attribute](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/parser-utils/src/idl-attributes.ts)**
- [ ] Add new rule
  - [ ] Add a test
  - [ ] Add a README document
    - [ ] Create an issue that requests translating the doc if you want.
  - [ ] Add to [index](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/rules/src/index.ts)
  - [ ] Add JSON schema to [schema.json](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/rules/schema.json)
  - [ ] Add to [initializer](https://github.com/markuplint/markuplint/blob/main/packages/markuplint/src/cli/init/index.ts)
  - [ ] Add to [`@markuplint/config-presets`](https://github.com/markuplint/markuplint/tree/main/packages/%40markuplint/config-presets)
- [ ] Add new parser
  - [ ] Add a test
    - [ ] Do a test with some parser.
  - [ ] Add to [initializer](https://github.com/markuplint/markuplint/blob/main/packages/markuplint/src/cli/init/index.ts)
