### PR TITLE
Fix evaluation of the transparent model

### DIFF
--- a/packages/@markuplint/rules/src/permitted-contents/index.spec.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/index.spec.ts
@@ -859,14 +859,6 @@ describe('verify', () => {
 		).toStrictEqual([
 			{
 				severity: 'error',
-				line: 2,
-				col: 7,
-				message:
-					'The "style" element is not allowed in the "noscript" element through the transparent model in this context',
-				raw: '<style>',
-			},
-			{
-				severity: 'error',
 				line: 5,
 				col: 7,
 				message:

--- a/packages/@markuplint/rules/src/permitted-contents/index.spec.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/index.spec.ts
@@ -1274,4 +1274,90 @@ describe('Issues', () => {
 			},
 		]);
 	});
+
+	test('#617', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					`<head>
+				<title>Title</title>
+				<noscript>
+					<style>
+						.selector {}
+					</style>
+				</noscript></head>`,
+				)
+			).violations,
+		).toStrictEqual([]);
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					`<noscript>
+					<style>
+						.selector {}
+					</style>
+				</noscript>`,
+				)
+			).violations,
+		).toStrictEqual([]);
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					`<div><noscript>
+					<style>
+						.selector {}
+					</style>
+				</noscript></div>`,
+				)
+			).violations,
+		).toStrictEqual([
+			{
+				severity: 'error',
+				line: 2,
+				col: 6,
+				message:
+					'The "style" element is not allowed in the "div" element through the transparent model in this context',
+				raw: '<style>',
+			},
+		]);
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					`<span><noscript>
+					<div>
+					</div>
+				</noscript></span>`,
+				)
+			).violations,
+		).toStrictEqual([
+			{
+				severity: 'error',
+				line: 2,
+				col: 6,
+				message:
+					'The "div" element is not allowed in the "span" element through the transparent model in this context',
+				raw: '<div>',
+			},
+		]);
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					`mixin meta(title)
+	meta(charset="UTF-8")
+	meta(name="viewport" content="width=device-width")
+	title= title
+	noscript
+		style`,
+					{
+						parser: require('@markuplint/pug-parser'),
+					},
+				)
+			).violations,
+		).toStrictEqual([]);
+	});
 });

--- a/packages/@markuplint/rules/src/permitted-contents/represent-transparent-nodes.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/represent-transparent-nodes.ts
@@ -23,9 +23,6 @@ export function representTransparentNodes(
 	if (parent) {
 		const { errors: parentErrors } = representTransparentNodes([parent], specs, options);
 		errors.push(...parentErrors);
-		// if (!Array.isArray(parentRes)) {
-		// 	return parentRes;
-		// }
 	}
 
 	for (const node of nodes) {

--- a/packages/@markuplint/rules/src/permitted-contents/start.spec.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/start.spec.ts
@@ -47,7 +47,7 @@ it('transparent: <a> with <svg>', () => {
 });
 
 it('conditional transparent: <audio>', () => {
-	expect(c('<audio src="path/to"><source /></audio>')[0].type).toBe('UNEXPECTED_EXTRA_NODE');
+	expect(c('<audio src="path/to"><source /></audio>')[0].type).toBe('MATCHED');
 	expect(c('<div><audio src="path/to"><source /></audio></div>', 'audio')[0].type).toBe('MATCHED');
 	expect(c('<div><audio src="path/to"><source /></audio></div>')[0].type).toBe('UNEXPECTED_EXTRA_NODE');
 });

--- a/packages/@markuplint/rules/src/permitted-contents/transparent.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/transparent.ts
@@ -1,8 +1,6 @@
 import type { ChildNode, Options, Result, Specs } from './types';
 
-import { countPattern } from './count-pattern';
 import { cmLog } from './debug';
-import { Collection } from './utils';
 
 const transparentLog = cmLog.extend('transparent');
 
@@ -21,16 +19,12 @@ export function transparent(nodes: ChildNode[], specs: Specs, options: Options, 
 
 	transparentLog('Transparent model element is component root');
 
-	const collection = new Collection(nodes);
-	const result = countPattern({ zeroOrMore: ':model(flow)' }, collection.unmatched, specs, options, depth);
-	collection.addMatched(result.matched);
-
 	return {
-		type: result.type,
-		matched: collection.matched,
-		unmatched: collection.unmatched,
-		zeroMatch: result.zeroMatch,
-		query: result.query,
-		hint: result.hint,
+		type: 'MATCHED',
+		matched: nodes.slice(),
+		unmatched: [],
+		zeroMatch: false,
+		query: 'transparent',
+		hint: {},
 	};
 }


### PR DESCRIPTION
Fixes #617

## What is the purpose of this PR?

- [x] Fix bug
- [ ] Fix typo
- [ ] Update specs
- [ ] Add new rule
- [ ] Add new parser
- [ ] Improve or refactor rules
- [ ] Add a new core feature
- [ ] Improve or refactor core features
- [ ] Update documents
- [ ] Others

### Description

Fix to evaluate the transparent model correctly.
Before fixed, when the transparent model element is a component root, it evaluates as the div element that allows the flow contents only.
This PR fixes returning the mark as matched whatever any element.

## Checklist

Fill out the checks for the applicable purpose.

- [x] Fix bug
  - [x] Add the test that can check whether resolved the issue.
- [ ] Update specs
  - [ ] Element
    - [ ] Update **[global attributes](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/html-spec/src/spec-common.attributes.json)**
    - [ ] Update **[content models](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/html-spec/src/spec-common.contents.json)**
    - [ ] Add also ARIA that you explored **ARIA in HTML [Recommendation](https://www.w3.org/TR/html-aria/) and [Editor's draft](https://w3c.github.io/html-aria/)**
  - [ ] Attribute
    - [ ] Update **[global attributes](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/html-spec/src/spec-common.attributes.json)**
    - [ ] Update **[IDL attribute](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/parser-utils/src/idl-attributes.ts)**
- [ ] Add new rule
  - [ ] Add a test
  - [ ] Add a README document
    - [ ] Create an issue that requests translating the doc if you want.
  - [ ] Add to [index](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/rules/src/index.ts)
  - [ ] Add JSON schema to [schema.json](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/rules/schema.json)
  - [ ] Add to [initializer](https://github.com/markuplint/markuplint/blob/main/packages/markuplint/src/cli/init/index.ts)
  - [ ] Add to [`@markuplint/config-presets`](https://github.com/markuplint/markuplint/tree/main/packages/%40markuplint/config-presets)
- [ ] Add new parser
  - [ ] Add a test
    - [ ] Do a test with some parser.
  - [ ] Add to [initializer](https://github.com/markuplint/markuplint/blob/main/packages/markuplint/src/cli/init/index.ts)
