### PR TITLE
Fix markuplint thorws SyntaxError when <noscript> followed by CRLF

### DIFF
--- a/packages/@markuplint/html-parser/src/index.spec.ts
+++ b/packages/@markuplint/html-parser/src/index.spec.ts
@@ -608,6 +608,28 @@ describe('parser', () => {
 		]);
 	});
 
+	/**
+	 * https://github.com/markuplint/markuplint/issues/737
+	 */
+	it('<noscript> (Issue: #737)', () => {
+		const doc = parse('<html><body><noscript>\r\n<div>text</div>\r\n</noscript></body></html>');
+		const map = nodeListToDebugMaps(doc.nodeList);
+		expect(map).toStrictEqual([
+			'[1:1]>[1:7](0,6)html: <html>',
+			'[N/A]>[N/A](N/A)head: ',
+			'[1:7]>[1:13](6,12)body: <body>',
+			'[1:13]>[1:23](12,22)noscript: <noscript>',
+			'[1:23]>[2:1](22,24)#text: ␣⏎',
+			'[2:1]>[2:6](24,29)div: <div>',
+			'[2:6]>[2:10](29,33)#text: text',
+			'[2:10]>[2:16](33,39)div: </div>',
+			'[2:16]>[3:1](39,41)#text: ␣⏎',
+			'[3:1]>[3:12](41,52)noscript: </noscript>',
+			'[3:12]>[3:19](52,59)body: </body>',
+			'[3:19]>[3:26](59,66)html: </html>',
+		]);
+	});
+
 	it('<form>', () => {
 		const doc = parse(`
 	<div>


### PR DESCRIPTION
Fixes #737

## What is the purpose of this PR?

- [x] Fix bug
- [ ] Fix typo
- [ ] Update specs
- [ ] Add new rule
- [ ] Add new parser
- [ ] Improve or refactor rules
- [ ] Add a new core feature
- [ ] Improve or refactor core features
- [ ] Update documents
- [ ] Others

### Description

parse5 parses `<noscript>` content if [scriptingEnabled: false](https://parse5.js.org/interfaces/parse5.ParserOptions.html#scriptingEnabled) option is passed.

This PR replaces home-grown parser with parse5.

## Checklist

Fill out the checks for the applicable purpose.

- [x] Fix bug
  - [x] Add the test that can check whether resolved the issue.
- [ ] Update specs
  - [ ] Element
    - [ ] Update **[global attributes](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/html-spec/src/spec-common.attributes.json)**
    - [ ] Update **[content models](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/html-spec/src/spec-common.contents.json)**
    - [ ] Add also ARIA that you explored **ARIA in HTML [Recommendation](https://www.w3.org/TR/html-aria/) and [Editor's draft](https://w3c.github.io/html-aria/)**
  - [ ] Attribute
    - [ ] Update **[global attributes](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/html-spec/src/spec-common.attributes.json)**
    - [ ] Update **[IDL attribute](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/parser-utils/src/idl-attributes.ts)**
- [ ] Add new rule
  - [ ] Add a test
  - [ ] Add a README document
    - [ ] Create an issue that requests translating the doc if you want.
  - [ ] Add to [index](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/rules/src/index.ts)
  - [ ] Add JSON schema to [schema.json](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/rules/schema.json)
  - [ ] Add to [`@markuplint/config-presets`](https://github.com/markuplint/markuplint/tree/main/packages/%40markuplint/config-presets)
    - [ ] And add to [Rulesets of base presets](https://markuplint.dev/docs/guides/presets#rulesets-of-base-presets)
      - [ ] Add to a [doc file](https://github.com/markuplint/markuplint/blob/main/website/docs/guides/presets.md)
      - [ ] Add to a [doc file (ja)](https://github.com/markuplint/markuplint/blob/main/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/presets.md), or create an issue that requests translating the doc if you want.
  - [ ] Add to the [Playground](https://playground.markuplint.dev/)
    - [ ] Add to a [config object](https://github.com/markuplint/markuplint/blob/main/playground/src/ml-playground-home.svelte)
- [ ] Add new parser
  - [ ] Add a test
    - [ ] Do a test with some parser.
  - [ ] Add to [initializer](https://github.com/markuplint/markuplint/blob/main/packages/markuplint/src/cli/init/index.ts)
