### PR TITLE
Add `--allow-warnings` option to CLI.

### DIFF
--- a/packages/markuplint/src/cli/bootstrap.ts
+++ b/packages/markuplint/src/cli/bootstrap.ts
@@ -17,6 +17,7 @@ Options
 	--locale                               Locale of the message of violation. Default is an OS setting.
 	--no-color,                            Output no color.
 	--problem-only,          -p            Output only problems, without passeds.
+	--allow-warnings                       Return status code 0 even if there are warnings.
 	--verbose                              Output with detailed information.
 
 	--init                                 Initialize settings interactively.
@@ -67,6 +68,11 @@ export const cli = meow(help, {
 		problemOnly: {
 			type: 'boolean',
 			alias: 'p',
+			default: false,
+		},
+		allowWarnings: {
+			type: 'boolean',
+			// TODO: It will be changed to `true` in the next major version.
 			default: false,
 		},
 		verbose: {

--- a/packages/markuplint/src/cli/command.ts
+++ b/packages/markuplint/src/cli/command.ts
@@ -54,9 +54,13 @@ export async function command(files: readonly Readonly<Target>[], options: CLIOp
 		if (!result) {
 			continue;
 		}
-		if (!hasError && result.violations.length > 0) {
+		const errorCount = result.violations.filter(v => v.severity === 'error').length;
+		const warningCount = result.violations.filter(v => v.severity === 'warning').length;
+
+		if (!hasError && (errorCount > 0 || (warningCount > 0 && !options.allowWarnings))) {
 			hasError = true;
 		}
+
 		if (fix) {
 			log('Overwrite file: %s', result.filePath);
 			await fs.writeFile(result.filePath, result.fixedCode, { encoding: 'utf8' });

--- a/packages/markuplint/src/cli/index.ts
+++ b/packages/markuplint/src/cli/index.ts
@@ -50,7 +50,6 @@ import search from './search';
 
 		const hasError = await command(files, cli.flags).catch(err => {
 			throw err;
-			// process.exit(1);
 		});
 		process.exit(hasError ? 1 : 0);
 	}

--- a/packages/markuplint/test/cli/index.spec.js
+++ b/packages/markuplint/test/cli/index.spec.js
@@ -49,8 +49,18 @@ describe('STDOUT Test', () => {
 			reject: false,
 		});
 		expect(stdout).toBe('');
-		expect(stderr.split('\n').length).toBe(34);
+		expect(stderr.split('\n').length).toBe(30);
 		expect(exitCode).toBe(1);
+	});
+
+	it('allow warnings', async () => {
+		const targetFilePath = path.resolve(__dirname, '../../../../test/fixture/002.html');
+		const { stdout, stderr, exitCode } = await execa(entryFilePath, ['--allow-warnings', escape(targetFilePath)], {
+			reject: false,
+		});
+		expect(stdout).toBe('');
+		expect(stderr.split('\n').length).toBe(24);
+		expect(exitCode).toBe(0);
 	});
 
 	it('format', async () => {

--- a/packages/markuplint/test/index.spec.js
+++ b/packages/markuplint/test/index.spec.js
@@ -70,14 +70,6 @@ describe('basic test', () => {
 				raw: 'content=ie=edge',
 				ruleId: 'attr-value-quotes',
 			},
-			{
-				severity: 'error',
-				message: 'Require the "h1" element',
-				line: 1,
-				col: 1,
-				raw: '<',
-				ruleId: 'required-h1',
-			},
 		]);
 	});
 

--- a/test/fixture/002.html
+++ b/test/fixture/002.html
@@ -7,6 +7,6 @@
 	<title>Document</title>
 </head>
 <body>
-
+	<h1>Title</h1>
 </body>
 </html>

--- a/website/docs/guides/cli.md
+++ b/website/docs/guides/cli.md
@@ -27,6 +27,7 @@ And returns `1` if the result has problems one or more.
 | `--locale`                 | none         | none                                     | OS setting | Locale of the message of violation.                                 |
 | `--no-color`               | none         | none                                     | false      | Output no color.                                                    |
 | `--problem-only`           | `-p`         | none                                     | false      | Output only problems.                                               |
+| `--allow-warnings`         | none         | none                                     | false      | Return status code 0 even if there are warnings.                    |
 | `--verbose`                | none         | none                                     | false      | Output with detailed information.                                   |
 
 ## Particular run

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/cli.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/cli.md
@@ -25,6 +25,7 @@ CLIはターゲットとなるHTMLファイルを可変長引数として受け�
 | `--locale`                 | なし             | なし                                         | OS設定による | メッセージの言語                                     |
 | `--no-color`               | なし             | なし                                         | false        | 出力をカラーリングしません                           |
 | `--problem-only`           | `-p`             | なし                                         | false        | 違反結果のみ出力します                               |
+| `--allow-warnings`         | none             | none                                         | false        | `warning`ではステータスコード`0`を返します           |
 | `--verbose`                | なし             | なし                                         | false        | 詳細な情報も同時に出力します                         |
 
 ## Particular run


### PR DESCRIPTION
Fixes #779 

## What is the purpose of this PR?

- [ ] Fix bug
- [ ] Fix typo
- [ ] Update specs
- [ ] Add new rule
- [ ] Add new parser
- [ ] Improve or refactor rules
- [ ] Add a new core feature
- [ ] Improve or refactor core features
- [ ] Update documents
- [x] Others

### Description

The `--allow-warnings` option returns status code 0 even if there are warnings.

## Checklist

Fill out the checks for the applicable purpose.

- [ ] Fix bug
  - [ ] Add the test that can check whether resolved the issue.
- [ ] Update specs
  - [ ] Element
    - [ ] Update **[global attributes](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/html-spec/src/spec-common.attributes.json)**
    - [ ] Update **[content models](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/html-spec/src/spec-common.contents.json)**
    - [ ] Add also ARIA that you explored **ARIA in HTML [Recommendation](https://www.w3.org/TR/html-aria/) and [Editor's draft](https://w3c.github.io/html-aria/)**
  - [ ] Attribute
    - [ ] Update **[global attributes](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/html-spec/src/spec-common.attributes.json)**
    - [ ] Update **[IDL attribute](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/parser-utils/src/idl-attributes.ts)**
- [ ] Add new rule
  - [ ] Add a test
  - [ ] Add a README document
    - [ ] Create an issue that requests translating the doc if you want.
  - [ ] Add to [index](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/rules/src/index.ts)
  - [ ] Add JSON schema to [schema.json](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/rules/schema.json)
  - [ ] Add to [`@markuplint/config-presets`](https://github.com/markuplint/markuplint/tree/main/packages/%40markuplint/config-presets)
    - [ ] And add to [Rulesets of base presets](https://markuplint.dev/docs/guides/presets#rulesets-of-base-presets)
      - [ ] Add to a [doc file](https://github.com/markuplint/markuplint/blob/main/website/docs/guides/presets.md)
      - [ ] Add to a [doc file (ja)](https://github.com/markuplint/markuplint/blob/main/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/presets.md), or create an issue that requests translating the doc if you want.
  - [ ] Add to the [Playground](https://playground.markuplint.dev/)
    - [ ] Add to a [config object](https://github.com/markuplint/markuplint/blob/main/playground/src/ml-playground-home.svelte)
- [ ] Add new parser
  - [ ] Add a test
    - [ ] Do a test with some parser.
  - [ ] Add to [initializer](https://github.com/markuplint/markuplint/blob/main/packages/markuplint/src/cli/init/index.ts)
