### PR TITLE
Supports the `as` attribute

### DIFF
--- a/packages/@markuplint/ml-core/src/index.spec.ts
+++ b/packages/@markuplint/ml-core/src/index.spec.ts
@@ -634,6 +634,28 @@ describe('Accessibility', () => {
 	});
 });
 
+describe('the `as` attribute pretending', () => {
+	test('Native element', () => {
+		const dom = createTestDocument('<span as="div"></span>');
+		expect(dom.nodeList[0].nodeName).toBe('SPAN');
+	});
+
+	test('Custom element', () => {
+		const dom = createTestDocument('<x-div as="div"></x-div>');
+		expect(dom.nodeList[0].nodeName).toBe('DIV');
+	});
+
+	test('Authored element', async () => {
+		const dom = createTestDocument('<XDiv as="div"></XDiv>', { parser: await import('@markuplint/jsx-parser') });
+		expect(dom.nodeList[0].nodeName).toBe('DIV');
+	});
+
+	test('Authored element (No parser)', () => {
+		const dom = createTestDocument('<Custom as="div"></Custom>');
+		expect(dom.nodeList[0].nodeName).toBe('CUSTOM');
+	});
+});
+
 describe('Issues', () => {
 	test('#607', async () => {
 		const dom = createTestDocument('<% %><div></div>', {

--- a/packages/@markuplint/ml-core/src/ml-dom/node/document.ts
+++ b/packages/@markuplint/ml-core/src/ml-dom/node/document.ts
@@ -3172,9 +3172,6 @@ export class MLDocument<T extends RuleConfigValue, O extends PlainData = undefin
 		if (docLog.enabled) {
 			docLog('Pretending: %O', pretenders);
 		}
-		if (!pretenders) {
-			return;
-		}
 		for (const node of this.nodeList) {
 			if (node.is(node.ELEMENT_NODE)) {
 				node.pretending(pretenders);

--- a/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
@@ -1538,6 +1538,19 @@ describe('Deprecated options', () => {
 			},
 		]);
 	});
+
+	test('The `as` attribute', async () => {
+		expect((await mlRuleTest(rule, '<a as="span"></a>')).violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 4,
+				message: 'The "as" attribute is disallowed',
+				raw: 'as',
+			},
+		]);
+		expect((await mlRuleTest(rule, '<x-link as="a" foo></x-link>')).violations).toStrictEqual([]);
+	});
 });
 
 describe('Issues', () => {

--- a/packages/@markuplint/rules/src/label-has-control/index.spec.ts
+++ b/packages/@markuplint/rules/src/label-has-control/index.spec.ts
@@ -28,3 +28,18 @@ test('Not single control', async () => {
 		},
 	]);
 });
+
+test('The `as` attribute', async () => {
+	expect((await mlRuleTest(rule, '<x-label as="label"><input><select></select></x-label>')).violations).toStrictEqual(
+		[
+			{
+				severity: 'warning',
+				line: 1,
+				col: 28,
+				raw: '<select>',
+				message: 'The "label" element associates only first control',
+			},
+		],
+	);
+	expect((await mlRuleTest(rule, '<x-label as="label"><input></x-label>')).violations).toStrictEqual([]);
+});

--- a/packages/@markuplint/rules/src/landmark-roles/index.spec.ts
+++ b/packages/@markuplint/rules/src/landmark-roles/index.spec.ts
@@ -186,3 +186,30 @@ test('Duplicated area: no-label', async () => {
 		},
 	]);
 });
+
+test('The `as` attribute', async () => {
+	expect(
+		(
+			await mlRuleTest(
+				rule,
+				`
+<html>
+<body>
+	<main>
+		<x-aside as="aside"></x-aside>
+	</main>
+</body>
+</html>
+`,
+			)
+		).violations,
+	).toStrictEqual([
+		{
+			severity: 'warning',
+			line: 5,
+			col: 3,
+			message: 'The "complementary" role should be top level',
+			raw: '<x-aside as="aside">',
+		},
+	]);
+});

--- a/packages/@markuplint/rules/src/no-boolean-attr-value/index.spec.ts
+++ b/packages/@markuplint/rules/src/no-boolean-attr-value/index.spec.ts
@@ -40,3 +40,20 @@ test('Updated the hidden attribute type to Enum form Boolean', async () => {
 	expect((await mlRuleTest(rule, '<div hidden="hidden"></div>')).violations.length).toBe(0);
 	expect((await mlRuleTest(rule, '<div hidden="until-found"></div>')).violations.length).toBe(0);
 });
+
+test('The `as` attribute', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		'<x-input as="input" type="text" required /><x-input as="input" type="text" required="required" />',
+	);
+
+	expect(violations).toStrictEqual([
+		{
+			severity: 'warning',
+			line: 1,
+			col: 84,
+			message: 'The "required" attribute is a boolean attribute. It doesn\'t need the value',
+			raw: '="required"',
+		},
+	]);
+});

--- a/packages/@markuplint/rules/src/no-default-value/index.spec.ts
+++ b/packages/@markuplint/rules/src/no-default-value/index.spec.ts
@@ -73,3 +73,23 @@ test('Updated the hidden attribute type to Enum form Boolean', async () => {
 	expect((await mlRuleTest(rule, '<div hidden="hidden"></div>')).violations.length).toBe(0);
 	expect((await mlRuleTest(rule, '<div hidden="until-found"></div>')).violations.length).toBe(0);
 });
+
+test('The `as` attribute', async () => {
+	const { violations } = await mlRuleTest(rule, '<x-canvas as="canvas" width="300" height="150"></x-canvas>');
+	expect(violations).toStrictEqual([
+		{
+			severity: 'warning',
+			line: 1,
+			col: 30,
+			raw: '300',
+			message: 'It is the default value',
+		},
+		{
+			severity: 'warning',
+			line: 1,
+			col: 43,
+			raw: '150',
+			message: 'It is the default value',
+		},
+	]);
+});

--- a/packages/@markuplint/rules/src/no-refer-to-non-existent-id/index.spec.ts
+++ b/packages/@markuplint/rules/src/no-refer-to-non-existent-id/index.spec.ts
@@ -204,6 +204,19 @@ test('fragment', async () => {
 	).toStrictEqual([]);
 });
 
+test('The `as` attribute', async () => {
+	const { violations } = await mlRuleTest(rule, '<x-label as="label" for="foo"></x-label>');
+	expect(violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 26,
+			raw: 'foo',
+			message: 'Missing "foo" ID',
+		},
+	]);
+});
+
 describe('Issues', () => {
 	test('#748', async () => {
 		expect(

--- a/packages/@markuplint/rules/src/permitted-contents/index.spec.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/index.spec.ts
@@ -1085,6 +1085,54 @@ describe('Pretenders Option', () => {
 			},
 		]);
 	});
+
+	test('The `as` attribute', async () => {
+		expect(
+			(
+				await mlRuleTest(rule, '<ul><MyComponent as="li"/></ul>', {
+					...jsxRuleOn,
+				})
+			).violations.length,
+		).toBe(0);
+		expect(
+			(
+				await mlRuleTest(rule, '<ul><MyComponent as="div"/></ul>', {
+					...jsxRuleOn,
+				})
+			).violations,
+		).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 5,
+				message: 'The "div" element is not allowed in the "ul" element in this context',
+				raw: '<MyComponent as="div"/>',
+			},
+		]);
+		expect(
+			(
+				await mlRuleTest(rule, '<svg><MyComponent as="rect"/></svg>', {
+					...jsxRuleOn,
+				})
+			).violations.length,
+		).toBe(0);
+		expect(
+			(
+				await mlRuleTest(rule, '<span><MyComponent as="a"><div></div></MyComponent></span>', {
+					...jsxRuleOn,
+				})
+			).violations,
+		).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 27,
+				raw: '<div>',
+				message:
+					'The "div" element is not allowed in the "span" element through the transparent model in this context',
+			},
+		]);
+	});
 });
 
 describe('Vue', () => {

--- a/packages/@markuplint/rules/src/placeholder-label-option/index.spec.ts
+++ b/packages/@markuplint/rules/src/placeholder-label-option/index.spec.ts
@@ -112,3 +112,28 @@ test("Invalid: Invalid: first option element's parent is optgroup", async () => 
 		},
 	]);
 });
+
+test('The `as` attribute', async () => {
+	expect(
+		(
+			await mlRuleTest(
+				rule,
+				`<x-select as="select" required>
+					<optgroup label="Group">
+						<option value="">Placeholder</option>
+					</optgroup>
+					<option value="option1">Option 1</option>
+					<option value="option2">Option 2</option>
+				</x-select>`,
+			)
+		).violations,
+	).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 1,
+			raw: '<x-select as="select" required>',
+			message: 'Need the placeholder label option',
+		},
+	]);
+});

--- a/packages/@markuplint/rules/src/require-accessible-name/index.spec.ts
+++ b/packages/@markuplint/rules/src/require-accessible-name/index.spec.ts
@@ -372,6 +372,30 @@ test('Pretenders Option', async () => {
 	]);
 });
 
+test('The `as` attribute', async () => {
+	expect((await mlRuleTest(rule, '<x-button as="button"></x-button>')).violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 1,
+			message: 'Require accessible name',
+			raw: '<x-button as="button">',
+		},
+	]);
+	expect((await mlRuleTest(rule, '<x-button as="button">Name</x-button>')).violations).toStrictEqual([]);
+	expect((await mlRuleTest(rule, '<x-image as="img"></x-image>')).violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 1,
+			message: 'Require accessible name',
+			raw: '<x-image as="img">',
+		},
+	]);
+	expect((await mlRuleTest(rule, '<x-image as="img" alt=""></x-image>')).violations).toStrictEqual([]);
+	expect((await mlRuleTest(rule, '<x-image as="img" alt="Name"></x-image>')).violations).toStrictEqual([]);
+});
+
 describe('Issues', () => {
 	// https://github.com/markuplint/markuplint/issues/536
 	test('#536', async () => {

--- a/packages/@markuplint/rules/src/require-accessible-name/index.ts
+++ b/packages/@markuplint/rules/src/require-accessible-name/index.ts
@@ -15,10 +15,6 @@ export default createRule<boolean, Option>({
 	},
 	async verify({ document, report, t }) {
 		await document.walkOn('Element', el => {
-			if (el.pretenderContext?.type === 'pretender') {
-				return;
-			}
-
 			if (accnameMayBeMutable(el, document)) {
 				return;
 			}

--- a/packages/@markuplint/rules/src/require-datetime/index.spec.ts
+++ b/packages/@markuplint/rules/src/require-datetime/index.spec.ts
@@ -53,3 +53,25 @@ test('Candidates', async () => {
 		},
 	]);
 });
+
+test('The `as` attribute', async () => {
+	expect((await mlRuleTest(rule, '<x-time as="time">2000/01/01</x-time>')).violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 1,
+			raw: '<x-time as="time">',
+			message: 'Need datetime="2000-01-01"',
+		},
+	]);
+
+	expect((await mlRuleTest(rule, '<x-time as="time">令和5年1月3日</x-time>')).violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 1,
+			raw: '<x-time as="time">',
+			message: 'Need datetime="2023-01-03"',
+		},
+	]);
+});

--- a/packages/@markuplint/rules/src/required-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/required-attr/index.spec.ts
@@ -413,3 +413,31 @@ test('custom element', async () => {
 		},
 	]);
 });
+
+test('The `as` attribute', async () => {
+	expect(
+		(
+			await mlRuleTest(rule, '<x-img as="img" src="/path/to/image.png"></x-img>', {
+				nodeRule: [
+					{
+						selector: 'img',
+						rule: {
+							severity: 'error',
+							value: 'alt',
+						},
+					},
+				],
+			})
+		).violations,
+	).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 1,
+			message: 'The "img" element expects the "alt" attribute',
+			raw: '<x-img as="img" src="/path/to/image.png">',
+		},
+	]);
+
+	expect((await mlRuleTest(rule, '<x-img as="img" src="/path/to/image.png"></x-img>')).violations).toStrictEqual([]);
+});

--- a/packages/@markuplint/rules/src/required-element/index.spec.ts
+++ b/packages/@markuplint/rules/src/required-element/index.spec.ts
@@ -186,4 +186,24 @@ describe('Pretenders Option', () => {
 			).violations,
 		).toStrictEqual([]);
 	});
+
+	test('The `as` attribute', async () => {
+		const { violations } = await mlRuleTest(rule, '<x-div as="div"><span>Text</span></x-div>', {
+			nodeRule: [
+				{
+					selector: 'div',
+					rule: ['a'],
+				},
+			],
+		});
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 1,
+				message: 'Require the "a" element',
+				raw: '<x-div as="div">',
+			},
+		]);
+	});
 });

--- a/packages/@markuplint/rules/src/required-h1/index.spec.ts
+++ b/packages/@markuplint/rules/src/required-h1/index.spec.ts
@@ -64,6 +64,21 @@ test('enable option "in-document-fragment"', async () => {
 	expect(violations.length).toBe(1);
 });
 
+test('The `as` attribute', async () => {
+	expect((await mlRuleTest(rule, '<html><body><x-h1 as="h1">text</x-h1></body></html>')).violations).toStrictEqual(
+		[],
+	);
+	expect((await mlRuleTest(rule, '<html><body><x-h2 as="h2">text</x-h2></body></html>')).violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 1,
+			message: 'Require the "h1" element',
+			raw: '<',
+		},
+	]);
+});
+
 test('Issue #57', async () => {
 	const { violations } = await mlRuleTest(rule, '');
 	expect(violations.length).toBe(0);

--- a/packages/@markuplint/rules/src/wai-aria/index.spec.ts
+++ b/packages/@markuplint/rules/src/wai-aria/index.spec.ts
@@ -280,6 +280,19 @@ describe('Set the implicit role explicitly', () => {
 
 		expect(violations.length).toBe(0);
 	});
+
+	test('The `as` attribute', async () => {
+		const { violations } = await mlRuleTest(rule, '<x-link as="a" href="path/to" role="link"></x-link>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 37,
+				message: 'The "link" role is the implicit role of the "a" element',
+				raw: 'link',
+			},
+		]);
+	});
 });
 
 describe('Set the default value of the property/state explicitly', () => {

--- a/test/fixture/017.html
+++ b/test/fixture/017.html
@@ -1,0 +1,1 @@
+<div as="span"></div>

--- a/test/fixture/astro/013.astro
+++ b/test/fixture/astro/013.astro
@@ -4,4 +4,4 @@ import { MyImage } from './MyImage.js';
 ---
 
 <MySection as="section"></MySection>
-<MyImage as="img" src="https://example.com/image.png" />
+<MyImage as="img" src="https://example.com/image.png" alt="accessible name" />

--- a/test/fixture/astro/013.astro
+++ b/test/fixture/astro/013.astro
@@ -1,0 +1,7 @@
+---
+import { MySection } from './MyComponent.js';
+import { MyImage } from './MyImage.js';
+---
+
+<MySection as="section"></MySection>
+<MyImage as="img" src="https://example.com/image.png" />

--- a/test/fixture/jsx/004.jsx
+++ b/test/fixture/jsx/004.jsx
@@ -1,0 +1,20 @@
+const Component = () => {
+	return (
+		<>
+			<div as="span">
+				<authoredcomponent as="div"></authoredcomponent>
+			</div>
+			<div>
+				<authoredcomponent2 as="div"></authoredcomponent2>
+			</div>
+			<div>
+				<authored-component as="div"></authored-component>
+			</div>
+			<span>
+				<AuthoredComponent as="div"></AuthoredComponent>
+			</span>
+		</>
+	);
+};
+
+module.exports = Component;

--- a/website/docs/guides/besides-html.md
+++ b/website/docs/guides/besides-html.md
@@ -194,3 +194,26 @@ It evaluates components as rendered HTML elements on each rule if you specify a 
 <!-- prettier-ignore-end -->
 
 See the details of [`pretenders`](/docs/configuration/properties#pretenders) property on the configuration if you want.
+
+### The `as` attribute
+
+If a component has the `as` attribute, it is evaluated as the element specified by this attribute.
+
+<!-- prettier-ignore-start -->
+```html
+<x-ul as="ul"><!-- Evaluate as <ul> -->
+  <x-li as="li"></x-li><!-- Evaluate as <li> -->
+  <x-li as="li"></x-li><!-- Evaluate as <li> -->
+  <x-li as="li"></x-li><!-- Evaluate as <li> -->
+</x-ul>
+```
+<!-- prettier-ignore-end -->
+
+This evaluation also applies to its attributes that are inherited from the component.
+
+<!-- prettier-ignore-start -->
+```html
+<!-- Evaluate as <img src="image.png" alt="image"> -->
+<x-img src="image.png" alt="image">
+```
+<!-- prettier-ignore-end -->

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/besides-html.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/besides-html.md
@@ -193,3 +193,26 @@ const Component = ({ list }) => {
 <!-- prettier-ignore-end -->
 
 必要であれば、設定の[`pretenders`](/docs/configuration/properties#pretenders)プロパティの詳細を参照してください。
+
+### `as`属性について
+
+コンポーネントに`as`属性が指定されている場合、その属性の値として指定された要素として評価されます。
+
+<!-- prettier-ignore-start -->
+```html
+<x-ul as="ul"><!-- <ul> として評価される -->
+  <x-li as="li"></x-li><!-- <li> として評価される -->
+  <x-li as="li"></x-li><!-- <li> として評価される -->
+  <x-li as="li"></x-li><!-- <li> として評価される -->
+</x-ul>
+```
+<!-- prettier-ignore-end -->
+
+これは、コンポーネントから継承された属性に対しても同様に評価されます。
+
+<!-- prettier-ignore-start -->
+```html
+<!-- <img src="image.png" alt="image"> として評価される -->
+<x-img src="image.png" alt="image">
+```
+<!-- prettier-ignore-end -->


### PR DESCRIPTION
Fixes #1283

## What is the purpose of this PR?

- [ ] Fix bug
- [ ] Fix typo
- [ ] Update specs
- [ ] Add new rule
- [ ] Add new parser
- [ ] Improve or refactor rules
- [x] Add a new core feature
- [ ] Improve or refactor core features
- [x] Update documents
- [ ] Others

### Description

- It evaluates the `as` attribute of the element besides HTML through the pretenders feature.
- Improve rules for pretended elements.
- Add tests