### PR TITLE
Support legacy SVG `transform` attribute value syntax

### DIFF
--- a/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
@@ -1642,4 +1642,10 @@ ol(itemscope itemtype="https://schema.org/BreadcrumbList")
 			(await mlRuleTest(rule, '<img src="foo.png" referrerpolicy="no-referrer"></img>')).violations,
 		).toStrictEqual([]);
 	});
+
+	test('#1357', async () => {
+		expect(
+			(await mlRuleTest(rule, '<svg><rect transform="translate(300 300) rotate(180)" /></svg>')).violations,
+		).toStrictEqual([]);
+	});
 });

--- a/packages/@markuplint/types/src/check.spec.ts
+++ b/packages/@markuplint/types/src/check.spec.ts
@@ -92,3 +92,14 @@ test('ItemProp', () => {
 	expect(check('item', 'ItemProp').matched).toBe(true);
 	expect(check('position', 'ItemProp').matched).toBe(true);
 });
+
+test('legacy-transform', () => {
+	expect(check('translate(300)', "<'transform'>").matched).toBeTruthy();
+	expect(check('translate(300px)', "<'transform'>").matched).toBeTruthy();
+	expect(check('translate(300 300)', "<'transform'>").matched).toBeTruthy();
+	expect(check('translate(300px 300px)', "<'transform'>").matched).toBeTruthy();
+	expect(check('translate(300 , 300)', "<'transform'>").matched).toBeTruthy();
+	expect(check('translate(300px , 300px)', "<'transform'>").matched).toBeTruthy();
+	expect(check('translate(300,300)', "<'transform'>").matched).toBeTruthy();
+	expect(check('translate(300px,300px)', "<'transform'>").matched).toBeTruthy();
+});

--- a/packages/@markuplint/types/src/css-syntax.spec.ts
+++ b/packages/@markuplint/types/src/css-syntax.spec.ts
@@ -172,3 +172,25 @@ test('case-sensitive', () => {
 		],
 	});
 });
+
+test('legacy-transform', () => {
+	const custom: CustomCssSyntax = {
+		ref: 'n/a',
+		syntax: {
+			apply: '<translate()>',
+			def: {
+				'translate()':
+					'translate( <length-percentage> , <length-percentage>? ) | translate( <length-percentage> <length-percentage>? )',
+				'length-percentage': '<length> | <percentage> | <svg-length>',
+			},
+		},
+	};
+	expect(cssSyntaxMatch('translate(300)', custom).matched).toBeTruthy();
+	expect(cssSyntaxMatch('translate(300px)', custom).matched).toBeTruthy();
+	expect(cssSyntaxMatch('translate(300 300)', custom).matched).toBeTruthy();
+	expect(cssSyntaxMatch('translate(300px 300px)', custom).matched).toBeTruthy();
+	expect(cssSyntaxMatch('translate(300 , 300)', custom).matched).toBeTruthy();
+	expect(cssSyntaxMatch('translate(300px , 300px)', custom).matched).toBeTruthy();
+	expect(cssSyntaxMatch('translate(300,300)', custom).matched).toBeTruthy();
+	expect(cssSyntaxMatch('translate(300px,300px)', custom).matched).toBeTruthy();
+});

--- a/packages/@markuplint/types/src/css-syntax.ts
+++ b/packages/@markuplint/types/src/css-syntax.ts
@@ -3,7 +3,7 @@ import type { CustomCssSyntax, CssSyntaxTokenizer, CSSSyntaxToken, GetNextToken,
 import { fork } from 'css-tree';
 
 import { log } from './debug.js';
-import { tokenizers } from './defs.js';
+import { tokenizers, overrides } from './defs.js';
 import { matched } from './match-result.js';
 
 const MIMIC_TAG_L = 'mimiccases---';
@@ -58,7 +58,10 @@ export function cssSyntaxMatch(value: string, type: CssSyntax | CustomCssSyntax)
 
 	// @ts-ignore
 	const lexer = fork({
-		types: typesExtended,
+		types: {
+			...overrides,
+			...typesExtended,
+		},
 		properties: propsExtended,
 	}).lexer;
 

--- a/packages/@markuplint/types/src/defs.ts
+++ b/packages/@markuplint/types/src/defs.ts
@@ -913,6 +913,33 @@ export const types: Defs = {
 	},
 };
 
+export const overrides: Record<string, string> = {
+	// Alias
+	'legacy-length-percentage': '<length> | <percentage> | <svg-length>',
+	'legacy-angle': '<angle> | <zero> | <number>',
+
+	/**
+	 * @see https://www.w3.org/TR/css-transforms-1/#funcdef-transform-translate
+	 */
+	'translate()':
+		'translate( <legacy-length-percentage> , <legacy-length-percentage>? ) | translate( <legacy-length-percentage> <legacy-length-percentage>? )',
+
+	/**
+	 * @see https://www.w3.org/TR/css-transforms-1/#funcdef-transform-scale
+	 */
+	'scale()': 'scale( [ <number> | <percentage> ]#{1,2} )',
+
+	/**
+	 * @see https://www.w3.org/TR/css-transforms-1/#funcdef-transform-rotate
+	 */
+	'rotate()': 'rotate( <legacy-angle> )',
+
+	/**
+	 * @see https://www.w3.org/TR/css-transforms-1/#funcdef-transform-skew
+	 */
+	'skew()': 'skew( <legacy-angle> , <legacy-angle>? ) | skew( <legacy-angle> <legacy-angle>? )',
+};
+
 export const tokenizers: Record<string, CssSyntaxTokenizer> = {
 	// RFC
 	// https://tools.ietf.org/rfc/bcp/bcp47.html


### PR DESCRIPTION
Fixes #1357 

## What is the purpose of this PR?

- [ ] Fix bug
- [ ] Fix typo
- [ ] Update specs
- [ ] Add new rule
- [ ] Add new parser
- [ ] Improve or refactor rules
- [ ] Add a new core feature
- [x] Improve or refactor core features
- [ ] Update documents
- [ ] Others
