### PR TITLE
Remove redundant type check

### DIFF
--- a/packages/@markuplint/parser-utils/src/parser.ts
+++ b/packages/@markuplint/parser-utils/src/parser.ts
@@ -1490,8 +1490,10 @@ export abstract class Parser<Node extends {} = {}, State extends unknown = null>
 			stack.add(id);
 
 			if (node.type === 'endtag') {
-				const openTag = newNodes.findLast(n => n.type === 'starttag' && n.nodeName === node.nodeName);
-				if (openTag && openTag.type === 'starttag' && !openTag.pairNode) {
+				const openTag = newNodes.findLast(
+					(n): n is MLASTElement => n.type === 'starttag' && n.nodeName === node.nodeName,
+				);
+				if (openTag && !openTag.pairNode) {
 					this.#pairing(openTag, node, false);
 					newNodes.push(node);
 					continue;


### PR DESCRIPTION
Part of #1049

## What is the purpose of this PR?

- [ ] Fix bug
- [ ] Fix typo
- [ ] Update specs
- [ ] Add new rule
- [ ] Add new parser
- [ ] Improve or refactor rules
- [ ] Add a new core feature
- [x] Improve or refactor core features
- [ ] Update documents
- [ ] Others

### Description

`Parser#siblingsCorrection` is relatively heavily invoked when there are many `<option>` elements as described in https://github.com/markuplint/markuplint/issues/1049#issuecomment-1937440404

I found `openTag.type === 'starttag'` in `#sibglingsCorrection` is redundant, since it is already known `true` after the tag is found by `findLast`.

This PR leverages an overload of `findLast` to remove that redundant check.

## Checklist

Fill out the checks for the applicable purpose.

- [ ] Fix bug
  - [ ] Add the test that can check whether resolved the issue.
- [ ] Update specs
  - [ ] Element
    - [ ] Update **[global attributes](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/html-spec/src/spec-common.attributes.json)**
    - [ ] Update **[content models](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/html-spec/src/spec-common.contents.json)**
    - [ ] Add also ARIA that you explored **ARIA in HTML [Recommendation](https://www.w3.org/TR/html-aria/) and [Editor's draft](https://w3c.github.io/html-aria/)**
  - [ ] Attribute
    - [ ] Update **[global attributes](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/html-spec/src/spec-common.attributes.json)**
    - [ ] Update **[IDL attribute](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/parser-utils/src/idl-attributes.ts)**
- [ ] Add new rule
  - [ ] Add a test
  - [ ] Add a README document
    - [ ] Create an issue that requests translating the doc if you want.
  - [ ] Add to [index](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/rules/src/index.ts)
  - [ ] Add JSON schema to [schema.json](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/rules/schema.json)
  - [ ] Add to [`@markuplint/config-presets`](https://github.com/markuplint/markuplint/tree/main/packages/%40markuplint/config-presets)
    - [ ] And add to [Rulesets of base presets](https://markuplint.dev/docs/guides/presets#rulesets-of-base-presets)
      - [ ] Add to a [doc file](https://github.com/markuplint/markuplint/blob/main/website/docs/guides/presets.md)
      - [ ] Add to a [doc file (ja)](https://github.com/markuplint/markuplint/blob/main/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/presets.md), or create an issue that requests translating the doc if you want.
  - [ ] Add to the [Playground](https://playground.markuplint.dev/)
    - [ ] Add to a [config object](https://github.com/markuplint/markuplint/blob/main/playground/src/ml-playground-home.svelte)
- [ ] Add new parser
  - [ ] Add a test
    - [ ] Do a test with some parser.
  - [ ] Add to [initializer](https://github.com/markuplint/markuplint/blob/main/packages/markuplint/src/cli/init/index.ts)
