### PR TITLE
optimization: Selector matching shortcut

### DIFF
--- a/packages/@markuplint/selector/src/selector.ts
+++ b/packages/@markuplint/selector/src/selector.ts
@@ -468,16 +468,14 @@ class SelectorTarget {
 		}
 	}
 
-	// cspell:disable
 	/**
-	 * Matching is executed in this order: ID > tag name > classes > attributes > psuedo-elements.
+	 * Matching is executed in this order: ID > tag name > classes > attributes > pseudo-elements.
 	 * If any of the selectors are unmatched, the rest of the selectors is skipped for better performance.
 	 *
 	 * @param el
 	 * @param scope
 	 * @private
 	 */
-	// cspell:enable
 	private _matchWithoutCombineChecking(
 		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
 		el: Node,

--- a/packages/@markuplint/selector/src/selector.ts
+++ b/packages/@markuplint/selector/src/selector.ts
@@ -468,6 +468,14 @@ class SelectorTarget {
 		}
 	}
 
+	/**
+	 * Matching is executed in this order: ID > tag name > classes > attributes > psuedo-elements.
+	 * If any of the selectors are unmatched, the rest of the selectors is skipped for better performance.
+	 *
+	 * @param el
+	 * @param scope
+	 * @private
+	 */
 	private _matchWithoutCombineChecking(
 		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
 		el: Node,

--- a/packages/@markuplint/selector/src/selector.ts
+++ b/packages/@markuplint/selector/src/selector.ts
@@ -468,6 +468,7 @@ class SelectorTarget {
 		}
 	}
 
+	// cspell:disable
 	/**
 	 * Matching is executed in this order: ID > tag name > classes > attributes > psuedo-elements.
 	 * If any of the selectors are unmatched, the rest of the selectors is skipped for better performance.
@@ -476,6 +477,7 @@ class SelectorTarget {
 	 * @param scope
 	 * @private
 	 */
+	// cspell:enable
 	private _matchWithoutCombineChecking(
 		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
 		el: Node,

--- a/packages/@markuplint/selector/src/selector.ts
+++ b/packages/@markuplint/selector/src/selector.ts
@@ -521,6 +521,22 @@ class SelectorTarget {
 		}
 		specificity[0] += this.id.length;
 
+		if (matched && this.tag && this.tag.type === 'tag') {
+			specificity[2] += 1;
+
+			let a = this.tag.value;
+			let b = el.localName;
+
+			if (isPureHTMLElement(el)) {
+				a = a.toLowerCase();
+				b = b.toLowerCase();
+			}
+
+			if (a !== b) {
+				matched = false;
+			}
+		}
+
 		if (matched && !this.class.every(className => el.classList.contains(className.value))) {
 			matched = false;
 		}
@@ -545,22 +561,6 @@ class SelectorTarget {
 					not.push(...(pseudoRes.not ?? []));
 					matched = false;
 				}
-			}
-		}
-
-		if (matched && this.tag && this.tag.type === 'tag') {
-			specificity[2] += 1;
-
-			let a = this.tag.value;
-			let b = el.localName;
-
-			if (isPureHTMLElement(el)) {
-				a = a.toLowerCase();
-				b = b.toLowerCase();
-			}
-
-			if (a !== b) {
-				matched = false;
 			}
 		}
 

--- a/packages/@markuplint/selector/src/selector.ts
+++ b/packages/@markuplint/selector/src/selector.ts
@@ -516,37 +516,39 @@ class SelectorTarget {
 			matched = false;
 		}
 
-		if (!this.id.every(id => id.value === el.id)) {
+		if (matched && !this.id.every(id => id.value === el.id)) {
 			matched = false;
 		}
 		specificity[0] += this.id.length;
 
-		if (!this.class.every(className => el.classList.contains(className.value))) {
+		if (matched && !this.class.every(className => el.classList.contains(className.value))) {
 			matched = false;
 		}
 		specificity[1] += this.class.length;
 
-		if (!this.attr.every(attr => attrMatch(attr, el))) {
+		if (matched && !this.attr.every(attr => attrMatch(attr, el))) {
 			matched = false;
 		}
 		specificity[1] += this.attr.length;
 
-		for (const pseudo of this.pseudo) {
-			const pseudoRes = pseudoMatch(pseudo, el, scope, this.#extended, this.depth);
+		if (matched) {
+			for (const pseudo of this.pseudo) {
+				const pseudoRes = pseudoMatch(pseudo, el, scope, this.#extended, this.depth);
 
-			specificity[0] += pseudoRes.specificity[0];
-			specificity[1] += pseudoRes.specificity[1];
-			specificity[2] += pseudoRes.specificity[2];
+				specificity[0] += pseudoRes.specificity[0];
+				specificity[1] += pseudoRes.specificity[1];
+				specificity[2] += pseudoRes.specificity[2];
 
-			if (pseudoRes.matched) {
-				has.push(...pseudoRes.has);
-			} else {
-				not.push(...(pseudoRes.not ?? []));
-				matched = false;
+				if (pseudoRes.matched) {
+					has.push(...pseudoRes.has);
+				} else {
+					not.push(...(pseudoRes.not ?? []));
+					matched = false;
+				}
 			}
 		}
 
-		if (this.tag && this.tag.type === 'tag') {
+		if (matched && this.tag && this.tag.type === 'tag') {
 			specificity[2] += 1;
 
 			let a = this.tag.value;


### PR DESCRIPTION
Part of https://github.com/markuplint/markuplint/issues/1049

## What is the purpose of this PR?

- [ ] Fix bug
- [ ] Fix typo
- [ ] Update specs
- [ ] Add new rule
- [ ] Add new parser
- [ ] Improve or refactor rules
- [ ] Add a new core feature
- [x] Improve or refactor core features
- [ ] Update documents
- [ ] Others

### Description

This PR implements the shortcircuit in matching, as described in #1094
[Ignoring whitespace](https://github.com/markuplint/markuplint/pull/1485/files?diff=split&w=1) is easier to review.


> ## Selector matching
>A simple selector will never match if one or more parts of the selector don't match.
>
>For example, input[type=button] will never match button[type=button] because input doesn't match button. Hence, we can skip the [type=button] matching.

Matching is executed in this order: ID > tag name > classes > attributes > psuedo-elements
If any of the selectors are unmatched, the rest of the selectors is skipped.

## Checklist

Fill out the checks for the applicable purpose.

- [ ] Fix bug
  - [ ] Add the test that can check whether resolved the issue.
- [ ] Update specs
  - [ ] Element
    - [ ] Update **[global attributes](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/html-spec/src/spec-common.attributes.json)**
    - [ ] Update **[content models](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/html-spec/src/spec-common.contents.json)**
    - [ ] Add also ARIA that you explored **ARIA in HTML [Recommendation](https://www.w3.org/TR/html-aria/) and [Editor's draft](https://w3c.github.io/html-aria/)**
  - [ ] Attribute
    - [ ] Update **[global attributes](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/html-spec/src/spec-common.attributes.json)**
    - [ ] Update **[IDL attribute](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/parser-utils/src/idl-attributes.ts)**
- [ ] Add new rule
  - [ ] Add a test
  - [ ] Add a README document
    - [ ] Create an issue that requests translating the doc if you want.
  - [ ] Add to [index](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/rules/src/index.ts)
  - [ ] Add JSON schema to [schema.json](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/rules/schema.json)
  - [ ] Add to [`@markuplint/config-presets`](https://github.com/markuplint/markuplint/tree/main/packages/%40markuplint/config-presets)
    - [ ] And add to [Rulesets of base presets](https://markuplint.dev/docs/guides/presets#rulesets-of-base-presets)
      - [ ] Add to a [doc file](https://github.com/markuplint/markuplint/blob/main/website/docs/guides/presets.md)
      - [ ] Add to a [doc file (ja)](https://github.com/markuplint/markuplint/blob/main/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/presets.md), or create an issue that requests translating the doc if you want.
  - [ ] Add to the [Playground](https://playground.markuplint.dev/)
    - [ ] Add to a [config object](https://github.com/markuplint/markuplint/blob/main/playground/src/ml-playground-home.svelte)
- [ ] Add new parser
  - [ ] Add a test
    - [ ] Do a test with some parser.
  - [ ] Add to [initializer](https://github.com/markuplint/markuplint/blob/main/packages/markuplint/src/cli/init/index.ts)
