### PR TITLE
optimization: Avoid costly Selector#toString when selector logs are disabled

### DIFF
--- a/packages/@markuplint/selector/src/selector.ts
+++ b/packages/@markuplint/selector/src/selector.ts
@@ -94,15 +94,21 @@ class Ruleset {
 		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
 		scope: ParentNode | null,
 	): SelectorResult[] {
-		coreLog(
-			'<%s> (%s)',
-			isElement(el) ? el.localName : el.nodeName,
-			scope ? (isElement(scope) ? scope.localName : scope.nodeName) : null,
-		);
+		if (coreLog.enabled) {
+			coreLog(
+				'<%s> (%s)',
+				isElement(el) ? el.localName : el.nodeName,
+				scope ? (isElement(scope) ? scope.localName : scope.nodeName) : null,
+			);
+		}
 		return this.#selectorGroup.map(selector => {
-			selLog('"%s"', selector.selector);
+			if (selLog.enabled) {
+				selLog('"%s"', selector.selector);
+			}
 			const res = selector.match(el, scope);
-			resLog('%s "%s" => %o', isElement(el) ? el.localName : el.nodeName, selector.selector, res);
+			if (resLog.enabled) {
+				resLog('%s "%s" => %o', isElement(el) ? el.localName : el.nodeName, selector.selector, res);
+			}
 			return res;
 		});
 	}


### PR DESCRIPTION
Part of #1049

## What is the purpose of this PR?

- [ ] Fix bug
- [ ] Fix typo
- [ ] Update specs
- [ ] Add new rule
- [ ] Add new parser
- [ ] Improve or refactor rules
- [ ] Add a new core feature
- [x] Improve or refactor core features
- [ ] Update documents
- [ ] Others

### Description

I observed that `Selector#toString()` (🟦  blue rectangles) is a relatively costly operation according to framegraph.
![image](https://github.com/markuplint/markuplint/assets/127635/e1023355-29b5-480b-b66a-5db7535e0462)

`Selector#toString` is called in `StructuredSelector#selector`, which is called on `selLog` and `resLog` even when those logs are not enabled 😨 

In this PR, `selLog` and `resLog` are called only when each log is enabled.

## Checklist

Fill out the checks for the applicable purpose.

- [ ] Fix bug
  - [ ] Add the test that can check whether resolved the issue.
- [ ] Update specs
  - [ ] Element
    - [ ] Update **[global attributes](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/html-spec/src/spec-common.attributes.json)**
    - [ ] Update **[content models](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/html-spec/src/spec-common.contents.json)**
    - [ ] Add also ARIA that you explored **ARIA in HTML [Recommendation](https://www.w3.org/TR/html-aria/) and [Editor's draft](https://w3c.github.io/html-aria/)**
  - [ ] Attribute
    - [ ] Update **[global attributes](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/html-spec/src/spec-common.attributes.json)**
    - [ ] Update **[IDL attribute](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/parser-utils/src/idl-attributes.ts)**
- [ ] Add new rule
  - [ ] Add a test
  - [ ] Add a README document
    - [ ] Create an issue that requests translating the doc if you want.
  - [ ] Add to [index](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/rules/src/index.ts)
  - [ ] Add JSON schema to [schema.json](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/rules/schema.json)
  - [ ] Add to [`@markuplint/config-presets`](https://github.com/markuplint/markuplint/tree/main/packages/%40markuplint/config-presets)
    - [ ] And add to [Rulesets of base presets](https://markuplint.dev/docs/guides/presets#rulesets-of-base-presets)
      - [ ] Add to a [doc file](https://github.com/markuplint/markuplint/blob/main/website/docs/guides/presets.md)
      - [ ] Add to a [doc file (ja)](https://github.com/markuplint/markuplint/blob/main/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/presets.md), or create an issue that requests translating the doc if you want.
  - [ ] Add to the [Playground](https://playground.markuplint.dev/)
    - [ ] Add to a [config object](https://github.com/markuplint/markuplint/blob/main/playground/src/ml-playground-home.svelte)
- [ ] Add new parser
  - [ ] Add a test
    - [ ] Do a test with some parser.
  - [ ] Add to [initializer](https://github.com/markuplint/markuplint/blob/main/packages/markuplint/src/cli/init/index.ts)
