### PR TITLE
optimization: Avoid costly getImplicitRole when explicitRole.role exists

### DIFF
--- a/packages/@markuplint/ml-spec/src/dom-traverse/get-computed-role.ts
+++ b/packages/@markuplint/ml-spec/src/dom-traverse/get-computed-role.ts
@@ -19,12 +19,12 @@ export function getComputedRole(
 	version: ARIAVersion,
 	assumeSingleNode = false,
 ): ComputedRole {
-	const implicitRole = getImplicitRole(specs, el, version);
+	let lazyImplicitRole: ComputedRole | undefined;
 	const explicitRole = getExplicitRole(specs, el, version);
 	const computedRole = explicitRole.role
 		? explicitRole
 		: {
-				...implicitRole,
+				...(lazyImplicitRole = getImplicitRole(specs, el, version)),
 				errorType: explicitRole.errorType === 'NO_EXPLICIT' ? undefined : explicitRole.errorType,
 			};
 
@@ -144,6 +144,8 @@ export function getComputedRole(
 	if (computedRole.role && !isPresentational(computedRole.role.name)) {
 		return computedRole;
 	}
+
+	const implicitRole = lazyImplicitRole ?? getImplicitRole(specs, el, version);
 
 	/**
 	 * > If an element is focusable,

--- a/packages/@markuplint/ml-spec/src/dom-traverse/has-required-owned-elements.ts
+++ b/packages/@markuplint/ml-spec/src/dom-traverse/has-required-owned-elements.ts
@@ -89,9 +89,8 @@ function getClosestNonPresentationalDescendants(
 ): ComputedRole[] {
 	const owned: ComputedRole[] = [];
 	for (const child of el.children) {
-		const implicitRole = getImplicitRole(specs, child, version);
 		const explicitRole = getExplicitRole(specs, child, version);
-		const computed = explicitRole.role ? explicitRole : implicitRole;
+		const computed = explicitRole.role ? explicitRole : getImplicitRole(specs, child, version);
 		if (isPresentational(computed.role?.name)) {
 			owned.push(...getClosestNonPresentationalDescendants(child, specs, version));
 			continue;

--- a/packages/@markuplint/rules/src/wai-aria/checkings/implicit-role.ts
+++ b/packages/@markuplint/rules/src/wai-aria/checkings/implicit-role.ts
@@ -6,15 +6,15 @@ import { getImplicitRoleName } from '@markuplint/ml-spec';
 export const checkingImplicitRole: AttrChecker<boolean, Options> =
 	({ attr }) =>
 	t => {
+		const tokens = attr.tokenList?.allTokens();
+		if (!tokens) {
+			return;
+		}
 		const implicitRole = getImplicitRoleName(
 			attr.ownerElement,
 			attr.rule.options.version,
 			attr.ownerMLDocument.specs,
 		);
-		const tokens = attr.tokenList?.allTokens();
-		if (!tokens) {
-			return;
-		}
 		for (const token of tokens) {
 			if (implicitRole === token.raw) {
 				return {


### PR DESCRIPTION
Part of #1049

## What is the purpose of this PR?

- [ ] Fix bug
- [ ] Fix typo
- [ ] Update specs
- [ ] Add new rule
- [ ] Add new parser
- [ ] Improve or refactor rules
- [ ] Add a new core feature
- [x] Improve or refactor core features
- [ ] Update documents
- [ ] Others

### Description

`getComputedRole` is one of heavy computations.
I noticed that implicit roles are not used on some cases.

So, this PR puts `getImplicitRole` off until it is needed.

The total process time of `getImplicitRole` (🟦 Blue rectangles) is now reduced:

before | after
---|---
<img width="1394" alt="image" src="https://github.com/markuplint/markuplint/assets/127635/ba9459da-eb03-4640-92f8-e4fe1d86c770"> | <img width="1391" alt="image" src="https://github.com/markuplint/markuplint/assets/127635/70416600-ceb0-45e5-9364-3ab1b0c787f7">



## Checklist

Fill out the checks for the applicable purpose.

- [ ] Fix bug
  - [ ] Add the test that can check whether resolved the issue.
- [ ] Update specs
  - [ ] Element
    - [ ] Update **[global attributes](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/html-spec/src/spec-common.attributes.json)**
    - [ ] Update **[content models](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/html-spec/src/spec-common.contents.json)**
    - [ ] Add also ARIA that you explored **ARIA in HTML [Recommendation](https://www.w3.org/TR/html-aria/) and [Editor's draft](https://w3c.github.io/html-aria/)**
  - [ ] Attribute
    - [ ] Update **[global attributes](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/html-spec/src/spec-common.attributes.json)**
    - [ ] Update **[IDL attribute](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/parser-utils/src/idl-attributes.ts)**
- [ ] Add new rule
  - [ ] Add a test
  - [ ] Add a README document
    - [ ] Create an issue that requests translating the doc if you want.
  - [ ] Add to [index](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/rules/src/index.ts)
  - [ ] Add JSON schema to [schema.json](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/rules/schema.json)
  - [ ] Add to [`@markuplint/config-presets`](https://github.com/markuplint/markuplint/tree/main/packages/%40markuplint/config-presets)
    - [ ] And add to [Rulesets of base presets](https://markuplint.dev/docs/guides/presets#rulesets-of-base-presets)
      - [ ] Add to a [doc file](https://github.com/markuplint/markuplint/blob/main/website/docs/guides/presets.md)
      - [ ] Add to a [doc file (ja)](https://github.com/markuplint/markuplint/blob/main/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/presets.md), or create an issue that requests translating the doc if you want.
  - [ ] Add to the [Playground](https://playground.markuplint.dev/)
    - [ ] Add to a [config object](https://github.com/markuplint/markuplint/blob/main/playground/src/ml-playground-home.svelte)
- [ ] Add new parser
  - [ ] Add a test
    - [ ] Do a test with some parser.
  - [ ] Add to [initializer](https://github.com/markuplint/markuplint/blob/main/packages/markuplint/src/cli/init/index.ts)
