### PR TITLE
optimization: speed up Parser#siblingsCorrection

### DIFF
--- a/packages/@markuplint/parser-utils/src/sort-nodes.ts
+++ b/packages/@markuplint/parser-utils/src/sort-nodes.ts
@@ -2,21 +2,16 @@ import type { MLASTNodeTreeItem } from '@markuplint/ml-ast';
 
 export function sortNodes(a: MLASTNodeTreeItem, b: MLASTNodeTreeItem) {
 	if (a.startOffset === b.startOffset) {
-		return sort(a, b, 'endOffset');
+		return sort(a.endOffset, b.endOffset);
 	}
 
-	return sort(a, b, 'startOffset');
+	return sort(a.startOffset, b.startOffset);
 }
 
-function sort<K extends keyof O, O extends {}>(a: O, b: O, key: K) {
-	if (Number.isNaN(a[key]) || Number.isNaN(b[key])) {
+function sort(a: number, b: number) {
+	const diff = a - b;
+	if (Number.isNaN(diff)) {
 		return 0;
 	}
-	if (a[key] < b[key]) {
-		return -1;
-	}
-	if (a[key] > b[key]) {
-		return 1;
-	}
-	return 0;
+	return diff;
 }


### PR DESCRIPTION
Part of #1049 

## What is the purpose of this PR?

- [ ] Fix bug
- [ ] Fix typo
- [ ] Update specs
- [ ] Add new rule
- [ ] Add new parser
- [ ] Improve or refactor rules
- [ ] Add a new core feature
- [x] Improve or refactor core features
- [ ] Update documents
- [ ] Others

### Description

This PR optimizes `Parser#siblingsCorrection` in two ways: 

1. Replace O(n) `.findLast` in `.siblingsCorrection` with O(1) lookup 
    - Labeled as `sC` in the below chart
2. In addition to that optimization, `sortNumber` is also optimized.
    - Labeled as `sC + sN` in the below chart

Test data: [1500+ options](https://github.com/momocus/sakazuki/blob/main/app/views/sakes/_kura_datalist.html.erb) as mentioned in #1049

<img width="658" alt="image" src="https://github.com/markuplint/markuplint/assets/127635/c52add53-722a-4b06-a880-26283ec8dc9e">

. | v4.1.0 | v4.1.1 | sC | sC + sN (this PR)
---| --: | --: | --: | --:
3rd quartile | 5.00 | 4.50 | 4.44 | 4.21
Median | 4.97 | 4.45 | 4.40 | 4.16
1st quartile | 4.92 | 4.42 | 4.39 | 4.13

As the result, the entire process time on many `<option>`s is 6.5% shorter compared to v4.1.1.
(4.16 / 4.45 = 0.935) 

## Checklist

Fill out the checks for the applicable purpose.

- [ ] Fix bug
  - [ ] Add the test that can check whether resolved the issue.
- [ ] Update specs
  - [ ] Element
    - [ ] Update **[global attributes](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/html-spec/src/spec-common.attributes.json)**
    - [ ] Update **[content models](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/html-spec/src/spec-common.contents.json)**
    - [ ] Add also ARIA that you explored **ARIA in HTML [Recommendation](https://www.w3.org/TR/html-aria/) and [Editor's draft](https://w3c.github.io/html-aria/)**
  - [ ] Attribute
    - [ ] Update **[global attributes](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/html-spec/src/spec-common.attributes.json)**
    - [ ] Update **[IDL attribute](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/parser-utils/src/idl-attributes.ts)**
- [ ] Add new rule
  - [ ] Add a test
  - [ ] Add a README document
    - [ ] Create an issue that requests translating the doc if you want.
  - [ ] Add to [index](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/rules/src/index.ts)
  - [ ] Add JSON schema to [schema.json](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/rules/schema.json)
  - [ ] Add to [`@markuplint/config-presets`](https://github.com/markuplint/markuplint/tree/main/packages/%40markuplint/config-presets)
    - [ ] And add to [Rulesets of base presets](https://markuplint.dev/docs/guides/presets#rulesets-of-base-presets)
      - [ ] Add to a [doc file](https://github.com/markuplint/markuplint/blob/main/website/docs/guides/presets.md)
      - [ ] Add to a [doc file (ja)](https://github.com/markuplint/markuplint/blob/main/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/presets.md), or create an issue that requests translating the doc if you want.
  - [ ] Add to the [Playground](https://playground.markuplint.dev/)
    - [ ] Add to a [config object](https://github.com/markuplint/markuplint/blob/main/playground/src/ml-playground-home.svelte)
- [ ] Add new parser
  - [ ] Add a test
    - [ ] Do a test with some parser.
  - [ ] Add to [initializer](https://github.com/markuplint/markuplint/blob/main/packages/markuplint/src/cli/init/index.ts)
