### PR TITLE
`@markuplint/esm-adapter` is supported only on Node.js versions below 22

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ on:
             - 'yarn.lock'
 
 env:
-    NODE_BUILD_VERSION: 20
+    NODE_BUILD_VERSION: 22
 
 jobs:
     dev-setup:
@@ -170,9 +170,9 @@ jobs:
                     - windows-latest
                 node: [18]
                 include:
-                    - node: 20
-                      os: ubuntu-latest
                     - node: 21
+                      os: ubuntu-latest
+                    - node: 22
                       os: ubuntu-latest
         steps:
             - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
@@ -217,10 +217,10 @@ jobs:
                 node: [18]
                 shard: [1/4, 2/4, 3/4, 4/4]
                 include:
-                    - node: 20
+                    - node: 21
                       os: ubuntu-latest
                       shard: 1/1
-                    - node: 21
+                    - node: 22
                       os: ubuntu-latest
                       shard: 1/1
         steps:

--- a/packages/@markuplint/esm-adapter/README.md
+++ b/packages/@markuplint/esm-adapter/README.md
@@ -4,6 +4,10 @@
 
 A library for utilizing ESM-converted Markuplint modules through a subprocess from a CJS environment.
 
+## CAUTION
+
+This module is supported only on Node.js versions **below 22**.
+
 ## Install
 
 ```shell

--- a/packages/@markuplint/esm-adapter/package.json
+++ b/packages/@markuplint/esm-adapter/package.json
@@ -25,6 +25,7 @@
 		"strict-event-emitter": "0.5.1"
 	},
 	"devDependencies": {
-		"@types/debug": "4.1.12"
+		"@types/debug": "4.1.12",
+		"semver": "7.6.2"
 	}
 }

--- a/packages/@markuplint/esm-adapter/package.json
+++ b/packages/@markuplint/esm-adapter/package.json
@@ -14,6 +14,9 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"engines": {
+		"node": "<22"
+	},
 	"scripts": {},
 	"dependencies": {
 		"debug": "4.3.4",

--- a/packages/@markuplint/esm-adapter/test/index.spec.js
+++ b/packages/@markuplint/esm-adapter/test/index.spec.js
@@ -2,11 +2,12 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 
 import { version as versionForTest } from 'markuplint';
+import { gt } from 'semver';
 import { describe, it, expect } from 'vitest';
 
 const { MLEngine } = require('../cjs/index.cjs');
 
-describe('test', () => {
+describe.skipIf(gt(process.version, '22.0.0'))('test', () => {
 	it('MLEngine.exec()', async () => {
 		await MLEngine.setModule('markuplint');
 		const engine = await MLEngine.fromCode('<span><div></div></span>', {

--- a/website/docs/api/index.md
+++ b/website/docs/api/index.md
@@ -52,3 +52,7 @@ console.log(result);
 `@markuplint/esm-adapter` was created specifically for VS Code extensions that do not support ESM. Because of this, the implemented APIs are extremely limited if you are not using them within an extension.
 Additionally, it internally uses **[Worker threads](https://nodejs.org/api/worker_threads.html#worker-threads)**, so it only works on the Node.js platform.
 :::
+
+:::warning
+`@markuplint/esm-adapter` is supported only on Node.js versions **below 22**.
+:::

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/api/index.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/api/index.md
@@ -52,3 +52,7 @@ console.log(result);
 `@markuplint/esm-adapter`はESMの対応していない**VS Code拡張機能**のために作られたモジュールです。拡張機能で利用しないAPIは実装されていないため極めて限定的です。
 また、内部的には**[Worker threads](https://nodejs.org/api/worker_threads.html#worker-threads)**を利用しているため、プラットフォームはNode.jsのみとなります。
 :::
+
+:::warning
+`@markuplint/esm-adapter`はNode.jsのバージョン**22未満**でのみサポートしています。
+:::


### PR DESCRIPTION
Fixes #1740 

## What is the purpose of this PR?

- [ ] Fix bug
- [ ] Fix typo
- [ ] Update specs
- [ ] Add new rule
- [ ] Add new parser
- [ ] Improve or refactor rules
- [ ] Add a new core feature
- [ ] Improve or refactor core features
- [ ] Update documents
- [x] Others

### Description

- Add Node.js version constraint to package.json (supports `<22`)
- Skip tests on Node.js versions greater than 22
