### PR TITLE
feat(ml-config): [Experimental] specify loading pretenders file

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -211,6 +211,76 @@
 					}
 				]
 			}
+		},
+		"pretender": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["selector", "as"],
+			"properties": {
+				"selector": { "type": "string" },
+				"as": {
+					"oneOf": [
+						{ "type": "string" },
+						{
+							"type": "object",
+							"additionalProperties": false,
+							"required": ["element"],
+							"properties": {
+								"element": { "type": "string" },
+								"namespace": {
+									"type": "string",
+									"enum": ["svg"]
+								},
+								"attrs": {
+									"type": "array",
+									"items": {
+										"type": "object",
+										"additionalProperties": false,
+										"required": ["name"],
+										"properties": {
+											"name": { "type": "string" },
+											"value": {
+												"oneOf": [
+													{ "type": "string" },
+													{
+														"type": "object",
+														"additionalProperties": false,
+														"required": ["fromAttr"],
+														"properties": {
+															"fromAttr": { "type": "string" }
+														}
+													}
+												]
+											}
+										}
+									}
+								},
+								"aria": {
+									"type": "object",
+									"additionalProperties": false,
+									"required": ["name"],
+									"properties": {
+										"name": { "type": "string" },
+										"value": {
+											"oneOf": [
+												{ "type": "boolean" },
+												{
+													"type": "object",
+													"additionalProperties": false,
+													"required": ["fromAttr"],
+													"properties": {
+														"fromAttr": { "type": "string" }
+													}
+												}
+											]
+										}
+									}
+								}
+							}
+						}
+					]
+				}
+			}
 		}
 	},
 	"type": "object",
@@ -233,74 +303,7 @@
 		"pretenders": {
 			"type": "array",
 			"items": {
-				"type": "object",
-				"additionalProperties": false,
-				"required": ["selector", "as"],
-				"properties": {
-					"selector": { "type": "string" },
-					"as": {
-						"oneOf": [
-							{ "type": "string" },
-							{
-								"type": "object",
-								"additionalProperties": false,
-								"required": ["element"],
-								"properties": {
-									"element": { "type": "string" },
-									"namespace": {
-										"type": "string",
-										"enum": ["svg"]
-									},
-									"attrs": {
-										"type": "array",
-										"items": {
-											"type": "object",
-											"additionalProperties": false,
-											"required": ["name"],
-											"properties": {
-												"name": { "type": "string" },
-												"value": {
-													"oneOf": [
-														{ "type": "string" },
-														{
-															"type": "object",
-															"additionalProperties": false,
-															"required": ["fromAttr"],
-															"properties": {
-																"fromAttr": { "type": "string" }
-															}
-														}
-													]
-												}
-											}
-										}
-									},
-									"aria": {
-										"type": "object",
-										"additionalProperties": false,
-										"required": ["name"],
-										"properties": {
-											"name": { "type": "string" },
-											"value": {
-												"oneOf": [
-													{ "type": "boolean" },
-													{
-														"type": "object",
-														"additionalProperties": false,
-														"required": ["fromAttr"],
-														"properties": {
-															"fromAttr": { "type": "string" }
-														}
-													}
-												]
-											}
-										}
-									}
-								}
-							}
-						]
-					}
-				}
+				"$ref": "#/definitions/pretender"
 			}
 		},
 		"overrideMode": {

--- a/config.schema.json
+++ b/config.schema.json
@@ -281,6 +281,12 @@
 					]
 				}
 			}
+		},
+		"pretenders": {
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/pretender"
+			}
 		}
 	},
 	"type": "object",
@@ -301,10 +307,7 @@
 		"nodeRules": { "$ref": "#/definitions/nodeRules" },
 		"childNodeRules": { "$ref": "#/definitions/childNodeRules" },
 		"pretenders": {
-			"type": "array",
-			"items": {
-				"$ref": "#/definitions/pretender"
-			}
+			"$ref": "#/definitions/pretenders"
 		},
 		"overrideMode": {
 			"type": "string",

--- a/config.schema.json
+++ b/config.schema.json
@@ -287,6 +287,31 @@
 			"items": {
 				"$ref": "#/definitions/pretender"
 			}
+		},
+		"pretenderDetails": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"files": {
+					"description": "@experimental",
+					"type": "array",
+					"minItems": 1,
+					"items": {
+						"type": "string"
+					}
+				},
+				"imports": {
+					"description": "@experimental",
+					"type": "array",
+					"minItems": 1,
+					"items": {
+						"type": "string"
+					}
+				},
+				"data": {
+					"$ref": "#/definitions/pretenders"
+				}
+			}
 		}
 	},
 	"type": "object",
@@ -307,7 +332,14 @@
 		"nodeRules": { "$ref": "#/definitions/nodeRules" },
 		"childNodeRules": { "$ref": "#/definitions/childNodeRules" },
 		"pretenders": {
-			"$ref": "#/definitions/pretenders"
+			"oneOf": [
+				{
+					"$ref": "#/definitions/pretenders"
+				},
+				{
+					"$ref": "#/definitions/pretenderDetails"
+				}
+			]
 		},
 		"overrideMode": {
 			"type": "string",

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
 	"lerna": "7.0.1",
 	"version": "independent",
 	"npmClient": "yarn",
-	"packages": ["packages/*", "packages/@markuplint/*", "vscode"],
+	"packages": ["packages/*", "packages/@markuplint/*", "packages/@markuplint-test/*", "vscode"],
 	"command": {
 		"version": {
 			"message": "chore(release): publish"

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
 	"workspaces": [
 		"packages/*",
 		"packages/@markuplint/*",
+		"packages/@markuplint-test/*",
 		"vscode"
 	],
 	"devDependencies": {

--- a/packages/@markuplint-test/react/package.json
+++ b/packages/@markuplint-test/react/package.json
@@ -1,0 +1,15 @@
+{
+	"name": "@markuplint-test/react",
+	"version": "0.0.0",
+	"private": true,
+	"type": "module",
+	"exports": {
+		".": "./index.js"
+	},
+	"scripts": {
+		"pretenders": "npx --yes @markuplint/pretenders \"*.jsx\" --out \"./pretenders.json\""
+	},
+	"devDependencies": {
+		"@markuplint/pretenders": "0.0.4"
+	}
+}

--- a/packages/@markuplint-test/react/pretenders.json
+++ b/packages/@markuplint-test/react/pretenders.json
@@ -1,0 +1,10 @@
+{
+	"version": "0.0.4",
+	"data": [
+		{
+			"selector": "Sample",
+			"as": "div",
+			"filePath": "sample.jsx:1:16"
+		}
+	]
+}

--- a/packages/@markuplint-test/react/sample.jsx
+++ b/packages/@markuplint-test/react/sample.jsx
@@ -1,0 +1,8 @@
+export function Sample() {
+	return (
+		<div>
+			<h1>Sample</h1>
+			<p>Sample</p>
+		</div>
+	);
+}

--- a/packages/@markuplint/file-resolver/package.json
+++ b/packages/@markuplint/file-resolver/package.json
@@ -39,6 +39,7 @@
 		"debug": "4.3.4",
 		"glob": "10.4.1",
 		"ignore": "5.3.1",
+		"import-meta-resolve": "4.1.0",
 		"jsonc": "2.0.0",
 		"minimatch": "9.0.4"
 	}

--- a/packages/@markuplint/file-resolver/src/config-provider.spec.ts
+++ b/packages/@markuplint/file-resolver/src/config-provider.spec.ts
@@ -47,6 +47,15 @@ test('001 + 002', async () => {
 				foo: '002',
 			},
 		],
+		pretenders: {
+			files: path.resolve(testDir, '..', 'pretenders.json'),
+			data: [
+				{
+					selector: 'MyComponent',
+					as: 'div',
+				},
+			],
+		},
 		rules: {
 			rule__enabled: true,
 			rule__disabled: false,
@@ -114,6 +123,15 @@ test('001 + 002 + 003', async () => {
 				name: path.resolve(testDir, '..', 'plugins', '001.js'),
 			},
 		],
+		pretenders: {
+			files: path.resolve(testDir, '..', 'pretenders.json'),
+			data: [
+				{
+					selector: 'MyComponent',
+					as: 'div',
+				},
+			],
+		},
 		rules: {
 			rule__enabled: false,
 			rule__disabled: true,

--- a/packages/@markuplint/file-resolver/src/config-provider.spec.ts
+++ b/packages/@markuplint/file-resolver/src/config-provider.spec.ts
@@ -31,7 +31,9 @@ test('001 + 002', async () => {
 		dummy2: false,
 		key: '002/.markuplintrc.json',
 		plugins: [
-			path.resolve(testDir, '001', 'a'),
+			{
+				name: path.resolve(testDir, '001', 'a'),
+			},
 			{
 				name: '@markuplint/file-resolver',
 				foo: '002',
@@ -93,7 +95,9 @@ test('001 + 002 + 003', async () => {
 		key: '003/.markuplintrc',
 		key2: '001-2.js',
 		plugins: [
-			path.resolve(testDir, '001', 'a'),
+			{
+				name: path.resolve(testDir, '001', 'a'),
+			},
 			{
 				name: '@markuplint/file-resolver',
 				foo: '002',
@@ -106,7 +110,9 @@ test('001 + 002 + 003', async () => {
 				name: path.resolve(testDir, '002', 'b'),
 				foo: '002',
 			},
-			path.resolve(testDir, '..', 'plugins', '001.js'),
+			{
+				name: path.resolve(testDir, '..', 'plugins', '001.js'),
+			},
 		],
 		rules: {
 			rule__enabled: false,

--- a/packages/@markuplint/file-resolver/src/config-provider.ts
+++ b/packages/@markuplint/file-resolver/src/config-provider.ts
@@ -258,7 +258,7 @@ export class ConfigProvider {
 		};
 	}
 
-	private async _pathResolve(config: Config, filePath: string): Promise<Config> {
+	private async _pathResolve(config: Config, filePath: string): Promise<OptimizedConfig> {
 		const optimizedConfig = mergeConfig(config);
 		const dir = path.dirname(filePath);
 		return {
@@ -268,6 +268,12 @@ export class ConfigProvider {
 			parser: await relPathToNameOrAbsPath(dir, optimizedConfig.parser),
 			specs: await relPathToNameOrAbsPath(dir, optimizedConfig.specs),
 			excludeFiles: await relPathToNameOrAbsPath(dir, optimizedConfig.excludeFiles),
+			pretenders: optimizedConfig.pretenders
+				? {
+						...optimizedConfig.pretenders,
+						files: await relPathToNameOrAbsPath(dir, optimizedConfig.pretenders?.files),
+					}
+				: undefined,
 			overrides: await relPathToNameOrAbsPath(dir, optimizedConfig.overrides, undefined, true),
 		};
 	}

--- a/packages/@markuplint/file-resolver/src/index.ts
+++ b/packages/@markuplint/file-resolver/src/index.ts
@@ -2,6 +2,7 @@ export type { MLFile } from './ml-file/index.js';
 export * from './config-provider.js';
 export * from './resolve-files.js';
 export * from './resolve-parser.js';
+export * from './resolve-pretenders.js';
 export * from './resolve-rules.js';
 export * from './resolve-specs.js';
 export * from './types.js';

--- a/packages/@markuplint/file-resolver/src/resolve-pretenders.spec.ts
+++ b/packages/@markuplint/file-resolver/src/resolve-pretenders.spec.ts
@@ -1,0 +1,35 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { test, expect } from 'vitest';
+
+import { resolvePretenders } from './resolve-pretenders.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+test('files', async () => {
+	const pretenders = await resolvePretenders({
+		files: [path.resolve(__dirname, '..', '..', '..', '@markuplint-test', 'react', 'pretenders.json')],
+	});
+	expect(pretenders).toStrictEqual([
+		{
+			selector: 'Sample',
+			as: 'div',
+			filePath: 'sample.jsx:1:16',
+		},
+	]);
+});
+
+test('imports', async () => {
+	const pretenders = await resolvePretenders({
+		imports: ['@markuplint-test/react'],
+	});
+	expect(pretenders).toStrictEqual([
+		{
+			selector: 'Sample',
+			as: 'div',
+			filePath: 'sample.jsx:1:16',
+		},
+	]);
+});

--- a/packages/@markuplint/file-resolver/src/resolve-pretenders.ts
+++ b/packages/@markuplint/file-resolver/src/resolve-pretenders.ts
@@ -1,0 +1,42 @@
+import type { OptimizedConfig, Pretender, PretenderFileData } from '@markuplint/ml-config';
+
+import { generalImport } from './general-import.js';
+
+type PretendersConfig = OptimizedConfig['pretenders'];
+
+export async function resolvePretenders(config: PretendersConfig): Promise<Pretender[]> {
+	if (!config) {
+		return [];
+	}
+
+	const data: Pretender[] = [];
+
+	if (config.files) {
+		for (const file of config.files) {
+			const pretenderFile = await generalImport<PretenderFileData>(file);
+			if (!pretenderFile?.data) {
+				continue;
+			}
+			data.push(...pretenderFile.data);
+		}
+	}
+
+	if (config.imports) {
+		for (const module of config.imports) {
+			const pretenderFile =
+				// eslint-disable-next-line unicorn/no-await-expression-member
+				(await generalImport<{ pretenders?: PretenderFileData }>(`${module}/package.json`))?.pretenders ??
+				(await generalImport<PretenderFileData>(`${module}/pretenders.json`));
+			if (!pretenderFile?.data) {
+				continue;
+			}
+			data.push(...pretenderFile.data);
+		}
+	}
+
+	if (config.data) {
+		data.push(...config.data);
+	}
+
+	return data;
+}

--- a/packages/@markuplint/file-resolver/src/types.ts
+++ b/packages/@markuplint/file-resolver/src/types.ts
@@ -1,8 +1,8 @@
-import type { Config } from '@markuplint/ml-config';
+import type { OptimizedConfig } from '@markuplint/ml-config';
 import type { Plugin } from '@markuplint/ml-core';
 
 export interface ConfigSet {
-	readonly config: Config;
+	readonly config: OptimizedConfig;
 	readonly plugins: readonly Plugin[];
 	readonly files: ReadonlySet<string>;
 	readonly errs: readonly Readonly<Error>[];

--- a/packages/@markuplint/file-resolver/test/fixtures/001/package.json
+++ b/packages/@markuplint/file-resolver/test/fixtures/001/package.json
@@ -10,6 +10,12 @@
 				"name": "b",
 				"foo": "001"
 			}
+		],
+		"pretenders": [
+			{
+				"selector": "MyComponent",
+				"as": "div"
+			}
 		]
 	}
 }

--- a/packages/@markuplint/file-resolver/test/fixtures/002/.markuplintrc.json
+++ b/packages/@markuplint/file-resolver/test/fixtures/002/.markuplintrc.json
@@ -12,6 +12,9 @@
 			"foo": "002"
 		}
 	],
+	"pretenders": {
+		"files": "../../pretenders.json"
+	},
 	"rules": {
 		"rule__enabled": true,
 		"rule__disabled": false,

--- a/packages/@markuplint/ml-config/src/merge-config.spec.ts
+++ b/packages/@markuplint/ml-config/src/merge-config.spec.ts
@@ -314,3 +314,102 @@ describe('mergeRule', () => {
 		});
 	});
 });
+
+describe('Preteners', () => {
+	test('test', () => {
+		expect(
+			mergeConfig(
+				{
+					pretenders: [
+						{
+							selector: 'MyComponent',
+							as: 'div',
+						},
+					],
+				},
+				{
+					pretenders: {
+						files: ['./pretenders.json'],
+					},
+				},
+			),
+		).toStrictEqual({
+			pretenders: {
+				files: ['./pretenders.json'],
+				data: [
+					{
+						selector: 'MyComponent',
+						as: 'div',
+					},
+				],
+			},
+		});
+	});
+
+	test('test', () => {
+		expect(
+			mergeConfig(
+				{
+					pretenders: [
+						{
+							selector: 'MyComponent',
+							as: 'div',
+						},
+					],
+				},
+				{
+					pretenders: undefined,
+				},
+			),
+		).toStrictEqual({
+			pretenders: {
+				data: [
+					{
+						selector: 'MyComponent',
+						as: 'div',
+					},
+				],
+			},
+		});
+	});
+
+	test('test', () => {
+		expect(
+			mergeConfig(
+				{
+					pretenders: [
+						{
+							selector: 'MyComponent',
+							as: 'div',
+						},
+					],
+				},
+				{
+					pretenders: {
+						files: ['../pretenders.json'],
+						data: [
+							{
+								selector: 'MyComponent2',
+								as: 'section',
+							},
+						],
+					},
+				},
+			),
+		).toStrictEqual({
+			pretenders: {
+				files: ['../pretenders.json'],
+				data: [
+					{
+						selector: 'MyComponent',
+						as: 'div',
+					},
+					{
+						selector: 'MyComponent2',
+						as: 'section',
+					},
+				],
+			},
+		});
+	});
+});

--- a/packages/@markuplint/ml-config/src/merge-config.spec.ts
+++ b/packages/@markuplint/ml-config/src/merge-config.spec.ts
@@ -18,7 +18,20 @@ describe('mergeConfig', () => {
 				},
 			),
 		).toStrictEqual({
-			plugins: ['a', 'b', 'c', 'd'],
+			plugins: [
+				{
+					name: 'a',
+				},
+				{
+					name: 'b',
+				},
+				{
+					name: 'c',
+				},
+				{
+					name: 'd',
+				},
+			],
 		});
 	});
 
@@ -34,8 +47,12 @@ describe('mergeConfig', () => {
 			),
 		).toStrictEqual({
 			plugins: [
-				'a',
-				'b',
+				{
+					name: 'a',
+				},
+				{
+					name: 'b',
+				},
 				{
 					name: 'c',
 					settings: {
@@ -44,7 +61,9 @@ describe('mergeConfig', () => {
 						foo2: 'foo2',
 					},
 				},
-				'd',
+				{
+					name: 'd',
+				},
 			],
 		});
 	});

--- a/packages/@markuplint/ml-config/src/merge-config.ts
+++ b/packages/@markuplint/ml-config/src/merge-config.ts
@@ -6,6 +6,8 @@ import type {
 	OptimizedConfig,
 	OverrideConfig,
 	OptimizedOverrideConfig,
+	PretenderDetails,
+	Pretender,
 } from './types.js';
 import type { Nullable } from '@markuplint/shared';
 import type { Writable } from 'type-fest';
@@ -32,7 +34,7 @@ export function mergeConfig(a: Config, b?: Config): OptimizedConfig {
 		parserOptions: mergeObject(a.parserOptions, b.parserOptions),
 		specs: mergeObject(a.specs, b.specs),
 		excludeFiles: concatArray(a.excludeFiles, b.excludeFiles, true),
-		pretenders: concatArray(a.pretenders, b.pretenders),
+		pretenders: mergePretenders(a.pretenders, b.pretenders),
 		rules: mergeRules(
 			// TODO: Deep merge
 			a.rules,
@@ -96,6 +98,29 @@ export function mergeRule(a: Nullable<AnyRule | AnyRuleV2>, b: AnyRule | AnyRule
 	};
 	deleteUndefProp(res);
 	return res;
+}
+
+function mergePretenders(
+	a?: readonly Pretender[] | PretenderDetails,
+	b?: readonly Pretender[] | PretenderDetails,
+): PretenderDetails | undefined {
+	if (!a && !b) {
+		return;
+	}
+	const aDetails = a ? convertPretenersToDetails(a) : undefined;
+	const bDetails = b ? convertPretenersToDetails(b) : undefined;
+	const details = mergeObject(aDetails, bDetails) ?? {};
+	deleteUndefProp(details);
+	return details;
+}
+
+function convertPretenersToDetails(pretenders: readonly Pretender[] | PretenderDetails): PretenderDetails {
+	if (isReadonlyArray(pretenders)) {
+		return {
+			data: pretenders,
+		};
+	}
+	return pretenders;
 }
 
 function mergeOverrides(

--- a/packages/@markuplint/ml-config/src/types.ts
+++ b/packages/@markuplint/ml-config/src/types.ts
@@ -36,11 +36,21 @@ export type NonNullablePlainData =
 			readonly [key: string]: NonNullablePlainData;
 	  };
 
-export type OverrideConfig = Omit<Config, '$schema' | 'extends' | 'overrideMode' | 'overrides'>;
+type NoInherit = '$schema' | 'extends' | 'overrideMode' | 'overrides';
+
+export type OverrideConfig = Omit<Config, NoInherit>;
+
+export type OptimizedConfig = Omit<Config, '$schema' | 'extends' | 'plugins' | 'overrides'> & {
+	readonly extends?: readonly string[];
+	readonly plugins?: readonly PluginConfig[];
+	readonly overrides?: Readonly<Record<string, OptimizedOverrideConfig>>;
+};
+
+export type OptimizedOverrideConfig = Omit<OptimizedConfig, NoInherit>;
 
 export type PluginConfig = {
 	readonly name: string;
-	readonly settings: Readonly<Record<string, NonNullablePlainData>>;
+	readonly settings?: Readonly<Record<string, NonNullablePlainData>>;
 };
 
 export type ParserConfig = {

--- a/packages/@markuplint/ml-config/src/types.ts
+++ b/packages/@markuplint/ml-config/src/types.ts
@@ -12,7 +12,7 @@ export type Config = {
 	readonly parserOptions?: ParserOptions;
 	readonly specs?: SpecConfig;
 	readonly excludeFiles?: readonly string[];
-	readonly pretenders?: readonly Pretender[];
+	readonly pretenders?: readonly Pretender[] | PretenderDetails;
 	readonly rules?: Rules;
 	readonly nodeRules?: readonly NodeRule[];
 	readonly childNodeRules?: readonly ChildNodeRule[];
@@ -40,9 +40,10 @@ type NoInherit = '$schema' | 'extends' | 'overrideMode' | 'overrides';
 
 export type OverrideConfig = Omit<Config, NoInherit>;
 
-export type OptimizedConfig = Omit<Config, '$schema' | 'extends' | 'plugins' | 'overrides'> & {
+export type OptimizedConfig = Omit<Config, '$schema' | 'extends' | 'plugins' | 'pretenders' | 'overrides'> & {
 	readonly extends?: readonly string[];
 	readonly plugins?: readonly PluginConfig[];
+	readonly pretenders?: PretenderDetails;
 	readonly overrides?: Readonly<Record<string, OptimizedOverrideConfig>>;
 };
 
@@ -59,6 +60,19 @@ export type ParserConfig = {
 
 export type SpecConfig = {
 	readonly [extensionPattern: string]: string /* module name or path */;
+};
+
+export type PretenderDetails = {
+	/**
+	 * @experimental
+	 */
+	readonly files?: readonly string[];
+
+	/**
+	 * @experimental
+	 */
+	readonly imports?: readonly string[];
+	readonly data?: readonly Pretender[];
 };
 
 export type PretenderFileData = {

--- a/packages/markuplint/src/api/ml-engine.ts
+++ b/packages/markuplint/src/api/ml-engine.ts
@@ -5,6 +5,7 @@ import type { PlainData } from '@markuplint/ml-config';
 import type { Ruleset, Plugin, Document, RuleConfigValue, MLFabric } from '@markuplint/ml-core';
 
 import { ConfigProvider, resolveFiles, resolveParser, resolveRules, resolveSpecs } from '@markuplint/file-resolver';
+import { mergeConfig } from '@markuplint/ml-config';
 import { MLCore, convertRuleset } from '@markuplint/ml-core';
 import { FSWatcher } from 'chokidar';
 import { Emitter } from 'strict-event-emitter';
@@ -304,7 +305,8 @@ export class MLEngine extends Emitter<MLEngineEventMap> {
 		this.emit('log', 'resolveConfig', JSON.stringify(this.#configProvider, null, 2));
 		configLog('configProvider: %s', this.#configProvider);
 
-		const defaultConfigKey = this.#options?.defaultConfig && this.#configProvider.set(this.#options?.defaultConfig);
+		const defaultConfigKey =
+			this.#options?.defaultConfig && this.#configProvider.set(mergeConfig(this.#options?.defaultConfig));
 		configLog('defaultConfigKey: %s', defaultConfigKey ?? 'N/A');
 		this.emit('log', 'defaultConfigKey', defaultConfigKey ?? 'N/A');
 
@@ -317,7 +319,7 @@ export class MLEngine extends Emitter<MLEngineEventMap> {
 		configLog('configFilePathsFromTarget: %s', configFilePathsFromTarget ?? 'N/A');
 		this.emit('log', 'configFilePathsFromTarget', configFilePathsFromTarget ?? 'N/A');
 
-		const configKey = this.#options?.config && this.#configProvider.set(this.#options.config);
+		const configKey = this.#options?.config && this.#configProvider.set(mergeConfig(this.#options.config));
 		configLog('option.config: %s', configKey ?? 'N/A');
 		this.emit('log', 'option.config', configFilePathsFromTarget ?? 'N/A');
 

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -34,3 +34,5 @@ community/code-of-conduct.md
 
 # Dynamically created files
 contributors.json
+
+pretenders.json

--- a/website/.markuplintrc
+++ b/website/.markuplintrc
@@ -4,6 +4,9 @@
     ".tsx$": "@markuplint/jsx-parser"
   },
   "specs": ["@markuplint/react-spec"],
+  "pretenders": {
+    "files": ["./pretenders.json"]
+  },
   "rules": {
     "attr-duplication": true,
     "attr-value-quotes": true,

--- a/website/package.json
+++ b/website/package.json
@@ -7,6 +7,7 @@
     "site:start": "yarn site:prebuild; docusaurus start",
     "site:build": "yarn site:prebuild; docusaurus build",
     "site:prebuild": "tsx scripts/prebuild/index.mts; npx prettier --write './src/**/*{ts,tsx,json,rc,md,mdx,css,scss}';",
+    "presite:lint": "npx @markuplint/pretenders \"./src/**/*.tsx\" --out \"./pretenders.json\"",
     "site:lint": "prettier --write './**/*{js,ts,tsx,mdx}' './*{json,rc,js}' '!./build/**/*' '!./.docusaurus/**/*'; eslint --fix './**/*.{js,ts,tsx}' './*.{js,ts}'; stylelint './**/*.css'; textlint --fix './website/i18n/ja'; cd ../; yarn cli './website/**/*.tsx'",
     "site:up": "yarn upgrade-interactive --latest"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5970,7 +5970,7 @@ import-local@3.1.0:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
 
-import-meta-resolve@^4.0.0, import-meta-resolve@^4.1.0:
+import-meta-resolve@4.1.0, import-meta-resolve@^4.0.0, import-meta-resolve@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz#f9db8bead9fafa61adb811db77a2bf22c5399706"
   integrity sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==


### PR DESCRIPTION
## 1. Create `pretenders.json`

Use [@markuplint/pretenders](https://github.com/markuplint/markuplint/tree/dev/packages/%40markuplint/pretenders)

```
npx @markuplint/pretenders "**/*.jsx" --out "pretenders.json"
```

## 2. Specify to `.markuplintrc`:

```json
{
  "pretenders": {
    "files": ["./pretenders.json"]
  },
}
```

