### PR TITLE
feat(types): avoid parsing and simply accept any value when the CSS includes `var()`

### DIFF
--- a/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
@@ -1553,6 +1553,10 @@ describe('Deprecated options', () => {
 	});
 });
 
+test('CSS Functions', async () => {
+	expect((await mlRuleTest(rule, '<div style="prop: var(--x)"></div>')).violations).toStrictEqual([]);
+});
+
 describe('Issues', () => {
 	test('#553', async () => {
 		expect(

--- a/packages/@markuplint/types/src/css-syntax.spec.ts
+++ b/packages/@markuplint/types/src/css-syntax.spec.ts
@@ -194,3 +194,7 @@ test('legacy-transform', () => {
 	expect(cssSyntaxMatch('translate(300,300)', custom).matched).toBeTruthy();
 	expect(cssSyntaxMatch('translate(300px,300px)', custom).matched).toBeTruthy();
 });
+
+test('var()', () => {
+	expect(cssSyntaxMatch('var(--x)', '<length>').matched).toBe(true);
+});

--- a/packages/@markuplint/types/src/css-syntax.ts
+++ b/packages/@markuplint/types/src/css-syntax.ts
@@ -104,6 +104,13 @@ export function cssSyntaxMatch(value: string, type: CssSyntax | CustomCssSyntax)
 	}
 
 	if (!('css' in result.error)) {
+		if (result.error.message === 'Matching for a tree with var() is not supported') {
+			// `var()` is not supported
+			// So, return matched
+			// @see https://github.com/csstree/csstree/issues/62
+			return matched();
+		}
+
 		throw result.error;
 	}
 


### PR DESCRIPTION
Fixes #1916 

## What is the purpose of this PR?

- [ ] Fix bug
- [ ] Fix typo
- [ ] Update specs
- [ ] Add new rule
- [ ] Add new parser
- [ ] Improve or refactor rules
- [ ] Add a new core feature
- [x] Improve or refactor core features
- [ ] Update documents
- [ ] Others

### Description

<!-- WRITE A DESCRIPTION -->

## Checklist

Fill out the checks for the applicable purpose.

- [ ] Fix bug
  - [ ] Add the test that can check whether resolved the issue.
- [ ] Update specs
  - [ ] Element
    - [ ] Update **[global attributes](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/html-spec/src/spec-common.attributes.json)**
    - [ ] Update **[content models](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/html-spec/src/spec-common.contents.json)**
    - [ ] Add also ARIA that you explored **ARIA in HTML [Recommendation](https://www.w3.org/TR/html-aria/) and [Editor's draft](https://w3c.github.io/html-aria/)**
  - [ ] Attribute
    - [ ] Update **[global attributes](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/html-spec/src/spec-common.attributes.json)**
    - [ ] Update **[IDL attribute](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/parser-utils/src/idl-attributes.ts)**
- [ ] Add new rule
  - [ ] Add a test
  - [ ] Add a README document
    - [ ] Create an issue that requests translating the doc if you want.
  - [ ] Add to [index](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/rules/src/index.ts)
  - [ ] Add JSON schema to [schema.json](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/rules/schema.json)
  - [ ] Add to [`@markuplint/config-presets`](https://github.com/markuplint/markuplint/tree/main/packages/%40markuplint/config-presets)
    - [ ] And add to [Rulesets of base presets](https://markuplint.dev/docs/guides/presets#rulesets-of-base-presets)
      - [ ] Add to a [doc file](https://github.com/markuplint/markuplint/blob/main/website/docs/guides/presets.md)
      - [ ] Add to a [doc file (ja)](https://github.com/markuplint/markuplint/blob/main/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/presets.md), or create an issue that requests translating the doc if you want.
- [ ] Add new parser
  - [ ] Add a test
    - [ ] Do a test with some parser.
  - [ ] Add to [initializer](https://github.com/markuplint/markuplint/blob/main/packages/markuplint/src/cli/init/create-config.ts)
