### PR TITLE
feat(markuplint): add `severity.parseError` option

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -212,6 +212,27 @@
 				]
 			}
 		},
+		"severity": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"parseError": {
+					"oneOf": [
+						{
+							"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/ml-config/schema.json#/definitions/severity"
+						},
+						{
+							"type": "string",
+							"enum": ["off"]
+						},
+						{
+							"type": "boolean"
+						}
+					],
+					"default": "error"
+				}
+			}
+		},
 		"pretender": {
 			"type": "object",
 			"additionalProperties": false,
@@ -331,6 +352,7 @@
 		"rules": { "$ref": "#/definitions/rules" },
 		"nodeRules": { "$ref": "#/definitions/nodeRules" },
 		"childNodeRules": { "$ref": "#/definitions/childNodeRules" },
+		"severity": { "$ref": "#/definitions/severity" },
 		"pretenders": {
 			"oneOf": [
 				{
@@ -358,6 +380,7 @@
 					"parserOptions": { "$ref": "#/definitions/parserOptions" },
 					"excludeFiles": { "$ref": "#/definitions/excludeFiles" },
 					"specs": { "$ref": "#/definitions/specs" },
+					"severity": { "$ref": "#/definitions/severity" },
 					"rules": { "$ref": "#/definitions/rules" },
 					"nodeRules": { "$ref": "#/definitions/nodeRules" },
 					"childNodeRules": { "$ref": "#/definitions/childNodeRules" }

--- a/packages/@markuplint/ml-config/src/merge-config.ts
+++ b/packages/@markuplint/ml-config/src/merge-config.ts
@@ -34,6 +34,7 @@ export function mergeConfig(a: Config, b?: Config): OptimizedConfig {
 		parserOptions: mergeObject(a.parserOptions, b.parserOptions),
 		specs: mergeObject(a.specs, b.specs),
 		excludeFiles: concatArray(a.excludeFiles, b.excludeFiles, true),
+		severity: mergeObject(a.severity, b.severity),
 		pretenders: mergePretenders(a.pretenders, b.pretenders),
 		rules: mergeRules(
 			// TODO: Deep merge

--- a/packages/@markuplint/ml-config/src/types.ts
+++ b/packages/@markuplint/ml-config/src/types.ts
@@ -12,6 +12,7 @@ export type Config = {
 	readonly parserOptions?: ParserOptions;
 	readonly specs?: SpecConfig;
 	readonly excludeFiles?: readonly string[];
+	readonly severity?: SeverityOptions;
 	readonly pretenders?: readonly Pretender[] | PretenderDetails;
 	readonly rules?: Rules;
 	readonly nodeRules?: readonly NodeRule[];
@@ -60,6 +61,10 @@ export type ParserConfig = {
 
 export type SpecConfig = {
 	readonly [extensionPattern: string]: string /* module name or path */;
+};
+
+export type SeverityOptions = {
+	readonly parseError?: Severity | 'off' | boolean;
 };
 
 export type PretenderDetails = {

--- a/packages/@markuplint/ml-core/src/types.ts
+++ b/packages/@markuplint/ml-core/src/types.ts
@@ -2,7 +2,7 @@ import type { AnyMLRule } from './ml-rule/index.js';
 import type { Ruleset } from './ruleset/index.js';
 import type { LocaleSet } from '@markuplint/i18n';
 import type { MLParser, ParserOptions } from '@markuplint/ml-ast';
-import type { Pretender } from '@markuplint/ml-config';
+import type { Pretender, SeverityOptions } from '@markuplint/ml-config';
 import type { ExtendedSpec, MLMLSpec } from '@markuplint/ml-spec';
 
 export type MLSchema = readonly [MLMLSpec, ...ExtendedSpec[]];
@@ -14,6 +14,7 @@ export type MLFabric = {
 	readonly locale: LocaleSet;
 	readonly schemas: MLSchema;
 	readonly parserOptions: ParserOptions;
+	readonly severity: SeverityOptions;
 	readonly pretenders: readonly Pretender[];
 	readonly configErrors?: readonly Readonly<Error>[];
 };

--- a/packages/markuplint/README.md
+++ b/packages/markuplint/README.md
@@ -84,6 +84,7 @@ Options
 	--problem-only,          -p            Output only problems, without passeds.
 	--verbose                              Output with detailed information.
 	--include-node-modules                 Include files in node_modules directory. Default: false.
+	--severity-parse-error,                Specifies the severity level of parse errors. Supports "error", "warning", and "off". Default: "error".
 
 	--init                                 Initialize settings interactively.
 

--- a/packages/markuplint/src/api/ml-engine.spec.ts
+++ b/packages/markuplint/src/api/ml-engine.spec.ts
@@ -206,3 +206,84 @@ describe('Config Priority', () => {
 		]);
 	});
 });
+
+describe('Parse Error Severity', () => {
+	it('from config', async () => {
+		const file = await MLEngine.toMLFile({
+			sourceCode: '#.(lang"en"\tspan=',
+			name: 'test.pug',
+		});
+
+		const options = {
+			config: {
+				parser: {
+					'.*': '@markuplint/pug-parser',
+				},
+			},
+		};
+
+		const defaults = await new MLEngine(file!, options).exec();
+		expect(defaults?.violations?.[0]?.severity).toBe('error');
+
+		const error = await new MLEngine(file!, {
+			config: { ...options.config, severity: { parseError: 'error' } },
+		}).exec();
+		expect(error?.violations?.[0]?.severity).toBe('error');
+
+		const warning = await new MLEngine(file!, {
+			config: { ...options.config, severity: { parseError: 'warning' } },
+		}).exec();
+		expect(warning?.violations?.[0]?.severity).toBe('warning');
+
+		const off = await new MLEngine(file!, {
+			config: { ...options.config, severity: { parseError: 'off' } },
+		}).exec();
+		expect(off?.violations?.[0]?.severity).toBeUndefined();
+
+		const boolTrue = await new MLEngine(file!, {
+			config: { ...options.config, severity: { parseError: true } },
+		}).exec();
+		expect(boolTrue?.violations?.[0]?.severity).toBe('error');
+
+		const boolFalse = await new MLEngine(file!, {
+			config: { ...options.config, severity: { parseError: false } },
+		}).exec();
+		expect(boolFalse?.violations?.[0]?.severity).toBeUndefined();
+	});
+
+	it('from API option', async () => {
+		const file = await MLEngine.toMLFile({
+			sourceCode: '#.(lang"en"\tspan=',
+			name: 'test.pug',
+		});
+
+		const options = {
+			config: {
+				parser: {
+					'.*': '@markuplint/pug-parser',
+				},
+			},
+		};
+
+		const defaults = await new MLEngine(file!, options).exec();
+		expect(defaults?.violations?.[0]?.severity).toBe('error');
+
+		const error = await new MLEngine(file!, { config: options.config, severity: { parseError: 'error' } }).exec();
+		expect(error?.violations?.[0]?.severity).toBe('error');
+
+		const warning = await new MLEngine(file!, {
+			config: options.config,
+			severity: { parseError: 'warning' },
+		}).exec();
+		expect(warning?.violations?.[0]?.severity).toBe('warning');
+
+		const off = await new MLEngine(file!, { config: options.config, severity: { parseError: 'off' } }).exec();
+		expect(off?.violations?.[0]?.severity).toBeUndefined();
+
+		const boolTrue = await new MLEngine(file!, { config: options.config, severity: { parseError: true } }).exec();
+		expect(boolTrue?.violations?.[0]?.severity).toBe('error');
+
+		const boolFalse = await new MLEngine(file!, { config: options.config, severity: { parseError: false } }).exec();
+		expect(boolFalse?.violations?.[0]?.severity).toBeUndefined();
+	});
+});

--- a/packages/markuplint/src/api/ml-engine.ts
+++ b/packages/markuplint/src/api/ml-engine.ts
@@ -267,6 +267,11 @@ export class MLEngine extends Emitter<MLEngineEventMap> {
 			return null;
 		}
 
+		const severity = {
+			...configSet.config.severity,
+			...this.#options?.severity,
+		};
+
 		const pretenders = await this.resolvePretenders(configSet);
 		fileLog('Resolved pretenders: %O', pretenders);
 
@@ -302,6 +307,7 @@ export class MLEngine extends Emitter<MLEngineEventMap> {
 		return {
 			parser,
 			parserOptions,
+			severity,
 			pretenders,
 			ruleset,
 			schemas,

--- a/packages/markuplint/src/api/types.ts
+++ b/packages/markuplint/src/api/types.ts
@@ -1,6 +1,6 @@
 import type { ConfigSet } from '@markuplint/file-resolver';
 import type { LocaleSet } from '@markuplint/i18n';
-import type { Config, Violation } from '@markuplint/ml-config';
+import type { Config, SeverityOptions, Violation } from '@markuplint/ml-config';
 import type { AnyMLRule, MLSchema, Ruleset } from '@markuplint/ml-core';
 
 export type APIOptions = {
@@ -13,6 +13,7 @@ export type APIOptions = {
 	readonly ignoreExt?: boolean;
 	readonly rules?: readonly Readonly<AnyMLRule>[];
 	readonly importPresetRules?: boolean;
+	readonly severity?: SeverityOptions;
 	/**
 	 * @deprecated
 	 */

--- a/packages/markuplint/src/cli/bootstrap.ts
+++ b/packages/markuplint/src/cli/bootstrap.ts
@@ -21,6 +21,7 @@ Options
 	--allow-empty-input                    Return status code 1 even if there are no input files.
 	--verbose                              Output with detailed information.
 	--include-node-modules                 Include files in node_modules directory. Default: false.
+	--severity-parse-error,                Specifies the severity level of parse errors. Supports "error", "warning", and "off". Default: "error".
 
 	--init                                 Initialize settings interactively.
 	--search                               Search lines of codes that include the target element by selectors.
@@ -99,6 +100,10 @@ export const cli = meow(help, {
 		includeNodeModules: {
 			type: 'boolean',
 			default: false,
+		},
+		severityParseError: {
+			type: 'string',
+			default: 'error',
 		},
 	},
 });

--- a/packages/markuplint/src/cli/command.ts
+++ b/packages/markuplint/src/cli/command.ts
@@ -1,7 +1,7 @@
 import type { CLIOptions } from './bootstrap.js';
 import type { APIOptions } from '../api/types.js';
 import type { Target } from '@markuplint/file-resolver';
-import type { Violation } from '@markuplint/ml-config';
+import type { Severity, SeverityOptions, Violation } from '@markuplint/ml-config';
 
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
@@ -48,6 +48,13 @@ export async function command(files: readonly Readonly<Target>[], options: CLIOp
 
 	const jsonOutput: (Violation & { filePath: string })[] = [];
 
+	const severityParseError = options.severityParseError.toLowerCase();
+	const severity: SeverityOptions = {
+		parseError: ['error', 'warning', 'off'].includes(severityParseError)
+			? (severityParseError as Severity | 'off')
+			: true,
+	};
+
 	for (const file of fileList) {
 		const engine = new MLEngine(file, {
 			configFile,
@@ -57,6 +64,7 @@ export async function command(files: readonly Readonly<Target>[], options: CLIOp
 			ignoreExt,
 			importPresetRules,
 			debug: verbose,
+			severity,
 			...apiOptions,
 		});
 		const result = await engine.exec();

--- a/packages/markuplint/src/cli/index.spec.ts
+++ b/packages/markuplint/src/cli/index.spec.ts
@@ -117,6 +117,38 @@ describe('STDOUT Test', () => {
 		});
 		expect(exitCode).toBe(1);
 	});
+
+	test('--severity-parse-error (no specified)', async () => {
+		const targetFilePath = path.resolve(__dirname, '../../../../test/fixture/pug/004.pug');
+		const { exitCode } = await execa(entryFilePath, [escape(targetFilePath)], {
+			reject: false,
+		});
+		expect(exitCode).toBe(1);
+	});
+
+	test('--severity-parse-error error', async () => {
+		const targetFilePath = path.resolve(__dirname, '../../../../test/fixture/pug/004.pug');
+		const { exitCode } = await execa(entryFilePath, ['--severity-parse-error', 'error', escape(targetFilePath)], {
+			reject: false,
+		});
+		expect(exitCode).toBe(1);
+	});
+
+	test('--severity-parse-error warning', async () => {
+		const targetFilePath = path.resolve(__dirname, '../../../../test/fixture/pug/004.pug');
+		const { exitCode } = await execa(entryFilePath, ['--severity-parse-error', 'warning', escape(targetFilePath)], {
+			reject: false,
+		});
+		expect(exitCode).toBe(1);
+	});
+
+	test('--severity-parse-error off', async () => {
+		const targetFilePath = path.resolve(__dirname, '../../../../test/fixture/pug/004.pug');
+		const { exitCode } = await execa(entryFilePath, ['--severity-parse-error', 'off', escape(targetFilePath)], {
+			reject: false,
+		});
+		expect(exitCode).toBe(0);
+	});
 });
 
 describe('Issues', () => {

--- a/test/fixture/pug/004.pug
+++ b/test/fixture/pug/004.pug
@@ -1,0 +1,1 @@
+#.(lang"en"\tspan=

--- a/website/docs/guides/cli.md
+++ b/website/docs/guides/cli.md
@@ -31,6 +31,7 @@ And returns `1` if the result has problems one or more.
 | `--no-allow-empty-input`   | none         | none                                     | false      | Return status code 1 even if there are no input files.              |
 | `--verbose`                | none         | none                                     | false      | Output with detailed information.                                   |
 | `--include-node-modules`   | none         | none                                     | false      | Include files in node_modules directory.                            |
+| `--severity-parse-error`   | none         | `error`, `warning` or `off`              | `error`    | Specifies the severity level of parse errors.                       |
 
 ## Particular run
 

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/cli.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/cli.md
@@ -29,6 +29,7 @@ CLIはターゲットとなるHTMLファイルを可変長引数として受け�
 | `--no-allow-empty-input`   | なし             | なし                                         | false        | ファイルが見つからなかった場合にステータスコード`1`を返します |
 | `--verbose`                | なし             | なし                                         | false        | 詳細な情報も同時に出力します                                  |
 | `--include-node-modules`   | なし             | なし                                         | false        | `node_module`ディレクトリ内のファイルを含めて評価します       |
+| `--severity-parse-error`   | なし             | `error`、`warning`もしくは`off`              | `error`      | パースエラーの深刻度レベルを指定します                        |
 
 ## Particular run
 


### PR DESCRIPTION
Fixes #2112 

## What is the purpose of this PR?

- [ ] Fix bug
- [ ] Fix typo
- [ ] Update specs
- [ ] Add new rule
- [ ] Add new parser
- [ ] Improve or refactor rules
- [x] Add a new core feature
- [ ] Improve or refactor core features
- [ ] Update documents
- [ ] Others

### Description

#### Configuration

Added `severity.parseError` option

```json
{
  "severity": {
    "parseError": "off"
  }
}
```

Added `--severity-parse-error` option

#### CLI

```sh
markuplint path/to/*.pug --severity-parse-error off
```
