### PR TITLE
refactor: drop Node.js v18

### DIFF
--- a/packages/@markuplint/create-rule/src/create-rule-to-core.spec.ts
+++ b/packages/@markuplint/create-rule/src/create-rule-to-core.spec.ts
@@ -55,7 +55,7 @@ test('create', async () => {
 	});
 	const testDir = await getTestDir(sandboxDirName);
 	const fileList = await readdir(testDir, { encoding: 'utf8' });
-	expect(fileList.sort()).toEqual([
+	expect(fileList.toSorted()).toEqual([
 		'README.ja.md',
 		'README.md',
 		'index.spec.ts',

--- a/packages/@markuplint/create-rule/src/transfer.spec.ts
+++ b/packages/@markuplint/create-rule/src/transfer.spec.ts
@@ -39,7 +39,7 @@ test('transfer', async () => {
 		},
 	});
 	const fileList = await glob(path.resolve(TEST_SANDBOX, '**', '*'));
-	expect(fileList.sort().map(file => path.relative(TEST_SANDBOX, file).split(path.sep).join('/'))).toEqual([
+	expect(fileList.toSorted().map(file => path.relative(TEST_SANDBOX, file).split(path.sep).join('/'))).toEqual([
 		'core',
 		'core/README.ja.md',
 		'core/README.md',

--- a/packages/@markuplint/file-resolver/src/config-provider.ts
+++ b/packages/@markuplint/file-resolver/src/config-provider.ts
@@ -99,7 +99,7 @@ export class ConfigProvider {
 		}
 		let configSet = await this._mergeConfigs(keys, cache, targetFile.path);
 
-		const filePath = [...configSet.files].reverse()[0];
+		const filePath = [...configSet.files].toReversed()[0];
 		if (!filePath) {
 			throw new ConfigParserError('Config file not found', {
 				filePath: targetFile.path,

--- a/packages/@markuplint/ml-core/src/ml-dom/node/document.ts
+++ b/packages/@markuplint/ml-core/src/ml-dom/node/document.ts
@@ -3017,8 +3017,7 @@ export class MLDocument<T extends RuleConfigValue, O extends PlainData = undefin
 				tokens.push(node.closeTag);
 			}
 		}
-		tokens.sort((a, b) => a.startOffset - b.startOffset);
-		this.#tokenList = Object.freeze(tokens);
+		this.#tokenList = Object.freeze(tokens.toSorted((a, b) => a.startOffset - b.startOffset));
 		return this.#tokenList;
 	}
 

--- a/packages/@markuplint/ml-spec/src/dom-traverse/matches-context-role.ts
+++ b/packages/@markuplint/ml-spec/src/dom-traverse/matches-context-role.ts
@@ -19,7 +19,7 @@ function matchesCondition(
 	specs: MLMLSpec,
 	version: ARIAVersion,
 ) {
-	const conditions = condition.split(/\s+>\s+/).reverse();
+	const conditions = condition.split(/\s+>\s+/).toReversed();
 
 	while (conditions.length > 0) {
 		if (!parentEl) {

--- a/packages/@markuplint/ml-spec/src/specs/content-model-category-to-tag-names.ts
+++ b/packages/@markuplint/ml-spec/src/specs/content-model-category-to-tag-names.ts
@@ -9,7 +9,7 @@ export function contentModelCategoryToTagNames(contentModel: Category, def: MLML
 		return cached;
 	}
 	const tags: readonly string[] | undefined = def['#contentModels'][contentModel];
-	const sortedTag = Object.freeze(tags && Array.isArray(tags) ? tags.sort() : []);
+	const sortedTag = Object.freeze(tags && Array.isArray(tags) ? tags.toSorted() : []);
 	cache.set(contentModel, sortedTag);
 	return sortedTag;
 }

--- a/packages/@markuplint/ml-spec/src/specs/get-aria.ts
+++ b/packages/@markuplint/ml-spec/src/specs/get-aria.ts
@@ -83,5 +83,5 @@ function optimizePermittedRoles(permittedRoles: ReadonlyDeep<PermittedRoles>) {
 		unique.add('presentation');
 	}
 
-	return [...unique].sort();
+	return [...unique].toSorted();
 }

--- a/packages/@markuplint/ml-spec/src/specs/get-attr-specs.ts
+++ b/packages/@markuplint/ml-spec/src/specs/get-attr-specs.ts
@@ -75,12 +75,12 @@ export function getAttrSpecs(localName: string, namespace: NamespaceURI | null, 
 		};
 	}
 
-	const attrList = Object.keys(attrs).map<Attribute>(name => {
-		const attr = attrs[name];
-		return { name, type: 'Any', ...attr };
-	});
-
-	attrList.sort(nameCompare);
+	const attrList = Object.keys(attrs)
+		.map<Attribute>(name => {
+			const attr = attrs[name];
+			return { name, type: 'Any', ...attr };
+		})
+		.toSorted(nameCompare);
 
 	cacheMap.set(localNameWithNS, attrList);
 	return attrList;

--- a/packages/@markuplint/ml-spec/src/specs/schema-to-spec.ts
+++ b/packages/@markuplint/ml-spec/src/specs/schema-to-spec.ts
@@ -79,7 +79,8 @@ export function schemaToSpec(schemas: readonly [MLMLSpec, ...ExtendedSpec[]]) {
 					specs.push(elSpec);
 					continue;
 				}
-				const exSpec = exSpecs.splice(index, 1)[0];
+				const removedSpecs = exSpecs.splice(index, 1);
+				const exSpec = removedSpecs[0];
 				specs.push({
 					...elSpec,
 					...exSpec,

--- a/packages/@markuplint/ml-spec/src/utils/merge-array.ts
+++ b/packages/@markuplint/ml-spec/src/utils/merge-array.ts
@@ -15,7 +15,8 @@ export function mergeArray<T extends NamedDefinition>(
 			result.push(bItem);
 			continue;
 		}
-		const aItem = result.splice(aIndex, 1)[0];
+		const removedItems = result.splice(aIndex, 1);
+		const aItem = removedItems[0];
 		if (typeof bItem === 'string') {
 			continue;
 		}

--- a/packages/@markuplint/parser-utils/src/ignore-block.ts
+++ b/packages/@markuplint/parser-utils/src/ignore-block.ts
@@ -21,12 +21,11 @@ export function ignoreBlock(source: string, tags: readonly IgnoreTag[], maskChar
 		replaced = text.replaced;
 		stack.push(...text.stack.map(res => ({ ...res, type: tag.type })));
 	}
-	stack.sort((a, b) => a.index - b.index);
 
 	return {
 		source,
 		replaced,
-		stack,
+		stack: stack.toSorted((a, b) => a.index - b.index),
 		maskChar,
 	};
 }

--- a/packages/@markuplint/parser-utils/src/parser.ts
+++ b/packages/@markuplint/parser-utils/src/parser.ts
@@ -283,10 +283,7 @@ export abstract class Parser<Node extends {} = {}, State extends unknown = null>
 	}
 
 	afterTraverse(nodeTree: readonly MLASTNodeTreeItem[]): readonly MLASTNodeTreeItem[] {
-		return Array.prototype.toSorted == null
-			? // TODO: Use sort instead of toSorted until we end support for Node 18
-				[...nodeTree].sort(sortNodes)
-			: nodeTree.toSorted(sortNodes);
+		return nodeTree.toSorted(sortNodes);
 	}
 
 	nodeize(originNode: Node, parentNode: MLASTParentNode | null, depth: number): readonly MLASTNodeTreeItem[] {
@@ -914,11 +911,7 @@ export abstract class Parser<Node extends {} = {}, State extends unknown = null>
 		}
 
 		Object.assign(parentNode, {
-			childNodes:
-				Array.prototype.toSorted == null
-					? // TODO: Use sort instead of toSorted until we end support for Node 18
-						[...newChildNodes].sort(sortNodes)
-					: newChildNodes.toSorted(sortNodes),
+			childNodes: newChildNodes.toSorted(sortNodes),
 		});
 	}
 
@@ -1435,11 +1428,7 @@ export abstract class Parser<Node extends {} = {}, State extends unknown = null>
 		/**
 		 * sorting
 		 */
-		const sorted =
-			Array.prototype.toSorted == null
-				? // TODO: Use sort instead of toSorted until we end support for Node 18
-					[...nodeOrders].sort(sortNodes)
-				: nodeOrders.toSorted(sortNodes);
+		const sorted = nodeOrders.toSorted(sortNodes);
 
 		/**
 		 * remove duplicated node

--- a/packages/@markuplint/parser-utils/src/parser.ts
+++ b/packages/@markuplint/parser-utils/src/parser.ts
@@ -924,13 +924,6 @@ export abstract class Parser<Node extends {} = {}, State extends unknown = null>
 		if (index === -1) {
 			return;
 		}
-		if (Array.prototype.toSpliced == null) {
-			const newChildNodes = [...parentNode.childNodes];
-			// TODO: Use splice instead of toSpliced until we end support for Node 18
-			newChildNodes.splice(index, 1, ...replacementChildNodes);
-			Object.assign(parentNode, { childNodes: newChildNodes });
-			return;
-		}
 		const newChildNodes = parentNode.childNodes.toSpliced(index, 1, ...replacementChildNodes);
 		Object.assign(parentNode, { childNodes: newChildNodes });
 	}
@@ -1470,12 +1463,6 @@ export abstract class Parser<Node extends {} = {}, State extends unknown = null>
 		const raw = firstNode.raw.slice(offsetOffset);
 
 		if (!raw) {
-			if (Array.prototype.toSpliced == null) {
-				const newNodeList = [...nodeList];
-				// TODO: Use splice instead of toSpliced until we end support for Node 18
-				newNodeList.splice(0, 1);
-				return newNodeList;
-			}
 			return nodeList.toSpliced(0, 1);
 		}
 

--- a/packages/@markuplint/pretenders/src/dependency-mapper.ts
+++ b/packages/@markuplint/pretenders/src/dependency-mapper.ts
@@ -64,7 +64,7 @@ export function dependencyMapper(map: Readonly<PretenderDirectorMap>): Pretender
 		linkedPretenders.push(pretender);
 	}
 
-	return linkedPretenders.sort(propSort('selector'));
+	return linkedPretenders.toSorted(propSort('selector'));
 }
 
 function getElName(identity: Identity) {

--- a/packages/@markuplint/rules/src/permitted-contents/choice.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/choice.ts
@@ -50,7 +50,7 @@ export function choice(
 		i++;
 	}
 
-	const barelyMatchedResult = unmatchedResults.sort((a, b) => {
+	const barelyMatchedResult = unmatchedResults.toSorted((a, b) => {
 		if (a.type !== b.type) {
 			if (a.type === 'UNEXPECTED_EXTRA_NODE') {
 				return -1;

--- a/packages/@markuplint/rules/src/permitted-contents/count-pattern.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/count-pattern.ts
@@ -235,7 +235,7 @@ function compereResult(
 	}
 
 	const result =
-		[a, b].sort(
+		[a, b].toSorted(
 			(a, b) => (b.hint.missing?.barelyMatchedElements ?? 0) - (a.hint.missing?.barelyMatchedElements ?? 0),
 		)[0] ?? a;
 

--- a/packages/@markuplint/rules/src/permitted-contents/order.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/order.ts
@@ -56,7 +56,7 @@ export function order(
 				continue;
 			}
 
-			const barelyMatchedResult = unmatchedResults.sort((a, b) => b.matched.length - a.matched.length)[0];
+			const barelyMatchedResult = unmatchedResults.toSorted((a, b) => b.matched.length - a.matched.length)[0];
 
 			if (!barelyMatchedResult) {
 				throw new Error('Unreachable code');

--- a/packages/@markuplint/rules/src/permitted-contents/utils.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/utils.ts
@@ -179,7 +179,7 @@ export function mergeHints(
 	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
 	b: Readonly<Hints>,
 ) {
-	const missing = [a.missing, b.missing].sort(
+	const missing = [a.missing, b.missing].toSorted(
 		(a, b) => (b?.barelyMatchedElements ?? 0) - (a?.barelyMatchedElements ?? 0),
 	)[0];
 	return cleanObject({

--- a/packages/@markuplint/spec-generator/src/aria.ts
+++ b/packages/@markuplint/spec-generator/src/aria.ts
@@ -148,7 +148,7 @@ async function getRoles(version: ARIAVersion, graphicsAria = false) {
 				? false
 				: undefined;
 		const ownedProperties = arrayUnique(
-			[...ownedRequiredProps, ...ownedInheritedProps, ...ownedProps].sort(nameCompare),
+			[...ownedRequiredProps, ...ownedInheritedProps, ...ownedProps].toSorted(nameCompare),
 		);
 		const prohibitedProperties = $features
 			.find('.role-disallowed li code')
@@ -205,9 +205,7 @@ async function getRoles(version: ARIAVersion, graphicsAria = false) {
 		}
 	}
 
-	roles.sort(nameCompare);
-
-	return roles;
+	return roles.toSorted(nameCompare);
 }
 
 async function getProps(version: ARIAVersion, roles: readonly ARIARoleInSchema[]) {
@@ -234,7 +232,7 @@ async function getProps(version: ARIAVersion, roles: readonly ARIARoleInSchema[]
 			})
 			.filter((s): s is string => !!s),
 	);
-	const arias = [...ariaNameList].sort().map((name): ARIAProperty => {
+	const arias = [...ariaNameList].toSorted().map((name): ARIAProperty => {
 		const $section = $(`#${name}`);
 		const className = $section.attr('class');
 		const type = className && /property/i.test(className) ? 'property' : 'state';
@@ -320,9 +318,7 @@ async function getProps(version: ARIAVersion, roles: readonly ARIARoleInSchema[]
 		return aria;
 	});
 
-	arias.sort(nameCompare);
-
-	return arias;
+	return arias.toSorted(nameCompare);
 }
 
 async function getAriaInHtml() {

--- a/packages/@markuplint/spec-generator/src/fetch.ts
+++ b/packages/@markuplint/spec-generator/src/fetch.ts
@@ -49,5 +49,5 @@ export function getReferences() {
 	current += 1;
 	bar.update(current, { process: '🎉 Finished.' });
 	bar.stop();
-	return [...cache.keys()].sort();
+	return [...cache.keys()].toSorted();
 }

--- a/packages/@markuplint/spec-generator/src/html-elements.ts
+++ b/packages/@markuplint/spec-generator/src/html-elements.ts
@@ -118,7 +118,7 @@ export async function getElements(filePattern: string) {
 	);
 
 	return specs
-		.sort(nameCompare)
-		.sort((a, b) => (a.namespace == b.namespace ? 0 : a.namespace === 'http://www.w3.org/2000/svg' ? 1 : -1))
+		.toSorted(nameCompare)
+		.toSorted((a, b) => (a.namespace == b.namespace ? 0 : a.namespace === 'http://www.w3.org/2000/svg' ? 1 : -1))
 		.filter(spec => spec.name !== 'h1-h6');
 }

--- a/packages/@markuplint/spec-generator/src/utils.ts
+++ b/packages/@markuplint/spec-generator/src/utils.ts
@@ -16,8 +16,7 @@ export function nameCompare(a: HasName | string, b: HasName | string) {
 
 export function sortObjectByKey<T>(o: T): T {
 	// @ts-ignore
-	const keys = Object.keys(o);
-	keys.sort(nameCompare);
+	const keys = Object.keys(o).toSorted(nameCompare);
 	// @ts-ignore
 	const newObj: T = {};
 	for (const key of keys) {

--- a/packages/@markuplint/types/gen/types.ts
+++ b/packages/@markuplint/types/gen/types.ts
@@ -27,11 +27,11 @@ fs.writeFileSync(
 		definitions: {
 			'css-syntax': {
 				type: 'string',
-				enum: [...new Set([...props, ...types]), ...Object.keys(tokenizers).map(t => `<${t}>`)].sort(),
+				enum: [...new Set([...props, ...types]), ...Object.keys(tokenizers).map(t => `<${t}>`)].toSorted(),
 			},
 			'extended-type': {
 				type: 'string',
-				enum: Object.keys(extendedTypes).sort(),
+				enum: Object.keys(extendedTypes).toSorted(),
 			},
 			'html-attr-requirement': {
 				type: 'string',
@@ -70,6 +70,6 @@ function oneOf(...keys: readonly string[]) {
 				$ref: `#/definitions/${key}`,
 			}))
 			// @ts-ignore Charactor sorting
-			.sort((a, b) => b.$ref - a.$ref),
+			.toSorted((a, b) => b.$ref - a.$ref),
 	};
 }

--- a/packages/@markuplint/types/src/whatwg/check-autocomplete.ts
+++ b/packages/@markuplint/types/src/whatwg/check-autocomplete.ts
@@ -336,7 +336,7 @@ export const checkAutoComplete: CustomSyntaxChecker = () => value => {
 		}
 	} else if (!hasPartOfAddress) {
 		expects.unshift(
-			...[...partOfAddress].reverse().map(token => ({
+			...partOfAddress.toReversed().map(token => ({
 				type: 'const' as const,
 				value: token,
 			})),

--- a/packages/markuplint/README.md
+++ b/packages/markuplint/README.md
@@ -25,7 +25,7 @@
 $ npx markuplint target.html
 ```
 
-Supported for _Node.js_ `v18.18.0` or later.
+Supported for _Node.js_ `v20.18.0` or later.
 
 ## Usage
 

--- a/packages/markuplint/src/version.ts
+++ b/packages/markuplint/src/version.ts
@@ -1,8 +1,3 @@
-import { createRequire } from 'node:module';
-
-const require = createRequire(import.meta.url);
-
-// TODO: Use import attribute in Node.js v22 and v20.10 or later
-const pkg = require('../package.json');
+import pkg from '../package.json' with { type: 'json' };
 
 export const version: string = pkg.version;

--- a/website/docs/guides/index.md
+++ b/website/docs/guides/index.md
@@ -16,7 +16,7 @@ It applies [recommended preset](/docs/guides/presets) if it doesn't find a [conf
 
 ### The required spec
 
-- **Node.js** v18.18.0 or later
+- **Node.js** v20.18.0 or later
 
 ### Using in your project
 

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/index.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/index.md
@@ -16,7 +16,7 @@ npx markuplint target.html
 
 ### 必須スペック
 
-- **Node.js** v18.18.0以上
+- **Node.js** v20.18.0以上
 
 ### プロジェクトでつかう
 


### PR DESCRIPTION
Updated Node.js version requirement to v20.18.0

- Use **ES2023**: `Array.prototype.toSorted` etc.
- Use **Import Attribute**
- Update documents