### PR TITLE
doc: add missing `npm add -D markuplint`

### DIFF
--- a/website/docs/guides/index.md
+++ b/website/docs/guides/index.md
@@ -24,10 +24,10 @@ Create a [configuration file](/docs/configuration) and install dependencies.
 
 ```shell
 npx markuplint --init
+npm add -D markuplint
 ```
 
-Answer questions interactively.
-By doing this, needed modules are installed includes `markuplint`.
+Answer questions interactively, then install `markuplint`.
 
 Add a command to the `scripts` option on `package.json`:
 


### PR DESCRIPTION
## What is the purpose of this PR?

- [x] Update documents

### Description

Although `npx markuplint --init` does not install the `markuplint` package anymore, the document still says that "needed modules are installed includes `markuplint`".
This PR corrects the outdated documentation.

## Checklist

N/A