### PR TITLE
fix(cli-utils): correct width calc for multibyte chars

### DIFF
--- a/packages/@markuplint/cli-utils/src/get-width.ts
+++ b/packages/@markuplint/cli-utils/src/get-width.ts
@@ -5,7 +5,7 @@ const eaw: { characterLength: (char: string) => number } = eastasianwidth;
 
 export function getWidth(s: string): number {
 	let width = 0;
-	for (const char of Array.from(s)) {
+	for (const char of s) {
 		// Get the number of character width per Unicode code point
 		width += eaw.characterLength(char);
 	}

--- a/packages/@markuplint/cli-utils/src/get-width.ts
+++ b/packages/@markuplint/cli-utils/src/get-width.ts
@@ -4,14 +4,10 @@ import eastasianwidth from 'eastasianwidth';
 const eaw: { characterLength: (char: string) => number } = eastasianwidth;
 
 export function getWidth(s: string): number {
-	return s.replaceAll(
-		// All characters
-		/./g,
-		// Wide characters to multi dots
-		char =>
-			'•'.repeat(
-				// Get the number of character width
-				eaw.characterLength(char),
-			),
-	).length;
+	let width = 0;
+	for (const char of Array.from(s)) {
+		// Get the number of character width per Unicode code point
+		width += eaw.characterLength(char);
+	}
+	return width;
 }


### PR DESCRIPTION
## Summary
- handle Unicode code points correctly when calculating width

## Testing
- `yarn test` *(fails: package missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_68419856594c832f9308e8f1603404ac