### PR TITLE
Add docs about specs

### DIFF
--- a/packages/@markuplint/html-spec/README.md
+++ b/packages/@markuplint/html-spec/README.md
@@ -130,6 +130,30 @@ When to change shared files:
 - Add/edit global attribute categories or items → `src/spec-common.attributes.json`
 - Add/edit reusable content model macros → `src/spec-common.contents.json`
 
+#### File naming conventions
+
+- HTML elements: `src/spec.<tag>.json` (lowercase), e.g. `spec.a.json`, `spec.dialog.json`
+- SVG elements: `src/spec.svg_<local>.json`, e.g. `spec.svg_text.json` → element name `svg:text`
+  - The generator infers the element name from the filename; do not add a `name` field manually
+
+#### Common editing recipes
+
+- Add a new element
+  - Create `src/spec.<tag>.json` (or `src/spec.svg_<local>.json`)
+  - Define `contentModel`, `globalAttrs`, minimal `attributes`, and `aria`
+  - Run `yarn up:gen` and verify `index.json`
+
+- Tighten an attribute type
+  - Update the attribute entry under `attributes` with the desired `type`
+  - If a new value type is needed, extend `@markuplint/types` first, then regenerate this package
+
+- Mark an attribute unstable
+  - Set `experimental: true`, `deprecated: true`, or `obsolete: true`
+  - Manual flags override MDN if the scraper disagrees
+
+- Restrict ARIA usage for an element
+  - Use `aria.properties`/`aria.permittedRoles` or add `aria.conditions` for context-specific rules
+
 3. Do not edit generated files
 
 - Do not modify `index.json` directly. Always update the files under `src/` and regenerate.

--- a/packages/@markuplint/html-spec/README.md
+++ b/packages/@markuplint/html-spec/README.md
@@ -2,6 +2,138 @@
 
 [![npm version](https://badge.fury.io/js/%40markuplint%2Fhtml-spec.svg)](https://www.npmjs.com/package/@markuplint/html-spec)
 
+This package is the canonical dataset of the HTML Schema for markuplint — HTML element specifications
+(structure, attributes, ARIA, and content models).
+
+### What’s in this package
+
+- Built output consumed by markuplint:
+  - `index.json`
+- Sources (do not edit generated files):
+  - `src/spec-*.json` (element specs and common data)
+  - Build script: `build.mjs` (invokes `@markuplint/spec-generator`)
+
+For the common schema shapes (JSON Schema), generation workflow, and spec-merging behavior, see
+`@markuplint/ml-spec` README.
+
+### Editing workflow (HTML spec data)
+
+1. Edit sources
+
+- Element specs: add or edit files under `src/spec-*.json` (e.g. `src/spec.a.json`)
+- Common data shared across elements:
+  - Attributes: `src/spec-common.attributes.json`
+  - Content models: `src/spec-common.contents.json`
+
+2. Regenerate the built dataset
+
+From the repository root (recommended):
+
+```bash
+yarn up:gen
+```
+
+or only for this package:
+
+```bash
+yarn workspace @markuplint/html-spec run gen
+```
+
+This runs the local build script (`build.mjs`) which invokes `@markuplint/spec-generator` and writes
+`index.json`, then formats it with Prettier.
+
+#### What `yarn up:gen` does exactly
+
+From the repository root, it executes:
+
+1. Change directory into this package
+   - `cd packages/@markuplint/html-spec/`
+2. Run the local `gen` script, which is an alias of:
+   - `node build.mjs` (generate `index.json`)
+   - `npx prettier --write index.json` (format the output)
+
+Inside `build.mjs`, the generator is called with the following inputs:
+
+- Output: `index.json`
+- HTML spec sources: `src/spec.*.json`
+- Common attributes: `src/spec-common.attributes.json`
+- Common content models: `src/spec-common.contents.json`
+
+No other files are modified. This command does not publish anything.
+
+### What the generator actually does
+
+The builder (`@markuplint/spec-generator`) produces a single Extended Spec JSON (`index.json`) by:
+
+- Reading every `src/spec.*.json` and inferring the element name from the filename
+  - Example: `src/spec.a.json` → name `a`
+- Scraping MDN for each element to enrich missing metadata
+  - Fills/updates: `cite` (MDN URL), `description`, `categories`, `omission` (tag omission hints),
+    and known attribute metadata (deprecated/obsolete/experimental/nonStandard)
+  - Your fields in `src/spec.*.json` take precedence when both exist (manual beats scraped)
+- Injecting obsolete elements not present in sources (WHATWG obsolete list + deprecated SVG)
+- Loading shared data
+  - Global attribute sets: `src/spec-common.attributes.json`
+  - Content model macros: `src/spec-common.contents.json` (its `models`)
+- Building ARIA definitions by scraping WAI-ARIA and HTML-ARIA
+  - Populates `def['#aria']` with roles, properties and graphics-ARIA per version (1.1/1.2/1.3)
+- Emitting the Extended Spec object `{ cites, def: { #globalAttrs, #aria, #contentModels }, specs: [...] }`
+  and formatting to `index.json`
+
+The output is consumed by markuplint and can be merged with other framework specs.
+
+### How to edit `src/spec.*.json`
+
+Each file describes one HTML element. Only specify what differs from the defaults or what you want
+to override from MDN. Recognized top-level keys include:
+
+- `contentModel`: allowed children pattern; see `@markuplint/ml-spec` content-model schema
+- `globalAttrs`: enable global attribute sets or list specific ones per category
+- `attributes`: element-specific attributes and their types/options
+- `aria`: implicit role, permitted roles, and ARIA property constraints for this element
+- `omission`: start/end tag omission rules (when applicable)
+
+Minimal example (anchor element):
+
+```json
+{
+  "contentModel": {
+    "contents": [{ "transparent": ":not(:model(interactive), a, [tabindex])" }]
+  },
+  "globalAttrs": {
+    "#HTMLGlobalAttrs": true,
+    "#GlobalEventAttrs": true,
+    "#ARIAAttrs": true,
+    "#HTMLLinkAndFetchingAttrs": ["href", "target", "rel"]
+  },
+  "attributes": {
+    "download": { "type": "Any" }
+  },
+  "aria": {
+    "implicitRole": "link",
+    "permittedRoles": ["button", "menuitem"],
+    "conditions": {
+      ":not([href])": { "implicitRole": "generic", "namingProhibited": true }
+    }
+  }
+}
+```
+
+Attribute entries follow the shape from `@markuplint/ml-spec` (`attributes.schema.json`):
+
+- Common fields: `type`, `defaultValue`, `required`, `requiredEither`, `noUse`, `condition`,
+  `ineffective`, `animatable`, `experimental`, `deprecated`, `obsolete`, `nonStandard`
+- Types come from `@markuplint/types` (`types.schema.json`)
+
+When to change shared files:
+
+- Add/edit global attribute categories or items → `src/spec-common.attributes.json`
+- Add/edit reusable content model macros → `src/spec-common.contents.json`
+
+3. Do not edit generated files
+
+- Do not modify `index.json` directly. Always update the files under `src/` and regenerate.
+
 ## Install
 
 [`markuplint`](https://www.npmjs.com/package/markuplint) package includes this package.

--- a/packages/@markuplint/ml-spec/README.md
+++ b/packages/@markuplint/ml-spec/README.md
@@ -182,6 +182,44 @@ Examples:
 }
 ```
 
+Transparent selector syntax
+
+- A CSS-like selector string with an extra pseudo: `:model(<CATEGORY>)`
+- You can combine standard selectors: type, class, id, attribute selectors, `:not(...)`, `:has(...)`,
+  combinators, etc.
+- `:model(<CATEGORY>)` matches any element belonging to the specified content category.
+
+Examples:
+
+```text
+:not(:model(interactive))
+:has(:model(interactive), a, [tabindex])
+```
+
+SVG categories
+
+The following categories are available for SVG elements (see `schemas/content-models.schema.json`):
+
+- `#SVGAnimation`
+- `#SVGBasicShapes`
+- `#SVGContainer`
+- `#SVGDescriptive`
+- `#SVGFilterPrimitive`
+- `#SVGFont`
+- `#SVGGradient`
+- `#SVGGraphics`
+- `#SVGGraphicsReferencing`
+- `#SVGLightSource`
+- `#SVGNeverRendered`
+- `#SVGNone`
+- `#SVGPaintServer`
+- `#SVGRenderable`
+- `#SVGShape`
+- `#SVGStructural`
+- `#SVGStructurallyExternal`
+- `#SVGTextContent`
+- `#SVGTextContentChild`
+
 ```json
 {
   "contentModel": {

--- a/packages/@markuplint/ml-spec/README.md
+++ b/packages/@markuplint/ml-spec/README.md
@@ -2,17 +2,140 @@
 
 [![npm version](https://badge.fury.io/js/%40markuplint%2Fml-spec.svg)](https://www.npmjs.com/package/@markuplint/ml-spec)
 
-## Install
+This package provides the HTML Schema (aka "Specs") shape definitions and utilities used by
+markuplint, plus the generated TypeScript types derived from those schemas. The canonical HTML
+element spec data itself is aggregated in `@markuplint/html-spec`.
 
-[`markuplint`](https://www.npmjs.com/package/markuplint) package includes this package.
+### Install
 
-<details>
-<summary>If you are installing purposely, how below:</summary>
+`markuplint` already bundles this package. If you need to install it explicitly:
 
-```shell
-$ npm install @markuplint/ml-spec
-
-$ yarn add @markuplint/ml-spec
+```bash
+npm install @markuplint/ml-spec
+# or
+yarn add @markuplint/ml-spec
 ```
 
-</details>
+### Terminology
+
+- "HTML Schema" and "Specs" are used interchangeably in markuplint to mean the JSON Schema that
+  describes HTML element specs (attributes, ARIA, content models, etc) and their TypeScript types.
+
+### What’s in this package
+
+- JSON Schemas (shape definitions):
+  - `schemas/element.schema.json`
+  - `schemas/aria.schema.json`
+  - `schemas/content-models.schema.json`
+  - `schemas/global-attributes.schema.json` (generated)
+  - `schemas/attributes.schema.json` (generated)
+- Generated TypeScript types (do not edit):
+  - `src/types/attributes.ts`
+  - `src/types/aria.ts`
+  - `src/types/permitted-structures.ts`
+- Schema generators:
+  - `gen/gen.ts` … builds `global-attributes.schema.json` and `attributes.schema.json`
+  - Global attribute categories data: `gen/global-attribute.data.*`
+- Spec merger (runtime behavior):
+  - `src/specs/schema-to-spec.ts` … merges the main HTML spec with
+    extended specs provided by other packages (e.g. Vue/React/Svelte specs)
+
+Note: Attribute value types are defined in `@markuplint/types`. The schemas here reference
+`@markuplint/types/types.schema.json`.
+
+### Where is the base HTML spec data?
+
+- Base HTML element specs live in `packages/@markuplint/html-spec/`:
+  - Built output: `packages/@markuplint/html-spec/index.json`
+  - Sources: `packages/@markuplint/html-spec/src/spec-*.json`
+  - Build script: `packages/@markuplint/html-spec/build.mjs` (invokes `@markuplint/spec-generator`)
+- This `@markuplint/ml-spec` package defines the JSON Schema shapes and the merging logic that
+  consume that data, but does not contain the canonical HTML element dataset.
+
+### Editing workflow (HTML Schema/Specs)
+
+1. Make changes to the schemas
+
+- Attributes schema shape: update `gen/gen.ts` if you need to change the structure of
+  `AttributeJSON`/`GlobalAttributes` (because `attributes.schema.json` is generated).
+- ARIA schema shape: edit `schemas/aria.schema.json`.
+- Content model schema shape: edit `schemas/content-models.schema.json`.
+- Element schema aggregator: edit `schemas/element.schema.json` (it composes refs to the above).
+- Global attribute categories/sets: edit `gen/global-attribute.data.*`, then regenerate via the commands below.
+
+If you want to change the concrete HTML element data (e.g., add/update element- or attribute-level
+entries), update `@markuplint/html-spec` (and, if necessary, `@markuplint/spec-generator`).
+
+2. Regenerate schemas and types
+
+From the repository root (recommended):
+
+```bash
+yarn up:schema
+```
+
+or only for this package:
+
+```bash
+yarn workspace @markuplint/ml-spec run schema
+```
+
+This will:
+
+- Run `gen/gen.ts` to output `global-attributes.schema.json` and `attributes.schema.json`
+- Convert JSON Schema to TypeScript via `json2ts` into `src/types/*.ts`
+- Format with Prettier and ESLint
+
+3. Build (optional) and sanity-check
+
+```bash
+yarn build
+```
+
+### Do not edit generated files
+
+- Do not modify files under `src/types/*.ts` or `schemas/attributes.schema.json` directly.
+  Change the source schema or generator instead and re-run the generation scripts.
+
+### How schema merging works (Specs extension)
+
+At runtime, markuplint can merge multiple specs. The merger in
+`src/specs/schema-to-spec.ts` follows these rules:
+
+- `def.#globalAttrs.#extends` from an extended spec augments the base `#HTMLGlobalAttrs` map.
+- For a given element, if both base and extended specs define the same attribute, the extended spec
+  wins on conflicting fields (shallow override per attribute). Arrays like `categories` are merged.
+
+This enables framework-specific specs (Vue/React/Svelte, etc.) to extend the HTML spec safely.
+
+### Relationship to @markuplint/types
+
+- Attribute value types (CSS keywords, extended types such as `URL`, `JSON`, etc.) are defined in
+  `@markuplint/types` and exposed via `types.schema.json`.
+- If you need a new attribute value type, modify `@markuplint/types` (e.g.
+  `packages/@markuplint/types/gen/specific-schema.json`) and regenerate that package first. Then
+  regenerate this package so references stay consistent.
+
+### Versioning policy
+
+- HTML Schema/Specs are not part of the public API surface of markuplint. Changes here are treated
+  as a minor release. Publishing is handled by Lerna during the normal release process.
+
+### Common tasks (quick recipes)
+
+- Add a new global attribute category or items
+  - Edit `gen/global-attribute.data.*`
+  - Run the generation script (see above)
+
+- Add a new optional field to `AttributeJSON`
+  - Update the shape in `gen/gen.ts` under `AttributeJSON`
+  - Regenerate and ensure the new field appears in `schemas/attributes.schema.json` and in
+    `src/types/attributes.ts`
+
+- Adjust ARIA fields (e.g., `permittedRoles` variants)
+  - Edit `schemas/aria.schema.json`
+  - Regenerate types via the schema scripts
+
+### License
+
+MIT

--- a/packages/@markuplint/ml-spec/README.md
+++ b/packages/@markuplint/ml-spec/README.md
@@ -86,6 +86,30 @@ This will:
 - Convert JSON Schema to TypeScript via `json2ts` into `src/types/*.ts`
 - Format with Prettier and ESLint
 
+#### What `yarn up:schema` does
+
+From the repository root, this executes schema maintenance across packages in order:
+
+1. `@markuplint/types`
+
+- Run `gen/types.ts` to build `types.schema.json` from css-tree keywords/types and
+  `gen/specific-schema.json`
+- Generate TypeScript types: `types.schema.json` → `src/types.schema.ts` (via `json2ts`)
+- Format (`prettier`/`eslint`) and build the package
+
+2. `@markuplint/ml-spec` (this package)
+
+- Run `gen/gen.ts` to output `schemas/global-attributes.schema.json` and `schemas/attributes.schema.json`
+- Generate TypeScript types from schemas:
+  - `schemas/content-models.schema.json` → `src/types/permitted-structures.ts`
+  - `schemas/attributes.schema.json` → `src/types/attributes.ts`
+  - `schemas/aria.schema.json` → `src/types/aria.ts`
+- Format (`prettier`/`eslint`)
+
+Dependency note: `schemas/attributes.schema.json` references
+`@markuplint/types/types.schema.json#/definitions/type`. Updating types first ensures references stay
+consistent; `yarn up:schema` takes care of this order.
+
 3. Build (optional) and sanity-check
 
 ```bash

--- a/packages/@markuplint/ml-spec/README.md
+++ b/packages/@markuplint/ml-spec/README.md
@@ -160,6 +160,50 @@ This enables framework-specific specs (Vue/React/Svelte, etc.) to extend the HTM
   - Edit `schemas/aria.schema.json`
   - Regenerate types via the schema scripts
 
+### Content model quick reference
+
+Content models describe allowed children for each element. See the JSON Schema
+`schemas/content-models.schema.json` and the generated TS types `src/types/permitted-structures.ts`.
+Also refer to the website docs: [Rule: permitted-contents](https://markuplint.dev/rules/permitted-contents).
+
+- Basic categories (strings): `"#flow"`, `"#phrasing"`, `"#interactive"`, …
+- Model item forms:
+  - `require` | `optional` | `oneOrMore` | `zeroOrMore`: a string, category, or nested patterns
+  - `choice`: 2–5 alternative pattern arrays
+  - `transparent`: inherits parent model filtered by selector string
+
+Examples:
+
+```json
+{
+  "contentModel": {
+    "contents": [{ "require": "#phrasing" }, { "optional": [{ "oneOrMore": "#interactive" }] }]
+  }
+}
+```
+
+```json
+{
+  "contentModel": {
+    "contents": [{ "choice": [[{ "oneOrMore": "#flow" }], [{ "require": "#phrasing" }]] }]
+  }
+}
+```
+
+```json
+{
+  "contentModel": {
+    "contents": [{ "transparent": ":not(:model(interactive))" }],
+    "conditional": [
+      {
+        "condition": "[type=button]",
+        "contents": [{ "require": "#phrasing" }]
+      }
+    ]
+  }
+}
+```
+
 ### License
 
 MIT

--- a/packages/@markuplint/spec-generator/README.md
+++ b/packages/@markuplint/spec-generator/README.md
@@ -1,3 +1,82 @@
 # @markuplint/spec-generator
 
-This is private package for generating `@markuplint/html-spec`
+Private builder used to generate `@markuplint/html-spec`.
+
+It assembles an Extended Spec JSON from the HTML element source files and external references
+(MDN, WAI‑ARIA, HTML‑ARIA), then writes `index.json` in `@markuplint/html-spec`.
+
+## How it is invoked
+
+Called from `packages/@markuplint/html-spec/build.mjs`:
+
+```ts
+await main({
+  outputFilePath: 'index.json',
+  htmlFilePattern: 'src/spec.*.json',
+  commonAttrsFilePath: 'src/spec-common.attributes.json',
+  commonContentsFilePath: 'src/spec-common.contents.json',
+});
+```
+
+You normally don't run this directly; use:
+
+- From repo root: `yarn up:gen`
+- Only html-spec: `yarn workspace @markuplint/html-spec run gen`
+
+## What it does
+
+1. Read element sources
+
+- Load every `src/spec.*.json` and infer the element name from the filename (e.g. `spec.a.json` → `a`).
+
+2. Enrich from MDN
+
+- Fetch the MDN element page and populate missing metadata:
+  - `cite`, `description`, `categories`, `omission`, attribute flags
+  - Existing fields in `src/spec.*.json` take precedence over scraped values
+  - Attributes are merged name-by-name; manual entries win
+
+3. Add obsolete elements
+
+- Inject HTML obsolete elements (WHATWG list) and some deprecated SVG elements if not present.
+
+4. Load shared data
+
+- `def['#globalAttrs']` from `src/spec-common.attributes.json`
+- `def['#contentModels']` from `src/spec-common.contents.json` (`models` key)
+
+5. Build ARIA definitions
+
+- Scrape WAI‑ARIA (1.1/1.2/1.3) and Graphics‑ARIA, plus HTML‑ARIA cross‑refs, to produce
+  `def['#aria']` (roles, properties, synonyms, defaults, and equivalent HTML attrs).
+
+6. Emit Extended Spec JSON
+
+- `{ cites, def: { #globalAttrs, #aria, #contentModels }, specs: [...] }` → `index.json`
+  (Pretty‑printed by the caller)
+
+## Source of truth vs. generated data
+
+- Source of truth for element specs is in `@markuplint/html-spec/src/`.
+- This generator is purely a build step; do not edit the output `index.json` by hand.
+
+## Precedence rules (important)
+
+- Manual data in `src/spec.*.json` overrides MDN‑scraped values on conflict.
+- Attribute objects are merged per name; manual keys win, MDN may fill missing flags.
+- Shared files under `src/spec-common.*.json` are imported as‑is.
+
+## Network and caching
+
+- Uses live HTTP fetch against MDN/W3C specs. There is an in‑process cache for the current run only.
+- If a fetch fails, the entry may be left empty; re‑run later or edit your manual source to cover it.
+
+## When to change this package
+
+- Only when the scraping targets change (DOM structure/URLs), or when the Extended Spec shape evolves
+  in `@markuplint/ml-spec`.
+
+## See also
+
+- `@markuplint/html-spec` README — how to edit the element sources.
+- `@markuplint/ml-spec` README — schema shapes, generation, and spec merging.


### PR DESCRIPTION
- **docs(ml-spec): document HTML Schema shapes, generation and merging**
- **docs(html-spec): explain generator behavior and editing guidance**
- **docs(ml-spec): document yarn up:schema sequence and scope**
- **docs(ml-spec): add content model quick reference with examples**
- **docs(ml-spec): document transparent selector syntax and SVG categories**
