### PR TITLE
chore(website): pin yarn 4.9.2 via packageManager; bump ts to 5.9.2

### DIFF
--- a/website/.yarnrc.yml
+++ b/website/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules

--- a/website/package.json
+++ b/website/package.json
@@ -42,13 +42,14 @@
     "stylelint-config-standard": "38.0.0",
     "stylelint-order": "7.0.0",
     "tsx": "4.20.3",
-    "typescript": "5.8.3"
+    "typescript": "5.9.2"
   },
   "engines": {
     "node": ">=22"
   },
   "volta": {
-    "node": "22.16.0",
+    "node": "24.5.0",
     "yarn": "4.9.2"
-  }
+  },
+  "packageManager": "yarn@4.9.2"
 }

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -8911,7 +8911,7 @@ __metadata:
     stylelint-config-standard: "npm:38.0.0"
     stylelint-order: "npm:7.0.0"
     tsx: "npm:4.20.3"
-    typescript: "npm:5.8.3"
+    typescript: "npm:5.9.2"
     unist-util-visit: "npm:5.0.0"
   languageName: unknown
   linkType: soft
@@ -13562,23 +13562,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.8.3":
-  version: 5.8.3
-  resolution: "typescript@npm:5.8.3"
+"typescript@npm:5.9.2":
+  version: 5.9.2
+  resolution: "typescript@npm:5.9.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/5f8bb01196e542e64d44db3d16ee0e4063ce4f3e3966df6005f2588e86d91c03e1fb131c2581baf0fb65ee79669eea6e161cd448178986587e9f6844446dbb48
+  checksum: 10c0/cd635d50f02d6cf98ed42de2f76289701c1ec587a363369255f01ed15aaf22be0813226bff3c53e99d971f9b540e0b3cc7583dbe05faded49b1b0bed2f638a18
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>":
-  version: 5.8.3
-  resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"
+"typescript@patch:typescript@npm%3A5.9.2#optional!builtin<compat/typescript>":
+  version: 5.9.2
+  resolution: "typescript@patch:typescript@npm%3A5.9.2#optional!builtin<compat/typescript>::version=5.9.2&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/39117e346ff8ebd87ae1510b3a77d5d92dae5a89bde588c747d25da5c146603a99c8ee588c7ef80faaf123d89ed46f6dbd918d534d641083177d5fac38b8a1cb
+  checksum: 10c0/34d2a8e23eb8e0d1875072064d5e1d9c102e0bdce56a10a25c0b917b8aa9001a9cf5c225df12497e99da107dc379360bc138163c66b55b95f5b105b50578067e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Pin Yarn 4.9.2 via packageManager in website to ensure Yarn 4 is used consistently
- Align Volta Node to 24.5.0 with repo root
- Add website/.yarnrc.yml (nodeLinker: node-modules)
- Update TypeScript to 5.9.2 and regenerate yarn.lock

## Rationale
Avoid Renovate artifact failures when the executor defaults to Yarn 1 by making the
intended Yarn 4 explicit via package.json and consistent config under website/.

## Test plan
- Ran `yarn install` under website successfully on Node 24.5.0, Yarn 4.9.2
- After merge, mark existing Renovate PRs with "rebase!" to re-run artifacts