### PR TITLE
fix: correct Mermaid diagram syntax in ARCHITECTURE.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -14,7 +14,7 @@ The Markuplint ecosystem consists of **19 packages** that depend on `@markuplint
 
 ```mermaid
 graph TD
-    A[@markuplint/ml-spec] --> B[@markuplint/html-spec]
+    A[ml-spec] --> B[html-spec]
     A --> C[Framework Specs]
     A --> D[Core Packages]
     A --> E[Parser Packages]


### PR DESCRIPTION
## Summary

Fix Mermaid diagram parsing error in ARCHITECTURE.md that prevents GitHub from rendering the diagram.

## Changes

- Remove @ symbols from Mermaid node names (`[@markuplint/ml-spec]` → `[ml-spec]`)
- Fix GitHub rendering issue where @ symbols cause parse errors

## Test plan

- [x] Verify Mermaid diagram renders correctly on GitHub
- [x] Confirm no functional changes to document content

🤖 Generated with [Claude Code](https://claude.ai/code)