### PR TITLE
chore(deps): remove ts-node dependency from @markuplint/create-rule

### DIFF
--- a/packages/@markuplint/create-rule/package.json
+++ b/packages/@markuplint/create-rule/package.json
@@ -26,7 +26,6 @@
 		"@markuplint/ml-core": "4.13.0",
 		"glob": "11.0.3",
 		"prettier": "3.6.2",
-		"ts-node": "10.9.2",
 		"typescript": "5.9.2"
 	},
 	"devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1806,7 +1806,6 @@ __metadata:
     fs-extra: "npm:11.3.1"
     glob: "npm:11.0.3"
     prettier: "npm:3.6.2"
-    ts-node: "npm:10.9.2"
     typescript: "npm:5.9.2"
   bin:
     create-rule: ./bin/create-rule.mjs


### PR DESCRIPTION
## What is the purpose of this PR?

- ~[ ] Fix bug~
- ~[ ] Fix typo~
- ~[ ] Update specs~
- ~[ ] Add new rule~
- ~[ ] Add new parser~
- ~[ ] Improve or refactor rules~
- ~[ ] Add a new core feature~
- ~[ ] Improve or refactor core features~
- ~[ ] Update documents~
- [x] Others

### Description

Previously, cosmiconfig-typescript-loader had depended on ts-node, so @markuplint/create-rule had also required ts-node as it depends on cosmiconfig-typescript-loader.

After ts-node dependency is introduced to @markuplint/create-rule, the following pull request was created.

https://github.com/Codex-/cosmiconfig-typescript-loader/pull/106

It seems like cosmiconfig-typescript-loader no longer depends on ts-node.

## Checklist

Fill out the checks for the applicable purpose.

- ~[ ] Fix bug~
  - ~[ ] Add the test that can check whether resolved the issue.~
- ~[ ] Update specs~
  - ~[ ] Element~
    - ~[ ] Update **[global attributes](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/html-spec/src/spec-common.attributes.json)**~
    - ~[ ] Update **[content models](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/html-spec/src/spec-common.contents.json)**~
    - ~[ ] Add also ARIA that you explored **ARIA in HTML [Recommendation](https://www.w3.org/TR/html-aria/) and [Editor's draft](https://w3c.github.io/html-aria/)**~
  - ~[ ] Attribute~
    - ~[ ] Update **[global attributes](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/html-spec/src/spec-common.attributes.json)**~
    - ~[ ] Update **[IDL attribute](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/parser-utils/src/idl-attributes.ts)**~
- ~[ ] Add new rule~
  - ~[ ] Add a test~
  - ~[ ] Add a README document~
    - ~[ ] Create an issue that requests translating the doc if you want.~
  - ~[ ] Add to [index](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/rules/src/index.ts)~
  - ~[ ] Add JSON schema to [schema.json](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/rules/schema.json)~
  - ~[ ] Add to [`@markuplint/config-presets`](https://github.com/markuplint/markuplint/tree/main/packages/%40markuplint/config-presets)~
    - ~[ ] And add to [Rulesets of base presets](https://markuplint.dev/docs/guides/presets#rulesets-of-base-presets)~
      - ~[ ] Add to a [doc file](https://github.com/markuplint/markuplint/blob/main/website/docs/guides/presets.md)~
      - ~[ ] Add to a [doc file (ja)](https://github.com/markuplint/markuplint/blob/main/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/presets.md), or create an issue that requests translating the doc if you want.~
- ~[ ] Add new parser~
  - ~[ ] Add a test~
    - ~[ ] Do a test with some parser.~
  - ~[ ] Add to [initializer](https://github.com/markuplint/markuplint/blob/main/packages/markuplint/src/cli/init/create-config.ts)~
