### PR TITLE
feat(vscode): add restart language server command

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -98,6 +98,13 @@
 				"fileMatch": "**/{.markuplintrc,.markuplintrc.json}",
 				"url": "https://raw.githubusercontent.com/markuplint/markuplint/main/config.schema.json"
 			}
+		],
+		"commands": [
+			{
+				"command": "markuplint.restartServer",
+				"title": "Restart Language Server",
+				"category": "Markuplint"
+			}
 		]
 	},
 	"scripts": {

--- a/vscode/src/const.ts
+++ b/vscode/src/const.ts
@@ -4,6 +4,7 @@ export const NAME = 'Markuplint';
 export const OUTPUT_CHANNEL_PRIMARY_CHANNEL_NAME = NAME;
 export const OUTPUT_CHANNEL_DIAGNOSTICS_CHANNEL_NAME = `${NAME} Diagnostics` as const;
 export const COMMAND_NAME_OPEN_LOG_COMMAND = `${ID}.openLog` as const;
+export const COMMAND_NAME_RESTART_SERVER = `${ID}.restartServer` as const;
 
 // Paths
 export const WATCHING_CONFIGURATION_GLOB =

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -28,7 +28,7 @@ import { StatusBar } from './status-bar.js';
 
 let client: LanguageClient;
 let logger: Logger;
-let dignosticslogger: Logger;
+let diagnosticsLogger: Logger;
 
 export function activate(
 	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
@@ -41,7 +41,7 @@ export function activate(
 	}
 
 	logger = new Logger(window.createOutputChannel(OUTPUT_CHANNEL_PRIMARY_CHANNEL_NAME, { log: true }));
-	dignosticslogger = new Logger(window.createOutputChannel(OUTPUT_CHANNEL_DIAGNOSTICS_CHANNEL_NAME, { log: true }));
+	diagnosticsLogger = new Logger(window.createOutputChannel(OUTPUT_CHANNEL_DIAGNOSTICS_CHANNEL_NAME, { log: true }));
 
 	const serverModule = context.asAbsolutePath(path.join('out', 'server.js'));
 
@@ -116,7 +116,7 @@ export function activate(
 		});
 
 		client.onNotification(logToDiagnosticsChannel, ([message, type]) => {
-			dignosticslogger.log(message, type);
+			diagnosticsLogger.log(message, type);
 		});
 
 		client.onNotification(errorToPopup, message => {

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -9,6 +9,7 @@ import { RevealOutputChannelOn, LanguageClient, TransportKind } from 'vscode-lan
 
 import {
 	COMMAND_NAME_OPEN_LOG_COMMAND,
+	COMMAND_NAME_RESTART_SERVER,
 	ID,
 	OUTPUT_CHANNEL_PRIMARY_CHANNEL_NAME,
 	OUTPUT_CHANNEL_DIAGNOSTICS_CHANNEL_NAME,
@@ -26,6 +27,8 @@ import {
 import { StatusBar } from './status-bar.js';
 
 let client: LanguageClient;
+let logger: Logger;
+let dignosticslogger: Logger;
 
 export function activate(
 	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
@@ -37,10 +40,8 @@ export function activate(
 		return;
 	}
 
-	const logger = new Logger(window.createOutputChannel(OUTPUT_CHANNEL_PRIMARY_CHANNEL_NAME, { log: true }));
-	const dignosticslogger = new Logger(
-		window.createOutputChannel(OUTPUT_CHANNEL_DIAGNOSTICS_CHANNEL_NAME, { log: true }),
-	);
+	logger = new Logger(window.createOutputChannel(OUTPUT_CHANNEL_PRIMARY_CHANNEL_NAME, { log: true }));
+	dignosticslogger = new Logger(window.createOutputChannel(OUTPUT_CHANNEL_DIAGNOSTICS_CHANNEL_NAME, { log: true }));
 
 	const serverModule = context.asAbsolutePath(path.join('out', 'server.js'));
 
@@ -135,6 +136,18 @@ export function activate(
 		logger.show();
 	});
 	context.subscriptions.push(openLogCommand);
+
+	const restartServerCommand = commands.registerCommand(COMMAND_NAME_RESTART_SERVER, async () => {
+		try {
+			void window.showInformationMessage('Restarting Markuplint language server...');
+			await client.stop();
+			await client.start();
+			void window.showInformationMessage('Markuplint language server restarted successfully.');
+		} catch (error) {
+			void window.showErrorMessage(`Failed to restart Markuplint language server: ${String(error)}`);
+		}
+	});
+	context.subscriptions.push(restartServerCommand);
 }
 
 export function deactivate() {

--- a/vscode/test/extension.spec.ts
+++ b/vscode/test/extension.spec.ts
@@ -1,0 +1,75 @@
+import assert from 'node:assert';
+
+import { suite, test } from 'mocha';
+import * as vscode from 'vscode';
+
+suite('Extension Tests', () => {
+	suite('Command Registration', () => {
+		test('markuplint.restartServer command should be registered', async () => {
+			const commands = await vscode.commands.getCommands(true);
+			assert.ok(commands.includes('markuplint.restartServer'), 'Restart server command should be registered');
+		});
+
+		test('markuplint.openLog command should be registered', async () => {
+			const commands = await vscode.commands.getCommands(true);
+			assert.ok(commands.includes('markuplint.openLog'), 'Open log command should be registered');
+		});
+	});
+
+	suite('Restart Server Command', () => {
+		test('should execute without throwing error', async () => {
+			// Open an HTML file to activate the extension
+			const doc = await vscode.workspace.openTextDocument({
+				language: 'html',
+				content: '<html><body><h1>Test</h1></body></html>',
+			});
+			await vscode.window.showTextDocument(doc);
+
+			// Wait for extension activation
+			await new Promise(resolve => setTimeout(resolve, 1000));
+
+			// Execute restart command - should not throw an error
+			await vscode.commands.executeCommand('markuplint.restartServer');
+
+			// Clean up
+			await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+		});
+
+		test('should work after restart', async function () {
+			// Increase timeout for this test
+			this.timeout(10_000);
+
+			// Open an HTML file
+			const doc = await vscode.workspace.openTextDocument({
+				language: 'html',
+				content: '<html><body><h1>Test</h1></body></html>',
+			});
+			await vscode.window.showTextDocument(doc);
+
+			// Wait for extension activation
+			await new Promise(resolve => setTimeout(resolve, 1000));
+
+			// Execute restart command
+			await vscode.commands.executeCommand('markuplint.restartServer');
+
+			// Wait for restart to complete
+			await new Promise(resolve => setTimeout(resolve, 3000));
+
+			// Verify diagnostics still work after restart
+			// Note: This is a basic check that the extension is still functional
+			const diagnostics = vscode.languages.getDiagnostics(doc.uri);
+			assert.ok(Array.isArray(diagnostics), 'Diagnostics should be available after restart');
+
+			// Clean up
+			await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+		});
+	});
+
+	suite('Extension Activation', () => {
+		test('extension should be active', () => {
+			const extension = vscode.extensions.getExtension('yusukehirao.vscode-markuplint');
+			assert.ok(extension, 'Extension should be installed');
+			assert.strictEqual(extension.isActive, true, 'Extension should be active');
+		});
+	});
+});


### PR DESCRIPTION
## What is the purpose of this PR?

- [ ] Fix bug
- [ ] Fix typo
- [ ] Update specs
- [ ] Add new rule
- [ ] Add new parser
- [ ] Improve or refactor rules
- [ ] Add a new core feature
- [ ] Improve or refactor core features
- [ ] Update documents
- [x] Others

### Description

#### Summary

Add `Markuplint: Restart Language Server` command to manually restart the language server without reloading VS Code.
Useful when dependencies are updated or the server stops responding.

#### Changes

- Add `markuplint.restartServer` command registration
- Implement restart handler in extension.ts
- Fix typo: `dignosticslogger` → `diagnosticsLogger`

## Checklist

Fill out the checks for the applicable purpose.

- [ ] Fix bug
  - [ ] Add the test that can check whether resolved the issue.
- [ ] Update specs
  - [ ] Element
    - [ ] Update **[global attributes](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/html-spec/src/spec-common.attributes.json)**
    - [ ] Update **[content models](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/html-spec/src/spec-common.contents.json)**
    - [ ] Add also ARIA that you explored **ARIA in HTML [Recommendation](https://www.w3.org/TR/html-aria/) and [Editor's draft](https://w3c.github.io/html-aria/)**
  - [ ] Attribute
    - [ ] Update **[global attributes](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/html-spec/src/spec-common.attributes.json)**
    - [ ] Update **[IDL attribute](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/parser-utils/src/idl-attributes.ts)**
- [ ] Add new rule
  - [ ] Add a test
  - [ ] Add a README document
    - [ ] Create an issue that requests translating the doc if you want.
  - [ ] Add to [index](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/rules/src/index.ts)
  - [ ] Add JSON schema to [schema.json](https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/rules/schema.json)
  - [ ] Add to [`@markuplint/config-presets`](https://github.com/markuplint/markuplint/tree/main/packages/%40markuplint/config-presets)
    - [ ] And add to [Rulesets of base presets](https://markuplint.dev/docs/guides/presets#rulesets-of-base-presets)
      - [ ] Add to a [doc file](https://github.com/markuplint/markuplint/blob/main/website/docs/guides/presets.md)
      - [ ] Add to a [doc file (ja)](https://github.com/markuplint/markuplint/blob/main/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/presets.md), or create an issue that requests translating the doc if you want.
- [ ] Add new parser
  - [ ] Add a test
    - [ ] Do a test with some parser.
  - [ ] Add to [initializer](https://github.com/markuplint/markuplint/blob/main/packages/markuplint/src/cli/init/create-config.ts)
