### PR TITLE
Add Claude Code custom commands

### DIFF
--- a/.claude/commands/doc.md
+++ b/.claude/commands/doc.md
@@ -1,0 +1,11 @@
+---
+description: Update documentation commands
+---
+
+Thoroughly identify any omissions or inconsistencies in the documentation. **The implementation is the absolute source of truth.**
+
+- README.md is intended for API users
+- ARCHITECTURE.md is intended for contributors
+- Other documents should match their respective content
+
+Use the language specified in each document.

--- a/.claude/commands/doc.md
+++ b/.claude/commands/doc.md
@@ -4,8 +4,24 @@ description: Update documentation commands
 
 Thoroughly identify any omissions or inconsistencies in the documentation. **The implementation is the absolute source of truth.**
 
+# Scope
+
 - README.md is intended for API users
 - ARCHITECTURE.md is intended for contributors
+- JSDoc comments in source code
 - Other documents should match their respective content
 
-Use the language specified in each document.
+# Rules
+
+- Use the language specified in each document
+- **NEVER modify the implementation** — do not change function bodies, type definitions, export statements, or even the ordering of functions and type definitions
+- If the intent of code or documentation is unclear, ask the user rather than guessing
+
+# JSDoc
+
+- Every exported function and type must have a JSDoc comment
+- Required tags:
+  - `@param` — for each parameter; type annotation may rely on TypeScript, but a description is mandatory
+  - `@returns` — description of the return value is mandatory
+  - `@template` — for each type parameter; include a description
+- Do not add redundant type annotations that TypeScript already provides — focus on describing the purpose and semantics

--- a/.claude/commands/git.md
+++ b/.claude/commands/git.md
@@ -32,18 +32,28 @@ description: Git manipulation rules
 - You must write in English
 - You must use the imperative mood
 - You must use conventional commits
-  - You must use the following types:
+  - You must use the types defined by `@commitlint/config-conventional`:
+    - `build`
+    - `chore`
+    - `ci`
+    - `docs`
     - `feat`
     - `fix`
-    - `docs`
+    - `perf`
     - `refactor`
+    - `revert`
+    - `style`
     - `test`
-    - `chore`
-  - You must use the following scopes:
-    - Each package name (without namespace)
-    - `repo`
-    - `deps`
-    - `github`
+  - Scopes are dynamically generated from Lerna packages (see `.commitlintrc.js`)
+    - Package names have `-markuplint` / `markuplint-` prefixes stripped
+    - Additional scopes:
+      - `release`
+      - `deps`
+      - `changelog`
+      - `github`
+      - `lint`
+      - `website`
+    - Scope is optional — omit it when changes span multiple packages or don't belong to one
 - The message body's lines must not be longer than 100 characters
 - The subject must not be sentence-case, start-case, pascal-case, upper-case
 

--- a/.claude/commands/git.md
+++ b/.claude/commands/git.md
@@ -1,0 +1,94 @@
+---
+description: Git manipulation rules
+---
+
+# Commit creation
+
+- When asked to "commit":
+  - **CRITICAL: ALWAYS start by checking `git status` to see current state**
+  - **CRITICAL: NEVER trust previous state or memory - always verify current staging area**
+  1. If files are already staged:
+     - **CRITICAL: NEVER use `git add` or `git restore` when staged files exist**
+     - **CRITICAL: NEVER modify the staging area in any way**
+     - Check staged files using `git diff --staged` and create a commit message using _only_ the staged files
+     - Execute `git commit` directly with the message (user will approve as appropriate)
+     - The user has already prepared the staging area - respect their decision completely
+  2. If no files are staged:
+     - Check the differences using `git status`
+     - Stage files sequentially based on the following commit granularity before committing:
+       - Separate commits by package
+       - Commit dependencies first (if dependency order is unclear, check using `npx lerna list --graph`)
+- **AFTER EACH COMMIT:**
+  - **CRITICAL: DO NOT automatically proceed to the next commit**
+  - **CRITICAL: DO NOT make assumptions about what to do next**
+  - **CRITICAL: DO NOT trust your memory of previous state**
+  - Stop and check the current state using `git status` and `git diff`
+  - Return to the beginning of this decision process (check if files are staged or not)
+  - Wait for user confirmation or new instructions before proceeding
+- If the OS, application settings, or context suggest a language other than English is being used, provide a translation and explanation of the commit message in that language immediately before executing the commit command.
+
+# Commit message format
+
+- You must write in English
+- You must use the imperative mood
+- You must use conventional commits
+  - You must use the following types:
+    - `feat`
+    - `fix`
+    - `docs`
+    - `refactor`
+    - `test`
+    - `chore`
+  - You must use the following scopes:
+    - Each package name (without namespace)
+    - `repo`
+    - `deps`
+    - `github`
+- The message body's lines must not be longer than 100 characters
+- The subject must not be sentence-case, start-case, pascal-case, upper-case
+
+# Commit message safety guidelines
+
+- For breaking changes or complex commit messages, ALWAYS use heredoc format (see below)
+- For simple, single-line commits, use single quotes (')
+- NEVER use multiple -m flags for breaking changes (causes commitlint parse errors)
+
+## Heredoc Format (REQUIRED for Breaking Changes)
+
+Use heredoc with command substitution to pass multi-line commit messages. This ensures:
+
+- Special characters (like exclamation marks) are preserved correctly
+- Multi-line messages are properly formatted
+- commitlint can parse the message correctly
+
+**Format:**
+
+```bash
+git commit -m "$(cat <<'EOF'
+type(scope)!: subject line
+
+BREAKING CHANGE: Rename all compiler-related types and functions
+
+Type renames:
+- OldName -> NewName
+- Another -> Change
+EOF
+)"
+```
+
+**Important notes:**
+
+- Use `<<'EOF'` (with quotes) to prevent variable expansion
+- Close with `)` after `EOF` to complete command substitution
+- Do NOT use multiple `-m` flags for breaking changes
+- The entire message must be wrapped in `"$(cat <<'EOF' ... EOF)"`
+
+## Simple Commits (Non-Breaking)
+
+For simple, single-line commits without breaking changes:
+
+```bash
+git commit -m 'type(scope): subject line'
+```
+
+For multi-line non-breaking commits, use heredoc format as well to ensure proper formatting

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,0 +1,7 @@
+---
+description: Create and push a pull request
+---
+
+1. Ensure that you are on a topic branch that is not `dev` or `main`.
+2. Review the changes on the current topic branch using appropriate `git` commands.
+3. Generate and execute a one-liner `gh pr create` command to create a pull request.

--- a/cspell.json
+++ b/cspell.json
@@ -36,6 +36,7 @@
 		"checkings",
 		"clampable",
 		"clsx",
+		"commitlintrc",
 		"cmyk",
 		"delim",
 		"didnt",


### PR DESCRIPTION
## Summary

- Add Claude Code custom commands for git, documentation, and PR workflows
- Align commit message rules with the actual commitlint configuration
- Add JSDoc documentation rules and implementation safety guidelines

## Changes

- `.claude/commands/git.md` — Commit creation rules, message format, and safety guidelines
- `.claude/commands/doc.md` — Documentation update rules including JSDoc requirements
- `.claude/commands/pr.md` — Pull request creation workflow
- `cspell.json` — Add `commitlintrc` to the dictionary