### PR TITLE
feat(html-spec): add interestfor attribute (Interest Invokers API)

### DIFF
--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -35277,6 +35277,10 @@
 				"hreflang": {
 					"description": "Hints at the human language of the linked URL. No built-in functionality. Allowed values are the same as the global lang attribute."
 				},
+				"interestfor": {
+					"type": "DOMID",
+					"experimental": true
+				},
 				"name": {
 					"description": "Was required to define a possible target location in a page. In HTML 4.01, id and name could both be used on <a>, as long as they had identical values. Note: Use the global attribute id instead.",
 					"deprecated": true
@@ -35459,6 +35463,10 @@
 				},
 				"href": {
 					"description": "The hyperlink target for the area. Its value is a valid URL. This attribute may be omitted; if so, the <area> element does not represent a hyperlink."
+				},
+				"interestfor": {
+					"type": "DOMID",
+					"experimental": true
 				},
 				"ping": {
 					"description": "Contains a space-separated list of URLs to which, when the hyperlink is followed, POST requests with the body PING will be sent by the browser (in the background). Typically used for tracking."
@@ -36086,6 +36094,10 @@
 				},
 				"formtarget": {
 					"description": "If the button is a submit button, this attribute is an author-defined name or standardized, underscore-prefixed keyword indicating where to display the response from submitting the form. This is the name of, or keyword for, a browsing context (a tab, window, or <iframe>). If this attribute is specified, it overrides the target attribute of the button's form owner. The following keywords have special meanings: _self: Load the response into the same browsing context as the current one. This is the default if the attribute is not specified. _blank: Load the response into a new unnamed browsing context — usually a new tab or window, depending on the user's browser settings. _parent: Load the response into the parent browsing context of the current one. If there is no parent, this option behaves the same way as _self. _top: Load the response into the top-level browsing context (that is, the browsing context that is an ancestor of the current one, and has no parent). If there is no parent, this option behaves the same way as _self."
+				},
+				"interestfor": {
+					"type": "DOMID",
+					"experimental": true
 				},
 				"name": {
 					"description": "The name of the button, submitted as a pair with the button's value as part of the form data, when that button is used to submit the form."
@@ -42023,6 +42035,10 @@
 				},
 				"hreflang": {
 					"description": "The human language of the URL or URL fragment that the hyperlink points to. Value type: <string>; Default value: none; Animatable: no"
+				},
+				"interestfor": {
+					"type": "DOMID",
+					"experimental": true
 				},
 				"ping": {
 					"description": "A space-separated list of URLs to which, when the hyperlink is followed, POST requests with the body PING will be sent by the browser (in the background). Typically used for tracking. For a more widely-supported feature addressing the same use cases, see Navigator.sendBeacon(). Value type: <list-of-URLs>; Default value: none; Animatable: no",

--- a/packages/@markuplint/html-spec/src/spec.a.json
+++ b/packages/@markuplint/html-spec/src/spec.a.json
@@ -16,7 +16,13 @@
 		"#ARIAAttrs": true,
 		"#HTMLLinkAndFetchingAttrs": ["href", "target", "download", "ping", "rel", "hreflang", "type", "referrerpolicy"]
 	},
-	"attributes": {},
+	"attributes": {
+		// https://open-ui.org/components/interest-invokers.explainer/
+		"interestfor": {
+			"type": "DOMID",
+			"experimental": true
+		}
+	},
 	"aria": {
 		"implicitRole": "link",
 		"permittedRoles": [

--- a/packages/@markuplint/html-spec/src/spec.area.json
+++ b/packages/@markuplint/html-spec/src/spec.area.json
@@ -35,6 +35,11 @@
 				"missingValueDefault": "rect",
 				"invalidValueDefault": "rect"
 			}
+		},
+		// https://open-ui.org/components/interest-invokers.explainer/
+		"interestfor": {
+			"type": "DOMID",
+			"experimental": true
 		}
 	},
 	"aria": {

--- a/packages/@markuplint/html-spec/src/spec.button.json
+++ b/packages/@markuplint/html-spec/src/spec.button.json
@@ -40,6 +40,11 @@
 		"commandfor": {
 			"type": "DOMID"
 		},
+		// https://open-ui.org/components/interest-invokers.explainer/
+		"interestfor": {
+			"type": "DOMID",
+			"experimental": true
+		},
 		// https://html.spec.whatwg.org/multipage/popover.html#attr-popovertarget
 		"popovertarget": {
 			"type": "DOMID"

--- a/packages/@markuplint/html-spec/src/spec.svg_a.json
+++ b/packages/@markuplint/html-spec/src/spec.svg_a.json
@@ -97,7 +97,13 @@
 		"#XLinkAttrs": ["xlink:href", "xlink:title"],
 		"#HTMLLinkAndFetchingAttrs": ["href", "target", "download", "ping", "rel", "hreflang", "type", "referrerpolicy"]
 	},
-	"attributes": {},
+	"attributes": {
+		// https://open-ui.org/components/interest-invokers.explainer/
+		"interestfor": {
+			"type": "DOMID",
+			"experimental": true
+		}
+	},
 	"aria": {
 		// link role if the element has a valid href or xlink:href attribute.
 		// For a elements that are not links,


### PR DESCRIPTION
## Summary

- Add experimental `interestfor` attribute (type: `DOMID`) to `<a>`, `<area>`, `<button>`, and `<svg:a>` elements
- Defined in both `src/spec.*.json` source files and generated `index.json`

## References

- [Interest Invokers Explainer (Open UI)](https://open-ui.org/components/interest-invokers.explainer/)
- [Using interest invokers (MDN)](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API/Using_interest_invokers)

## Notes

- `description` is not included due to a known bug in spec-generator's attribute merge logic (`'name' in current` check skips MDN data merge when spec file defines the attribute). This will be fixed in a separate PR.
- Marked as `experimental: true` in spec files as a workaround.

## Test plan

- [x] JSON is valid
- [x] `yarn up:gen` produces identical interestfor output (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)