### PR TITLE
feat(html-spec): deprecate browsingtopics attribute on iframe

### DIFF
--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -37616,7 +37616,7 @@
 				},
 				"browsingtopics": {
 					"description": "A boolean attribute that, if present, specifies that the selected topics for the current user should be sent with the request for the <iframe>'s source. See Using the Topics API for more details.",
-					"experimental": true,
+					"deprecated": true,
 					"nonStandard": true
 				},
 				"credentialless": {


### PR DESCRIPTION
## Summary

- Change `browsingtopics` from `experimental` to `deprecated` on `<iframe>` per Topics API status update

## Test plan

- [x] JSON is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)