### PR TITLE
feat(html-spec): add input switch attribute

### DIFF
--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -38653,6 +38653,11 @@
 						"[type='range' i]"
 					]
 				},
+				"switch": {
+					"type": "Boolean",
+					"experimental": true,
+					"condition": ["[type='checkbox' i]"]
+				},
 				"tabindex": {
 					"description": "Global attribute valid for all elements, including all the input types, an integer attribute indicating if the element can take input focus (is focusable), if it should participate to sequential keyboard navigation. As all input types except for input of type hidden are focusable, this attribute should not be used on form controls, because doing so would require the management of the focus order for all elements within the document with the risk of harming usability and accessibility if done incorrectly."
 				},

--- a/packages/@markuplint/html-spec/src/spec.input.json
+++ b/packages/@markuplint/html-spec/src/spec.input.json
@@ -218,6 +218,12 @@
 			},
 			"condition": ["[type='button' i]", "[type='image' i]", "[type='reset' i]", "[type='submit' i]"]
 		},
+		// https://html.spec.whatwg.org/multipage/input.html#the-input-element:attr-input-switch
+		"switch": {
+			"type": "Boolean",
+			"experimental": true,
+			"condition": ["[type='checkbox' i]"]
+		},
 		// https://html.spec.whatwg.org/multipage/input.html#attr-input-readonly
 		"readonly": {
 			"condition": [


### PR DESCRIPTION
## Summary
- Add experimental `switch` attribute for `<input type="checkbox">` elements
- Enables the toggle switch UI pattern per the [HTML Living Standard](https://html.spec.whatwg.org/multipage/input.html#the-input-element:attr-input-switch)
- Adds type definition to `spec.input.json` and generated entry in `index.json`

## Test plan
- [ ] Verify `yarn up:gen` produces identical output (idempotent)
- [ ] Verify JSON validity of `index.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)