### PR TITLE
feat(html-spec): add iframe privateToken attribute

### DIFF
--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -37652,6 +37652,10 @@
 				"name": {
 					"type": "NavigableTargetName"
 				},
+				"privateToken": {
+					"type": "Any",
+					"experimental": true
+				},
 				"referrerpolicy": {
 					"description": "Indicates which referrer to send when fetching the frame's resource: no-referrer The Referer header will not be sent. no-referrer-when-downgrade The Referer header will not be sent to origins without TLS (HTTPS). origin The sent referrer will be limited to the origin of the referring page: its scheme, host, and port. origin-when-cross-origin The referrer sent to other origins will be limited to the scheme, the host, and the port. Navigations on the same origin will still include the path. same-origin A referrer will be sent for same origin, but cross-origin requests will contain no referrer information. strict-origin Only send the origin of the document as the referrer when the protocol security level stays the same (HTTPS→HTTPS), but don't send it to a less secure destination (HTTPS→HTTP). strict-origin-when-cross-origin (default) Send a full URL when performing a same-origin request, only send the origin when the protocol security level stays the same (HTTPS→HTTPS), and send no header to a less secure destination (HTTPS→HTTP). unsafe-url The referrer will include the origin and the path (but not the fragment, password, or username). This value is unsafe, because it leaks origins and paths from TLS-protected resources to insecure origins."
 				},

--- a/packages/@markuplint/html-spec/src/spec.iframe.json
+++ b/packages/@markuplint/html-spec/src/spec.iframe.json
@@ -60,6 +60,11 @@
 		// https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allowfullscreen
 		"allowfullscreen": {
 			"type": "Boolean"
+		},
+		// https://developer.mozilla.org/en-US/docs/Web/API/HTMLIFrameElement/privateToken
+		"privateToken": {
+			"type": "Any",
+			"experimental": true
 		}
 	},
 	"aria": {


### PR DESCRIPTION
## Summary
- Add experimental `privateToken` attribute for `<iframe>` elements
- Supports the [Private State Token API](https://wicg.github.io/trust-token-api/) (formerly Trust Tokens)
- Adds type definition to `spec.iframe.json` and generated entry in `index.json`

> **Note:** The attribute name is camelCase (`privateToken`) rather than the typical all-lowercase HTML convention. This is per the [WICG spec](https://wicg.github.io/trust-token-api/) which defines the content attribute as `privateToken` to match the DOM API (`RequestInit.privateToken`). [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/iframe#privatetoken) also documents it as camelCase.

## Test plan
- [ ] Verify `yarn up:gen` produces identical output (idempotent)
- [ ] Verify JSON validity of `index.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)