### PR TITLE
feat(html-spec): add template shadowrootreferencetarget attribute

### DIFF
--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -41158,6 +41158,10 @@
 						"invalidValueDefault": "none"
 					}
 				},
+				"shadowrootreferencetarget": {
+					"type": "DOMID",
+					"experimental": true
+				},
 				"shadowrootserializable": {
 					"type": "Boolean"
 				}

--- a/packages/@markuplint/html-spec/src/spec.template.json
+++ b/packages/@markuplint/html-spec/src/spec.template.json
@@ -30,6 +30,11 @@
 		// https://html.spec.whatwg.org/multipage/scripting.html#attr-template-shadowrootserializable
 		"shadowrootserializable": {
 			"type": "Boolean"
+		},
+		// https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/template#shadowrootreferencetarget
+		"shadowrootreferencetarget": {
+			"type": "DOMID",
+			"experimental": true
 		}
 	},
 	"aria": {


### PR DESCRIPTION
## Summary
- Add experimental `shadowrootreferencetarget` attribute for `<template>` elements
- Enables [declarative shadow DOM](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/template#shadowrootreferencetarget) to reference a target element by ID
- Type: `DOMID`
- Adds type definition to `spec.template.json` and generated entry in `index.json`

## Test plan
- [ ] Verify `yarn up:gen` produces identical output (idempotent)
- [ ] Verify JSON validity of `index.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)