### PR TITLE
feat(html-spec): add svg:switch requiredExtensions and systemLanguage

### DIFF
--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -47575,7 +47575,14 @@
 					"writing-mode"
 				]
 			},
-			"attributes": {}
+			"attributes": {
+				"requiredExtensions": {
+					"description": "A space-separated list of URL values referencing the language extensions the user agent must support for the element to be rendered."
+				},
+				"systemLanguage": {
+					"description": "A comma-separated list of supported language tags."
+				}
+			}
 		},
 		{
 			"name": "svg:symbol",


### PR DESCRIPTION
## Summary
- Add `requiredExtensions` and `systemLanguage` attribute descriptions for `<svg:switch>` element
- These attributes are used for conditional processing in SVG (the `globalAttrs` already referenced `#SVGConditionalProcessingAttrs`, but the `attributes` section was empty)
- Descriptions sourced from MDN

## Test plan
- [ ] Verify `yarn up:gen` produces identical output (idempotent)
- [ ] Verify JSON validity of `index.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)