### PR TITLE
fix(spec-generator): merge MDN data into spec-defined attributes

### DIFF
--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -35278,8 +35278,10 @@
 					"description": "Hints at the human language of the linked URL. No built-in functionality. Allowed values are the same as the global lang attribute."
 				},
 				"interestfor": {
-					"type": "DOMID",
-					"experimental": true
+					"description": "Defines the <a> element as an interest invoker. Its value is the id of the target element, which will be affected in some way (normally shown or hidden) when interest is shown or lost on the invoker element (for example, by hovering/unhovering or focusing/blurring it). See Using interest invokers for more details and examples.",
+					"experimental": true,
+					"nonStandard": true,
+					"type": "DOMID"
 				},
 				"name": {
 					"description": "Was required to define a possible target location in a page. In HTML 4.01, id and name could both be used on <a>, as long as they had identical values. Note: Use the global attribute id instead.",
@@ -35447,11 +35449,13 @@
 			},
 			"attributes": {
 				"alt": {
+					"description": "A text string alternative to display on browsers that do not display images. The text should be phrased so that it presents the user with the same kind of choice as the image would offer when displayed without the alternative text. This attribute is required only if the href attribute is used.",
 					"type": "Any",
 					"required": true,
 					"condition": "[href]"
 				},
 				"coords": {
+					"description": "The coords attribute details the coordinates of the shape attribute in size, shape, and placement of an <area>. This attribute must not be used if shape is set to default. rect: the value is x1,y1,x2,y2. The value specifies the coordinates of the top-left and bottom-right corner of the rectangle. For example, in <area shape=\"rect\" coords=\"0,0,253,27\" href=\"#\" target=\"_blank\" alt=\"Mozilla\"> the coordinates are 0,0 and 253,27, indicating the top-left and bottom-right corners of the rectangle, respectively. circle: the value is x,y,radius. Value specifies the coordinates of the circle center and the radius. For example: <area shape=\"circle\" coords=\"130,136,60\" href=\"#\" target=\"_blank\" alt=\"MDN\"> poly: the value is x1,y1,x2,y2,..,xn,yn. Value specifies the coordinates of the edges of the polygon. If the first and last coordinate pairs are not the same, the browser will add the last coordinate pair to close the polygon The values are numbers of CSS pixels. Our shape generator can help you generate the coords syntax by selecting points on an image you upload.",
 					"type": {
 						"token": "Number",
 						"disallowToSurroundBySpaces": true,
@@ -35465,8 +35469,10 @@
 					"description": "The hyperlink target for the area. Its value is a valid URL. This attribute may be omitted; if so, the <area> element does not represent a hyperlink."
 				},
 				"interestfor": {
-					"type": "DOMID",
-					"experimental": true
+					"description": "Defines the <area> element as an interest invoker. Its value is the id of the target element, which will be affected in some way (normally shown or hidden) when interest is shown or lost on the invoker element (for example, by hovering/unhovering or focusing/blurring it). See Using interest invokers for more details and examples.",
+					"experimental": true,
+					"nonStandard": true,
+					"type": "DOMID"
 				},
 				"ping": {
 					"description": "Contains a space-separated list of URLs to which, when the hyperlink is followed, POST requests with the body PING will be sent by the browser (in the background). Typically used for tracking."
@@ -35478,6 +35484,7 @@
 					"description": "For anchors containing the href attribute, this attribute specifies the relationship of the target object to the link object. The value is a space-separated list of link types. The values and their semantics will be registered by some authority that might have meaning to the document author. The default relationship, if no other is given, is void. Use this attribute only if the href attribute is present."
 				},
 				"shape": {
+					"description": "The shape of the associated hot spot. The specifications for HTML defines the values rect, which defines a rectangular region; circle, which defines a circular region; poly, which defines a polygon; and default, which indicates the entire region beyond any defined shapes.",
 					"type": {
 						"enum": ["rect", "circle", "poly", "default"],
 						"missingValueDefault": "rect",
@@ -35664,6 +35671,7 @@
 			},
 			"attributes": {
 				"href": {
+					"description": "The base URL to be used throughout the document for relative URLs. Absolute and relative URLs are allowed. data: and javascript: URLs are not allowed.",
 					"type": "BaseURL"
 				},
 				"target": {
@@ -35826,6 +35834,7 @@
 			},
 			"attributes": {
 				"cite": {
+					"description": "A URL that designates a source document or message for the information quoted. This attribute is intended to point to information explaining the context or the reference for the quote.",
 					"type": "URL"
 				}
 			}
@@ -36062,6 +36071,7 @@
 					"description": "This Boolean attribute specifies that the button should have input focus when the page loads. Only one element in a document can have this attribute."
 				},
 				"command": {
+					"description": "Specifies the action to be performed on an element being controlled by a control <button> specified via the commandfor attribute. The possible values are: \"show-modal\" The button will show a <dialog> as modal. If the dialog is already modal, no action will be taken. This is a declarative equivalent of calling the HTMLDialogElement.showModal() method on the <dialog> element. \"close\" The button will close a <dialog> element. If the dialog is already closed, no action will be taken. This is a declarative equivalent of calling the HTMLDialogElement.close() method on the <dialog> element. When used with the value attribute, the button's value will be passed as the dialog's returnValue property. \"request-close\" The button will trigger a cancel event on a <dialog> element to request that the browser dismiss it, followed by a close event. This differs from the close command in that authors can call Event.preventDefault() on the cancel event to prevent the <dialog> from closing. If the dialog is already closed, no action will be taken. This is a declarative equivalent of calling the HTMLDialogElement.requestClose() method on the <dialog> element. When used with the button's value attribute, the value will be passed as the dialog's returnValue property. \"show-popover\" The button will show a hidden popover. If you try to show an already showing popover, no action will be taken. See Popover API for more details. This is equivalent to setting a value of show for the popovertargetaction attribute, and also provides a declarative equivalent to calling the HTMLElement.showPopover() method on the popover element. \"hide-popover\" The button will hide a showing popover. If you try to hide an already hidden popover, no action will be taken. See Popover API for more details. This is equivalent to setting a value of hide for the popovertargetaction attribute, and also provides a declarative equivalent to calling the HTMLElement.hidePopover() method on the popover element. \"toggle-popover\" The button will toggle a popover between showing and hidden. If the popover is hidden, it will be shown; if the popover is showing, it will be hidden. See Popover API for more details. This is equivalent to setting a value of toggle for the popovertargetaction attribute, and also provides a declarative equivalent to calling the HTMLElement.togglePopover() method on the popover element. Custom values This attribute can represent custom values that are prefixed with a two hyphen characters (--). Buttons with a custom value will dispatch the CommandEvent on the controlled element.",
 					"type": [
 						{
 							"enum": ["toggle-popover", "show-popover", "hide-popover", "close", "show-modal"],
@@ -36072,6 +36082,7 @@
 					]
 				},
 				"commandfor": {
+					"description": "Turns a <button> element into a command button, controlling a given interactive element by issuing the command specified in the button's command attribute. The commandfor attribute takes the ID of the element to control as its value. This is a more general version of popovertarget.",
 					"type": "DOMID"
 				},
 				"disabled": {
@@ -36096,16 +36107,20 @@
 					"description": "If the button is a submit button, this attribute is an author-defined name or standardized, underscore-prefixed keyword indicating where to display the response from submitting the form. This is the name of, or keyword for, a browsing context (a tab, window, or <iframe>). If this attribute is specified, it overrides the target attribute of the button's form owner. The following keywords have special meanings: _self: Load the response into the same browsing context as the current one. This is the default if the attribute is not specified. _blank: Load the response into a new unnamed browsing context — usually a new tab or window, depending on the user's browser settings. _parent: Load the response into the parent browsing context of the current one. If there is no parent, this option behaves the same way as _self. _top: Load the response into the top-level browsing context (that is, the browsing context that is an ancestor of the current one, and has no parent). If there is no parent, this option behaves the same way as _self."
 				},
 				"interestfor": {
-					"type": "DOMID",
-					"experimental": true
+					"description": "Defines the <button> element as an interest invoker. Its value is the id of a target element, which will be affected in some way (normally shown or hidden) when interest is shown or lost on the invoker element (for example, by hovering/unhovering or focusing/blurring it). See Using interest invokers for more details and examples.",
+					"experimental": true,
+					"nonStandard": true,
+					"type": "DOMID"
 				},
 				"name": {
 					"description": "The name of the button, submitted as a pair with the button's value as part of the form data, when that button is used to submit the form."
 				},
 				"popovertarget": {
+					"description": "Turns a <button> element into a popover control button; takes the ID of the popover element to control as its value. Establishing a relationship between a popover and its invoker button using the popovertarget attribute has two additional useful effects: The browser creates an implicit aria-details and aria-expanded relationship between popover and invoker, and places the popover in a logical position in the keyboard focus navigation order when shown. This makes the popover more accessible to keyboard and assistive technology (AT) users (see also Popover accessibility features). The browser creates an implicit anchor reference between the two, making it very convenient to position popovers relative to their controls using CSS anchor positioning. See Popover anchor positioning for more details.",
 					"type": "DOMID"
 				},
 				"popovertargetaction": {
+					"description": "Specifies the action to be performed on a popover element being controlled by a control <button>. Possible values are: \"hide\" The button will hide a shown popover. If you try to hide an already hidden popover, no action will be taken. \"show\" The button will show a hidden popover. If you try to show an already showing popover, no action will be taken. \"toggle\" The button will toggle a popover between showing and hidden. If the popover is hidden, it will be shown; if the popover is showing, it will be hidden. If popovertargetaction is omitted, \"toggle\" is the default action that will be performed by the control button.",
 					"type": {
 						"enum": ["toggle", "show", "hide"],
 						"disallowToSurroundBySpaces": true,
@@ -36114,6 +36129,7 @@
 					}
 				},
 				"type": {
+					"description": "The default behavior of the button. Possible values are: submit: The button submits the form data to the server. This is the default if the attribute is not specified for buttons associated with a <form>, or if the attribute is an empty or invalid value. reset: The button resets all the controls to their initial values, like <input type=\"reset\">. (This behavior tends to annoy users.) button: The button has no default behavior, and does nothing when pressed by default. It can have client-side scripts listen to the element's events, which are triggered when the events occur.",
 					"type": {
 						"enum": ["submit", "reset", "button"],
 						"invalidValueDefault": "submit",
@@ -36121,6 +36137,7 @@
 					}
 				},
 				"value": {
+					"description": "Defines the value associated with the button's name when it's submitted with the form data. This value is passed to the server in params when the form is submitted using this button. When used with the close or request-close commands, the value attribute sets the returnValue of the <dialog> element being controlled.",
 					"type": "Any"
 				}
 			}
@@ -36150,6 +36167,7 @@
 			},
 			"attributes": {
 				"height": {
+					"description": "The height of the coordinate space in CSS pixels. Defaults to 150.",
 					"defaultValue": "150"
 				},
 				"moz-opaque": {
@@ -36158,6 +36176,7 @@
 					"nonStandard": true
 				},
 				"width": {
+					"description": "The width of the coordinate space in CSS pixels. Defaults to 300.",
 					"defaultValue": "300"
 				}
 			}
@@ -36305,6 +36324,7 @@
 					"deprecated": true
 				},
 				"span": {
+					"description": "Specifies the number of consecutive columns the <col> element spans. The value must be a positive integer greater than zero. If not present, its default value is 1.",
 					"type": {
 						"type": "integer",
 						"gt": 0,
@@ -36370,6 +36390,7 @@
 					"deprecated": true
 				},
 				"span": {
+					"description": "Specifies the number of consecutive columns the <colgroup> element spans. The value must be a positive integer greater than zero. If not present, its default value is 1. Note: The span attribute is not permitted if there are one or more <col> elements within the <colgroup>.",
 					"type": {
 						"type": "integer",
 						"gt": 0,
@@ -36416,6 +36437,7 @@
 			},
 			"attributes": {
 				"value": {
+					"description": "This attribute specifies the machine-readable translation of the content of the element.",
 					"type": "Any",
 					"required": true
 				}
@@ -36516,9 +36538,11 @@
 			},
 			"attributes": {
 				"cite": {
+					"description": "A URI for a resource that explains the change (for example, meeting minutes).",
 					"type": "URL"
 				},
 				"datetime": {
+					"description": "This attribute indicates the time and date of the change and must be a valid date string with an optional time. If the value cannot be parsed as a date with an optional time string, the element does not have an associated timestamp. For the format of the string without a time, see Date strings. The format of the string if it includes both date and time is covered in Local date and time strings.",
 					"type": "DateTime"
 				}
 			}
@@ -36554,9 +36578,11 @@
 			},
 			"attributes": {
 				"name": {
+					"description": "This attribute enables multiple <details> elements to be connected, with only one open at a time. This allows developers to easily create UI features such as accordions without scripting. The name attribute specifies a group name — give multiple <details> elements the same name value to group them. Only one of the grouped <details> elements can be open at a time — opening one will cause another to close. If multiple grouped <details> elements are given the open attribute, only the first one in the source order will be rendered open. Note: <details> elements don't have to be adjacent to one another in the source to be part of the same group.",
 					"type": "NoEmptyAny"
 				},
 				"open": {
+					"description": "This Boolean attribute indicates whether the details — that is, the contents of the <details> element — are currently visible. The details are shown when this attribute exists, or hidden when this attribute is absent. By default this attribute is absent which means the details are not visible. Note: You have to remove this attribute entirely to make the details hidden. open=\"false\" makes the details visible because this attribute is Boolean.",
 					"type": "Boolean"
 				}
 			}
@@ -36613,6 +36639,7 @@
 			},
 			"attributes": {
 				"closedby": {
+					"description": "Specifies the types of user actions that can be used to close the <dialog> element. This attribute distinguishes three methods by which a dialog might be closed: A light dismiss user action, in which the <dialog> is closed when the user clicks or taps outside it. This is equivalent to the \"light dismiss\" behavior of \"auto\" state popovers. A platform-specific user action, such as pressing the Esc key on desktop platforms, or a \"back\" or \"dismiss\" gesture on mobile platforms. A developer-specified mechanism such as a <button> with a click handler that invokes HTMLDialogElement.close() or a <form> submission. Possible values are: any The dialog can be dismissed using any of the three methods. closerequest The dialog can be dismissed with a platform-specific user action or a developer-specified mechanism. none The dialog can only be dismissed with a developer-specified mechanism. If the <dialog> element does not have a valid closedby value specified, then if it was opened using showModal(), it behaves as if the value was \"closerequest\" otherwise, it behaves as if the value was \"none\".",
 					"type": {
 						"enum": ["any", "closerequest", "none"],
 						"invalidValueDefault": "auto",
@@ -36620,6 +36647,7 @@
 					}
 				},
 				"open": {
+					"description": "Indicates that the dialog box is active and is available for interaction. If the open attribute is not set, the dialog box will not be visible to the user. It is recommended to use the .show() or .showModal() method to render dialogs, rather than the open attribute. If a <dialog> is opened using the open attribute, it is non-modal. Note: While you can toggle between the open and closed states of non-modal dialog boxes by toggling the presence of the open attribute, this approach is not recommended. See open for more information.",
 					"type": "Boolean"
 				},
 				"tabindex": {
@@ -36850,10 +36878,12 @@
 					"description": "The displayed height of the resource, in CSS pixels. This must be an absolute value; percentages are not allowed."
 				},
 				"src": {
+					"description": "The URL of the resource being embedded.",
 					"type": "URL",
 					"required": "[itemprop]"
 				},
 				"type": {
+					"description": "The MIME type to use to select the plug-in to instantiate.",
 					"type": "MIMEType"
 				},
 				"width": {
@@ -37076,6 +37106,7 @@
 					"deprecated": true
 				},
 				"accept-charset": {
+					"description": "The character encoding accepted by the server. The specification allows a single case-insensitive value of \"UTF-8\", reflecting the ubiquity of this encoding (historically multiple character encodings could be specified as a comma-separated or space-separated list).",
 					"type": {
 						"enum": ["utf-8"],
 						"caseInsensitive": true
@@ -37088,6 +37119,7 @@
 					"description": "Controls whether inputted text is automatically capitalized and, if so, in what manner. See the autocapitalize global attribute page for more information."
 				},
 				"autocomplete": {
+					"description": "Indicates whether input elements can by default have their values automatically completed by the browser. autocomplete attributes on form elements override it on <form>. Possible values: off: The browser may not automatically complete entries. (Browsers tend to ignore this for suspected login forms; see Managing autofill for login fields.) on: The browser may automatically complete entries.",
 					"type": {
 						"enum": ["on", "off"],
 						"invalidValueDefault": "on",
@@ -37109,12 +37141,14 @@
 					}
 				},
 				"name": {
+					"description": "The name of the form. The value must not be the empty string, and must be unique among the form elements in the forms collection that it is in, if any. The name becomes a property of the Window, Document, and document.forms objects, containing a reference to the form element.",
 					"type": "NoEmptyAny"
 				},
 				"novalidate": {
 					"type": "Boolean"
 				},
 				"rel": {
+					"description": "Controls the annotations and what kinds of links the form creates. Annotations include external, nofollow, opener, noopener, and noreferrer. Link types include help, prev, next, search, and license. The rel value is a space-separated list of these enumerated values.",
 					"type": "LinkTypeForFormElement"
 				},
 				"target": {
@@ -37616,9 +37650,11 @@
 					"deprecated": true
 				},
 				"allow": {
+					"description": "Specifies a Permissions Policy for the <iframe>. The policy defines what features are available to the <iframe> (for example, access to the microphone, camera, battery, web-share, etc.) based on the origin of the request. See iframes in the Permissions-Policy topic for examples. Note: A Permissions Policy specified by the allow attribute implements a further restriction on top of the policy specified in the Permissions-Policy header. It doesn't replace it.",
 					"type": "SerializedPermissionsPolicy"
 				},
 				"allowfullscreen": {
+					"description": "Set to true if the <iframe> can activate fullscreen mode by calling the requestFullscreen() method. Note: This attribute is considered a legacy attribute and redefined as allow=\"fullscreen *\".",
 					"type": "Boolean"
 				},
 				"allowpaymentrequest": {
@@ -37662,16 +37698,19 @@
 					"deprecated": true
 				},
 				"name": {
+					"description": "A targetable name for the embedded browsing context. This can be used in the target attribute of the <a>, <form>, or <base> elements; the formtarget attribute of the <input> or <button> elements; or the windowName parameter in the window.open() method. In addition, the name becomes a property of the Window and Document objects, containing a reference to the embedded window or the element itself.",
 					"type": "NavigableTargetName"
 				},
 				"privateToken": {
-					"type": "Any",
-					"experimental": true
+					"description": "Contains a string representation of an options object representing a private state token operation; this object has the same structure as the RequestInit dictionary's privateToken property. IFrames containing this attribute can initiate operations such as issuing or redeeming tokens when their embedded content is loaded.",
+					"experimental": true,
+					"type": "Any"
 				},
 				"referrerpolicy": {
 					"description": "Indicates which referrer to send when fetching the frame's resource: no-referrer The Referer header will not be sent. no-referrer-when-downgrade The Referer header will not be sent to origins without TLS (HTTPS). origin The sent referrer will be limited to the origin of the referring page: its scheme, host, and port. origin-when-cross-origin The referrer sent to other origins will be limited to the scheme, the host, and the port. Navigations on the same origin will still include the path. same-origin A referrer will be sent for same origin, but cross-origin requests will contain no referrer information. strict-origin Only send the origin of the document as the referrer when the protocol security level stays the same (HTTPS→HTTPS), but don't send it to a less secure destination (HTTPS→HTTP). strict-origin-when-cross-origin (default) Send a full URL when performing a same-origin request, only send the origin when the protocol security level stays the same (HTTPS→HTTPS), and send no header to a less secure destination (HTTPS→HTTP). unsafe-url The referrer will include the origin and the path (but not the fragment, password, or username). This value is unsafe, because it leaks origins and paths from TLS-protected resources to insecure origins."
 				},
 				"sandbox": {
+					"description": "Controls the restrictions applied to the content embedded in the <iframe>. The value of the attribute can either be empty to apply all restrictions, or space-separated tokens to lift particular restrictions: allow-downloads Allows downloading files through an <a> or <area> element with the download attribute, as well as through the navigation that leads to a download of a file. This works regardless of whether the user clicked on the link, or JS code initiated it without user interaction. allow-forms Allows the page to submit forms. If this keyword is not used, a form will be displayed as normal, but submitting it will not trigger input validation, send data to a web server, or close a dialog. allow-modals Allows the page to open modal windows by Window.alert(), Window.confirm(), Window.print() and Window.prompt(), while opening a <dialog> is allowed regardless of this keyword. It also allows the page to receive BeforeUnloadEvent event. allow-orientation-lock Lets the resource lock the screen orientation. allow-pointer-lock Allows the page to use the Pointer Lock API. allow-popups Allows popups (created, for example, by Window.open() or target=\"_blank\"). If this keyword is not used, such functionality will silently fail. allow-popups-to-escape-sandbox Allows a sandboxed document to open a new browsing context without forcing the sandboxing flags upon it. This will allow, for example, a third-party advertisement to be safely sandboxed without forcing the same restrictions upon the page the ad links to. If this flag is not included, a redirected page, popup window, or new tab will be subject to the same sandbox restrictions as the originating <iframe>. allow-presentation Allows embedders to have control over whether an iframe can start a presentation session. allow-same-origin If this token is not used, the resource is treated as being from a special origin that always fails the same-origin policy (potentially preventing access to data storage/cookies and some JavaScript APIs). Note: When allow-same-origin is present, a same-origin parent document can still access and interact with the iframe's DOM even if allow-scripts is not set. The allow-scripts token only controls script execution within the embedded browsing context and does not affect DOM access from the parent. allow-scripts Allows the page to run scripts (but not create pop-up windows). If this keyword is not used, this operation is not allowed. allow-storage-access-by-user-activation Experimental Allows a document loaded in the <iframe> to use the Storage Access API to request access to unpartitioned cookies. allow-top-navigation Lets the resource navigate the top-level browsing context (the one named _top). allow-top-navigation-by-user-activation Lets the resource navigate the top-level browsing context, but only if initiated by a user gesture. allow-top-navigation-to-custom-protocols Allows navigations to non-http protocols built into browser or registered by a website. This feature is also activated by allow-popups or allow-top-navigation keyword. Note: When the embedded document has the same origin as the embedding page, it is strongly discouraged to use both allow-scripts and allow-same-origin, as that lets the embedded document remove the sandbox attribute — making it no more secure than not using the sandbox attribute at all. Sandboxing is useless if the attacker can display content outside a sandboxed iframe — such as if the viewer opens the frame in a new tab. Such content should be also served from a separate origin to limit potential damage. Note: When redirecting the user, opening a popup window, or opening a new tab from an embedded page within an <iframe> with the sandbox attribute, the new browsing context is subject to the same sandbox restrictions. This can create issues — for example, if a page embedded within an <iframe> without a sandbox=\"allow-forms\" or sandbox=\"allow-popups-to-escape-sandbox\" attribute set on it opens a new site in a separate tab, form submission in that new browsing context will silently fail.",
 					"type": {
 						"token": {
 							"enum": [
@@ -37701,10 +37740,12 @@
 					"deprecated": true
 				},
 				"src": {
+					"description": "The URL of the page to embed. Use a value of about:blank to embed an empty page that conforms to the same-origin policy. Also note that programmatically removing an <iframe>'s src attribute (e.g., via Element.removeAttribute()) causes about:blank to be loaded in the frame in Firefox (from version 65), Chromium-based browsers, and Safari/iOS. Note: The about:blank page uses the embedding document's URL as its base URL when resolving any relative URLs, such as anchor links.",
 					"required": "[itemprop]",
 					"ineffective": "[srcdoc]"
 				},
 				"srcdoc": {
+					"description": "Inline HTML to embed, overriding the src attribute. Its content should follow the syntax of a full HTML document, which includes the doctype directive, <html>, <body> tags, etc., although most of them can be omitted, leaving only the body content. This doc will have about:srcdoc as its location. If a browser does not support the srcdoc attribute, it will fall back to the URL in the src attribute. Note: The about:srcdoc page uses the embedding document's URL as its base URL when resolving any relative URLs, such as anchor links.",
 					"type": "Any"
 				},
 				"width": {
@@ -37798,6 +37839,7 @@
 					"deprecated": true
 				},
 				"alt": {
+					"description": "Defines text that can replace the image in the page. Note: Browsers do not always display images. There are a number of situations in which a browser might not display images, such as: Non-visual browsers (such as those used by people with visual impairments) The user chooses not to display images (saving bandwidth, privacy reasons) The image is invalid or an unsupported type In these cases, the browser may replace the image with the text in the element's alt attribute. For these reasons and others, provide a useful value for alt whenever possible. Setting this attribute to an empty string (alt=\"\") indicates that this image is not a key part of the content (it's decoration or a tracking pixel), and that non-visual browsers may omit it from rendering. Visual browsers will also hide the broken image icon if the alt attribute is empty and the image failed to display. This attribute is also used when copying and pasting the image to text, or saving a linked image to a bookmark.",
 					"type": "Any"
 				},
 				"attributionsrc": {
@@ -37812,6 +37854,7 @@
 					"description": "Indicates if the fetching of the image must be done using a CORS request. Image data from a CORS-enabled image returned from a CORS request can be reused in the <canvas> element without being marked \"tainted\". If the crossorigin attribute is not specified, then a non-CORS request is sent (without the Origin request header), and the browser marks the image as tainted and restricts access to its image data, preventing its usage in <canvas> elements. If the crossorigin attribute is specified, then a CORS request is sent (with the Origin request header); but if the server does not opt into allowing cross-origin access to the image data by the origin site (by not sending any Access-Control-Allow-Origin response header, or by not including the site's origin in any Access-Control-Allow-Origin response header it does send), then the browser blocks the image from loading, and logs a CORS error to the devtools console. Allowed values: anonymous A CORS request is sent with credentials omitted (that is, no cookies, X.509 certificates, or Authorization request header). use-credentials The CORS request is sent with any credentials included (that is, cookies, X.509 certificates, and the Authorization request header). If the server does not opt into sharing credentials with the origin site (by sending back the Access-Control-Allow-Credentials: true response header), then the browser marks the image as tainted and restricts access to its image data. If the attribute has an invalid value, browsers handle it as if the anonymous value was used. See CORS settings attributes for additional information."
 				},
 				"decoding": {
+					"description": "This attribute provides a hint to the browser as to whether it should perform image decoding along with rendering the other DOM content in a single presentation step that looks more \"correct\" (sync), or render and present the other DOM content first and then decode the image and present it later (async). In practice, async means that the next paint does not wait for the image to decode. It is often difficult to perceive any noticeable effect when using decoding on static <img> elements. They'll likely be initially rendered as empty images while the image files are fetched (either from the network or from the cache) and then handled independently anyway, so the \"syncing\" of content updates is less apparent. However, the blocking of rendering while decoding happens, while often quite small, can be measured — even if it is difficult to observe with the human eye. See What does the image decoding attribute actually do? for a more detailed analysis (tunetheweb.com, 2023). Using different decoding types can result in more noticeable differences when dynamically inserting <img> elements into the DOM via JavaScript — see HTMLImageElement.decoding for more details. Allowed values: sync Decode the image synchronously along with rendering the other DOM content, and present everything together. async Decode the image asynchronously, after rendering and presenting the other DOM content. auto No preference for the decoding mode; the browser decides what is best for the user. This is the default value.",
 					"type": {
 						"enum": ["sync", "async", "auto"],
 						"invalidValueDefault": "auto",
@@ -37832,6 +37875,7 @@
 					"deprecated": true
 				},
 				"ismap": {
+					"description": "This Boolean attribute indicates that the image is part of a server-side map. If so, the coordinates where the user clicked on the image are sent to the server. Note: This attribute is allowed only if the <img> element is a descendant of an <a> element with a valid href attribute. This gives users without pointing devices a fallback destination.",
 					"type": "Boolean",
 					"condition": "a[href] img"
 				},
@@ -37853,14 +37897,17 @@
 					"description": "One or more values separated by commas, which can be source sizes or the auto keyword. The spec requires that the sizes attribute to only be present when srcset uses width descriptors. A source size consists of: A media condition, omitted for the last item in the list. A source size value. Media conditions describe properties of the viewport, not the image. For example, (height <= 500px) 1000px proposes using an image source of 1000px width if the viewport height is 500px or less. Because a source size descriptor specifies the width to use for the image during layout, the media condition is typically (but not necessarily) based on the width. Source size values specify the intended display size of the image. User agents use the current source size to select one of the sources supplied by the srcset attribute, when those sources are described using width (w) descriptors. The selected source size affects the intrinsic size of the image (the image's display size if no CSS styling is applied). A source size value can be any non-negative length. It must not use CSS functions other than the math functions. Units are interpreted in the same way as media queries, meaning that all relative length units are relative to the document root rather than the <img> element. For example, an em value is relative to the root font size, not the font size of the image. Percentage values are not allowed. If the sizes attribute is not provided, it has a default value of 100vw (the viewport width). The auto keyword can replace the whole list of sizes or the first entry in the list. It is only valid when combined with loading=\"lazy\", and resolves to the concrete size of the image. Since the intrinsic size of the image is not yet known, width and height attributes (or CSS equivalents) should also be specified to prevent the browser from assuming the default image width of 300px. For better backward compatibility with browsers that do not support auto, you can include fallback sizes after auto in the sizes attribute: html<img loading=\"lazy\" width=\"200\" height=\"200\" sizes=\"auto, (max-width: 30em) 100vw, (max-width: 50em) 50vw, calc(33vw - 100px)\" srcset=\" swing-200.jpg 200w, swing-400.jpg 400w, swing-800.jpg 800w, swing-1600.jpg 1600w \" src=\"swing-400.jpg\" alt=\"Kettlebell Swing\" />"
 				},
 				"src": {
+					"description": "The image URL. At least one of src and srcset is required for an <img> element. If srcset is specified, src is used in one of two ways: as a fallback for browsers that don't support srcset. if srcset uses the \"x\" descriptor, then src is equivalent to a source with the density descriptor 1x; that is, the image specified by src is used on low-density screens (such as typical 72 DPI or 96 DPI displays).",
 					"type": "URL",
 					"requiredEither": ["srcset"]
 				},
 				"srcset": {
+					"description": "One or more strings separated by commas, indicating possible image sources for the user agent to use. Each string is composed of: A URL to an image Optionally, whitespace followed by one of: A width descriptor (a positive integer directly followed by w). It must match the intrinsic width of the referenced image. The width descriptor is divided by the source size given in the sizes attribute to calculate the effective pixel density. For example, to provide an image resource to be used when the renderer needs a 450 pixel wide image, use the width descriptor 450w. When a srcset contains \"w\" descriptors, the browser uses those descriptors together with the sizes attribute to pick a resource. A pixel density descriptor (a positive floating point number directly followed by x). It specifies the condition in which the corresponding image resource should be used as the display's pixel density. For example, to provide an image resource to be used when the pixel density is double the standard density, use the pixel density descriptor 2x or 2.0x. If no descriptor is specified, the source is assigned the default descriptor of 1x. It is incorrect to mix width descriptors and pixel density descriptors in the same srcset attribute. Duplicate descriptors (for instance, two sources in the same srcset which are both described with 2x) are also invalid. Space characters, other than the whitespace separating the URL and the corresponding condition descriptor, are ignored; this includes both leading and trailing space, as well as space before or after each comma. However, if an image candidate string contains no descriptors and no whitespace after the URL, the following image candidate string, if there is one, must begin with one or more whitespace, or the comma will be considered part of the URL. When the <img> element's srcset uses x descriptors, browsers also consider the URL in the src attribute (if present) as a candidate, and assign it a default descriptor of 1x. On the other hand, if the srcset attribute uses width descriptors, src is not considered, and the sizes attribute is used instead. The user agent selects any of the available sources at its discretion. This provides them with significant leeway to tailor their selection based on things like user preferences or bandwidth conditions. See our Responsive images tutorial for an example.",
 					"type": "Srcset",
 					"requiredEither": ["src"]
 				},
 				"usemap": {
+					"description": "The partial URL (starting with #) of an image map associated with the element. Note: You cannot use this attribute if the <img> element is inside an <a> or <button> element.",
 					"type": "HashName",
 					"condition": ":is(:not(a):not(button)) img"
 				},
@@ -38373,6 +38420,7 @@
 			},
 			"attributes": {
 				"accept": {
+					"description": "Valid for the file input type only, the accept attribute defines which file types are selectable in a file upload control. See the file input type.",
 					"type": {
 						"token": "Accept",
 						"caseInsensitive": true,
@@ -38382,10 +38430,13 @@
 					"condition": "[type='file' i]"
 				},
 				"alpha": {
+					"description": "Valid for the color input type only, the alpha attribute provides the end user with the ability to set the opacity of the color being selected.",
+					"experimental": true,
 					"type": "Boolean",
 					"condition": "[type='color' i]"
 				},
 				"alt": {
+					"description": "Valid for the image button only, the alt attribute provides alternative text for the image, displaying the value of the attribute if the image src is missing or otherwise fails to load. See the image input type.",
 					"type": "Any",
 					"condition": "[type='image' i]"
 				},
@@ -38393,6 +38444,7 @@
 					"description": "Controls whether inputted text is automatically capitalized and, if so, in what manner. See the autocapitalize global attribute page for more information."
 				},
 				"autocomplete": {
+					"description": "(Not a Boolean attribute!) The autocomplete attribute takes as its value a space-separated string that describes what, if any, type of autocomplete functionality the input should provide. A typical implementation of autocomplete recalls previous values entered in the same input field, but more complex forms of autocomplete can exist. For instance, a browser could integrate with a device's contacts list to autocomplete email addresses in an email input field. See autocomplete for permitted values. The autocomplete attribute is valid on hidden, text, search, url, tel, email, date, month, week, time, datetime-local, number, range, color, and password. This attribute has no effect on input types that do not return numeric or text data, being valid for all input types except checkbox, radio, file, or any of the button types. See the autocomplete attribute for additional information, including information on password security and how autocomplete is slightly different for hidden than for other input types.",
 					"condition": [
 						":not([type])",
 						"[type='hidden' i]",
@@ -38419,10 +38471,13 @@
 					"description": "Introduced in the HTML Media Capture specification and valid for the file input type only, the capture attribute defines which media—microphone, video, or camera—should be used to capture a new file for upload with file upload control in supporting scenarios. See the file input type."
 				},
 				"checked": {
+					"description": "Valid for both radio and checkbox types, checked is a Boolean attribute. If present on a radio type, it indicates that the radio button is the currently selected one in the group of same-named radio buttons. If present on a checkbox type, it indicates that the checkbox is checked by default (when the page loads). It does not indicate whether this checkbox is currently checked: if the checkbox's state is changed, this content attribute does not reflect the change. (Only the HTMLInputElement's checked IDL attribute is updated.) Note: Unlike other input controls, a checkboxes and radio buttons value are only included in the submitted data if they are currently checked. If they are, the name and the value(s) of the checked controls are submitted. For example, if a checkbox whose name is fruit has a value of cherry, and the checkbox is checked, the form data submitted will include fruit=cherry. If the checkbox isn't active, it isn't listed in the form data at all. The default value for checkboxes and radio buttons is on.",
 					"type": "Boolean",
 					"condition": ["[type='checkbox' i]", "[type='radio' i]"]
 				},
 				"colorspace": {
+					"description": "Valid for the color input type only, the colorspace attribute specifies the color space that is used by the type=\"color\" input. Possible enumerated values are: \"limited-srgb\": The color is in the sRGB color space. This includes rgb(), hsl(), hwb(), and <hex-color> values. The color value is limited to 8-bits per r, g, and b component. This is the default. \"display-p3\": The Display P3 color space, e.g., color(display-p3 1.84 -0.19 0.72 / 0.6)",
+					"experimental": true,
 					"type": {
 						"enum": ["limited-srgb", "display-p3"],
 						"invalidValueDefault": "limited-srgb",
@@ -38431,6 +38486,7 @@
 					"condition": "[type='color' i]"
 				},
 				"dirname": {
+					"description": "Valid for hidden, text, search, url, tel, and email input types, the dirname attribute enables the submission of the directionality of the element. When included, the form control will submit with two name/value pairs: the first being the name and value, and the second being the value of the dirname attribute as the name, with a value of ltr or rtl as set by the browser. html<form action=\"page.html\" method=\"post\"> <label> Fruit: <input type=\"text\" name=\"fruit\" dirname=\"fruit-dir\" value=\"cherry\" /> </label> <input type=\"submit\" /> </form> <!-- page.html?fruit=cherry&fruit-dir=ltr --> When the form above is submitted, the input cause both the name / value pair of fruit=cherry and the dirname / direction pair of fruit-dir=ltr to be sent. For more information, see the dirname attribute.",
 					"condition": [
 						":not([type])",
 						"[type='hidden' i]",
@@ -38465,6 +38521,7 @@
 					"description": "Valid for the image and submit input types only. See the submit input type for more information."
 				},
 				"height": {
+					"description": "Valid for the image input button only, the height is the height of the image file to display to represent the graphical submit button. See the image input type.",
 					"condition": "[type='image' i]"
 				},
 				"id": {
@@ -38478,6 +38535,7 @@
 					"description": "Global value valid for all elements, it provides a hint to browsers as to the type of virtual keyboard configuration to use when editing this element or its contents. Values include none, text, tel, url, email, numeric, decimal, and search."
 				},
 				"list": {
+					"description": "The value given to the list attribute should be the id of a <datalist> element located in the same document. The <datalist> provides a list of predefined values to suggest to the user for this input. Any values in the list that are not compatible with the type are not included in the suggested options. The values provided are suggestions, not requirements: users can select from this predefined list or provide a different value. It is valid on text, search, url, tel, email, date, month, week, time, datetime-local, number, range, and color. Per the specifications, the list attribute is not supported by the hidden, password, checkbox, radio, file, or any of the button types. Depending on the browser, the user may see a custom color palette suggested, tic marks along a range, or even an input that opens like a <select> but allows for non-listed values. Check out the browser compatibility table for the other input types. See the <datalist> element.",
 					"type": "DOMID",
 					"condition": [
 						":not([type])",
@@ -38497,6 +38555,7 @@
 					]
 				},
 				"max": {
+					"description": "Valid for date, month, week, time, datetime-local, number, and range, it defines the greatest value in the range of permitted values. If the value entered into the element exceeds this, the element fails constraint validation. If the value of the max attribute isn't a number, then the element has no maximum value. There is a special case: if the data type is periodic (such as for dates or times), the value of max may be lower than the value of min, which indicates that the range may wrap around; for example, this allows you to specify a time range from 10 PM to 4 AM.",
 					"type": ["DateTime", "Number"],
 					"condition": [
 						"[type='date' i]",
@@ -38509,6 +38568,7 @@
 					]
 				},
 				"maxlength": {
+					"description": "Valid for text, search, url, tel, email, and password, it defines the maximum string length (measured in UTF-16 code units) that the user can enter into the field. This must be an integer value of 0 or higher. If no maxlength is specified, or an invalid value is specified, the field has no maximum length. This value must also be greater than or equal to the value of minlength. The input will fail constraint validation if the length of the text entered into the field is greater than maxlength UTF-16 code units long. By default, browsers prevent users from entering more characters than allowed by the maxlength attribute. Constraint validation is only applied when the value is changed by the user. See Client-side validation for more information.",
 					"condition": [
 						":not([type])",
 						"[type='text' i]",
@@ -38520,6 +38580,7 @@
 					]
 				},
 				"min": {
+					"description": "Valid for date, month, week, time, datetime-local, number, and range, it defines the most negative value in the range of permitted values. If the value entered into the element is less than this, the element fails constraint validation. If the value of the min attribute isn't a number, then the element has no minimum value. This value must be less than or equal to the value of the max attribute. If the min attribute is present but is not specified or is invalid, no min value is applied. If the min attribute is valid and a non-empty value is less than the minimum allowed by the min attribute, constraint validation will prevent form submission. See Client-side validation for more information. There is a special case: if the data type is periodic (such as for dates or times), the value of max may be lower than the value of min, which indicates that the range may wrap around; for example, this allows you to specify a time range from 10 PM to 4 AM.",
 					"type": ["DateTime", "Number"],
 					"condition": [
 						"[type='date' i]",
@@ -38532,6 +38593,7 @@
 					]
 				},
 				"minlength": {
+					"description": "Valid for text, search, url, tel, email, and password, it defines the minimum string length (measured in UTF-16 code units) that the user can enter into the entry field. This must be a non-negative integer value smaller than or equal to the value specified by maxlength. If no minlength is specified, or an invalid value is specified, the input has no minimum length. The input will fail constraint validation if the length of the text entered into the field is fewer than minlength UTF-16 code units long, preventing form submission. Constraint validation is only applied when the value is changed by the user. See Client-side validation for more information.",
 					"condition": [
 						":not([type])",
 						"[type='text' i]",
@@ -38543,6 +38605,7 @@
 					]
 				},
 				"multiple": {
+					"description": "The Boolean multiple attribute, if set, means the user can enter comma separated email addresses in the email widget or can choose more than one file with the file input. See the email and file input type.",
 					"type": "Boolean",
 					"condition": ["[type='email' i]", "[type='file' i]"]
 				},
@@ -38554,6 +38617,7 @@
 					"nonStandard": true
 				},
 				"pattern": {
+					"description": "Valid for text, search, url, tel, email, and password, the pattern attribute is used to compile a regular expression that the input's value must match in order for the value to pass constraint validation. It must be a valid JavaScript regular expression, as used by the RegExp type, and as documented in our guide on regular expressions. No forward slashes should be specified around the pattern text. When compiling the regular expression: the pattern will be implicitly wrapped with ^(?: and )$, such that the match is required against the entire input value, i.e., ^(?:<pattern>)$. the 'v' flag is specified so that the pattern is treated as a sequence of Unicode code points, instead of as ASCII. If the pattern attribute is present but is not specified or is invalid, no regular expression is applied and this attribute is ignored completely. If the pattern attribute is valid and a non-empty value does not match the pattern, constraint validation will prevent form submission. If the multiple is present, the compiled regular expression is matched against each comma separated value. Note: If using the pattern attribute, inform the user about the expected format by including explanatory text nearby. You can also include a title attribute to explain what the requirements are to match the pattern; most browsers will display this title as a tooltip. The visible explanation is required for accessibility. The tooltip is an enhancement. See Client-side validation for more information.",
 					"type": "Pattern",
 					"condition": [
 						":not([type])",
@@ -38566,6 +38630,7 @@
 					]
 				},
 				"placeholder": {
+					"description": "Valid for text, search, url, tel, email, password, and number, the placeholder attribute provides a brief hint to the user as to what kind of information is expected in the field. It should be a word or short phrase that provides a hint as to the expected type of data, rather than an explanation or prompt. The text must not include carriage returns or line feeds. So for example if a field is expected to capture a user's first name, and its label is \"First Name\", a suitable placeholder might be \"e.g., Mustafa\". Note: The placeholder attribute is not as semantically useful as other ways to explain your form, and can cause unexpected technical issues with your content. See Labels for more information.",
 					"type": "OneLineAny",
 					"condition": [
 						":not([type])",
@@ -38579,10 +38644,12 @@
 					]
 				},
 				"popovertarget": {
+					"description": "Turns an <input type=\"button\"> element into a popover control button; takes the ID of the popover element to control as its value. See the Popover API landing page for more details. Establishing a relationship between a popover and its invoker button using the popovertarget attribute has two additional useful effects: The browser creates an implicit aria-details and aria-expanded relationship between popover and invoker, and places the popover in a logical position in the keyboard focus navigation order when shown. This makes the popover more accessible to keyboard and assistive technology (AT) users (see also Popover accessibility features). The browser creates an implicit anchor reference between the two, making it very convenient to position popovers relative to their controls using CSS anchor positioning. See Popover anchor positioning for more details.",
 					"type": "DOMID",
 					"condition": ["[type='button' i]", "[type='image' i]", "[type='reset' i]", "[type='submit' i]"]
 				},
 				"popovertargetaction": {
+					"description": "Specifies the action to be performed on a popover element being controlled by a control <input type=\"button\">. Possible values are: \"hide\" The button will hide a shown popover. If you try to hide an already hidden popover, no action will be taken. \"show\" The button will show a hidden popover. If you try to show an already showing popover, no action will be taken. \"toggle\" The button will toggle a popover between showing and hidden. If the popover is hidden, it will be shown; if the popover is showing, it will be hidden. If popovertargetaction is omitted, \"toggle\" is the default action that will be performed by the control button.",
 					"type": {
 						"enum": ["toggle", "show", "hide"],
 						"disallowToSurroundBySpaces": true,
@@ -38592,6 +38659,7 @@
 					"condition": ["[type='button' i]", "[type='image' i]", "[type='reset' i]", "[type='submit' i]"]
 				},
 				"readonly": {
+					"description": "A Boolean attribute which, if present, indicates that the user should not be able to edit the value of the input. The readonly attribute is supported by the text, search, url, tel, email, date, month, week, time, datetime-local, number, and password input types. See the HTML attribute: readonly for more information.",
 					"condition": [
 						":not([type])",
 						"[type='text' i]",
@@ -38609,6 +38677,7 @@
 					]
 				},
 				"required": {
+					"description": "required is a Boolean attribute which, if present, indicates that the user must specify a value for the input before the owning form can be submitted. The required attribute is supported by text, search, url, tel, email, date, month, week, time, datetime-local, number, password, checkbox, radio, and file inputs. See Client-side validation and the HTML attribute: required for more information.",
 					"condition": [
 						":not([type])",
 						"[type='text' i]",
@@ -38633,6 +38702,7 @@
 					"nonStandard": true
 				},
 				"size": {
+					"description": "Valid for email, password, tel, url, and text, the size attribute specifies how much of the input is shown. Basically creates same result as setting CSS width property with a few specialties. The actual unit of the value depends on the input type. For password and text, it is a number of characters (or em units) with a default value of 20, and for others, it is pixels (or px units). CSS width takes precedence over the size attribute.",
 					"type": {
 						"type": "integer",
 						"gt": 0
@@ -38649,9 +38719,11 @@
 					"defaultValue": "20"
 				},
 				"src": {
+					"description": "Valid for the image input button only, the src is string specifying the URL of the image file to display to represent the graphical submit button. See the image input type.",
 					"condition": "[type='image' i]"
 				},
 				"step": {
+					"description": "Valid for date, month, week, time, datetime-local, number, and range, the step attribute is a number that specifies the granularity that the value must adhere to. Only values which are a whole number of steps from the step base are valid. The step base is min if specified, value otherwise, or 0 if neither is provided (except for week, which has a default step base of −259,200,000, representing the start of week 1970-W01). If not explicitly included: step defaults to 1 for number and range. Each date/time input type has a default step value appropriate for the type; see the individual input pages: date, datetime-local, month, time, and week. The value must be a positive number—integer or float—or the special value any, which means no stepping is implied, and any value is allowed (barring other constraints, such as min and max). For example, if you have <input type=\"number\" min=\"10\" step=\"2\">, then any even integer, 10 or greater, is valid. If omitted, <input type=\"number\">, any integer is valid, but floats (like 4.2) are not valid, because step defaults to 1. For 4.2 to be valid, step would have had to be set to any, 0.1, 0.2, or the min value would have had to be a number ending in .2, such as <input type=\"number\" min=\"-5.2\">. Note: When the data entered by the user doesn't adhere to the stepping configuration, the value is considered invalid in constraint validation and will match the :invalid pseudoclass. See Client-side validation for more information.",
 					"type": [
 						"Number",
 						{
@@ -38670,8 +38742,9 @@
 					]
 				},
 				"switch": {
-					"type": "Boolean",
+					"description": "Valid for checkbox input only, switch is a Boolean attribute that indicates whether the checkbox input should be rendered as a switch. Note: This attribute is still experimental and has limited browser support. The attribute is ignored on unsupported browsers.",
 					"experimental": true,
+					"type": "Boolean",
 					"condition": ["[type='checkbox' i]"]
 				},
 				"tabindex": {
@@ -38681,6 +38754,7 @@
 					"description": "Global attribute valid for all elements, including all input types, containing a text representing advisory information related to the element it belongs to. Such information can typically, but not necessarily, be presented to the user as a tooltip. The title should NOT be used as the primary explanation of the purpose of the form control. Instead, use the <label> element with a for attribute set to the form control's id attribute. See Labels below."
 				},
 				"type": {
+					"description": "A string specifying the type of control to render. For example, to create a checkbox, a value of checkbox is used. If omitted (or an unknown value is specified), the input type text is used, creating a plaintext input field. Permitted values are listed in Input types above.",
 					"type": {
 						"enum": [
 							"hidden",
@@ -38712,6 +38786,7 @@
 					"defaultValue": "text"
 				},
 				"value": {
+					"description": "The input control's value. When specified in the HTML, this is the initial value, and from then on it can be altered or retrieved at any time using JavaScript to access the respective HTMLInputElement object's value property. The value attribute is always optional, though should be considered mandatory for checkbox, radio, and hidden.",
 					"type": "Any"
 				},
 				"webkitdirectory": {
@@ -38719,6 +38794,7 @@
 					"nonStandard": true
 				},
 				"width": {
+					"description": "Valid for the image input button only, the width is the width of the image file to display to represent the graphical submit button. See the image input type.",
 					"condition": "[type='image' i]"
 				}
 			}
@@ -38751,9 +38827,11 @@
 			},
 			"attributes": {
 				"cite": {
+					"description": "This attribute defines the URI of a resource that explains the change, such as a link to meeting minutes or a ticket in a troubleshooting system.",
 					"type": "URL"
 				},
 				"datetime": {
+					"description": "This attribute indicates the time and date of the change and must be a valid date with an optional time string. If the value cannot be parsed as a date with an optional time string, the element does not have an associated timestamp. For the format of the string without a time, see Format of a valid date string. The format of the string if it includes both date and time is covered in Format of a valid local date and time string.",
 					"type": "DateTime"
 				}
 			}
@@ -38842,6 +38920,7 @@
 			},
 			"attributes": {
 				"for": {
+					"description": "The value is the id of the labelable form control in the same document, associating the <label> with that form control. Note that its JavaScript reflection property is htmlFor.",
 					"type": "DOMID"
 				}
 			}
@@ -38910,6 +38989,7 @@
 					"deprecated": true
 				},
 				"value": {
+					"description": "This integer attribute indicates the current ordinal value of the list item as defined by the <ol> element. The only allowed value for this attribute is a number, even if the list is displayed with Roman numerals or letters. List items that follow this one continue numbering from the value set. This attribute has no meaning for unordered lists (<ul>) or for menus (<menu>).",
 					"type": "Int",
 					"condition": "ol > li"
 				}
@@ -38946,6 +39026,7 @@
 			},
 			"attributes": {
 				"as": {
+					"description": "This attribute is required when rel=\"preload\" has been set on the <link> element, optional when rel=\"modulepreload\" has been set, and otherwise should not be used. It specifies the type of content being loaded by the <link>, which is necessary for request matching, application of correct content security policy, and setting of correct Accept request header. Furthermore, rel=\"preload\" uses this as a signal for request prioritization. The table below lists the valid values for this attribute and the elements or resources they apply to. Value Applies To audio <audio> elements document <iframe> and <frame> elements embed <embed> elements fetch fetch, XHR Note: This value also requires <link> to contain the crossorigin attribute, see CORS-enabled fetches. font CSS @font-face Note: This value also requires <link> to contain the crossorigin attribute, see CORS-enabled fetches. image <img> and <picture> elements with srcset or imageset attributes, SVG <image> elements, CSS *-image rules object <object> elements script <script> elements, Worker importScripts style <link rel=stylesheet> elements, CSS @import track <track> elements video <video> elements worker Worker, SharedWorker",
 					"type": {
 						"enum": [
 							"fetch",
@@ -38974,6 +39055,7 @@
 					"condition": ["[rel='preload' i]", "[rel='modulepreload' i]"]
 				},
 				"blocking": {
+					"description": "This attribute explicitly indicates that certain operations should be blocked until specific conditions are met. It must only be used when the rel attribute contains the expect or stylesheet keywords. With rel=\"expect\", it indicates that operations should be blocked until a specific DOM node has been parsed. With rel=\"stylesheet\", it indicates that operations should be blocked until an external stylesheet and its critical subresources have been fetched and applied to the document. The operations that are to be blocked must be a space-separated list of blocking tokens listed below. Currently there is only one token: render: The rendering of content on the screen is blocked. Note: Only link elements in the document's <head> can possibly block rendering. By default, a link element with rel=\"stylesheet\" in the <head> blocks rendering when the browser discovers it during parsing. If such a link element is added dynamically via script, you must additionally set blocking = \"render\" for it to block rendering.",
 					"type": {
 						"token": {
 							"enum": ["render"]
@@ -38996,6 +39078,7 @@
 					"description": "This enumerated attribute indicates whether CORS must be used when fetching the resource. CORS-enabled images can be reused in the <canvas> element without being tainted. The allowed values are: anonymous A cross-origin request (i.e., with an Origin HTTP header) is performed, but no credential is sent (i.e., no cookie, X.509 certificate, or HTTP Basic authentication). If the server does not give credentials to the origin site (by not setting the Access-Control-Allow-Origin HTTP header) the resource will be tainted and its usage restricted. use-credentials A cross-origin request (i.e., with an Origin HTTP header) is performed along with a credential sent (i.e., a cookie, certificate, and/or HTTP Basic authentication is performed). If the server does not give credentials to the origin site (through Access-Control-Allow-Credentials HTTP header), the resource will be tainted and its usage restricted. If the attribute is not present, the resource is fetched without a CORS request (i.e., without sending the Origin HTTP header), preventing its non-tainted usage. If invalid, it is handled as if the enumerated keyword anonymous was used. See CORS settings attributes for additional information."
 				},
 				"disabled": {
+					"description": "For rel=\"stylesheet\" only, the disabled Boolean attribute indicates whether the described stylesheet should be loaded and applied to the document. If disabled is specified in the HTML when it is loaded, the stylesheet will not be loaded during page load. Instead, the stylesheet will be loaded on-demand, if and when the disabled attribute is changed to false or removed. Setting the disabled property in the DOM causes the stylesheet to be removed from the document's Document.styleSheets list.",
 					"type": "Boolean"
 				},
 				"fetchpriority": {
@@ -39008,16 +39091,19 @@
 					"description": "This attribute indicates the language of the linked resource. It is purely advisory. Values should be valid BCP 47 language tags. Use this attribute only if the href attribute is present."
 				},
 				"imagesizes": {
+					"description": "For rel=\"preload\" and as=\"image\" only, the imagesizes attribute has similar syntax and semantics as the sizes attribute that indicates to preload the appropriate resource used by an img element with corresponding values for its srcset and sizes attributes.",
 					"type": "SourceSizeList",
 					"condition": "[imagesrcset][rel~='preload' i][as='image' i]",
 					"required": "[imagesrcset]"
 				},
 				"imagesrcset": {
+					"description": "For rel=\"preload\" and as=\"image\" only, the imagesrcset attribute has similar syntax and semantics as the srcset attribute that indicates to preload the appropriate resource used by an img element with corresponding values for its srcset and sizes attributes.",
 					"type": "Srcset",
 					"condition": "[imagesizes][rel~='preload' i][as='image' i]",
 					"required": "[imagesizes]"
 				},
 				"integrity": {
+					"description": "Contains inline metadata — a base64-encoded cryptographic hash of the resource (file) you're telling the browser to fetch. The browser can use this to verify that the fetched resource has been delivered without unexpected manipulation. The attribute must only be specified when the rel attribute is specified to stylesheet, preload, or modulepreload. See Subresource Integrity.",
 					"condition": ["[rel~='stylesheet' i]", "[rel~='preload' i]", "[rel~='modulepreload' i]"]
 				},
 				"itemprop": {
@@ -39030,6 +39116,7 @@
 					"description": "A string indicating which referrer to use when fetching the resource. For detailed explanations and examples of each policy, see the Referrer-Policy header documentation. no-referrer means that the Referer header will not be sent. no-referrer-when-downgrade means that no Referer header will be sent when navigating to an origin without TLS (HTTPS). This is a user agent's default behavior, if no policy is otherwise specified. origin means that the referrer will be the origin of the page, which is roughly the scheme, the host, and the port. origin-when-cross-origin means that navigating to other origins will be limited to the scheme, the host, and the port, while navigating on the same origin will include the referrer's path. same-origin means that the referrer (origin, path, and query string) is sent for same-origin requests, but no referrer is sent for cross-origin requests. strict-origin means that only the origin is sent when the protocol security level stays the same (HTTPS→HTTPS). No referrer is sent to less secure destinations (HTTPS→HTTP). This is important for HTTPS pages because it prevents leaking referrer information to insecure origins. strict-origin-when-cross-origin means that the full referrer is sent for same-origin requests. For cross-origin requests, only the origin is sent when the protocol stays the same (HTTPS→HTTPS), and no referrer is sent when downgrading to HTTP. This is the default value, which balances functionality with privacy and security for HTTPS sites. unsafe-url means that the referrer will include the origin and the path (but not the fragment, password, or username). This case is unsafe because it can leak origins and paths from TLS-protected resources to insecure origins."
 				},
 				"rel": {
+					"description": "This attribute names a relationship of the linked document to the current document. The attribute must be a space-separated list of link type values.",
 					"type": "LinkTypeForLinkElement",
 					"requiredEither": ["itemprop"]
 				},
@@ -39039,6 +39126,7 @@
 					"deprecated": true
 				},
 				"sizes": {
+					"description": "This attribute defines the sizes of the icons for visual media contained in the resource. It must be present only if the rel contains a value of icon or a non-standard type such as Apple's apple-touch-icon. It may have the following values: any, meaning that the icon can be scaled to any size as it is in a vector format, like image/svg+xml. a white-space separated list of sizes, each in the format <width in pixels>x<height in pixels> or <width in pixels>X<height in pixels>. Each of these sizes must be contained in the resource. Note: Most icon formats are only able to store one single icon; therefore, most of the time, the sizes attribute contains only one entry. Microsoft's ICO format and Apple's ICNS format can store multiple icon sizes in a single file. ICO has better browser support, so you should use this format if cross-browser support is a concern.",
 					"type": {
 						"token": "IconSize",
 						"caseInsensitive": true,
@@ -39130,6 +39218,7 @@
 			},
 			"attributes": {
 				"name": {
+					"description": "The name attribute gives the map a name so that it can be referenced. The attribute must be present and must have a non-empty value with no space characters. The value of the name attribute must not be equal to the value of the name attribute of another <map> element in the same document. If the id attribute is also specified, both attributes must have the same value.",
 					"type": "NoEmptyAny"
 				}
 			}
@@ -39341,6 +39430,7 @@
 			},
 			"attributes": {
 				"charset": {
+					"description": "This attribute declares the document's character encoding. If the attribute is present, its value must be an ASCII case-insensitive match for the string \"utf-8\", because UTF-8 is the only valid encoding for HTML5 documents. <meta> elements which declare a character encoding must be located entirely within the first 1024 bytes of the document.",
 					"type": {
 						"enum": ["utf-8"],
 						"caseInsensitive": true
@@ -39348,11 +39438,13 @@
 					"condition": [":not([itemprop])", ":not([name])", ":not([http-equiv])"]
 				},
 				"content": {
+					"description": "This attribute contains the value for the http-equiv or name attribute, depending on which is used.",
 					"type": "Any",
 					"required": ["[name]", "[http-equiv]", "[itemprop]"],
 					"condition": ["[name]", "[http-equiv]", "[itemprop]"]
 				},
 				"http-equiv": {
+					"description": "Defines a pragma directive, which are instructions for the browser for processing the document. The attribute's name is short for http-equivalent because the allowed values are names of equivalent HTTP headers.",
 					"type": {
 						"enum": [
 							"content-type",
@@ -39370,9 +39462,11 @@
 					"condition": [":not([name])", ":not([http-equiv])", ":not([charset])"]
 				},
 				"media": {
+					"description": "The media attribute defines which media the theme color defined in the content attribute should be applied to. Its value is a media query, which defaults to all if the attribute is missing. This attribute is only relevant when the element's name attribute is set to theme-color. Otherwise, it has no effect, and should not be included.",
 					"condition": "[name='theme-color']"
 				},
 				"name": {
+					"description": "The name and content attributes can be used together to provide document metadata in terms of name-value pairs, with the name attribute giving the metadata name, and the content attribute giving the value.",
 					"type": "Any",
 					"requiredEither": ["itemprop", "http-equiv", "charset"],
 					"condition": [":not([itemprop])", ":not([http-equiv])", ":not([charset])"]
@@ -39419,21 +39513,27 @@
 			},
 			"attributes": {
 				"high": {
+					"description": "The lower numeric bound of the high end of the measured range. This must be less than the maximum value (max attribute), and it also must be greater than the low value and minimum value (low attribute and min attribute, respectively), if any are specified. If unspecified, or if greater than the maximum value, the high value is equal to the maximum value.",
 					"type": "Number"
 				},
 				"low": {
+					"description": "The upper numeric bound of the low end of the measured range. This must be greater than the minimum value (min attribute), and it also must be less than the high value and maximum value (high attribute and max attribute, respectively), if any are specified. If unspecified, or if less than the minimum value, the low value is equal to the minimum value.",
 					"type": "Number"
 				},
 				"max": {
+					"description": "The upper numeric bound of the measured range. This must be greater than the minimum value (min attribute), if specified. If unspecified, the maximum value is 1.",
 					"type": "Number"
 				},
 				"min": {
+					"description": "The lower numeric bound of the measured range. This must be less than the maximum value (max attribute), if specified. If unspecified, the minimum value is 0.",
 					"type": "Number"
 				},
 				"optimum": {
+					"description": "This attribute indicates the optimal numeric value. It must be within the range (as defined by the min attribute and max attribute). When used with the low attribute and high attribute, it gives an indication where along the range is considered preferable. For example, if it is between the min attribute and the low attribute, then the lower range is considered preferred. The browser may color the meter's bar differently depending on whether the value is less than or equal to the optimum value.",
 					"type": "Number"
 				},
 				"value": {
+					"description": "The current numeric value. This must be between the minimum and maximum values (min attribute and max attribute) if they are specified. If unspecified or malformed, the value is 0. If specified, but not within the range given by the min attribute and max attribute, the value is equal to the nearest end of the range. Note: Unless the value attribute is between 0 and 1 (inclusive), the min and max attributes should define the range so that the value attribute's value is within it.",
 					"type": "Number"
 				}
 			}
@@ -39621,6 +39721,7 @@
 					"deprecated": true
 				},
 				"data": {
+					"description": "The address of the resource as a valid URL. At least one of data and type must be defined.",
 					"type": "URL",
 					"requiredEither": ["type"]
 				},
@@ -39635,6 +39736,7 @@
 					"description": "The height of the displayed resource, as in <integer> in CSS pixels."
 				},
 				"name": {
+					"description": "The name of valid browsing context (HTML5), or the name of the control (HTML 4). The name becomes a property of the Window and Document objects, containing a reference to the embedded window or the element itself.",
 					"type": "NavigableTargetName"
 				},
 				"standby": {
@@ -39642,6 +39744,7 @@
 					"deprecated": true
 				},
 				"type": {
+					"description": "The content type of the resource specified by data. At least one of data and type must be defined.",
 					"type": "MIMEType",
 					"requiredEither": ["data"]
 				},
@@ -39713,12 +39816,15 @@
 					"nonStandard": true
 				},
 				"reversed": {
+					"description": "This Boolean attribute specifies that the list's items are in reverse order. Items will be numbered from high to low.",
 					"type": "Boolean"
 				},
 				"start": {
+					"description": "An integer to start counting from for the list items. Always an Arabic numeral (1, 2, 3, etc.), even when the numbering type is letters or Roman numerals. For example, to start numbering elements from the letter \"d\" or the Roman numeral \"iv,\" use start=\"4\".",
 					"type": "Int"
 				},
 				"type": {
+					"description": "Sets the numbering type: a for lowercase letters A for uppercase letters i for lowercase Roman numerals I for uppercase Roman numerals 1 for numbers (default) The specified type is used for the entire list unless a different type attribute is used on an enclosed <li> element. Note: Unless the type of the list number matters (like legal or technical documents where items are referenced by their number/letter), use the CSS list-style-type property instead.",
 					"type": {
 						"enum": ["1", "a", "A", "i", "I"],
 						"caseInsensitive": false,
@@ -39760,6 +39866,7 @@
 					"description": "If this Boolean attribute is set, none of the items in this option group is selectable. Often browsers grey out such control and it won't receive any browsing events, like mouse clicks or focus-related ones."
 				},
 				"label": {
+					"description": "The name of the group of options, which the browser can use when labeling the options in the user interface. This attribute is mandatory if this element is used.",
 					"type": "Any",
 					"required": true
 				}
@@ -39831,12 +39938,15 @@
 					"description": "If this Boolean attribute is set, this option is not checkable. Often browsers grey out such control and it won't receive any browsing event, like mouse clicks or focus-related ones. If this attribute is not set, the element can still be disabled if one of its ancestors is a disabled <optgroup> element."
 				},
 				"label": {
+					"description": "This attribute is text for the label indicating the meaning of the option. If the label attribute isn't defined, its value is that of the element text content.",
 					"type": "Any"
 				},
 				"selected": {
+					"description": "If present, this Boolean attribute indicates that the option is initially selected. If the <option> element is the descendant of a <select> element whose multiple attribute is not set, only one single <option> of this <select> element may have the selected attribute.",
 					"type": "Boolean"
 				},
 				"value": {
+					"description": "The content of this attribute represents the value to be submitted with the form, should this option be selected. If this attribute is omitted, the value is taken from the text content of the option element.",
 					"type": "Any"
 				}
 			}
@@ -39866,6 +39976,7 @@
 			},
 			"attributes": {
 				"for": {
+					"description": "A space-separated list of other elements' ids, indicating that those elements contributed input values to (or otherwise affected) the calculation.",
 					"type": {
 						"token": "DOMID",
 						"separator": "space",
@@ -40080,9 +40191,11 @@
 			},
 			"attributes": {
 				"max": {
+					"description": "This attribute describes how much work the task indicated by the progress element requires. The max attribute, if present, must have a value greater than 0 and be a valid floating point number. The default value is 1.",
 					"type": "Number"
 				},
 				"value": {
+					"description": "This attribute specifies how much of the task that has been completed. It must be a valid floating point number between 0 and max, or between 0 and 1 if max is omitted. If there is no value attribute, the progress bar is indeterminate; this indicates that an activity is ongoing with no indication of how long it is expected to take.",
 					"type": "Number"
 				}
 			}
@@ -40115,6 +40228,7 @@
 			},
 			"attributes": {
 				"cite": {
+					"description": "The value of this attribute is a URL that designates a source document or message for the information quoted. This attribute is intended to point to information explaining the context or the reference for the quote.",
 					"type": "URL"
 				}
 			}
@@ -40336,6 +40450,7 @@
 			},
 			"attributes": {
 				"async": {
+					"description": "For classic scripts, if the async attribute is present, then the classic script will be fetched in parallel to parsing and evaluated as soon as it is available. For module scripts, if the async attribute is present then the scripts and all their dependencies will be fetched in parallel to parsing and evaluated as soon as they are available. Warning: This attribute must not be used if the src attribute is absent (i.e., for inline scripts) for classic scripts, in this case it would have no effect. This attribute allows the elimination of parser-blocking JavaScript where the browser would have to load and evaluate scripts before continuing to parse. defer has a similar effect in this case. If the attribute is specified with the defer attribute, the element will act as if only the async attribute is specified. This is a boolean attribute: the presence of a boolean attribute on an element represents the true value, and the absence of the attribute represents the false value. See Browser compatibility for notes on browser support. See also Async scripts for asm.js.",
 					"type": "Boolean",
 					"condition": ["[src]", "[type='module' i]"],
 					"ineffective": ":not([src]):not([type='module' i])"
@@ -40345,6 +40460,7 @@
 					"deprecated": true
 				},
 				"blocking": {
+					"description": "This attribute explicitly indicates that certain operations should be blocked until the script has executed. The operations that are to be blocked must be a space-separated list of blocking tokens. Currently there is only one token: render: The rendering of content on the screen is blocked. Note: Only script elements in the document's <head> can possibly block rendering. Scripts are not render-blocking by default; if a script element does not include type=\"module\", async, or defer, then it blocks parsing, not rendering. If such a script element is added dynamically via script, you must set blocking = \"render\" for it to block rendering.",
 					"type": {
 						"token": {
 							"enum": ["render"]
@@ -40361,6 +40477,7 @@
 					"description": "Normal script elements pass minimal information to the window.onerror for scripts which do not pass the standard CORS checks. To allow error logging for sites which use a separate domain for static media, use this attribute. See CORS settings attributes for a more descriptive explanation of its valid arguments."
 				},
 				"defer": {
+					"description": "This Boolean attribute is set to indicate to a browser that the script is meant to be executed after the document has been parsed, but before firing DOMContentLoaded event. Scripts with the defer attribute will prevent the DOMContentLoaded event from firing until the script has loaded and finished evaluating. Warning: This attribute must not be used if the src attribute is absent (i.e., for inline scripts), in this case it would have no effect. The defer attribute has no effect on module scripts — they defer by default. Scripts with the defer attribute will execute in the order in which they appear in the document. This attribute allows the elimination of parser-blocking JavaScript where the browser would have to load and evaluate scripts before continuing to parse. async has a similar effect in this case. If the attribute is specified with the async attribute, the element will act as if only the async attribute is specified.",
 					"type": "Boolean",
 					"condition": "[src]",
 					"ineffective": ["[type='module' i]", ":not([src])", "[async]"]
@@ -40369,6 +40486,7 @@
 					"description": "Provides a hint of the relative priority to use when fetching an external script. Allowed values: high Fetch the external script at a high priority relative to other external scripts. low Fetch the external script at a low priority relative to other external scripts. auto Don't set a preference for the fetch priority. This is the default. It is used if no value or an invalid value is set."
 				},
 				"integrity": {
+					"description": "This attribute contains inline metadata that a user agent can use to verify that a fetched resource has been delivered without unexpected manipulation. The attribute must not be specified when the src attribute is absent. See Subresource Integrity.",
 					"condition": "[src]"
 				},
 				"language": {
@@ -40377,6 +40495,7 @@
 					"nonStandard": true
 				},
 				"nomodule": {
+					"description": "This Boolean attribute is set to indicate that the script should not be executed in browsers that support ES modules — in effect, this can be used to serve fallback scripts to older browsers that do not support modular JavaScript code.",
 					"type": "Boolean",
 					"condition": ":not([type='module' i])"
 				},
@@ -40387,9 +40506,11 @@
 					"description": "Indicates which referrer to send when fetching the script, or resources fetched by the script: no-referrer: The Referer header will not be sent. no-referrer-when-downgrade: The Referer header will not be sent to origins without TLS (HTTPS). origin: The sent referrer will be limited to the origin of the referring page: its scheme, host, and port. origin-when-cross-origin: The referrer sent to other origins will be limited to the scheme, the host, and the port. Navigations on the same origin will still include the path. same-origin: A referrer will be sent for same origin, but cross-origin requests will contain no referrer information. strict-origin: Only send the origin of the document as the referrer when the protocol security level stays the same (HTTPS→HTTPS), but don't send it to a less secure destination (HTTPS→HTTP). strict-origin-when-cross-origin (default): Send a full URL when performing a same-origin request, only send the origin when the protocol security level stays the same (HTTPS→HTTPS), and send no header to a less secure destination (HTTPS→HTTP). unsafe-url: The referrer will include the origin and the path (but not the fragment, password, or username). This value is unsafe, because it leaks origins and paths from TLS-protected resources to insecure origins. Note: An empty string value (\"\") is both the default value, and a fallback value if referrerpolicy is not supported. If referrerpolicy is not explicitly specified on the <script> element, it will adopt a higher-level referrer policy, i.e., one set on the whole document or domain. If a higher-level policy is not available, the empty string is treated as being equivalent to strict-origin-when-cross-origin."
 				},
 				"src": {
+					"description": "This attribute specifies the URI of an external script; this can be used as an alternative to embedding a script directly within a document.",
 					"type": "URL"
 				},
 				"type": {
+					"description": "This attribute indicates the type of script represented. The value of this attribute will be one of the following: Attribute is not set (default), an empty string, or a JavaScript MIME type Indicates that the script is a \"classic script\", containing JavaScript code. Authors are encouraged to omit the attribute if the script refers to JavaScript code rather than specify a MIME type. JavaScript MIME types are listed in the IANA media types specification. importmap This value indicates that the body of the element contains an import map. The import map is a JSON object that developers can use to control how the browser resolves module specifiers when importing JavaScript modules. module This value causes the code to be treated as a JavaScript module. The processing of the script contents is deferred. The charset and defer attributes have no effect. For information on using module, see our JavaScript modules guide. Unlike classic scripts, module scripts require the use of the CORS protocol for cross-origin fetching. speculationrules Experimental This value indicates that the body of the element contains speculation rules. Speculation rules take the form of a JSON object that determine what resources should be prefetched or prerendered by the browser. This is part of the Speculation Rules API. Any other value The embedded content is treated as a data block, and won't be processed by the browser. Developers must use a valid MIME type that is not a JavaScript MIME type to denote data blocks. All of the other attributes will be ignored, including the src attribute.",
 					"type": [
 						"MIMEType",
 						{
@@ -40560,6 +40681,7 @@
 					"description": "The <form> element to associate the <select> with (its form owner). The value of this attribute must be the id of a <form> in the same document. (If this attribute is not set, the <select> is associated with its ancestor <form> element, if any.) This attribute lets you associate <select> elements to <form>s anywhere in the document, not just inside a <form>. It can also override an ancestor <form> element."
 				},
 				"multiple": {
+					"description": "This Boolean attribute indicates that multiple options can be selected in the list. If it is not specified, then only one option can be selected at a time. When multiple is specified, most browsers will show a scrolling list box instead of a single line dropdown. Multiple selected options are submitted using the URLSearchParams array convention, i.e., name=value1&name=value2.",
 					"type": "Boolean"
 				},
 				"name": {
@@ -40569,6 +40691,7 @@
 					"description": "A Boolean attribute indicating that an option with a non-empty string value must be selected."
 				},
 				"size": {
+					"description": "If the control is presented as a scrolling list box (e.g., when multiple is specified), this attribute represents the number of rows in the list that should be visible at one time. Browsers are not required to present a select element as a scrolled list box. The default value is 0. Note: According to the HTML specification, the default value for size should be 1; however, in practice, this has been found to break some websites, and no other browser currently does that, so Mozilla has opted to continue to return 0 for the time being with Firefox.",
 					"type": {
 						"type": "integer",
 						"gt": 0
@@ -40601,6 +40724,7 @@
 			},
 			"attributes": {
 				"name": {
+					"description": "The slot's name. When the slot's containing component gets rendered, the slot is rendered with the custom element's child that has a matching slot attribute. A named slot is a <slot> element with a name attribute. Unnamed slots have the name default to the empty string. Names should be unique per shadow root: if you have two slots with the same name, all of the elements with a matching slot attribute will be assigned to the first slot with that name.",
 					"type": "NoEmptyAny"
 				}
 			}
@@ -40655,27 +40779,34 @@
 			},
 			"attributes": {
 				"height": {
+					"description": "Specifies the intrinsic height of the image in pixels. Allowed if the parent of <source> is a <picture>. Not allowed if the parent is <audio> or <video>. The height value must be an integer without any units.",
 					"condition": "picture > source"
 				},
 				"media": {
+					"description": "Specifies the media query for the resource's intended media.",
 					"type": "<media-query-list>"
 				},
 				"sizes": {
+					"description": "Specifies a list of source sizes that describe the final rendered width of the image. Allowed if the parent of <source> is <picture>. Not allowed if the parent is <audio> or <video>. The list consists of source sizes separated by commas. Each source size is media condition-length pair. Before laying the page out, the browser uses this information to determine which image defined in srcset to display. Note that sizes will take effect only if width descriptors are provided with srcset, not pixel density descriptors (i.e., 200w should be used instead of 2x).",
 					"condition": "picture > source"
 				},
 				"src": {
+					"description": "Specifies the URL of the media resource. Required if the parent of <source> is <audio> or <video>. Not allowed if the parent is <picture>.",
 					"type": "URL",
 					"required": ":is(video, audio) > source",
 					"condition": ":is(video, audio) > source"
 				},
 				"srcset": {
+					"description": "Specifies a comma-separated list of one or more image URLs and their descriptors. Required if the parent of <source> is <picture>. Not allowed if the parent is <audio> or <video>. The list consists of strings separated by commas, indicating a set of possible images for the browser to use. Each string is composed of: A URL specifying an image location. An optional width descriptor—a positive integer directly followed by \"w\", such as 300w. An optional pixel density descriptor—a positive floating number directly followed by \"x\", such as 2x. Each string in the list must have either a width descriptor or a pixel density descriptor to be valid. These two descriptors should not be used together; only one should be used consistently throughout the list. The value of each descriptor in the list must be unique. The browser chooses the most adequate image to display at a given point of time based on these descriptors. If the descriptors are not specified, the default value used is 1x. If the sizes attribute is also present, then each string must include a width descriptor. If the browser does not support srcset, then src will be used for the default image source.",
 					"required": "picture > source",
 					"condition": "picture > source"
 				},
 				"type": {
+					"description": "Specifies the MIME media type of the image or other media type, optionally including a codecs parameter.",
 					"type": "MIMEType"
 				},
 				"width": {
+					"description": "Specifies the intrinsic width of the image in pixels. Allowed if the parent of <source> is a <picture>. Not allowed if the parent is <audio> or <video>. The width value must be an integer without any units.",
 					"condition": "picture > source"
 				}
 			}
@@ -40795,6 +40926,7 @@
 			},
 			"attributes": {
 				"blocking": {
+					"description": "This attribute explicitly indicates that certain operations should be blocked on the fetching of critical subresources and the application of the stylesheet to the document. @import-ed stylesheets are generally considered as critical subresources, whereas background-image and fonts are not. The operations that are to be blocked must be a space-separated list of blocking tokens listed below. Currently there is only one token: render: The rendering of content on the screen is blocked. Note: Only style elements in the document's <head> can possibly block rendering. By default, a style element in the <head> blocks rendering when the browser discovers it during parsing. If such a style element is added dynamically via script, you must additionally set blocking = \"render\" for it to block rendering.",
 					"type": {
 						"token": {
 							"enum": ["render"]
@@ -40804,6 +40936,7 @@
 					}
 				},
 				"media": {
+					"description": "This attribute defines which media the style should be applied to. Its value is a media query, which defaults to all if the attribute is missing.",
 					"type": "<media-query-list>"
 				},
 				"nonce": {
@@ -41167,12 +41300,15 @@
 			},
 			"attributes": {
 				"shadowrootclonable": {
+					"description": "Sets the value of the clonable property of a ShadowRoot created using this element to true. If set, a clone of the shadow host (the parent element of this <template>) created with Node.cloneNode() or Document.importNode() will include a shadow root in the copy.",
 					"type": "Boolean"
 				},
 				"shadowrootdelegatesfocus": {
+					"description": "Sets the value of the delegatesFocus property of a ShadowRoot created using this element to true. If this is set and a non-focusable element in the shadow tree is selected, then focus is delegated to the first focusable element in the tree. The value defaults to false.",
 					"type": "Boolean"
 				},
 				"shadowrootmode": {
+					"description": "Creates a shadow root for the parent element. It is a declarative version of the Element.attachShadow() method and accepts the same enumerated values. open Exposes the internal shadow root DOM for JavaScript (recommended for most use cases). closed Hides the internal shadow root DOM from JavaScript. Note: The HTML parser creates a ShadowRoot object in the DOM for the first <template> in a node with this attribute set to an allowed value. If the attribute is not set, or not set to an allowed value — or if a ShadowRoot has already been declaratively created in the same parent — then an HTMLTemplateElement is constructed. A HTMLTemplateElement cannot subsequently be changed into a shadow root after parsing, for example, by setting HTMLTemplateElement.shadowRootMode. Note: You may find the non-standard shadowroot attribute in older tutorials and examples that used to be supported in Chrome 90-110. This attribute has since been removed and replaced by the standard shadowrootmode attribute.",
 					"type": {
 						"enum": ["open", "closed"],
 						"missingValueDefault": "none",
@@ -41180,10 +41316,13 @@
 					}
 				},
 				"shadowrootreferencetarget": {
-					"type": "DOMID",
-					"experimental": true
+					"description": "Sets the value of the referenceTarget property of a ShadowRoot created using this element. The value should be the ID of an element inside the shadow DOM. If set, target references to the host element from outside the shadow DOM will cause the referenced target element to become the effective target of the reference to the host element.",
+					"experimental": true,
+					"nonStandard": true,
+					"type": "DOMID"
 				},
 				"shadowrootserializable": {
+					"description": "Sets the value of the serializable property of a ShadowRoot created using this element to true. If set, the shadow root may be serialized by calling the Element.getHTML() or ShadowRoot.getHTML() methods with the options.serializableShadowRoots parameter set true. The value defaults to false.",
 					"type": "Boolean"
 				}
 			}
@@ -41239,6 +41378,7 @@
 					"description": "This Boolean attribute lets you specify that a form control should have input focus when the page loads. Only one form-associated element in a document can have this attribute specified."
 				},
 				"cols": {
+					"description": "The visible width of the text control, in average character widths. If it is specified, it must be a positive integer. If it is not specified, the default value is 20.",
 					"type": {
 						"type": "integer",
 						"gt": 0
@@ -41264,6 +41404,7 @@
 					"description": "The name of the control."
 				},
 				"placeholder": {
+					"description": "A hint to the user of what can be entered in the control. Carriage returns or line-feeds within the placeholder text must be treated as line breaks when rendering the hint. Note: Placeholders should only be used to show an example of the type of data that should be entered into a form; they are not a substitute for a proper <label> element tied to the input. See <input> labels for a full explanation.",
 					"type": "Any"
 				},
 				"readonly": {
@@ -41273,6 +41414,7 @@
 					"description": "This attribute specifies that the user must fill in a value before submitting a form."
 				},
 				"rows": {
+					"description": "The number of visible text lines for the control. If it is specified, it must be a positive integer. If it is not specified, the default value is 2.",
 					"type": {
 						"type": "integer",
 						"gt": 0
@@ -41283,6 +41425,7 @@
 					"description": "Specifies whether the <textarea> is subject to spell-checking by the underlying browser/OS. The value can be: true: Indicates that the element needs to have its spelling and grammar checked. default : Indicates that the element is to act according to a default behavior, possibly based on the parent element's own spellcheck value. false : Indicates that the element should not be spell-checked."
 				},
 				"wrap": {
+					"description": "Indicates how the control should wrap the value for form submission. Possible values are: hard: The browser automatically inserts line breaks (CR+LF) so that each line is no longer than the width of the control; the cols attribute must be specified for this to take effect soft: The browser ensures that all line breaks in the entered value are a CR+LF pair, but no additional line breaks are added to the value. off Non-standard : Like soft but changes appearance to white-space: pre so line segments exceeding cols are not wrapped and the <textarea> becomes horizontally scrollable. If this attribute is not specified, soft is its default value.",
 					"type": {
 						"enum": ["soft", "hard"],
 						"missingValueDefault": "soft",
@@ -41384,6 +41527,7 @@
 			},
 			"attributes": {
 				"abbr": {
+					"description": "A short, abbreviated description of the header cell's content provided as an alternative label to use for the header cell when referencing the cell in other contexts. Some user-agents, such as screen readers, may present this description before the content itself.",
 					"type": "Any"
 				},
 				"align": {
@@ -41420,6 +41564,7 @@
 					"description": "A non-negative integer value indicating how many rows the header cell spans or extends. The default value is 1; if its value is set to 0, the header cell will extend to the end of the table grouping section (<thead>, <tbody>, <tfoot>, even if implicitly defined), that the <th> belongs to. Values higher than 65534 are clipped at 65534."
 				},
 				"scope": {
+					"description": "Defines the cells that the header (defined in the <th>) element relates to. Possible enumerated values are: row: the header relates to all cells of the row it belongs to; col: the header relates to all cells of the column it belongs to; rowgroup: the header belongs to a rowgroup and relates to all of its cells; colgroup: the header belongs to a colgroup and relates to all of its cells. If the scope attribute is not specified, or its value is not row, col, rowgroup, or colgroup, then browsers automatically select the set of cells to which the header cell applies.",
 					"type": {
 						"enum": ["row", "col", "rowgroup", "colgroup"],
 						"missingValueDefault": "auto",
@@ -41509,6 +41654,7 @@
 			},
 			"attributes": {
 				"datetime": {
+					"description": "This attribute indicates the time and/or date of the element and must be in one of the formats described below.",
 					"type": "DateTime"
 				}
 			}
@@ -41609,9 +41755,11 @@
 			},
 			"attributes": {
 				"default": {
+					"description": "This attribute indicates that the track should be enabled unless the user's preferences indicate that another track is more appropriate. This may only be used on one track element per media element.",
 					"type": "Boolean"
 				},
 				"kind": {
+					"description": "How the text track is meant to be used. If omitted the default kind is subtitles. If the attribute contains an invalid value, it will use metadata. The following keywords are allowed: subtitles Subtitles provide transcription or translation of the dialog. They are suitable for when the sound is available but not understood, such as speech or text that is not English in an English language film. Subtitles may contain additional content, usually extra background information. For example the text at the beginning of the Star Wars films, or the date, time, and location of a scene. Subtitles' information complements the audio and video. It is often embedded in the video itself, but can also be provided separately, especially for whole-film translations. captions Closed captions provide transcription or translation of the dialog, sound effects, relevant musical cues, and other relevant audio information, such as the cue's source (e.g., character, environment). They are suitable for when sound is unavailable or not clearly audible (e.g., because it is muted, drowned-out by ambient noise, or because the user is deaf). descriptions Descriptions summarize the video component of the media resource. They are intended to be synthesized as audio when the visual component is obscured, unavailable, or not usable (e.g., because the user is interacting with the application without a screen while driving, or because the user is blind). chapters Chapter titles are intended to be used when the user is navigating the media resource. metadata Tracks used by scripts. Not visible to the user.",
 					"type": {
 						"enum": ["subtitles", "captions", "descriptions", "chapters", "metadata"],
 						"missingValueDefault": "metadata",
@@ -41619,13 +41767,16 @@
 					}
 				},
 				"label": {
+					"description": "A user-readable title of the text track which is used by the browser when listing available text tracks.",
 					"type": "NoEmptyAny"
 				},
 				"src": {
+					"description": "Address of the track (.vtt file). Must be a valid URL. This attribute must be specified and its URL value must have the same origin as the document — unless the <audio> or <video> parent element of the track element has a crossorigin attribute.",
 					"type": "URL",
 					"required": true
 				},
 				"srclang": {
+					"description": "Language of the track text data. It must be a valid BCP 47 language tag. If the kind attribute is set to subtitles, then srclang must be defined.",
 					"type": "BCP47"
 				}
 			}
@@ -41827,6 +41978,7 @@
 					"description": "If this attribute is present, the browser will offer controls to allow the user to control video playback, including volume, seeking, and pause/resume playback."
 				},
 				"controlslist": {
+					"description": "The controlslist attribute, when specified, helps the browser select what controls to show for the video element whenever the browser shows its own set of controls (that is, when the controls attribute is specified). The allowed values are nodownload, nofullscreen and noremoteplayback. Use the disablepictureinpicture attribute if you want to disable the Picture-In-Picture mode (and the control).",
 					"type": {
 						"token": {
 							"enum": ["nodownload", "nofullscreen", "noremoteplayback"]
@@ -41856,9 +42008,11 @@
 					"description": "A Boolean attribute that indicates the default audio mute setting contained in the video. If set, the audio will be initially silenced. Its default value is false, meaning the audio will be played when the video is played."
 				},
 				"playsinline": {
+					"description": "A Boolean attribute indicating that the video is to be played \"inline\", that is, within the element's playback area. Note that the absence of this attribute does not imply that the video will always be played in fullscreen.",
 					"type": "Boolean"
 				},
 				"poster": {
+					"description": "A URL for an image to be shown while the video is downloading. If this attribute isn't specified, nothing is displayed until the first frame is available, then the first frame is shown as the poster frame.",
 					"type": "URL"
 				},
 				"preload": {
@@ -42050,8 +42204,10 @@
 					"description": "The human language of the URL or URL fragment that the hyperlink points to. Value type: <string>; Default value: none; Animatable: no"
 				},
 				"interestfor": {
-					"type": "DOMID",
-					"experimental": true
+					"description": "Defines the <a> element as an interest invoker. Its value is the id of a target element that will be affected in some way (normally shown or hidden) when interest is shown or lost on the invoker element (for example, by hovering/unhovering or focusing/blurring it). See Using interest invokers for more details and examples. Value type: <string>; Default value: none; Animatable: no",
+					"experimental": true,
+					"nonStandard": true,
+					"type": "DOMID"
 				},
 				"ping": {
 					"description": "A space-separated list of URLs to which, when the hyperlink is followed, POST requests with the body PING will be sent by the browser (in the background). Typically used for tracking. For a more widely-supported feature addressing the same use cases, see Navigator.sendBeacon(). Value type: <list-of-URLs>; Default value: none; Animatable: no",
@@ -42245,6 +42401,7 @@
 			},
 			"attributes": {
 				"keyPoints": {
+					"description": "This attribute indicate, in the range [0,1], how far is the object along the path for each keyTimes associated values. Value type: <number>*; Default value: none; Animatable: no",
 					"type": "<key-points>"
 				},
 				"origin": {
@@ -42252,9 +42409,11 @@
 					"defaultValue": "default"
 				},
 				"path": {
+					"description": "This attribute defines the path of the motion, using the same syntax as the d attribute. Value type: <string>; Default value: none; Animatable: no",
 					"type": "<svg-path>"
 				},
 				"rotate": {
+					"description": "This attribute defines a rotation applied to the element animated along a path, usually to make it pointing in the direction of the animation. Value type: <number> | auto | auto-reverse; Default value: 0; Animatable: no",
 					"type": "<rotate>"
 				}
 			}
@@ -42424,6 +42583,7 @@
 					"description": "The y-axis coordinate of the center of the circle. Value type: <length> | <percentage>; Default value: 0; Animatable: yes"
 				},
 				"pathLength": {
+					"description": "The total length for the circle's circumference, in user units. Value type: <number>; Default value: none; Animatable: yes",
 					"type": "<number>",
 					"animatable": true
 				},
@@ -42527,6 +42687,7 @@
 			},
 			"attributes": {
 				"clipPathUnits": {
+					"description": "Defines the coordinate system for the contents of the <clipPath> element. Value type: userSpaceOnUse | objectBoundingBox; Default value: userSpaceOnUse; Animatable: yes",
 					"type": {
 						"enum": ["userSpaceOnUse", "objectBoundingBox"],
 						"disallowToSurroundBySpaces": false
@@ -42830,6 +42991,7 @@
 					"description": "The y position of the center of the ellipse. Value type: <length> | <percentage>; Default value: 0; Animatable: yes"
 				},
 				"pathLength": {
+					"description": "This attribute lets specify the total length for the path, in user units. Value type: <number>; Default value: none; Animatable: yes",
 					"type": "<number>",
 					"animatable": true
 				},
@@ -45586,6 +45748,7 @@
 			},
 			"attributes": {
 				"crossorigin": {
+					"description": "Defines the value of the credentials flag for CORS requests. Value type: [ anonymous | use-credentials ]?; Default value: None; Animatable: yes",
 					"type": {
 						"enum": ["", "anonymous", "use-credentials"],
 						"sameStates": {
@@ -45605,9 +45768,11 @@
 					"description": "The height the image renders at. Unlike HTML's <img>, this attribute is required. Value type: <length> | <percentage>; Default value: auto; Animatable: yes"
 				},
 				"href": {
+					"description": "Points at a URL for the image file. Value type: <URL>; Default value: none; Animatable: no",
 					"type": "URL"
 				},
 				"preserveAspectRatio": {
+					"description": "Controls how the image is scaled. Value type: (none | xMinYMin | xMidYMin | xMaxYMin | xMinYMid | xMidYMid | xMaxYMid | xMinYMax | xMidYMax | xMaxYMax) (meet | slice)?; Default value: xMidYMid meet; Animatable: yes",
 					"type": "<preserve-aspect-ratio>",
 					"defaultValue": "xMidYMid meet"
 				},
@@ -45735,25 +45900,30 @@
 			},
 			"attributes": {
 				"pathLength": {
+					"description": "Defines the total path length in user units. Value type: <number>; Default value: none; Animatable: yes",
 					"type": "<number>",
 					"animatable": true
 				},
 				"x1": {
+					"description": "Defines the x-axis coordinate of the line starting point. Value type: <length> | <percentage> | <number>; Default value: 0; Animatable: yes",
 					"type": ["<svg-length>", "<percentage>", "<number>"],
 					"defaultValue": "0",
 					"animatable": true
 				},
 				"x2": {
+					"description": "Defines the x-axis coordinate of the line ending point. Value type: <length> | <percentage> | <number>; Default value: 0; Animatable: yes",
 					"type": ["<svg-length>", "<percentage>", "<number>"],
 					"defaultValue": "0",
 					"animatable": true
 				},
 				"y1": {
+					"description": "Defines the y-axis coordinate of the line starting point. Value type: <length> | <percentage> | <number>; Default value: 0; Animatable: yes",
 					"type": ["<svg-length>", "<percentage>", "<number>"],
 					"defaultValue": "0",
 					"animatable": true
 				},
 				"y2": {
+					"description": "Defines the y-axis coordinate of the line ending point. Value type: <length> | <percentage> | <number>; Default value: 0; Animatable: yes",
 					"type": ["<svg-length>", "<percentage>", "<number>"],
 					"defaultValue": "0",
 					"animatable": true
@@ -45862,10 +46032,12 @@
 			},
 			"attributes": {
 				"gradientTransform": {
+					"description": "This attribute provides additional transformation to the gradient coordinate system. Value type: <transform-list>; Default value: identity transform; Animatable: yes",
 					"type": "<transform-list>",
 					"animatable": true
 				},
 				"gradientUnits": {
+					"description": "This attribute defines the coordinate system for attributes x1, x2, y1, y2 Value type: userSpaceOnUse | objectBoundingBox; Default value: objectBoundingBox; Animatable: yes",
 					"type": {
 						"enum": ["userSpaceOnUse", "objectBoundingBox"],
 						"disallowToSurroundBySpaces": false
@@ -45874,10 +46046,12 @@
 					"animatable": true
 				},
 				"href": {
+					"description": "This attribute defines a reference to another <linearGradient> element that will be used as a template. Value type: <URL>; Default value: none; Animatable: yes",
 					"type": "URL",
 					"animatable": true
 				},
 				"spreadMethod": {
+					"description": "This attribute indicates how the gradient behaves if it starts or ends inside the bounds of the shape containing the gradient. Value type: pad | reflect | repeat; Default value: pad; Animatable: yes",
 					"type": {
 						"enum": ["pad", "reflect", "repeat"],
 						"disallowToSurroundBySpaces": false
@@ -45886,11 +46060,13 @@
 					"animatable": true
 				},
 				"x1": {
+					"description": "This attribute defines the x coordinate of the starting point of the vector gradient along which the linear gradient is drawn. Value type: <length>; Default value: 0%; Animatable: yes",
 					"type": ["<svg-length>", "<percentage>"],
 					"defaultValue": "0%",
 					"animatable": true
 				},
 				"x2": {
+					"description": "This attribute defines the x coordinate of the ending point of the vector gradient along which the linear gradient is drawn. Value type: <length>; Default value: 100%; Animatable: yes",
 					"type": ["<svg-length>", "<percentage>"],
 					"defaultValue": "100%",
 					"animatable": true
@@ -45900,11 +46076,13 @@
 					"deprecated": true
 				},
 				"y1": {
+					"description": "This attribute defines the y coordinate of the starting point of the vector gradient along which the linear gradient is drawn. Value type: <length>; Default value: 0%; Animatable: yes",
 					"type": ["<svg-length>", "<percentage>"],
 					"defaultValue": "0%",
 					"animatable": true
 				},
 				"y2": {
+					"description": "This attribute defines the y coordinate of the ending point of the vector gradient along which the linear gradient is drawn. Value type: <length>; Default value: 0%; Animatable: yes",
 					"type": ["<svg-length>", "<percentage>"],
 					"defaultValue": "0%",
 					"animatable": true
@@ -46023,11 +46201,13 @@
 			},
 			"attributes": {
 				"markerHeight": {
+					"description": "This attribute defines the height of the marker viewport. Value type: <length>; Default value: 3; Animatable: yes",
 					"type": ["<svg-length>", "<percentage>", "<number>"],
 					"defaultValue": "3",
 					"animatable": true
 				},
 				"markerUnits": {
+					"description": "This attribute defines the coordinate system for the attributes markerWidth, markerHeight and the contents of the <marker>. Value type: userSpaceOnUse | strokeWidth; Default value: strokeWidth; Animatable: yes",
 					"type": {
 						"enum": ["userSpaceOnUse", "strokeWidth"],
 						"disallowToSurroundBySpaces": false
@@ -46035,11 +46215,13 @@
 					"defaultValue": "strokeWidth"
 				},
 				"markerWidth": {
+					"description": "This attribute defines the width of the marker viewport. Value type: <length>; Default value: 3; Animatable: yes",
 					"type": ["<svg-length>", "<percentage>", "<number>"],
 					"defaultValue": "3",
 					"animatable": true
 				},
 				"orient": {
+					"description": "This attribute defines the orientation of the marker relative to the shape it is attached to. Value type: auto | auto-start-reverse | <angle>; Default value: 0; Animatable: yes",
 					"type": [
 						{
 							"enum": ["auto", "auto-start-reverse"],
@@ -46052,11 +46234,13 @@
 					"animatable": true
 				},
 				"preserveAspectRatio": {
+					"description": "This attribute defines how the svg fragment must be deformed if it is embedded in a container with a different aspect ratio. Value type: (none | xMinYMin | xMidYMin | xMaxYMin | xMinYMid | xMidYMid | xMaxYMid | xMinYMax | xMidYMax | xMaxYMax) (meet | slice)?; Default value: xMidYMid meet; Animatable: yes",
 					"type": "<preserve-aspect-ratio>",
 					"defaultValue": "xMidYMid meet",
 					"animatable": true
 				},
 				"refX": {
+					"description": "This attribute defines the x coordinate for the reference point of the marker. Value type: left | center | right | <coordinate>; Default value: 0; Animatable: yes",
 					"type": [
 						"<percentage>",
 						"<number>",
@@ -46069,6 +46253,7 @@
 					"animatable": true
 				},
 				"refY": {
+					"description": "This attribute defines the y coordinate for the reference point of the marker. Value type: top | center | bottom | <coordinate>; Default value: 0; Animatable: yes",
 					"type": [
 						"<percentage>",
 						"<number>",
@@ -46081,6 +46266,7 @@
 					"animatable": true
 				},
 				"viewBox": {
+					"description": "This attribute defines the bound of the SVG viewport for the current SVG fragment. Value type: <list-of-numbers>; Default value: none; Animatable: yes",
 					"type": "<view-box>",
 					"animatable": true
 				}
@@ -46198,12 +46384,14 @@
 			},
 			"attributes": {
 				"height": {
+					"description": "This attribute defines the height of the masking area. Value type: <length>; Default value: 120%; Animatable: yes",
 					"defaultValue": "120%"
 				},
 				"mask-type": {
 					"description": "This attribute defines the mask mode for the contents for the contents of the <mask>. Value type: alpha | luminance; Default value: luminance; Animatable: yes"
 				},
 				"maskContentUnits": {
+					"description": "This attribute defines the coordinate system for the contents of the <mask>. Value type: userSpaceOnUse | objectBoundingBox; Default value: userSpaceOnUse; Animatable: yes",
 					"type": {
 						"enum": ["userSpaceOnUse", "objectBoundingBox"]
 					},
@@ -46211,6 +46399,7 @@
 					"animatable": true
 				},
 				"maskUnits": {
+					"description": "This attribute defines the coordinate system for attributes x, y, width and height on the <mask>. Value type: userSpaceOnUse | objectBoundingBox; Default value: objectBoundingBox; Animatable: yes",
 					"type": {
 						"enum": ["userSpaceOnUse", "objectBoundingBox"],
 						"disallowToSurroundBySpaces": false
@@ -46219,12 +46408,15 @@
 					"animatable": true
 				},
 				"width": {
+					"description": "This attribute defines the width of the masking area. Value type: <length>; Default value: 120%; Animatable: yes",
 					"defaultValue": "120%"
 				},
 				"x": {
+					"description": "This attribute defines the x-axis coordinate of the top-left corner of the masking area. Value type: <coordinate>; Default value: -10%; Animatable: yes",
 					"defaultValue": "-10%"
 				},
 				"y": {
+					"description": "This attribute defines the y-axis coordinate of the top-left corner of the masking area. Value type: <coordinate>; Default value: -10%; Animatable: yes",
 					"defaultValue": "-10%"
 				}
 			}
@@ -46395,6 +46587,7 @@
 					"description": "This attribute defines the shape of the path. Value type: <string>; Default value: ''; Animatable: yes"
 				},
 				"pathLength": {
+					"description": "This attribute lets authors specify the total length for the path, in user units. Value type: <number>; Default value: none; Animatable: yes",
 					"type": "<number>",
 					"animatable": true
 				}
@@ -46512,13 +46705,16 @@
 			},
 			"attributes": {
 				"height": {
+					"description": "This attribute determines the height of the pattern tile. Value type: <length>; Default value: 0; Animatable: yes",
 					"defaultValue": "0"
 				},
 				"href": {
+					"description": "This attribute reference a template pattern that provides default values for the <pattern> attributes. Value type: <URL>; Default value: none; Animatable: yes",
 					"type": "URL",
 					"animatable": true
 				},
 				"patternContentUnits": {
+					"description": "This attribute defines the coordinate system for the contents of the <pattern>. Value type: userSpaceOnUse | objectBoundingBox; Default value: userSpaceOnUse; Animatable: yes Note: This attribute has no effect if a viewBox attribute is specified on the <pattern> element.",
 					"type": {
 						"enum": ["userSpaceOnUse", "objectBoundingBox"],
 						"disallowToSurroundBySpaces": false
@@ -46527,10 +46723,12 @@
 					"animatable": true
 				},
 				"patternTransform": {
+					"description": "This attribute contains the definition of an optional additional transformation from the pattern coordinate system onto the target coordinate system. Value type: <transform-list>; Default value: identity transform; Animatable: yes",
 					"type": "<transform-list>",
 					"animatable": true
 				},
 				"patternUnits": {
+					"description": "This attribute defines the coordinate system for attributes x, y, width, and height. Value type: userSpaceOnUse | objectBoundingBox; Default value: objectBoundingBox; Animatable: yes",
 					"type": {
 						"enum": ["userSpaceOnUse", "objectBoundingBox"],
 						"disallowToSurroundBySpaces": false
@@ -46539,15 +46737,18 @@
 					"animatable": true
 				},
 				"preserveAspectRatio": {
+					"description": "This attribute defines how the SVG fragment must be deformed if it is embedded in a container with a different aspect ratio. Value type: (none | xMinYMin | xMidYMin | xMaxYMin | xMinYMid | xMidYMid | xMaxYMid | xMinYMax | xMidYMax | xMaxYMax) (meet | slice)?; Default value: xMidYMid meet; Animatable: yes",
 					"type": "<preserve-aspect-ratio>",
 					"defaultValue": "xMidYMid meet",
 					"animatable": true
 				},
 				"viewBox": {
+					"description": "This attribute defines the bound of the SVG viewport for the pattern fragment. Value type: <list-of-numbers>; Default value: none; Animatable: yes",
 					"type": "<view-box>",
 					"animatable": true
 				},
 				"width": {
+					"description": "This attribute determines the width of the pattern tile. Value type: <length>; Default value: 0; Animatable: yes",
 					"defaultValue": "0"
 				},
 				"x": {
@@ -46671,10 +46872,12 @@
 			},
 			"attributes": {
 				"pathLength": {
+					"description": "This attribute lets specify the total length for the path, in user units. Value type: <number>; Default value: none; Animatable: yes",
 					"type": "<number>",
 					"animatable": true
 				},
 				"points": {
+					"description": "This attribute defines the list of points (pairs of x,y absolute coordinates) required to draw the polygon. Value type: <number>+; Default value: \"\"; Animatable: yes",
 					"type": "<points>",
 					"animatable": true
 				}
@@ -46789,10 +46992,12 @@
 			},
 			"attributes": {
 				"pathLength": {
+					"description": "This attribute lets specify the total length for the path, in user units. Value type: <number>; Default value: none; Animatable: yes",
 					"type": "<number>",
 					"animatable": true
 				},
 				"points": {
+					"description": "This attribute defines the list of points (pairs of x,y absolute coordinates) required to draw the polyline Value type: <number>+; Default value: \"\"; Animatable: yes",
 					"type": "<points>",
 					"animatable": true
 				}
@@ -46900,33 +47105,40 @@
 			},
 			"attributes": {
 				"cx": {
+					"description": "This attribute defines the x coordinate of the end circle of the radial gradient. Value type: <length>; Default value: 50%; Animatable: yes",
 					"type": ["<svg-length>", "<percentage>"],
 					"defaultValue": "50%",
 					"animatable": true
 				},
 				"cy": {
+					"description": "This attribute defines the y coordinate of the end circle of the radial gradient. Value type: <length>; Default value: 50%; Animatable: yes",
 					"type": ["<svg-length>", "<percentage>"],
 					"defaultValue": "50%",
 					"animatable": true
 				},
 				"fr": {
+					"description": "This attribute defines the radius of the start circle of the radial gradient. The gradient will be drawn such that the 0% <stop> is mapped to the perimeter of the start circle. Value type: <length>; Default value: 0%; Animatable: yes",
 					"type": ["<svg-length>", "<percentage>"],
 					"defaultValue": "0%",
 					"animatable": true
 				},
 				"fx": {
+					"description": "This attribute defines the x coordinate of the start circle of the radial gradient. Value type: <length>; Default value: Same as cx; Animatable: yes",
 					"type": ["<svg-length>", "<percentage>"],
 					"animatable": true
 				},
 				"fy": {
+					"description": "This attribute defines the y coordinate of the start circle of the radial gradient. Value type: <length>; Default value: Same as cy; Animatable: yes",
 					"type": ["<svg-length>", "<percentage>"],
 					"animatable": true
 				},
 				"gradientTransform": {
+					"description": "This attribute provides additional transformation to the gradient coordinate system. Value type: <transform-list>; Default value: identity transform; Animatable: yes",
 					"type": "<transform-list>",
 					"animatable": true
 				},
 				"gradientUnits": {
+					"description": "This attribute defines the coordinate system for attributes cx, cy, r, fx, fy, fr Value type: userSpaceOnUse | objectBoundingBox; Default value: objectBoundingBox; Animatable: yes",
 					"type": {
 						"enum": ["userSpaceOnUse", "objectBoundingBox"],
 						"disallowToSurroundBySpaces": false
@@ -46935,15 +47147,18 @@
 					"animatable": true
 				},
 				"href": {
+					"description": "This attribute defines a reference to another <radialGradient> element that will be used as a template. Value type: <URL>; Default value: none; Animatable: yes",
 					"type": "URL",
 					"animatable": true
 				},
 				"r": {
+					"description": "This attribute defines the radius of the end circle of the radial gradient. The gradient will be drawn such that the 100% <stop> is mapped to the perimeter of the end circle. Value type: <length>; Default value: 50%; Animatable: yes",
 					"type": ["<svg-length>", "<percentage>"],
 					"defaultValue": "50%",
 					"animatable": true
 				},
 				"spreadMethod": {
+					"description": "This attribute indicates how the gradient behaves if it starts or ends inside the bounds of the shape containing the gradient. Value type: pad | reflect | repeat; Default value: pad; Animatable: yes",
 					"type": {
 						"enum": ["pad", "reflect", "repeat"],
 						"disallowToSurroundBySpaces": false
@@ -47075,6 +47290,7 @@
 					"description": "The height of the rect. Value type: auto | <length> | <percentage>; Default value: auto; Animatable: yes"
 				},
 				"pathLength": {
+					"description": "The total length of the rectangle's perimeter, in user units. Value type: <number>; Default value: none; Animatable: yes",
 					"type": "<number>",
 					"animatable": true
 				},
@@ -47120,6 +47336,7 @@
 			},
 			"attributes": {
 				"crossorigin": {
+					"description": "This attribute defines CORS settings as define for the HTML <script> element. Value type: [ anonymous | use-credentials ]?; Default value: ?; Animatable: yes",
 					"type": {
 						"enum": ["anonymous", "use-credentials", ""],
 						"disallowToSurroundBySpaces": false
@@ -47132,9 +47349,11 @@
 					"nonStandard": true
 				},
 				"href": {
+					"description": "The URL to the script to load. Value type: <URL>; Default value: none; Animatable: no",
 					"type": "URL"
 				},
 				"type": {
+					"description": "This attribute defines type of the script language to use. Value type: <media-type>; Default value: application/ecmascript; Animatable: no",
 					"type": "MIMEType",
 					"defaultValue": "application/ecmascript"
 				},
@@ -47183,6 +47402,7 @@
 			},
 			"attributes": {
 				"to": {
+					"description": "This attribute defines the value to be applied to the target attribute for the duration of the animation. The value must match the requirements of the target attribute. Value type: <anything>; Default value: none; Animatable: no",
 					"type": "NoEmptyAny"
 				}
 			}
@@ -47281,16 +47501,19 @@
 			},
 			"attributes": {
 				"offset": {
+					"description": "This attribute defines where the gradient stop is placed along the gradient vector. Value type: <number> | <percentage>; Default value: 0; Animatable: yes",
 					"type": ["<number>", "<percentage>"],
 					"defaultValue": "0",
 					"animatable": true
 				},
 				"stop-color": {
+					"description": "This attribute defines the color of the gradient stop. It can be used as a CSS property. Value type: <color>; Default value: black; Animatable: yes",
 					"type": "<color>",
 					"defaultValue": "black",
 					"animatable": true
 				},
 				"stop-opacity": {
+					"description": "This attribute defines the opacity of the gradient stop. It can be used as a CSS property. Value type: <opacity-value>; Default value: 1; Animatable: yes",
 					"type": "<'opacity'>",
 					"defaultValue": "1",
 					"animatable": true
@@ -47321,13 +47544,16 @@
 			},
 			"attributes": {
 				"media": {
+					"description": "This attribute defines to which media the style applies. Value type: <media-query-list>; Default value: all; Animatable: no",
 					"type": "<media-query-list>",
 					"defaultValue": "all"
 				},
 				"title": {
+					"description": "This attribute is the title of the style sheet which can be used to switch between alternate style sheets. Value type: <string>; Default value: none; Animatable: no",
 					"type": "Any"
 				},
 				"type": {
+					"description": "This attribute defines type of the style sheet language to use as a media type string. Value type: <media-type>; Default value: text/css; Animatable: no",
 					"type": "MIMEType",
 					"defaultValue": "text/css"
 				}
@@ -47455,8 +47681,9 @@
 			},
 			"attributes": {
 				"baseProfile": {
-					"type": "Any",
-					"deprecated": true
+					"description": "The minimum SVG language profile that the document requires. Value type: <string>; Default value: none; Animatable: no",
+					"deprecated": true,
+					"type": "Any"
 				},
 				"contentScriptType": {
 					"type": "Any",
@@ -47469,25 +47696,30 @@
 					"deprecated": true
 				},
 				"height": {
+					"description": "The displayed height of the rectangular viewport. (Not the height of its coordinate system.) Value type: <length> | <percentage>; Default value: auto; Animatable: yes",
 					"defaultValue": "auto"
 				},
 				"onunload": {
 					"type": "FunctionBody"
 				},
 				"preserveAspectRatio": {
+					"description": "How the svg fragment must be deformed if it is displayed with a different aspect ratio. Value type: (none | xMinYMin | xMidYMin | xMaxYMin | xMinYMid | xMidYMid | xMaxYMid | xMinYMax | xMidYMax | xMaxYMax) (meet | slice)?; Default value: xMidYMid meet; Animatable: yes",
 					"type": "<preserve-aspect-ratio>",
 					"defaultValue": "xMidYMid meet",
 					"animatable": true
 				},
 				"version": {
-					"type": "Any",
-					"deprecated": true
+					"description": "Which version of SVG is used for the inner content of the element. Value type: <number>; Default value: none; Animatable: no",
+					"deprecated": true,
+					"type": "Any"
 				},
 				"viewBox": {
+					"description": "The SVG viewport coordinates for the current SVG fragment. Value type: <list-of-numbers>; Default value: none; Animatable: yes",
 					"type": "<view-box>",
 					"animatable": true
 				},
 				"width": {
+					"description": "The displayed width of the rectangular viewport. (Not the width of its coordinate system.) Value type: <length> | <percentage>; Default value: auto; Animatable: yes",
 					"defaultValue": "auto"
 				},
 				"x": {
@@ -47664,10 +47896,12 @@
 					"description": "This attribute determines the height of the symbol. Value type: <length> | <percentage>; Default value: auto; Animatable: yes"
 				},
 				"preserveAspectRatio": {
+					"description": "This attribute defines how the svg fragment must be deformed if it is embedded in a container with a different aspect ratio. Value type: (none | xMinYMin | xMidYMin | xMaxYMin | xMinYMid | xMidYMid | xMaxYMid | xMinYMax | xMidYMax | xMaxYMax) (meet | slice)?; Default value: xMidYMid meet; Animatable: yes",
 					"type": "<preserve-aspect-ratio>",
 					"defaultValue": "xMidYMid meet"
 				},
 				"refX": {
+					"description": "This attribute determines the x coordinate of the reference point of the symbol. Value type: <length> | <percentage> | left | center | right; Default value: None; Animatable: yes",
 					"type": [
 						"<svg-length>",
 						"<percentage>",
@@ -47678,6 +47912,7 @@
 					]
 				},
 				"refY": {
+					"description": "This attribute determines the y coordinate of the reference point of the symbol. Value type: <length> | <percentage> | top | center | bottom; Default value: None; Animatable: yes",
 					"type": [
 						"<svg-length>",
 						"<percentage>",
@@ -47688,6 +47923,7 @@
 					]
 				},
 				"viewBox": {
+					"description": "This attribute defines the bound of the SVG viewport for the current symbol. Value type: <list-of-numbers>; Default value: none; Animatable: yes",
 					"type": "<view-box>"
 				},
 				"width": {
@@ -47813,14 +48049,17 @@
 			},
 			"attributes": {
 				"dx": {
+					"description": "Shifts the text position horizontally from a previous text element, or shifts the position of each individual glyph if a list of values is provided. Value type: List of (<length> | <percentage>); Default value: none; Animatable: yes",
 					"type": "<text-coordinate>",
 					"animatable": true
 				},
 				"dy": {
+					"description": "Shifts the text position vertically from a previous text element, or shifts the position of each individual glyph if a list of values is provided. Value type: List of (<length> | <percentage>); Default value: none; Animatable: yes",
 					"type": "<text-coordinate>",
 					"animatable": true
 				},
 				"lengthAdjust": {
+					"description": "How the text is stretched or compressed to fit the width defined by the textLength attribute. Value type: spacing | spacingAndGlyphs; Default value: spacing; Animatable: yes",
 					"type": {
 						"enum": ["spacing", "spacingAndGlyphs"],
 						"disallowToSurroundBySpaces": false
@@ -47829,19 +48068,23 @@
 					"animatable": true
 				},
 				"rotate": {
+					"description": "Rotates orientation of each individual glyph. Can rotate glyphs individually. Value type: <list-of-number>; Default value: none; Animatable: yes",
 					"type": "<list-of-numbers>",
 					"animatable": true
 				},
 				"textLength": {
+					"description": "A width that the text should be scaled to fit. Value type: <length> | <percentage>; Default value: none; Animatable: yes",
 					"type": ["<svg-length>", "<percentage>"],
 					"animatable": true
 				},
 				"x": {
+					"description": "The x coordinate of the starting point of the text baseline, or the x coordinate of each individual glyph if a list of values is provided. Value type: List of (<length> | <percentage>); Default value: 0; Animatable: yes",
 					"type": "<text-coordinate>",
 					"defaultValue": "0",
 					"animatable": true
 				},
 				"y": {
+					"description": "The y coordinate of the starting point of the text baseline, or the y coordinate of each individual glyph if a list of values is provided. Value type: List of (<length> | <percentage>); Default value: 0; Animatable: yes",
 					"type": "<text-coordinate>",
 					"defaultValue": "0",
 					"animatable": true
@@ -47962,10 +48205,12 @@
 			},
 			"attributes": {
 				"href": {
+					"description": "The URL to the path or basic shape on which to render the text. If the path attribute is set, href has no effect. Value type: <URL>; Default value: none; Animatable: yes",
 					"type": "URL",
 					"animatable": true
 				},
 				"lengthAdjust": {
+					"description": "Where length adjustment should be applied to the text: the space between glyphs, or both the space and the glyphs themselves. Value type: spacing | spacingAndGlyphs; Default value: spacing; Animatable: yes",
 					"type": {
 						"enum": ["spacing", "spacingAndGlyphs"],
 						"disallowToSurroundBySpaces": false
@@ -47974,6 +48219,7 @@
 					"animatable": true
 				},
 				"method": {
+					"description": "Which method to render individual glyphs along the path. Value type: align | stretch; Default value: align; Animatable: yes",
 					"type": {
 						"enum": ["align", "stretch"],
 						"disallowToSurroundBySpaces": false
@@ -47982,10 +48228,14 @@
 					"animatable": true
 				},
 				"path": {
+					"description": "The path on which the text should be rendered. Value type: <path_data>; Default value: none; Animatable: yes",
+					"experimental": true,
 					"type": "<svg-path>",
 					"animatable": true
 				},
 				"side": {
+					"description": "Which side of the path the text should be rendered. Value type: left | right; Default value: left; Animatable: yes",
+					"experimental": true,
 					"type": {
 						"enum": ["left", "right"],
 						"disallowToSurroundBySpaces": false
@@ -47994,6 +48244,7 @@
 					"animatable": true
 				},
 				"spacing": {
+					"description": "How space between glyphs should be handled. Value type: auto | exact; Default value: exact; Animatable: yes",
 					"type": {
 						"enum": ["auto", "exact"],
 						"disallowToSurroundBySpaces": false
@@ -48002,10 +48253,12 @@
 					"animatable": true
 				},
 				"startOffset": {
+					"description": "How far the beginning of the text should be offset from the beginning of the path. Value type: <length> | <percentage> | <number>; Default value: 0; Animatable: yes",
 					"type": ["<svg-length>", "<percentage>"],
 					"animatable": true
 				},
 				"textLength": {
+					"description": "The width of the space into which the text will render. Value type: <length> | <percentage> | <number>; Default value: auto; Animatable: yes",
 					"type": ["<svg-length>", "<percentage>"],
 					"animatable": true
 				}
@@ -48145,14 +48398,17 @@
 			},
 			"attributes": {
 				"dx": {
+					"description": "Shifts the text position horizontally from a previous text element, or shifts the position of each individual glyph if a list of values is provided. Value type: List of (<length> | <percentage>); Default value: none; Animatable: yes",
 					"type": "<text-coordinate>",
 					"animatable": true
 				},
 				"dy": {
+					"description": "Shifts the text position vertically from a previous text element, or shifts the position of each individual glyph if a list of values is provided. Value type: List of (<length> | <percentage>); Default value: none; Animatable: yes",
 					"type": "<text-coordinate>",
 					"animatable": true
 				},
 				"lengthAdjust": {
+					"description": "How the text is stretched or compressed to fit the width defined by the textLength attribute. Value type: spacing | spacingAndGlyphs; Default value: spacing; Animatable: yes",
 					"type": {
 						"enum": ["spacing", "spacingAndGlyphs"],
 						"disallowToSurroundBySpaces": false
@@ -48161,18 +48417,22 @@
 					"animatable": true
 				},
 				"rotate": {
+					"description": "Rotates orientation of each individual glyph. Can rotate glyphs individually. Value type: <list-of-number>; Default value: none; Animatable: yes",
 					"type": "<list-of-numbers>",
 					"animatable": true
 				},
 				"textLength": {
+					"description": "A width that the text should be scaled to fit. Value type: <length> | <percentage>; Default value: none; Animatable: yes",
 					"type": ["<svg-length>", "<percentage>"],
 					"animatable": true
 				},
 				"x": {
+					"description": "The x coordinate of the starting point of the text baseline, or the x coordinate of each individual glyph if a list of values is provided. Value type: List of (<length> | <percentage>); Default value: 0; Animatable: yes",
 					"type": "<text-coordinate>",
 					"animatable": true
 				},
 				"y": {
+					"description": "The y coordinate of the starting point of the text baseline, or the y coordinate of each individual glyph if a list of values is provided. Value type: List of (<length> | <percentage>); Default value: 0; Animatable: yes",
 					"type": "<text-coordinate>",
 					"animatable": true
 				}
@@ -48293,6 +48553,7 @@
 					"description": "The height of the <use> element. Value type: <length>; Default value: 0; Animatable: yes"
 				},
 				"href": {
+					"description": "The URL to an element/fragment that needs to be duplicated. See Usage notes for details on common pitfalls. Value type: <URL>; Default value: none; Animatable: yes",
 					"type": "URL"
 				},
 				"width": {
@@ -48336,9 +48597,11 @@
 			},
 			"attributes": {
 				"preserveAspectRatio": {
+					"description": "This attribute defines how the SVG fragment must be deformed if it is embedded in a container with a different aspect ratio. Value type: (none | xMinYMin | xMidYMin | xMaxYMin | xMinYMid | xMidYMid | xMaxYMid | xMinYMax | xMidYMax | xMaxYMax) (meet | slice)?; Default value: xMidYMid meet; Animatable: yes",
 					"type": "<preserve-aspect-ratio>"
 				},
 				"viewBox": {
+					"description": "This attribute defines the bound of the SVG viewport for the pattern fragment. Value type: <list-of-numbers>; Default value: none; Animatable: yes",
 					"type": "<view-box>"
 				},
 				"viewTarget": {
@@ -48346,11 +48609,12 @@
 					"deprecated": true
 				},
 				"zoomAndPan": {
+					"description": "This attribute specifies whether the SVG document can be magnified and panned. Value type: disable | magnify; Default value: magnify; Animatable: no",
+					"deprecated": true,
 					"type": {
 						"enum": ["disable", "magnify"]
 					},
-					"defaultValue": "magnify",
-					"deprecated": true
+					"defaultValue": "magnify"
 				}
 			}
 		}

--- a/packages/@markuplint/spec-generator/src/html-elements.ts
+++ b/packages/@markuplint/spec-generator/src/html-elements.ts
@@ -111,15 +111,26 @@ export async function getElements(filePattern: string) {
 								continue;
 							}
 
-							if (typeof current === 'object' && 'name' in current) {
-								attrs[mdnAttr.name] = {
-									// @ts-ignore for key order that "name" is first
-									name: mdnAttr.name,
-									// @ts-ignore for key order that "description" is second
-									...mdnData.attributes,
-									// @ts-ignore
-									...current,
-								};
+							if (typeof current === 'object') {
+								if ('name' in current) {
+									attrs[mdnAttr.name] = {
+										// @ts-ignore for key order that "name" is first
+										name: mdnAttr.name,
+										// @ts-ignore for key order that "description" is second
+										...mdnData.attributes,
+										// @ts-ignore
+										...current,
+									};
+								} else {
+									attrs[mdnAttr.name] = {
+										description: mdnAttr.description,
+										experimental: mdnAttr.experimental,
+										obsolete: mdnAttr.obsolete,
+										deprecated: mdnAttr.deprecated,
+										nonStandard: mdnAttr.nonStandard,
+										...current,
+									};
+								}
 							}
 						}
 


### PR DESCRIPTION
## Summary
- Fix attribute merge bug in `spec-generator` where MDN-scraped data (description, experimental, deprecated, nonStandard flags) was not merged into attributes defined in `spec.*.json` source files
- Root cause: the condition `'name' in current` at `html-elements.ts:114` only matched attributes that had been through a previous merge pass, skipping spec-defined attributes like `{ "type": "DOMID" }`
- Now spec-defined attributes without `name` also get MDN data merged, with spec-side values taking precedence
- Regenerated `index.json` — 283 descriptions and flags now correctly appear on previously bare attributes

## Test plan
- [ ] Verify `yarn build --scope @markuplint/spec-generator` succeeds
- [ ] Verify `yarn up:gen` produces identical output (idempotent)
- [ ] Spot-check that spec-defined attributes (e.g. `interestfor`, `shadowrootmode`) now include MDN descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)