### PR TITLE
style(html-spec): fix prettier formatting in documentation markdown tables

### DIFF
--- a/packages/@markuplint/html-spec/SKILL.md
+++ b/packages/@markuplint/html-spec/SKILL.md
@@ -284,10 +284,10 @@ Report results as:
 6. **Reference authoritative specs for significant changes.** Use WebSearch to verify against HTML Living Standard, WAI-ARIA, and HTML-ARIA before modifying manual spec files.
 7. **Use conventional commit prefixes based on the nature of the change:**
 
-   | Change type               | Prefix  | Example                                              |
-   | ------------------------- | ------- | ---------------------------------------------------- |
-   | Description updates only  | `chore` | `chore(html-spec): update role descriptions`         |
-   | Attribute/spec additions  | `feat`  | `feat(html-spec): add input switch attribute`        |
-   | Spec data corrections     | `fix`   | `fix(html-spec): correct ARIA mapping for button`    |
+   | Change type              | Prefix  | Example                                           |
+   | ------------------------ | ------- | ------------------------------------------------- |
+   | Description updates only | `chore` | `chore(html-spec): update role descriptions`      |
+   | Attribute/spec additions | `feat`  | `feat(html-spec): add input switch attribute`     |
+   | Spec data corrections    | `fix`   | `fix(html-spec): correct ARIA mapping for button` |
 
 8. **Separate spec changes into individual PRs.** Each specification change (new attribute, ARIA mapping fix, etc.) should be on its own branch and PR. Description-only updates can be batched into a single PR.

--- a/packages/@markuplint/html-spec/docs/element-spec-format.md
+++ b/packages/@markuplint/html-spec/docs/element-spec-format.md
@@ -193,12 +193,12 @@ The `attributes` object maps attribute names to definitions. Each definition may
 
 These boolean flags indicate the standardization status of an attribute:
 
-| Flag           | Meaning                                                                                                    |
-| -------------- | ---------------------------------------------------------------------------------------------------------- |
-| `experimental` | Part of an emerging specification that is not yet stable. Browsers may have partial or prefixed support.    |
+| Flag           | Meaning                                                                                                       |
+| -------------- | ------------------------------------------------------------------------------------------------------------- |
+| `experimental` | Part of an emerging specification that is not yet stable. Browsers may have partial or prefixed support.      |
 | `deprecated`   | Officially discouraged by the specification. Still recognized by browsers but should not be used in new code. |
-| `obsolete`     | Removed from the specification entirely. May not be recognized by modern browsers at all.                   |
-| `nonStandard`  | Not part of any W3C or WHATWG specification. Vendor-specific or proprietary.                                |
+| `obsolete`     | Removed from the specification entirely. May not be recognized by modern browsers at all.                     |
+| `nonStandard`  | Not part of any W3C or WHATWG specification. Vendor-specific or proprietary.                                  |
 
 **`deprecated` vs `obsolete`:** `deprecated` means the spec still defines the attribute
 but discourages its use (e.g., `<table border>`). `obsolete` means the attribute has been

--- a/packages/@markuplint/html-spec/docs/maintenance.ja.md
+++ b/packages/@markuplint/html-spec/docs/maintenance.ja.md
@@ -185,11 +185,11 @@ description の表現変更などの表面的な変更は、更新された `ind
 
 変更の性質に応じた conventional commit プレフィックスを使用する:
 
-| 変更種別                | プレフィックス | 例                                                   |
-| ----------------------- | -------------- | ---------------------------------------------------- |
-| description 更新のみ    | `chore`        | `chore(html-spec): update role descriptions`         |
-| 属性追加・仕様変更      | `feat`         | `feat(html-spec): add input switch attribute`        |
-| spec データ修正         | `fix`          | `fix(html-spec): correct ARIA mapping for button`    |
+| 変更種別             | プレフィックス | 例                                                |
+| -------------------- | -------------- | ------------------------------------------------- |
+| description 更新のみ | `chore`        | `chore(html-spec): update role descriptions`      |
+| 属性追加・仕様変更   | `feat`         | `feat(html-spec): add input switch attribute`     |
+| spec データ修正      | `fix`          | `fix(html-spec): correct ARIA mapping for button` |
 
 **PR の分離:** 仕様変更（新属性の追加、ARIA マッピング修正など）はそれぞれ個別の
 ブランチ・PR で作成する。description のみの更新は 1 つの PR にまとめてよい。

--- a/packages/@markuplint/html-spec/docs/maintenance.md
+++ b/packages/@markuplint/html-spec/docs/maintenance.md
@@ -225,11 +225,11 @@ Stage and commit `index.json` (and any modified `src/` files if applicable).
 
 Use conventional commit prefixes based on the nature of the change:
 
-| Change type               | Prefix  | Example                                              |
-| ------------------------- | ------- | ---------------------------------------------------- |
-| Description updates only  | `chore` | `chore(html-spec): update role descriptions`         |
-| Attribute/spec additions  | `feat`  | `feat(html-spec): add input switch attribute`        |
-| Spec data corrections     | `fix`   | `fix(html-spec): correct ARIA mapping for button`    |
+| Change type              | Prefix  | Example                                           |
+| ------------------------ | ------- | ------------------------------------------------- |
+| Description updates only | `chore` | `chore(html-spec): update role descriptions`      |
+| Attribute/spec additions | `feat`  | `feat(html-spec): add input switch attribute`     |
+| Spec data corrections    | `fix`   | `fix(html-spec): correct ARIA mapping for button` |
 
 **PR separation:** Each specification change (new attribute, ARIA mapping fix, etc.)
 should be on its own branch and PR. Description-only updates can be batched into a


### PR DESCRIPTION
## Summary

- Fix prettier formatting issues in 4 html-spec documentation files
- Tables had inconsistent padding that failed CI `lint-check:prettier`

## Test plan

- [x] `yarn lint-check` passes locally (cspell 0 issues, eslint 0 errors, prettier 0 issues)
- [x] Pre-commit hooks (prettier, cspell, commitlint) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)