### PR TITLE
ci: restore ESLint job to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,6 +139,52 @@ jobs:
                       packages/@markuplint/html-spec/index.json
                   key: prod-node${{ env.NODE_BUILD_VERSION }}-${{ github.sha }}
 
+    lint:
+        needs: [dev-setup, build]
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+            - name: Use Node.js ${{ env.NODE_BUILD_VERSION }}
+              uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+              with:
+                  node-version: ${{ env.NODE_BUILD_VERSION }}
+
+            - name: Enable Corepack and setup Yarn v4
+              run: |
+                  corepack enable
+                  yarn --version
+
+            - name: Get yarn cache directory path
+              id: yarn-cache-dir-path
+              run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
+
+            - name: Cache Restore devDependencies
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
+              with:
+                  path: |
+                      '**/node_modules'
+                      ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                  key: dev-depends-ubuntu-latest-node${{ env.NODE_BUILD_VERSION }}-${{ hashFiles('yarn.lock', '.yarnrc.yml') }}
+
+            - name: Install dependencies
+              run: yarn install --immutable
+
+            - name: Cache Restore Production
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
+              with:
+                  path: |
+                      packages/**/lib
+                      packages/**/cjs
+                      packages/**/esm
+                      packages/@markuplint/config-presets/preset.*.json
+                      packages/@markuplint/html-spec/index.js
+                      packages/@markuplint/html-spec/index.json
+                  key: prod-node${{ env.NODE_BUILD_VERSION }}-${{ github.sha }}
+
+            - name: ESLint
+              run: yarn lint-check:eslint
+
     os-setup:
         runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
## Summary

- PR #3111 moved the lint job from `test.yml` to a separate `lint.yml`, but only included prettier and spellcheck
- ESLint was accidentally dropped from CI entirely
- ESLint requires built artifacts, so it must remain in `test.yml` (with `needs: [dev-setup, build]`)
- This PR restores the ESLint job to `test.yml`

## Test plan

- [ ] Verify the lint job runs ESLint successfully in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)