### PR TITLE
build(svelte-parser): upgrade svelte from 5.43.4 to 5.50.0

### DIFF
--- a/packages/@markuplint/svelte-parser/package.json
+++ b/packages/@markuplint/svelte-parser/package.json
@@ -32,6 +32,6 @@
 		"@markuplint/html-parser": "4.6.22",
 		"@markuplint/ml-ast": "4.4.10",
 		"@markuplint/parser-utils": "4.8.10",
-		"svelte": "5.43.4"
+		"svelte": "5.50.0"
 	}
 }

--- a/packages/@markuplint/svelte-parser/src/svelte-parser/index.spec.ts
+++ b/packages/@markuplint/svelte-parser/src/svelte-parser/index.spec.ts
@@ -243,6 +243,10 @@ describe('Issues', () => {
 				start: 0,
 				end: 65,
 				attributes: [],
+				name_loc: {
+					start: { character: 1, column: 1, line: 1 },
+					end: { character: 14, column: 14, line: 1 },
+				},
 				fragment: {
 					type: 'Fragment',
 					nodes: [
@@ -252,6 +256,10 @@ describe('Issues', () => {
 							start: 15,
 							end: 49,
 							attributes: [],
+							name_loc: {
+								start: { character: 16, column: 16, line: 1 },
+								end: { character: 19, column: 19, line: 1 },
+							},
 							fragment: {
 								type: 'Fragment',
 								nodes: [
@@ -466,6 +474,10 @@ describe('Issues', () => {
 					name: 'func',
 					start: 69,
 					end: 73,
+					loc: {
+						start: { character: 69, column: 10, line: 5 },
+						end: { character: 73, column: 14, line: 5 },
+					},
 				},
 				parameters: [
 					{
@@ -597,6 +609,10 @@ describe('Issues', () => {
 										start: 120,
 										end: 131,
 										attributes: [],
+										name_loc: {
+											start: { character: 121, column: 5, line: 7 },
+											end: { character: 124, column: 8, line: 7 },
+										},
 										fragment: {
 											type: 'Fragment',
 											nodes: [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -3072,7 +3072,7 @@ __metadata:
     "@markuplint/html-parser": "npm:4.6.22"
     "@markuplint/ml-ast": "npm:4.4.10"
     "@markuplint/parser-utils": "npm:4.8.10"
-    svelte: "npm:5.43.4"
+    svelte: "npm:5.50.0"
   languageName: unknown
   linkType: soft
 
@@ -7958,6 +7958,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"devalue@npm:^5.6.2":
+  version: 5.6.2
+  resolution: "devalue@npm:5.6.2"
+  checksum: 10c0/654f257ec525a2d3f35c941bfbb361148bc65ced060710969fbaa1c45abf1c9d7c4fcb77310bf8d2fb73c34cf60bad10710e7bf5b15643bbc082518ea04cb00b
+  languageName: node
+  linkType: hard
+
 "diff@npm:^4.0.1":
   version: 4.0.2
   resolution: "diff@npm:4.0.2"
@@ -9135,12 +9142,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esrap@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "esrap@npm:2.1.0"
+"esrap@npm:^2.2.2":
+  version: 2.2.3
+  resolution: "esrap@npm:2.2.3"
   dependencies:
     "@jridgewell/sourcemap-codec": "npm:^1.4.15"
-  checksum: 10c0/42f9f8b49972989a58082dda58c3862689c9c45f3245fd9bfa7e84a00de9cdc422d73621fad1c5d4872c12875869bd770cda80be20ffb1244e6c27b192a3f7b0
+  checksum: 10c0/6eda59f9968e52b9b150dec0cb8acf2f42fef62b16918cefb64d25e5aeaa969cf44ca2a6260b14994cb7e5ac2e78ab8170158339901ab0e913c52f780891ab95
   languageName: node
   linkType: hard
 
@@ -17138,9 +17145,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"svelte@npm:5.43.4":
-  version: 5.43.4
-  resolution: "svelte@npm:5.43.4"
+"svelte@npm:5.50.0":
+  version: 5.50.0
+  resolution: "svelte@npm:5.50.0"
   dependencies:
     "@jridgewell/remapping": "npm:^2.3.4"
     "@jridgewell/sourcemap-codec": "npm:^1.5.0"
@@ -17150,13 +17157,14 @@ __metadata:
     aria-query: "npm:^5.3.1"
     axobject-query: "npm:^4.1.0"
     clsx: "npm:^2.1.1"
+    devalue: "npm:^5.6.2"
     esm-env: "npm:^1.2.1"
-    esrap: "npm:^2.1.0"
+    esrap: "npm:^2.2.2"
     is-reference: "npm:^3.0.3"
     locate-character: "npm:^3.0.0"
     magic-string: "npm:^0.30.11"
     zimmerframe: "npm:^1.1.2"
-  checksum: 10c0/a48c581b502bc4a58e46822c4ad973cdd3d84f922cfdc6df1fea2eb0381d4b8063561a5699ff557e02d3a220701cb1bf8c776c9771c6bac77312cd04410dade2
+  checksum: 10c0/58acd1e42da5065228d2c673aee56a4eaf655272a82541ba8fc97050a7ab3bd54dd66a40bc46aff8fdc65b66ce9c8b613a7f316d1d1e31b0b93e7eac6b8ae4c8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Upgrade `svelte` dependency in `@markuplint/svelte-parser` from 5.43.4 to 5.50.0
- Update test expectations to include `name_loc` property added to `BaseElement` nodes in Svelte 5.45.3
- Update test expectations to include `loc` property added to `SnippetBlock` expression identifier

## Test plan
- [x] `npx vitest run packages/@markuplint/svelte-parser` — 86/86 passed
- [x] `npx vitest run packages/markuplint` — 59/59 passed
- [x] `yarn build --scope @markuplint/svelte-parser` — success

🤖 Generated with [Claude Code](https://claude.com/claude-code)