### PR TITLE
fix(html-spec): correct implicit role typo for meter element

### DIFF
--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -39486,7 +39486,7 @@
 				]
 			},
 			"aria": {
-				"implicitRole": "mater",
+				"implicitRole": "meter",
 				"permittedRoles": false,
 				"properties": {
 					"global": true,

--- a/packages/@markuplint/html-spec/src/spec.meter.json
+++ b/packages/@markuplint/html-spec/src/spec.meter.json
@@ -41,7 +41,7 @@
 		}
 	},
 	"aria": {
-		"implicitRole": "mater",
+		"implicitRole": "meter",
 		"permittedRoles": false,
 		"properties": {
 			"global": true,

--- a/packages/@markuplint/rules/src/wai-aria/index.spec.ts
+++ b/packages/@markuplint/rules/src/wai-aria/index.spec.ts
@@ -1315,3 +1315,29 @@ aria-checked={isChecked}
 		]);
 	});
 });
+
+describe('meter element implicit role', () => {
+	test('meter has implicit role "meter"', async () => {
+		const { violations } = await mlRuleTest(rule, '<meter value="50" min="0" max="100">50%</meter>');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('meter with explicit role="meter" is redundant', async () => {
+		const { violations } = await mlRuleTest(rule, '<meter value="50" min="0" max="100" role="meter">50%</meter>');
+		expect(violations.length).toBeGreaterThan(0);
+	});
+
+	test('meter does not permit role overwriting', async () => {
+		const { violations } = await mlRuleTest(rule, '<meter value="50" min="0" max="100" role="button">50%</meter>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 43,
+				message:
+					'Cannot overwrite the "button" role to the "meter" element according to ARIA in HTML specification',
+				raw: 'button',
+			},
+		]);
+	});
+});


### PR DESCRIPTION
## Summary

- Fix typo in `<meter>` element's `implicitRole`: `"mater"` → `"meter"`
- Add wai-aria rule tests for meter implicit role (valid, redundant, disallowed)

## Test plan

- [x] `wai-aria` rule correctly recognizes `<meter>` implicit role as `meter`
- [x] `wai-aria` rule reports redundant `role="meter"` on `<meter>`
- [x] `wai-aria` rule reports error for disallowed role on `<meter>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)