### PR TITLE
feat(html-spec): add request-close to button command attribute

### DIFF
--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -36074,7 +36074,14 @@
 					"description": "Specifies the action to be performed on an element being controlled by a control <button> specified via the commandfor attribute. The possible values are: \"show-modal\" The button will show a <dialog> as modal. If the dialog is already modal, no action will be taken. This is a declarative equivalent of calling the HTMLDialogElement.showModal() method on the <dialog> element. \"close\" The button will close a <dialog> element. If the dialog is already closed, no action will be taken. This is a declarative equivalent of calling the HTMLDialogElement.close() method on the <dialog> element. When used with the value attribute, the button's value will be passed as the dialog's returnValue property. \"request-close\" The button will trigger a cancel event on a <dialog> element to request that the browser dismiss it, followed by a close event. This differs from the close command in that authors can call Event.preventDefault() on the cancel event to prevent the <dialog> from closing. If the dialog is already closed, no action will be taken. This is a declarative equivalent of calling the HTMLDialogElement.requestClose() method on the <dialog> element. When used with the button's value attribute, the value will be passed as the dialog's returnValue property. \"show-popover\" The button will show a hidden popover. If you try to show an already showing popover, no action will be taken. See Popover API for more details. This is equivalent to setting a value of show for the popovertargetaction attribute, and also provides a declarative equivalent to calling the HTMLElement.showPopover() method on the popover element. \"hide-popover\" The button will hide a showing popover. If you try to hide an already hidden popover, no action will be taken. See Popover API for more details. This is equivalent to setting a value of hide for the popovertargetaction attribute, and also provides a declarative equivalent to calling the HTMLElement.hidePopover() method on the popover element. \"toggle-popover\" The button will toggle a popover between showing and hidden. If the popover is hidden, it will be shown; if the popover is showing, it will be hidden. See Popover API for more details. This is equivalent to setting a value of toggle for the popovertargetaction attribute, and also provides a declarative equivalent to calling the HTMLElement.togglePopover() method on the popover element. Custom values This attribute can represent custom values that are prefixed with a two hyphen characters (--). Buttons with a custom value will dispatch the CommandEvent on the controlled element.",
 					"type": [
 						{
-							"enum": ["toggle-popover", "show-popover", "hide-popover", "close", "show-modal"],
+							"enum": [
+								"toggle-popover",
+								"show-popover",
+								"hide-popover",
+								"close",
+								"request-close",
+								"show-modal"
+							],
 							"invalidValueDefault": "unknown",
 							"missingValueDefault": "unknown"
 						},

--- a/packages/@markuplint/html-spec/src/spec.button.json
+++ b/packages/@markuplint/html-spec/src/spec.button.json
@@ -29,7 +29,7 @@
 		"command": {
 			"type": [
 				{
-					"enum": ["toggle-popover", "show-popover", "hide-popover", "close", "show-modal"],
+					"enum": ["toggle-popover", "show-popover", "hide-popover", "close", "request-close", "show-modal"],
 					"invalidValueDefault": "unknown",
 					"missingValueDefault": "unknown"
 				},

--- a/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
@@ -1326,7 +1326,7 @@ test('Multiple Type', async () => {
 			col: 18,
 			line: 1,
 			message:
-				'The "command" attribute expects either "toggle-popover", "show-popover", "hide-popover", "close", "show-modal". Or, the "command" attribute expects the custom command format. Did you mean "--invalid"? (https://html.spec.whatwg.org/multipage/form-elements.html#valid-custom-command)',
+				'The "command" attribute expects either "toggle-popover", "show-popover", "hide-popover", "close", "request-close", "show-modal". Or, the "command" attribute expects the custom command format. Did you mean "--invalid"? (https://html.spec.whatwg.org/multipage/form-elements.html#valid-custom-command)',
 			raw: 'invalid',
 		},
 	]);

--- a/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
@@ -1710,3 +1710,38 @@ ol(itemscope itemtype="https://schema.org/BreadcrumbList")
 		]);
 	});
 });
+
+describe('button command attribute', () => {
+	test('command="request-close" is valid', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<dialog id="d"><button command="request-close" commandfor="d">Close</button></dialog>',
+		);
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('command="close" is valid', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<dialog id="d"><button command="close" commandfor="d">Close</button></dialog>',
+		);
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('command="invalid-value" is invalid', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<dialog id="d"><button command="invalid-value" commandfor="d">Close</button></dialog>',
+		);
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 33,
+				message:
+					'The "command" attribute expects either "toggle-popover", "show-popover", "hide-popover", "close", "request-close", "show-modal". Or, the "command" attribute expects the custom command format. Did you mean "--invalid-value"? (https://html.spec.whatwg.org/multipage/form-elements.html#valid-custom-command)',
+				raw: 'invalid-value',
+			},
+		]);
+	});
+});


### PR DESCRIPTION
## Summary

- Add `request-close` to the `<button>` element's `command` attribute enum values
- Ref: whatwg/html#11045

## Test plan

- [x] `invalid-attr` rule accepts `<button command="request-close" commandfor="d">`
- [x] `invalid-attr` rule accepts `<button command="close" commandfor="d">`
- [x] `invalid-attr` rule rejects `<button command="invalid-value">` with specific error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)