### PR TITLE
fix(html-spec): add permitted roles to button per html-aria

### DIFF
--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -36027,14 +36027,18 @@
 				"permittedRoles": [
 					"checkbox",
 					"combobox",
+					"gridcell",
 					"link",
 					"menuitem",
 					"menuitemcheckbox",
 					"menuitemradio",
 					"option",
 					"radio",
+					"separator",
+					"slider",
 					"switch",
-					"tab"
+					"tab",
+					"treeitem"
 				],
 				"1.1": {
 					"permittedRoles": [

--- a/packages/@markuplint/html-spec/src/spec.button.json
+++ b/packages/@markuplint/html-spec/src/spec.button.json
@@ -76,14 +76,18 @@
 		"permittedRoles": [
 			"checkbox",
 			"combobox",
+			"gridcell",
 			"link",
 			"menuitem",
 			"menuitemcheckbox",
 			"menuitemradio",
 			"option",
 			"radio",
+			"separator",
+			"slider",
 			"switch",
-			"tab"
+			"tab",
+			"treeitem"
 		],
 		"1.1": {
 			"permittedRoles": [

--- a/packages/@markuplint/rules/src/wai-aria/index.spec.ts
+++ b/packages/@markuplint/rules/src/wai-aria/index.spec.ts
@@ -1315,3 +1315,75 @@ aria-checked={isChecked}
 		]);
 	});
 });
+
+describe('button element permitted roles', () => {
+	test('button with role="separator" is valid', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<button role="separator" aria-valuenow="50">Drag to resize</button>',
+		);
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('button with role="gridcell" is valid', async () => {
+		const { violations } = await mlRuleTest(rule, '<button role="gridcell">Cell</button>');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('button with role="slider" is valid', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<button role="slider" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100">50</button>',
+		);
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('button with role="treeitem" is valid', async () => {
+		const { violations } = await mlRuleTest(rule, '<button role="treeitem">Item</button>');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('button with role="tab" is valid', async () => {
+		const { violations } = await mlRuleTest(rule, '<button role="tab">Tab 1</button>');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('button with role="navigation" is not permitted', async () => {
+		const { violations } = await mlRuleTest(rule, '<button role="navigation">Nav</button>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 15,
+				message:
+					'Cannot overwrite the "navigation" role to the "button" element according to ARIA in HTML specification',
+				raw: 'navigation',
+			},
+		]);
+	});
+
+	test('button with role="separator" is not permitted in ARIA 1.1', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<button role="separator" aria-valuenow="50">Drag to resize</button>',
+			{ rule: { options: { version: '1.1' } } },
+		);
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 15,
+				message:
+					'Cannot overwrite the "separator" role to the "button" element according to ARIA in HTML specification',
+				raw: 'separator',
+			},
+			{
+				severity: 'error',
+				line: 1,
+				col: 26,
+				message: 'The "aria-valuenow" ARIA property is disallowed on the "button" role',
+				raw: 'aria-valuenow="50"',
+			},
+		]);
+	});
+});


### PR DESCRIPTION
## Summary

- Add `gridcell`, `separator`, `slider`, `treeitem` to `<button>` element's permitted roles
- These roles are listed in the W3C Recommendation (ARIA in HTML, 05 August 2025)
- The `"1.1"` override is unchanged (these roles were not permitted for button in ARIA 1.1)
- Ref: w3c/html-aria#489

## Test plan

- [x] `wai-aria` rule accepts `<button role="separator">`, `role="gridcell"`, `role="slider"`, `role="treeitem"`
- [x] `wai-aria` rule still accepts existing permitted roles (`role="tab"`)
- [x] `wai-aria` rule rejects non-permitted roles (`role="navigation"`)
- [x] `wai-aria` rule rejects new roles when ARIA version is set to 1.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)