### PR TITLE
fix(html-spec): update html element implicit role to generic

### DIFF
--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -37576,9 +37576,14 @@
 				]
 			},
 			"aria": {
-				"implicitRole": "document",
-				"permittedRoles": false,
-				"properties": false
+				"implicitRole": "generic",
+				"permittedRoles": ["document", "generic"],
+				"namingProhibited": true,
+				"properties": false,
+				"1.1": {
+					"implicitRole": "document",
+					"permittedRoles": false
+				}
 			},
 			"omission": false,
 			"globalAttrs": {

--- a/packages/@markuplint/html-spec/src/spec.html.json
+++ b/packages/@markuplint/html-spec/src/spec.html.json
@@ -19,8 +19,13 @@
 	},
 	"attributes": {},
 	"aria": {
-		"implicitRole": "document",
-		"permittedRoles": false,
-		"properties": false
+		"implicitRole": "generic",
+		"permittedRoles": ["document", "generic"],
+		"namingProhibited": true,
+		"properties": false,
+		"1.1": {
+			"implicitRole": "document",
+			"permittedRoles": false
+		}
 	}
 }

--- a/packages/@markuplint/rules/src/wai-aria/index.spec.ts
+++ b/packages/@markuplint/rules/src/wai-aria/index.spec.ts
@@ -1341,3 +1341,52 @@ describe('meter element implicit role', () => {
 		]);
 	});
 });
+
+describe('html element implicit role', () => {
+	test('html with role="document" is valid', async () => {
+		const { violations } = await mlRuleTest(rule, '<html role="document"><head></head><body></body></html>');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('html with role="generic" is implicit role (redundant)', async () => {
+		const { violations } = await mlRuleTest(rule, '<html role="generic"><head></head><body></body></html>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 13,
+				message: 'The "generic" role is the implicit role of the "html" element',
+				raw: 'generic',
+			},
+		]);
+	});
+
+	test('html with role="banner" is not permitted', async () => {
+		const { violations } = await mlRuleTest(rule, '<html role="banner"><head></head><body></body></html>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 13,
+				message:
+					'Cannot overwrite the "banner" role to the "html" element according to ARIA in HTML specification',
+				raw: 'banner',
+			},
+		]);
+	});
+
+	test('html with role="document" is implicit role in ARIA 1.1 (redundant)', async () => {
+		const { violations } = await mlRuleTest(rule, '<html role="document"><head></head><body></body></html>', {
+			rule: { options: { version: '1.1' } },
+		});
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 13,
+				message: 'The "document" role is the implicit role of the "html" element',
+				raw: 'document',
+			},
+		]);
+	});
+});


### PR DESCRIPTION
## Summary
- Update `<html>` element implicit role from `document` to `generic` (per w3c/aria#2504, HTML-AAM fix)
- Add permitted roles `document` and `generic` (per w3c/html-aria#550, both NOT RECOMMENDED)
- Add `namingProhibited: true` (spec says "No aria-* attributes")
- Add ARIA 1.1 override: `implicitRole: "document"`, `permittedRoles: false`

## Test plan
- [x] `wai-aria` rule tests: `<html role="document">` is valid (permitted role)
- [x] `wai-aria` rule tests: `<html role="generic">` triggers implicit role warning (redundant)
- [x] `wai-aria` rule tests: `<html role="banner">` is rejected (not permitted)
- [x] `wai-aria` rule tests: `<html role="document">` in ARIA 1.1 triggers implicit role warning
- [x] `yarn test` — all passing (svelte-parser failures are pre-existing on dev)
- [x] `yarn lint` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)