### PR TITLE
feat(html-spec): add headingoffset and headingreset attributes

### DIFF
--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -275,6 +275,16 @@
 						"enum": ["enter", "done", "go", "next", "previous", "search", "send"]
 					}
 				},
+				"headingoffset": {
+					"type": {
+						"type": "integer",
+						"gte": 0,
+						"lte": 8
+					}
+				},
+				"headingreset": {
+					"type": "Boolean"
+				},
 				"hidden": {
 					"type": {
 						"enum": ["", "hidden", "until-found"]

--- a/packages/@markuplint/html-spec/src/spec-common.attributes.json
+++ b/packages/@markuplint/html-spec/src/spec-common.attributes.json
@@ -71,6 +71,18 @@
 				"enum": ["enter", "done", "go", "next", "previous", "search", "send"]
 			}
 		},
+		// https://html.spec.whatwg.org/multipage/sections.html#attr-heading-offset
+		"headingoffset": {
+			"type": {
+				"type": "integer",
+				"gte": 0,
+				"lte": 8
+			}
+		},
+		// https://html.spec.whatwg.org/multipage/sections.html#attr-heading-reset
+		"headingreset": {
+			"type": "Boolean"
+		},
 		// https://html.spec.whatwg.org/multipage/interaction.html#attr-hidden
 		"hidden": {
 			"type": {

--- a/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
@@ -1745,3 +1745,39 @@ describe('button command attribute', () => {
 		]);
 	});
 });
+
+describe('headingoffset and headingreset attributes', () => {
+	test('headingoffset with valid value is valid', async () => {
+		const { violations } = await mlRuleTest(rule, '<section headingoffset="1"><h2>Title</h2></section>');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('headingoffset="0" is valid', async () => {
+		const { violations } = await mlRuleTest(rule, '<div headingoffset="0"><h1>Title</h1></div>');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('headingoffset="8" is valid (max)', async () => {
+		const { violations } = await mlRuleTest(rule, '<div headingoffset="8"><h1>Title</h1></div>');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('headingoffset with non-integer value is invalid', async () => {
+		const { violations } = await mlRuleTest(rule, '<div headingoffset="abc"><h1>Title</h1></div>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 21,
+				message:
+					'It includes unexpected characters. the "headingoffset" attribute expects integer greater than or equal to 0 less than or equal to 8',
+				raw: 'abc',
+			},
+		]);
+	});
+
+	test('headingreset is valid', async () => {
+		const { violations } = await mlRuleTest(rule, '<div headingreset><h1>Title</h1></div>');
+		expect(violations).toStrictEqual([]);
+	});
+});


### PR DESCRIPTION
## Summary
- Add `headingoffset` (integer, 0-8) and `headingreset` (boolean) to global attributes
- Both are defined on `HTMLElement` and apply to all HTML elements
- Ref: whatwg/html#11086 (merged 2025-09-11), whatwg/html#11979 (merged 2025-12-02)

## Test plan
- [x] `invalid-attr` rule tests: `<section headingoffset="1">` is valid
- [x] `invalid-attr` rule tests: `headingoffset="0"` and `headingoffset="8"` are valid (boundary values)
- [x] `invalid-attr` rule tests: `headingoffset="abc"` produces correct error message
- [x] `invalid-attr` rule tests: `<div headingreset>` is valid
- [x] `yarn test` — 141 files, 1393 tests passed
- [x] `yarn lint` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)