### PR TITLE
feat(create-rule): Add non-interactive CLI mode to create-rule with JSON output

### DIFF
--- a/packages/@markuplint/create-rule/README.md
+++ b/packages/@markuplint/create-rule/README.md
@@ -36,19 +36,19 @@ $ npx @markuplint/create-rule -p project -n my-plugin -r no-empty-alt --json
 
 ### Options
 
-| Option | Short | Description | Default |
-| --- | --- | --- | --- |
-| `--purpose <type>` | `-p` | Purpose: `project`, `package`, or `core` | _(required)_ |
-| `--plugin-name <name>` | `-n` | Plugin/directory name in kebab-case | _(required for project/package)_ |
-| `--rule-name <name>` | `-r` | Rule name in kebab-case | _(required)_ |
-| `--lang <lang>` | `-l` | Language: `ts` or `js` | `ts` |
-| `--test` | `-t` | Generate test files | `true` |
-| `--no-test` | | Skip test file generation | |
-| `--description <text>` | `-d` | Rule description | _(required for core)_ |
-| `--category <cat>` | `-c` | Category (see below) | _(required for core)_ |
-| `--severity <level>` | `-s` | Severity: `error` or `warning` | _(required for core)_ |
-| `--json` | | Output result as JSON | `false` |
-| `--help` | `-h` | Show help message | |
+| Option                 | Short | Description                              | Default                          |
+| ---------------------- | ----- | ---------------------------------------- | -------------------------------- |
+| `--purpose <type>`     | `-p`  | Purpose: `project`, `package`, or `core` | _(required)_                     |
+| `--plugin-name <name>` | `-n`  | Plugin/directory name in kebab-case      | _(required for project/package)_ |
+| `--rule-name <name>`   | `-r`  | Rule name in kebab-case                  | _(required)_                     |
+| `--lang <lang>`        | `-l`  | Language: `ts` or `js`                   | `ts`                             |
+| `--test`               | `-t`  | Generate test files                      | `true`                           |
+| `--no-test`            |       | Skip test file generation                |                                  |
+| `--description <text>` | `-d`  | Rule description                         | _(required for core)_            |
+| `--category <cat>`     | `-c`  | Category (see below)                     | _(required for core)_            |
+| `--severity <level>`   | `-s`  | Severity: `error` or `warning`           | _(required for core)_            |
+| `--json`               |       | Output result as JSON                    | `false`                          |
+| `--help`               | `-h`  | Show help message                        |                                  |
 
 Available categories: `validation`, `a11y`, `naming-convention`, `maintainability`, `style`
 

--- a/packages/@markuplint/create-rule/README.md
+++ b/packages/@markuplint/create-rule/README.md
@@ -4,13 +4,55 @@
 
 ## Overview
 
-A CLI scaffolding tool for creating new markuplint rules. It provides an interactive wizard that generates all the boilerplate files needed for rule development, including source files, tests, and configuration.
+A CLI scaffolding tool for creating new markuplint rules. It provides both an interactive wizard and a non-interactive CLI mode that generates all the boilerplate files needed for rule development, including source files, tests, and configuration.
 
 ## Usage
+
+### Interactive mode
+
+Run without arguments to start the guided wizard:
 
 ```shell
 $ npx @markuplint/create-rule
 ```
+
+### Non-interactive mode
+
+Pass CLI options to create a rule in a single command:
+
+```shell
+# Add a rule to this project
+$ npx @markuplint/create-rule -p project -n my-plugin -r no-empty-alt
+
+# Create a publishable package (JavaScript, no tests)
+$ npx @markuplint/create-rule -p package -n my-plugin -r no-empty-alt -l js --no-test
+
+# Contribute to core
+$ npx @markuplint/create-rule -p core -r no-empty-alt -d "Disallow empty alt" -c a11y -s error
+
+# JSON output (useful for scripting and AI tooling)
+$ npx @markuplint/create-rule -p project -n my-plugin -r no-empty-alt --json
+```
+
+### Options
+
+| Option | Short | Description | Default |
+| --- | --- | --- | --- |
+| `--purpose <type>` | `-p` | Purpose: `project`, `package`, or `core` | _(required)_ |
+| `--plugin-name <name>` | `-n` | Plugin/directory name in kebab-case | _(required for project/package)_ |
+| `--rule-name <name>` | `-r` | Rule name in kebab-case | _(required)_ |
+| `--lang <lang>` | `-l` | Language: `ts` or `js` | `ts` |
+| `--test` | `-t` | Generate test files | `true` |
+| `--no-test` | | Skip test file generation | |
+| `--description <text>` | `-d` | Rule description | _(required for core)_ |
+| `--category <cat>` | `-c` | Category (see below) | _(required for core)_ |
+| `--severity <level>` | `-s` | Severity: `error` or `warning` | _(required for core)_ |
+| `--json` | | Output result as JSON | `false` |
+| `--help` | `-h` | Show help message | |
+
+Available categories: `validation`, `a11y`, `naming-convention`, `maintainability`, `style`
+
+> When contributing to core (`--purpose core`), `--lang` is always TypeScript and `--test` is always enabled regardless of the options provided.
 
 ## Modes
 

--- a/packages/@markuplint/create-rule/src/cli.ts
+++ b/packages/@markuplint/create-rule/src/cli.ts
@@ -35,6 +35,9 @@ const icons: Record<string, string> = {
 	tsconfig: '💎',
 };
 
+/**
+ * Prints the CLI usage information, options, and examples to stdout.
+ */
 function printHelp() {
 	process.stdout.write(`
 Usage: create-rule [options]
@@ -69,17 +72,31 @@ Examples:
 `);
 }
 
+/**
+ * Sentinel class thrown when `--help` is requested to signal a
+ * successful early exit without using `process.exit`.
+ */
 class HelpRequested {
 	readonly code = 0;
 }
 
+/**
+ * Throws an error with the given message and a usage hint.
+ * Used for CLI argument validation failures.
+ *
+ * @param message - The validation error message to include.
+ */
 function fail(message: string): never {
 	throw new Error(`${message}\nRun 'create-rule --help' for usage.`);
 }
 
 /**
- * Parse CLI arguments and build CreateRuleHelperParams.
- * Returns null if no arguments were provided (indicating interactive mode).
+ * Parses `process.argv` into validated {@link CreateRuleHelperParams}.
+ *
+ * @returns The parsed parameters and output format flag, or `null` when
+ *          no arguments are provided (indicating interactive mode).
+ * @throws {HelpRequested} When `--help` is passed.
+ * @throws {Error} When required options are missing or values are invalid.
  */
 function parseCliArgs(): { params: CreateRuleHelperParams; json: boolean } | null {
 	const { values } = parseArgs({
@@ -214,7 +231,12 @@ export async function createRule() {
 }
 
 /**
- * Non-interactive rule creation from parsed CLI options.
+ * Creates a rule non-interactively from pre-validated CLI options.
+ * Runs the scaffold, prints results (or JSON), and installs dependencies.
+ *
+ * @param params - The validated rule creation parameters.
+ * @param json - When `true`, outputs the result as JSON instead of
+ *               the human-readable file list.
  */
 async function createRuleNonInteractive(params: CreateRuleHelperParams, json: boolean) {
 	const result = await createRuleHelper(params);

--- a/packages/@markuplint/create-rule/src/cli.ts
+++ b/packages/@markuplint/create-rule/src/cli.ts
@@ -1,11 +1,28 @@
-import type { CreateRuleCreatorCoreParams, CreateRuleLanguage, CreateRulePurpose } from './types.js';
+import type {
+	CreateRuleCreatorCoreParams,
+	CreateRuleHelperParams,
+	CreateRuleLanguage,
+	CreateRulePurpose,
+} from './types.js';
 
 import path from 'node:path';
+import { parseArgs } from 'node:util';
 
 import { input, installModule, select, confirm, font, header, xterm } from '@markuplint/cli-utils';
 
 import { createRuleHelper } from './create-rule-helper.js';
 import { isMarkuplintRepo } from './is-markuplint-repo.js';
+
+const KEBAB_CASE = /^[a-z][\da-z]*(?:-[a-z][\da-z]*)*$/i;
+
+const CATEGORIES = ['validation', 'a11y', 'naming-convention', 'maintainability', 'style'] as const;
+const SEVERITIES = ['error', 'warning'] as const;
+
+const PURPOSE_MAP: Record<string, CreateRulePurpose> = {
+	project: 'ADD_TO_PROJECT',
+	package: 'PUBLISH_AS_PACKAGE',
+	core: 'CONTRIBUTE_TO_CORE',
+};
 
 /**
  * Icon mapping for scaffold output display, keyed by base file name.
@@ -18,18 +35,234 @@ const icons: Record<string, string> = {
 	tsconfig: '💎',
 };
 
+function printHelp() {
+	process.stdout.write(`
+Usage: create-rule [options]
+
+  Without options, starts the interactive wizard.
+  With options, creates a rule non-interactively.
+
+Options:
+  -p, --purpose <type>       Purpose: project, package, or core (required)
+  -n, --plugin-name <name>   Plugin/directory name (required for project/package)
+  -r, --rule-name <name>     Rule name in kebab-case (required)
+  -l, --lang <lang>          Language: ts or js (default: ts, ignored for core)
+  -t, --test                 Generate test files (default: true)
+      --no-test              Skip test file generation
+  -d, --description <text>   Rule description (required for core)
+  -c, --category <cat>       Category (required for core):
+                               validation, a11y, naming-convention,
+                               maintainability, style
+  -s, --severity <level>     Severity: error or warning (required for core)
+      --json                 Output result as JSON
+  -h, --help                 Show this help message
+
+Examples:
+  # Add a rule to this project
+  create-rule -p project -n my-plugin -r no-empty-alt
+
+  # Create a publishable package
+  create-rule -p package -n my-plugin -r no-empty-alt -l js --no-test
+
+  # Contribute to core
+  create-rule -p core -r no-empty-alt -d "Disallow empty alt" -c a11y -s error
+`);
+}
+
+class HelpRequested {
+	readonly code = 0;
+}
+
+function fail(message: string): never {
+	throw new Error(`${message}\nRun 'create-rule --help' for usage.`);
+}
+
+/**
+ * Parse CLI arguments and build CreateRuleHelperParams.
+ * Returns null if no arguments were provided (indicating interactive mode).
+ */
+function parseCliArgs(): { params: CreateRuleHelperParams; json: boolean } | null {
+	const { values } = parseArgs({
+		options: {
+			purpose: { type: 'string', short: 'p' },
+			'plugin-name': { type: 'string', short: 'n' },
+			'rule-name': { type: 'string', short: 'r' },
+			lang: { type: 'string', short: 'l' },
+			test: { type: 'boolean', short: 't', default: true },
+			'no-test': { type: 'boolean', default: false },
+			description: { type: 'string', short: 'd' },
+			category: { type: 'string', short: 'c' },
+			severity: { type: 'string', short: 's' },
+			json: { type: 'boolean', default: false },
+			help: { type: 'boolean', short: 'h', default: false },
+		},
+		strict: true,
+	});
+
+	if (values.help) {
+		printHelp();
+		throw new HelpRequested();
+	}
+
+	// No arguments → interactive mode
+	if (!values.purpose && !values['rule-name'] && !values['plugin-name']) {
+		return null;
+	}
+
+	// Validate purpose
+	if (!values.purpose) {
+		fail('--purpose is required in non-interactive mode');
+	}
+	const purpose = PURPOSE_MAP[values.purpose];
+	if (!purpose) {
+		fail(`Invalid --purpose "${values.purpose}". Must be one of: project, package, core`);
+	}
+
+	// Validate rule name
+	if (!values['rule-name']) {
+		fail('--rule-name is required');
+	}
+	const ruleName = values['rule-name'];
+	if (!KEBAB_CASE.test(ruleName)) {
+		fail(`Invalid --rule-name "${ruleName}". Must be kebab-case (e.g., "no-empty-alt")`);
+	}
+
+	// Validate plugin name
+	let pluginName = '';
+	if (purpose !== 'CONTRIBUTE_TO_CORE') {
+		if (!values['plugin-name']) {
+			fail('--plugin-name is required for project/package purpose');
+		}
+		pluginName = values['plugin-name'];
+		if (!KEBAB_CASE.test(pluginName)) {
+			fail(`Invalid --plugin-name "${pluginName}". Must be kebab-case (e.g., "my-plugin")`);
+		}
+	}
+
+	// Language
+	const langInput = values.lang ?? 'ts';
+	let lang: CreateRuleLanguage;
+	if (purpose === 'CONTRIBUTE_TO_CORE') {
+		lang = 'TYPESCRIPT';
+	} else if (langInput === 'ts') {
+		lang = 'TYPESCRIPT';
+	} else if (langInput === 'js') {
+		lang = 'JAVASCRIPT';
+	} else {
+		fail(`Invalid --lang "${langInput}". Must be "ts" or "js"`);
+	}
+
+	// Test
+	const needTest = purpose === 'CONTRIBUTE_TO_CORE' ? true : !values['no-test'];
+
+	// Core-specific params
+	let core: CreateRuleCreatorCoreParams | undefined;
+	if (purpose === 'CONTRIBUTE_TO_CORE') {
+		if (!values.description) {
+			fail('--description is required for core purpose');
+		}
+		if (!values.category) {
+			fail('--category is required for core purpose');
+		}
+		if (!(CATEGORIES as readonly string[]).includes(values.category)) {
+			fail(`Invalid --category "${values.category}". Must be one of: ${CATEGORIES.join(', ')}`);
+		}
+		if (!values.severity) {
+			fail('--severity is required for core purpose');
+		}
+		if (!(SEVERITIES as readonly string[]).includes(values.severity)) {
+			fail(`Invalid --severity "${values.severity}". Must be one of: ${SEVERITIES.join(', ')}`);
+		}
+		core = {
+			description: values.description,
+			category: values.category,
+			severity: values.severity,
+		};
+	}
+
+	return {
+		params: { purpose, pluginName, ruleName, lang, needTest, core },
+		json: values.json ?? false,
+	};
+}
+
+/**
+ * CLI entry point for creating a new markuplint rule.
+ *
+ * Supports two modes:
+ * - **Non-interactive**: When CLI options are provided, creates the rule directly.
+ * - **Interactive**: When no options are provided, starts the guided wizard.
+ *
+ * @returns Resolves when the rule has been fully scaffolded and dependencies installed.
+ */
+export async function createRule() {
+	let parsed: { params: CreateRuleHelperParams; json: boolean } | null;
+	try {
+		parsed = parseCliArgs();
+	} catch (error) {
+		if (error instanceof HelpRequested) {
+			return;
+		}
+		throw error;
+	}
+
+	if (parsed) {
+		await createRuleNonInteractive(parsed.params, parsed.json);
+	} else {
+		await createRuleInteractive();
+	}
+}
+
+/**
+ * Non-interactive rule creation from parsed CLI options.
+ */
+async function createRuleNonInteractive(params: CreateRuleHelperParams, json: boolean) {
+	const result = await createRuleHelper(params);
+
+	if (!json) {
+		process.stdout.write(header('Create a rule'));
+		process.stdout.write('\n\n');
+	}
+
+	if (json) {
+		const output = {
+			files: result.files.map(file => ({
+				name: file.fileName + file.ext,
+				path: path.resolve(file.destDir, file.fileName + file.ext),
+				test: file.test,
+			})),
+			dependencies: result.dependencies,
+			devDependencies: result.devDependencies,
+		};
+		process.stdout.write(JSON.stringify(output, null, 2) + '\n');
+	} else {
+		for (const file of result.files) {
+			printFile(
+				params.pluginName || 'core',
+				file.test ? '🖍 ' : (icons[file.name] ?? '🛡 '),
+				file.fileName,
+				path.resolve(file.destDir, file.fileName + file.ext),
+			);
+		}
+	}
+
+	if (result.dependencies.length > 0) {
+		await installModule(result.dependencies);
+	}
+
+	if (result.devDependencies.length > 0) {
+		await installModule(result.devDependencies, true);
+	}
+}
+
 /**
  * Interactive CLI wizard for creating a new markuplint rule.
  *
  * Guides the user through selecting a purpose, naming the plugin and rule,
  * choosing a language, and optionally generating tests. After scaffolding,
  * it prints the generated files and installs any required dependencies.
- *
- * This function is the main entry point invoked by the `create-rule` CLI binary.
- *
- * @returns Resolves when the rule has been fully scaffolded and dependencies installed.
  */
-export async function createRule() {
+async function createRuleInteractive() {
 	process.stdout.write(header('Create a rule'));
 	process.stdout.write('\n');
 	process.stdout.write('\n');
@@ -96,7 +329,7 @@ export async function createRule() {
 	const result = await createRuleHelper({ purpose, pluginName, ruleName, lang, needTest, core });
 
 	for (const file of result.files) {
-		output(
+		printFile(
 			pluginName || 'core',
 			file.test ? '🖍 ' : (icons[file.name] ?? '🛡 '),
 			file.fileName,
@@ -119,12 +352,12 @@ export async function createRule() {
  * @param name - The plugin or module name used as a prefix.
  * @param icon - The icon character to display next to the file name.
  * @param title - The display title (typically the file name).
- * @param path - The absolute path to the generated file.
+ * @param filePath - The absolute path to the generated file.
  */
-function output(name: string, icon: string, title: string, path: string) {
+function printFile(name: string, icon: string, title: string, filePath: string) {
 	const _marker = xterm(39)('✔') + ' ';
 	const _title = (icon: string, title: string) => `${icon} ` + font.bold(`${name}/${title}`);
-	const _file = (path: string) => ' ' + font.cyanBright(path);
-	process.stdout.write(_marker + _title(icon, title) + _file(path));
+	const _file = (filePath: string) => ' ' + font.cyanBright(filePath);
+	process.stdout.write(_marker + _title(icon, title) + _file(filePath));
 	process.stdout.write('\n');
 }

--- a/packages/@markuplint/create-rule/src/cli.ts
+++ b/packages/@markuplint/create-rule/src/cli.ts
@@ -81,13 +81,14 @@ class HelpRequested {
 }
 
 /**
- * Throws an error with the given message and a usage hint.
- * Used for CLI argument validation failures.
- *
- * @param message - The validation error message to include.
+ * Error thrown when CLI arguments are invalid or missing.
+ * Includes a usage hint directing users to `--help`.
  */
-function fail(message: string): never {
-	throw new Error(`${message}\nRun 'create-rule --help' for usage.`);
+class UsageHintError extends Error {
+	constructor(message: string) {
+		super(`${message}\nRun 'create-rule --help' for usage.`);
+		this.name = 'UsageHintError';
+	}
 }
 
 /**
@@ -96,7 +97,7 @@ function fail(message: string): never {
  * @returns The parsed parameters and output format flag, or `null` when
  *          no arguments are provided (indicating interactive mode).
  * @throws {HelpRequested} When `--help` is passed.
- * @throws {Error} When required options are missing or values are invalid.
+ * @throws {UsageHintError} When required options are missing or values are invalid.
  */
 function parseCliArgs(): { params: CreateRuleHelperParams; json: boolean } | null {
 	const { values } = parseArgs({
@@ -128,45 +129,52 @@ function parseCliArgs(): { params: CreateRuleHelperParams; json: boolean } | nul
 
 	// Validate purpose
 	if (!values.purpose) {
-		fail('--purpose is required in non-interactive mode');
+		throw new UsageHintError('--purpose is required in non-interactive mode');
 	}
 	const purpose = PURPOSE_MAP[values.purpose];
 	if (!purpose) {
-		fail(`Invalid --purpose "${values.purpose}". Must be one of: project, package, core`);
+		throw new UsageHintError(`Invalid --purpose "${values.purpose}". Must be one of: project, package, core`);
 	}
 
 	// Validate rule name
 	if (!values['rule-name']) {
-		fail('--rule-name is required');
+		throw new UsageHintError('--rule-name is required');
 	}
 	const ruleName = values['rule-name'];
 	if (!KEBAB_CASE.test(ruleName)) {
-		fail(`Invalid --rule-name "${ruleName}". Must be kebab-case (e.g., "no-empty-alt")`);
+		throw new UsageHintError(`Invalid --rule-name "${ruleName}". Must be kebab-case (e.g., "no-empty-alt")`);
 	}
 
 	// Validate plugin name
 	let pluginName = '';
 	if (purpose !== 'CONTRIBUTE_TO_CORE') {
 		if (!values['plugin-name']) {
-			fail('--plugin-name is required for project/package purpose');
+			throw new UsageHintError('--plugin-name is required for project/package purpose');
 		}
 		pluginName = values['plugin-name'];
 		if (!KEBAB_CASE.test(pluginName)) {
-			fail(`Invalid --plugin-name "${pluginName}". Must be kebab-case (e.g., "my-plugin")`);
+			throw new UsageHintError(`Invalid --plugin-name "${pluginName}". Must be kebab-case (e.g., "my-plugin")`);
 		}
 	}
 
 	// Language
-	const langInput = values.lang ?? 'ts';
 	let lang: CreateRuleLanguage;
 	if (purpose === 'CONTRIBUTE_TO_CORE') {
 		lang = 'TYPESCRIPT';
-	} else if (langInput === 'ts') {
-		lang = 'TYPESCRIPT';
-	} else if (langInput === 'js') {
-		lang = 'JAVASCRIPT';
 	} else {
-		fail(`Invalid --lang "${langInput}". Must be "ts" or "js"`);
+		switch (values.lang ?? 'ts') {
+			case 'ts': {
+				lang = 'TYPESCRIPT';
+				break;
+			}
+			case 'js': {
+				lang = 'JAVASCRIPT';
+				break;
+			}
+			default: {
+				throw new UsageHintError(`Invalid --lang "${values.lang}". Must be "ts" or "js"`);
+			}
+		}
 	}
 
 	// Test
@@ -176,19 +184,23 @@ function parseCliArgs(): { params: CreateRuleHelperParams; json: boolean } | nul
 	let core: CreateRuleCreatorCoreParams | undefined;
 	if (purpose === 'CONTRIBUTE_TO_CORE') {
 		if (!values.description) {
-			fail('--description is required for core purpose');
+			throw new UsageHintError('--description is required for core purpose');
 		}
 		if (!values.category) {
-			fail('--category is required for core purpose');
+			throw new UsageHintError('--category is required for core purpose');
 		}
 		if (!(CATEGORIES as readonly string[]).includes(values.category)) {
-			fail(`Invalid --category "${values.category}". Must be one of: ${CATEGORIES.join(', ')}`);
+			throw new UsageHintError(
+				`Invalid --category "${values.category}". Must be one of: ${CATEGORIES.join(', ')}`,
+			);
 		}
 		if (!values.severity) {
-			fail('--severity is required for core purpose');
+			throw new UsageHintError('--severity is required for core purpose');
 		}
 		if (!(SEVERITIES as readonly string[]).includes(values.severity)) {
-			fail(`Invalid --severity "${values.severity}". Must be one of: ${SEVERITIES.join(', ')}`);
+			throw new UsageHintError(
+				`Invalid --severity "${values.severity}". Must be one of: ${SEVERITIES.join(', ')}`,
+			);
 		}
 		core = {
 			description: values.description,


### PR DESCRIPTION
Fixes #???

## What is the purpose of this PR?

- [ ] Fix bug
- [ ] Fix typo
- [ ] Update specs
- [ ] Add new rule
- [ ] Add new parser
- [ ] Improve or refactor rules
- [ ] Add a new core feature
- [x] Improve or refactor core features
- [x] Update documents
- [ ] Others

### Description

This PR adds a non-interactive CLI mode to the `@markuplint/create-rule` tool, complementing the existing interactive wizard. Users can now create rules in a single command by passing CLI options, making it suitable for automation, scripting, and AI tooling integration.

**Key changes:**

1. **Non-interactive mode**: Pass CLI options (`-p`, `-n`, `-r`, etc.) to create a rule without prompts
2. **CLI argument parsing**: Implemented comprehensive argument validation with helpful error messages
3. **JSON output support**: Added `--json` flag to output results as structured JSON for programmatic consumption
4. **Help documentation**: Added `--help` flag with usage examples and option descriptions
5. **Updated README**: Documented both interactive and non-interactive modes with examples and a complete options table

**Supported options:**
- `--purpose` / `-p`: project, package, or core (required)
- `--plugin-name` / `-n`: Plugin directory name (required for project/package)
- `--rule-name` / `-r`: Rule name in kebab-case (required)
- `--lang` / `-l`: TypeScript or JavaScript (default: ts)
- `--test` / `--no-test`: Control test file generation
- `--description` / `-d`: Rule description (required for core)
- `--category` / `-c`: Rule category (required for core)
- `--severity` / `-s`: Error or warning (required for core)
- `--json`: Output as JSON instead of human-readable format
- `--help` / `-h`: Show help message

**Examples:**
```bash
# Add a rule to this project
npx @markuplint/create-rule -p project -n my-plugin -r no-empty-alt

# Create a publishable package
npx @markuplint/create-rule -p package -n my-plugin -r no-empty-alt -l js --no-test

# Contribute to core
npx @markuplint/create-rule -p core -r no-empty-alt -d "Disallow empty alt" -c a11y -s error

# JSON output for scripting
npx @markuplint/create-rule -p project -n my-plugin -r no-empty-alt --json
```

## Checklist

- [x] Improve or refactor core features
  - [x] Add comprehensive CLI argument validation
  - [x] Maintain backward compatibility with interactive mode
  - [x] Add JSON output for programmatic use
- [x] Update documents
  - [x] Update README with usage examples and options table
  - [x] Add help text with examples

https://claude.ai/code/session_01UXX718wS6UCeYfqUdYphfc