### PR TITLE
docs: add SKILL.md feedback from html-spec update work

### DIFF
--- a/.claude/commands/git.md
+++ b/.claude/commands/git.md
@@ -126,3 +126,15 @@ git commit -m 'type(scope): subject line'
 ```
 
 For multi-line non-breaking commits, use heredoc format as well to ensure proper formatting
+
+# Pre-commit verification for spec changes
+
+When committing changes to spec packages (Tier 2–3), run the full test suite:
+
+```bash
+yarn test
+yarn lint
+```
+
+Spec data propagates to `@markuplint/rules` and `@markuplint/ml-spec` tests.
+Package-level tests alone will miss cross-package regressions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,77 @@
+# Skills & Commands
+
+Use the following skills and commands for common tasks. **Always invoke the appropriate skill rather than performing the task manually.**
+
+## Commands (slash commands)
+
+| Command | Description                                            | File                              |
+| ------- | ------------------------------------------------------ | --------------------------------- |
+| `/git`  | Commit rules, message format, and package commit order | [git.md](.claude/commands/git.md) |
+| `/pr`   | Create and push a pull request via `gh pr create`      | [pr.md](.claude/commands/pr.md)   |
+| `/doc`  | Update documentation (README, ARCHITECTURE, JSDoc)     | [doc.md](.claude/commands/doc.md) |
+
+## Skills
+
+### Global
+
+| Skill             | Description                                            | File                                                  |
+| ----------------- | ------------------------------------------------------ | ----------------------------------------------------- |
+| framework-parsers | Create and maintain framework parser and spec packages | [SKILL.md](.claude/skills/framework-parsers/SKILL.md) |
+
+### Package Skills
+
+Each package has a `SKILL.md` with package-specific maintenance guidance.
+
+| Package                       | Description                                                           | File                                                      |
+| ----------------------------- | --------------------------------------------------------------------- | --------------------------------------------------------- |
+| `markuplint`                  | Maintenance tasks for markuplint                                      | [SKILL.md](packages/markuplint/SKILL.md)                  |
+| `@markuplint/ml-core`         | Maintenance tasks for the core linting engine (MLDOM, MLRule, MLCore) | [SKILL.md](packages/@markuplint/ml-core/SKILL.md)         |
+| `@markuplint/ml-ast`          | Maintenance tasks for ml-ast                                          | [SKILL.md](packages/@markuplint/ml-ast/SKILL.md)          |
+| `@markuplint/ml-config`       | Maintenance tasks for ml-config                                       | [SKILL.md](packages/@markuplint/ml-config/SKILL.md)       |
+| `@markuplint/ml-spec`         | Verify documentation claims against web standards and source code     | [SKILL.md](packages/@markuplint/ml-spec/SKILL.md)         |
+| `@markuplint/rules`           | Maintenance tasks for rules (testing spec changes)                    | [SKILL.md](packages/@markuplint/rules/SKILL.md)           |
+| `@markuplint/types`           | Verify documentation claims against web standards and source code     | [SKILL.md](packages/@markuplint/types/SKILL.md)           |
+| `@markuplint/selector`        | Maintenance tasks for selector                                        | [SKILL.md](packages/@markuplint/selector/SKILL.md)        |
+| `@markuplint/parser-utils`    | Maintenance tasks for parser-utils                                    | [SKILL.md](packages/@markuplint/parser-utils/SKILL.md)    |
+| `@markuplint/html-parser`     | Maintenance tasks for html-parser                                     | [SKILL.md](packages/@markuplint/html-parser/SKILL.md)     |
+| `@markuplint/html-spec`       | Maintenance tasks for html-spec                                       | [SKILL.md](packages/@markuplint/html-spec/SKILL.md)       |
+| `@markuplint/spec-generator`  | Maintenance tasks for spec-generator                                  | [SKILL.md](packages/@markuplint/spec-generator/SKILL.md)  |
+| `@markuplint/i18n`            | Maintenance tasks for i18n (internationalization)                     | [SKILL.md](packages/@markuplint/i18n/SKILL.md)            |
+| `@markuplint/create-rule`     | Maintenance tasks for create-rule (CLI scaffolding tool)              | [SKILL.md](packages/@markuplint/create-rule/SKILL.md)     |
+| `@markuplint/react-spec`      | Maintenance tasks for react-spec                                      | [SKILL.md](packages/@markuplint/react-spec/SKILL.md)      |
+| `@markuplint/vue-parser`      | Maintenance tasks for vue-parser                                      | [SKILL.md](packages/@markuplint/vue-parser/SKILL.md)      |
+| `@markuplint/vue-spec`        | Maintenance tasks for vue-spec                                        | [SKILL.md](packages/@markuplint/vue-spec/SKILL.md)        |
+| `@markuplint/svelte-parser`   | Maintenance tasks for svelte-parser                                   | [SKILL.md](packages/@markuplint/svelte-parser/SKILL.md)   |
+| `@markuplint/svelte-spec`     | Maintenance tasks for svelte-spec                                     | [SKILL.md](packages/@markuplint/svelte-spec/SKILL.md)     |
+| `@markuplint/jsx-parser`      | Maintenance tasks for jsx-parser                                      | [SKILL.md](packages/@markuplint/jsx-parser/SKILL.md)      |
+| `@markuplint/astro-parser`    | Maintenance tasks for astro-parser                                    | [SKILL.md](packages/@markuplint/astro-parser/SKILL.md)    |
+| `@markuplint/pug-parser`      | Maintenance tasks for pug-parser                                      | [SKILL.md](packages/@markuplint/pug-parser/SKILL.md)      |
+| `@markuplint/ejs-parser`      | Maintenance tasks for ejs-parser                                      | [SKILL.md](packages/@markuplint/ejs-parser/SKILL.md)      |
+| `@markuplint/erb-parser`      | Maintenance tasks for erb-parser                                      | [SKILL.md](packages/@markuplint/erb-parser/SKILL.md)      |
+| `@markuplint/liquid-parser`   | Maintenance tasks for liquid-parser                                   | [SKILL.md](packages/@markuplint/liquid-parser/SKILL.md)   |
+| `@markuplint/mustache-parser` | Maintenance tasks for mustache-parser                                 | [SKILL.md](packages/@markuplint/mustache-parser/SKILL.md) |
+| `@markuplint/nunjucks-parser` | Maintenance tasks for nunjucks-parser                                 | [SKILL.md](packages/@markuplint/nunjucks-parser/SKILL.md) |
+| `@markuplint/php-parser`      | Maintenance tasks for php-parser                                      | [SKILL.md](packages/@markuplint/php-parser/SKILL.md)      |
+| `@markuplint/smarty-parser`   | Maintenance tasks for smarty-parser                                   | [SKILL.md](packages/@markuplint/smarty-parser/SKILL.md)   |
+
+## Worktree Usage
+
+When working on feature branches that involve multiple PRs or long-running tasks,
+**proactively use `git worktree`** to avoid blocking the user's main working directory.
+
+```bash
+git worktree add /tmp/markuplint-worktree -b <branch-name> dev
+cd /tmp/markuplint-worktree
+yarn install
+yarn build   # Required before yarn up:gen works
+```
+
+### Important Notes
+
+- **Always run `yarn install && yarn build`** in the worktree before any generation or test commands
+- **Husky hooks do NOT run in worktrees** — run `yarn lint` manually before committing
+- Clean up worktrees when done:
+  ```bash
+  git worktree remove /tmp/markuplint-worktree
+  git branch -D <temp-branch-name>
+  ```

--- a/packages/@markuplint/html-spec/SKILL.md
+++ b/packages/@markuplint/html-spec/SKILL.md
@@ -255,6 +255,40 @@ These boolean flags indicate the standardization status of an attribute:
 5. Verify the flag change in `index.json`
 6. Run tests: `yarn workspace @markuplint/html-spec run test`
 
+## ARIA Version System
+
+### Resolution Logic
+
+`resolveVersion()` (`@markuplint/ml-spec/src/utils/resolve-version.ts`) checks
+`aria[version]` first, falls back to top-level `aria`. The runtime default is
+`ARIA_RECOMMENDED_VERSION = '1.2'` (`@markuplint/ml-spec/src/utils/aria-version.ts`).
+
+### Key Placement Rules
+
+| Key              | Meaning                                                   | Mutability                                   |
+| ---------------- | --------------------------------------------------------- | -------------------------------------------- |
+| Top-level `aria` | Default / latest. Fallback for versions without overrides | Mutable — update to match current W3C Rec    |
+| `"1.1"`          | ARIA 1.1 snapshot                                         | **Frozen** — never add new roles             |
+| `"1.2"`          | ARIA 1.2 snapshot (rarely needed)                         | Only create when top-level diverges from 1.2 |
+
+### Decision: Where to add new permittedRoles
+
+1. Is the role in the W3C Recommendation "ARIA in HTML" (ARIA 1.2 based, Aug 2025)?
+   → Add to **top-level only**
+2. Is the role ARIA 1.3 draft-only (not in W3C Rec)?
+   → Add to **top-level**, AND create `"1.2"` key with the current 1.2 list to freeze it
+3. Was the role in the original ARIA 1.1 spec for this element?
+   → It should already be in `"1.1"`. **Never add new roles to `"1.1"`**.
+
+### permittedRoles Quick Reference
+
+| Pattern                                  | Meaning                             |
+| ---------------------------------------- | ----------------------------------- |
+| `true`                                   | Any role allowed                    |
+| `false`                                  | No roles allowed                    |
+| `["role1", "role2"]`                     | Specific roles (alphabetical order) |
+| `[{"name": "role", "deprecated": true}]` | Deprecated role                     |
+
 ## Task: check
 
 Verify cross-package consistency between `@markuplint/html-spec` and related packages.
@@ -274,6 +308,35 @@ Report results as:
 | # | Check | Status | Notes |
 ```
 
+## Testing Requirements for Spec Changes
+
+Spec data changes propagate to multiple test suites. Always run `yarn test`
+(full suite) before committing.
+
+### Test Matrix
+
+| Change type                         | Primary test file                            | Also check                                                    |
+| ----------------------------------- | -------------------------------------------- | ------------------------------------------------------------- |
+| ARIA (implicitRole, permittedRoles) | `rules/src/wai-aria/index.spec.ts`           | `ml-spec/src/algorithm/aria/get-permitted-roles-spec.spec.ts` |
+| Attributes (new/changed)            | `rules/src/invalid-attr/index.spec.ts`       | Existing tests with changed enum error messages               |
+| Content model                       | `rules/src/permitted-contents/index.spec.ts` | —                                                             |
+
+### Cross-Package Impact
+
+- **Hardcoded role arrays**: `ml-spec/.../get-permitted-roles-spec.spec.ts` has
+  hardcoded `permittedRoles` for img, button, input, form, etc. Update these
+  when changing `permittedRoles` in html-spec.
+- **Enum error messages**: Adding a value to an enum (e.g., button `command`)
+  changes the error message string in existing `invalid-attr` tests.
+
+### Test Conventions
+
+- `toStrictEqual` with exact `{ severity, line, col, message, raw }` — never `toBeGreaterThan(0)`
+- Always include both valid (empty violations) and invalid (exact violation) cases
+- ARIA version in tests: `{ rule: { options: { version: '1.1' } } }`
+- Some roles require ARIA attributes: focusable `separator` → `aria-valuenow`,
+  `meter` → `aria-valuenow`
+
 ## Rules
 
 1. **`index.json` is generated -- never edit it directly.** Always modify `src/` files and regenerate.
@@ -291,3 +354,5 @@ Report results as:
    | Spec data corrections    | `fix`   | `fix(html-spec): correct ARIA mapping for button` |
 
 8. **Separate spec changes into individual PRs.** Each specification change (new attribute, ARIA mapping fix, etc.) should be on its own branch and PR. Description-only updates can be batched into a single PR.
+9. **Run `yarn test` (full suite) before committing.** Spec changes affect `@markuplint/rules` and `@markuplint/ml-spec` tests.
+10. **Keep `permittedRoles` arrays in alphabetical order.**

--- a/packages/@markuplint/ml-spec/SKILL.md
+++ b/packages/@markuplint/ml-spec/SKILL.md
@@ -101,3 +101,16 @@ For WARN items, produce an advisory note with a suggested improvement (not manda
 4. **Numeric claims must be exact.** Count arrays, enum values, union members, and Set entries in the source code to verify numbers stated in documentation.
 5. **Algorithm descriptions must match the actual code flow.** Verify that documented step orders, condition checks, and branching logic correspond to the implementation.
 6. **Use WebSearch for spec verification.** Always fetch the latest version of the referenced specification — do not rely on cached knowledge.
+
+## Hardcoded Test Data
+
+The following test files contain hardcoded spec data that must stay in sync
+with `@markuplint/html-spec`:
+
+| Test file                                             | Data                                                       | Trigger                                                 |
+| ----------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------- |
+| `src/algorithm/aria/get-permitted-roles-spec.spec.ts` | `permittedRoles` arrays for img, button, input, form, etc. | `permittedRoles` changes in `html-spec/src/spec.*.json` |
+
+When `@markuplint/html-spec` ARIA mappings change, update these arrays.
+The arrays are version-specific — update only the correct version's expectations
+(e.g., `'1.2'` tests but not `'1.1'` tests for newly added roles).

--- a/packages/@markuplint/rules/SKILL.md
+++ b/packages/@markuplint/rules/SKILL.md
@@ -1,0 +1,76 @@
+---
+description: Perform maintenance tasks for @markuplint/rules
+---
+
+# rules-maintenance
+
+Maintain rule test suites, especially when `@markuplint/html-spec` changes.
+
+## Input
+
+`$ARGUMENTS` specifies the task:
+
+| Task                              | Description                           |
+| --------------------------------- | ------------------------------------- |
+| `add-spec-tests <rule> <element>` | Add tests after a spec change         |
+| `update-test-expectations`        | Fix tests broken by spec data changes |
+
+## Task: add-spec-tests
+
+### Which test file?
+
+| Spec change                         | Test file                              |
+| ----------------------------------- | -------------------------------------- |
+| ARIA (implicitRole, permittedRoles) | `src/wai-aria/index.spec.ts`           |
+| Attributes (new/changed/enum)       | `src/invalid-attr/index.spec.ts`       |
+| Content model                       | `src/permitted-contents/index.spec.ts` |
+
+### Test Pattern
+
+```typescript
+import { mlRuleTest } from 'markuplint';
+import rule from './index.js';
+
+// Valid case — no violations
+const { violations } = await mlRuleTest(rule, '<img src="x.png" alt="desc" role="math">');
+expect(violations).toStrictEqual([]);
+
+// Invalid case — exact violation object
+const { violations } = await mlRuleTest(rule, '<img src="x.png" alt="desc" role="navigation">');
+expect(violations).toStrictEqual([
+  {
+    severity: 'error',
+    line: 1,
+    col: 38,
+    message: 'Cannot overwrite the "navigation" role to the "img" element according to ARIA in HTML specification',
+    raw: 'navigation',
+  },
+]);
+
+// ARIA version test
+const { violations } = await mlRuleTest(rule, '<button role="separator" ...>', {
+  rule: { options: { version: '1.1' } },
+});
+```
+
+### Conventions
+
+- `toStrictEqual` with exact `{ severity, line, col, message, raw }` — **never** loose assertions
+- Always include both valid and invalid cases
+- Some roles need ARIA attributes in HTML: `separator` → `aria-valuenow`, `meter` → `aria-valuenow`
+
+## Task: update-test-expectations
+
+When `html-spec` data changes break existing tests:
+
+1. Run `yarn test` to find failures
+2. Verify the new behavior is correct (not a regression)
+3. Update expected violation objects (message strings, etc.)
+4. Common cause: adding enum values changes error message strings
+
+## Rules
+
+1. **Always run `yarn test` (full suite)**, not just the rules package
+2. **Use `toStrictEqual` with exact objects** — no loose assertions
+3. **Check `ml-spec` algorithm tests** when changing ARIA mappings —
+   `ml-spec/src/algorithm/aria/get-permitted-roles-spec.spec.ts` has hardcoded role arrays


### PR DESCRIPTION
## Summary

- Add ARIA version system guide and testing requirements to `html-spec` SKILL.md
- Create new `rules` SKILL.md for spec change testing patterns
- Add hardcoded test data warning to `ml-spec` SKILL.md
- Add pre-commit verification for spec changes to git command
- Move `CLAUDE.md` into repo root and add rules skill registration + worktree guide

## Context

Feedback from the html-spec update work (6 PRs) where issues arose:
- ARIA versioning misunderstanding (adding new roles to `"1.1"`)
- Missed hardcoded test data updates in `ml-spec`
- Enum value additions changing existing test error messages
- Running only package-level tests instead of full suite
- Using loose assertions (`toBeGreaterThan(0)`) instead of exact checks

## Test plan

- [x] `yarn lint` — 0 issues
- [x] `yarn build` — 37 packages passed
- [x] `yarn test` — 1388 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)