### PR TITLE
feat(rules): support Invoker Commands API in neighbor-popovers rule

### DIFF
--- a/packages/@markuplint/rules/src/neighbor-popovers/README.ja.md
+++ b/packages/@markuplint/rules/src/neighbor-popovers/README.ja.md
@@ -12,10 +12,21 @@ description: ポップオーバートリガーと対応するターゲットが�
 
 [HTML Living Standard 6.12.1 The popover target attributes](https://momdo.github.io/html/popover.html#the-popover-target-attributes:~:text=%E5%8F%AF%E8%83%BD%E3%81%AA%E9%99%90%E3%82%8A%E3%81%84%E3%81%A4%E3%81%A7%E3%82%82%E3%80%81%E3%83%9D%E3%83%83%E3%83%97%E3%82%AA%E3%83%BC%E3%83%90%E3%83%BC%E8%A6%81%E7%B4%A0%E3%81%8CDOM%E5%86%85%E3%81%AE%E3%83%88%E3%83%AA%E3%82%AC%E3%83%BC%E8%A6%81%E7%B4%A0%E3%81%AE%E7%9B%B4%E5%BE%8C%E3%81%AB%E9%85%8D%E7%BD%AE%E3%81%95%E3%82%8C%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%99%E3%82%8B%E3%80%82%E3%81%9D%E3%81%86%E3%81%99%E3%82%8B%E3%81%93%E3%81%A8%E3%81%A7%E3%80%81%E3%83%9D%E3%83%83%E3%83%97%E3%82%AA%E3%83%BC%E3%83%90%E3%83%BC%E3%81%8C%E3%80%81%E3%82%B9%E3%82%AF%E3%83%AA%E3%83%BC%E3%83%B3%E3%83%AA%E3%83%BC%E3%83%80%E3%83%BC%E3%81%AA%E3%81%A9%E3%81%AE%E6%94%AF%E6%8F%B4%E6%8A%80%E8%A1%93%E3%81%AE%E3%83%A6%E3%83%BC%E3%82%B6%E3%83%BC%E3%81%AB%E5%AF%BE%E3%81%97%E3%81%A6%E3%80%81%E3%83%97%E3%83%AD%E3%82%B0%E3%83%A9%E3%83%A0%E4%B8%8A%E3%81%AE%E8%AB%96%E7%90%86%E7%9A%84%E3%81%AA%E8%AA%AD%E3%81%BF%E4%B8%8A%E3%81%92%E9%A0%86%E5%BA%8F%E3%81%A7%E5%85%AC%E9%96%8B%E3%81%95%E3%82%8C%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%AA%E3%82%8B%E3%80%82)より引用
 
+このルールは以下の両方を使用してポップオーバートリガーを検出します：
+
+- `popovertarget`属性
+- [Invoker Commands API](https://open-ui.org/components/invokers.explainer/)（ポップオーバー関連の`command`値（`toggle-popover`、`show-popover`、`hide-popover`）を持つ`commandfor`属性）
+
 ❌ 間違ったコード例
 
 ```html
 <button popovertarget="foo">トリガー</button>
+<p>知覚要素がトリガーとそのターゲットの間に存在しています。</p>
+<div id="foo" popover>ポップオーバー</div>
+```
+
+```html
+<button command="toggle-popover" commandfor="foo">トリガー</button>
 <p>知覚要素がトリガーとそのターゲットの間に存在しています。</p>
 <div id="foo" popover>ポップオーバー</div>
 ```
@@ -37,6 +48,11 @@ description: ポップオーバートリガーと対応するターゲットが�
 
 ```html
 <button popovertarget="foo">トリガー</button>
+<div id="foo" popover>ポップオーバー</div>
+```
+
+```html
+<button command="toggle-popover" commandfor="foo">トリガー</button>
 <div id="foo" popover>ポップオーバー</div>
 ```
 

--- a/packages/@markuplint/rules/src/neighbor-popovers/README.md
+++ b/packages/@markuplint/rules/src/neighbor-popovers/README.md
@@ -11,10 +11,21 @@ Warns when popover triggers and their corresponding targets are not adjacent.
 
 Cite: [HTML Living Standard 6.12.1 The popover target attributes](https://html.spec.whatwg.org/multipage/popover.html#the-popover-target-attributes:~:text=Whenever%20possible%20ensure%20the%20popover%20element%20is%20placed%20immediately%20after%20its%20triggering%20element%20in%20the%20DOM.%20Doing%20so%20will%20help%20ensure%20that%20the%20popover%20is%20exposed%20in%20a%20logical%20programmatic%20reading%20order%20for%20users%20of%20assistive%20technology%2C%20such%20as%20screen%20readers.)
 
+This rule detects popover triggers using both:
+
+- The `popovertarget` attribute
+- The [Invoker Commands API](https://open-ui.org/components/invokers.explainer/) (`commandfor` attribute with a popover-related `command` value: `toggle-popover`, `show-popover`, or `hide-popover`)
+
 ❌ Examples of **incorrect** code for this rule
 
 ```html
 <button popovertarget="foo">Trigger</button>
+<p>There are perceptible nodes between the trigger and corresponding target.</p>
+<div id="foo" popover>Popover</div>
+```
+
+```html
+<button command="toggle-popover" commandfor="foo">Trigger</button>
 <p>There are perceptible nodes between the trigger and corresponding target.</p>
 <div id="foo" popover>Popover</div>
 ```
@@ -36,6 +47,11 @@ Cite: [HTML Living Standard 6.12.1 The popover target attributes](https://html.s
 
 ```html
 <button popovertarget="foo">Trigger</button>
+<div id="foo" popover>Popover</div>
+```
+
+```html
+<button command="toggle-popover" commandfor="foo">Trigger</button>
 <div id="foo" popover>Popover</div>
 ```
 

--- a/packages/@markuplint/rules/src/neighbor-popovers/index.spec.ts
+++ b/packages/@markuplint/rules/src/neighbor-popovers/index.spec.ts
@@ -173,3 +173,137 @@ describe('Complex', () => {
 		).toBe(1);
 	});
 });
+
+describe('Invoker Commands API (commandfor + command)', () => {
+	test('Correct: toggle-popover', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					`
+<button command="toggle-popover" commandfor="foo">Trigger</button>
+<div id="foo" popover>Popover</div>
+  `,
+				)
+			).violations.length,
+		).toBe(0);
+	});
+
+	test('Correct: show-popover', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					`
+<button command="show-popover" commandfor="foo">Trigger</button>
+<div id="foo" popover>Popover</div>
+  `,
+				)
+			).violations.length,
+		).toBe(0);
+	});
+
+	test('Correct: hide-popover', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					`
+<button command="hide-popover" commandfor="foo">Trigger</button>
+<div id="foo" popover>Popover</div>
+  `,
+				)
+			).violations.length,
+		).toBe(0);
+	});
+
+	test('Incorrect: perceptible content between trigger and target', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					`
+<button command="toggle-popover" commandfor="foo">Trigger</button>
+<p>Paragraph</p>
+<div id="foo" popover>Popover</div>
+  `,
+				)
+			).violations,
+		).toStrictEqual([
+			{
+				severity: 'error',
+				line: 3,
+				col: 4,
+				message: 'Detected perceptible nodes between the trigger and corresponding target',
+				raw: 'Paragraph',
+			},
+		]);
+	});
+
+	test('Correct: non-popover command is ignored', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					`
+<button command="close" commandfor="foo">Trigger</button>
+<p>Paragraph</p>
+<dialog id="foo">Dialog</dialog>
+  `,
+				)
+			).violations.length,
+		).toBe(0);
+	});
+
+	test('Correct: commandfor without command is ignored', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					`
+<button commandfor="foo">Trigger</button>
+<p>Paragraph</p>
+<div id="foo" popover>Popover</div>
+  `,
+				)
+			).violations.length,
+		).toBe(0);
+	});
+
+	test('Case-insensitive command value', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					`
+<button command="TOGGLE-POPOVER" commandfor="foo">Trigger</button>
+<p>Paragraph</p>
+<div id="foo" popover>Popover</div>
+  `,
+				)
+			).violations.length,
+		).toBe(1);
+	});
+
+	test('Incorrect: complex nested case', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					`
+<div>
+  <button command="toggle-popover" commandfor="foo">Trigger</button>
+</div>
+
+<div>
+  <h2>Title</h2>
+  <div>
+    <div id="foo" popover>Popover</div>
+  </div>
+</div>
+  `,
+				)
+			).violations.length,
+		).toBe(1);
+	});
+});

--- a/packages/@markuplint/rules/src/neighbor-popovers/index.ts
+++ b/packages/@markuplint/rules/src/neighbor-popovers/index.ts
@@ -8,18 +8,36 @@ import meta from './meta.js';
 const ARIA_VERSION = '1.2';
 
 /**
+ * Command values from the Invoker Commands API that relate to popover behavior.
+ * Comparison is case-insensitive per the HTML spec.
+ */
+const POPOVER_COMMANDS = new Set(['toggle-popover', 'show-popover', 'hide-popover']);
+
+/**
  * Rule that detects perceptible content between a popover trigger and its target.
  *
- * When a `[popovertarget]` element and its corresponding `[popover]` target exist
- * in the DOM, any focusable elements, elements with accessible names, or non-whitespace
- * text nodes between them are reported as violations.
+ * When a `[popovertarget]` element or a `[commandfor]` element with a popover-related
+ * `command` attribute and its corresponding `[popover]` target exist in the DOM, any
+ * focusable elements, elements with accessible names, or non-whitespace text nodes
+ * between them are reported as violations.
  */
 export default createRule({
 	meta: meta,
 	verify({ document, report, t }) {
-		const triggers = document.querySelectorAll('[popovertarget]');
+		const triggers = document.querySelectorAll('[popovertarget], [commandfor]');
 		Triggers: for (const trigger of triggers) {
-			const targetId = trigger.getAttribute('popovertarget');
+			let targetId: string | null = null;
+
+			const popovertarget = trigger.getAttribute('popovertarget');
+			if (popovertarget) {
+				targetId = popovertarget;
+			} else {
+				const command = trigger.getAttribute('command');
+				if (command && POPOVER_COMMANDS.has(command.toLowerCase())) {
+					targetId = trigger.getAttribute('commandfor');
+				}
+			}
+
 			if (!targetId) {
 				continue;
 			}


### PR DESCRIPTION
Fixes #3065 

## What is the purpose of this PR?

- [ ] Fix bug
- [x] Improve or refactor rules
- [x] Update documents

### Description

This PR extends the `neighbor-popovers` rule to support the [Invoker Commands API](https://open-ui.org/components/invokers.explainer/) in addition to the existing `popovertarget` attribute.

The rule now detects popover triggers using both:
- The `popovertarget` attribute (existing)
- The `commandfor` attribute with popover-related `command` values: `toggle-popover`, `show-popover`, or `hide-popover` (new)

This ensures that the rule properly validates the DOM adjacency requirement for both popover trigger mechanisms, helping developers maintain accessible markup structure regardless of which API they use.

#### Changes:
- Updated rule logic to detect both `[popovertarget]` and `[commandfor]` elements
- Added validation to check if `command` attribute contains a popover-related value (case-insensitive)
- Added comprehensive test cases for all three popover command types
- Updated README documentation (both English and Japanese) with examples and explanations
- Added edge case tests (non-popover commands, missing command attribute, case sensitivity)

## Checklist

- [x] Improve or refactor rules
  - [x] Add tests for the new functionality
- [x] Update documents
  - [x] Update README.md
  - [x] Update README.ja.md

https://claude.ai/code/session_01LGHNEwgQUAMkicjKtj9HbX