### PR TITLE
feat(rules): add ignoreOmittedElements option to required-element

### DIFF
--- a/packages/@markuplint/rules/src/required-element/README.ja.md
+++ b/packages/@markuplint/rules/src/required-element/README.ja.md
@@ -64,4 +64,26 @@ h1要素が必要な場合は[`required-h1`](../required-h1/)ルールを使用�
 }
 ```
 
+### `ignoreOmittedElements`オプションの設定 {#setting-ignore-omitted-elements}
+
+HTMLでは特定のタグを省略できます（例：`<tbody>`）。HTMLパーサーはこれらの省略された要素をゴーストノードとして暗黙的に生成します。デフォルトでは、これらのゴースト要素も要件を満たすものとして扱われます。`ignoreOmittedElements`を`true`に設定すると、ソースコードに明示的に記述された要素のみが要件を満たすようになります。
+
+```json class=config
+{
+  "nodeRules": [
+    {
+      "selector": "table",
+      "rules": {
+        "required-element": {
+          "value": ["tbody"],
+          "options": {
+            "ignoreOmittedElements": true
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
 <!-- textlint-enable ja-technical-writing/ja-no-mixed-period -->

--- a/packages/@markuplint/rules/src/required-element/README.md
+++ b/packages/@markuplint/rules/src/required-element/README.md
@@ -62,3 +62,25 @@ If specified to `nodeRules` or `childNodeRules`, It searches the element from ch
   ]
 }
 ```
+
+### Setting `ignoreOmittedElements` option {#setting-ignore-omitted-elements}
+
+HTML allows certain tags to be omitted (e.g., `<tbody>`). The HTML parser implicitly creates these omitted elements as ghost nodes. By default, these ghost elements satisfy the requirement. Set `ignoreOmittedElements` to `true` to require that elements are explicitly written in the source.
+
+```json class=config
+{
+  "nodeRules": [
+    {
+      "selector": "table",
+      "rules": {
+        "required-element": {
+          "value": ["tbody"],
+          "options": {
+            "ignoreOmittedElements": true
+          }
+        }
+      }
+    }
+  ]
+}
+```

--- a/packages/@markuplint/rules/src/required-element/index.spec.ts
+++ b/packages/@markuplint/rules/src/required-element/index.spec.ts
@@ -102,6 +102,56 @@ describe('React', () => {
 	});
 });
 
+describe('ghost/omitted elements', () => {
+	test('ghost tbody should not satisfy the requirement with ignoreOmittedElements', async () => {
+		const { violations } = await mlRuleTest(rule, '<table><tr><th>Heading</th><td>Text</td></tr></table>', {
+			nodeRule: [
+				{
+					selector: 'table',
+					rule: { value: ['tbody'], options: { ignoreOmittedElements: true } },
+				},
+			],
+		});
+		expect(violations.length).toBe(1);
+		expect(violations[0].message).toBe('Require the "tbody" element');
+	});
+
+	test('explicit tbody should satisfy the requirement', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<table><tbody><tr><th>Heading</th><td>Text</td></tr></tbody></table>',
+			{
+				nodeRule: [
+					{
+						selector: 'table',
+						rule: { value: ['tbody'], options: { ignoreOmittedElements: true } },
+					},
+				],
+			},
+		);
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('ghost tbody should satisfy the requirement by default (backwards compat)', async () => {
+		const { violations } = await mlRuleTest(rule, '<table><tr><th>Heading</th><td>Text</td></tr></table>', {
+			nodeRule: [
+				{
+					selector: 'table',
+					rule: ['tbody'],
+				},
+			],
+		});
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('global rule: ghost tbody ignored with option', async () => {
+		const { violations } = await mlRuleTest(rule, '<table><tr><td>Text</td></tr></table>', {
+			rule: { value: ['tbody'], options: { ignoreOmittedElements: true } },
+		});
+		expect(violations.length).toBe(1);
+	});
+});
+
 describe('Pretenders Option', () => {
 	test('Outer', async () => {
 		const { violations } = await mlRuleTest(rule, '<html><Head><title>Title</title></Head></html>', {

--- a/packages/@markuplint/rules/src/required-element/index.ts
+++ b/packages/@markuplint/rules/src/required-element/index.ts
@@ -8,6 +8,8 @@ import meta from './meta.js';
 type Options = {
 	/** Whether to skip validation for elements that contain mutable (dynamic) content. */
 	ignoreHasMutableContents: boolean;
+	/** Whether to ignore omitted (ghost) elements that are implicitly created by the HTML parser. */
+	ignoreOmittedElements: boolean;
 };
 
 /**
@@ -23,12 +25,16 @@ export default createRule<string[], Options>({
 	defaultValue: [],
 	defaultOptions: {
 		ignoreHasMutableContents: true,
+		ignoreOmittedElements: false,
 	},
 	async verify({ document, report, t }) {
 		const hasMutableContent = document.nodeList.some(n => n.is(n.ELEMENT_NODE) && n.hasMutableChildren());
 		if (!hasMutableContent) {
 			for (const query of document.rule.value) {
-				const exists = document.querySelectorAll(query);
+				const matched = document.querySelectorAll(query);
+				const exists = document.rule.options.ignoreOmittedElements
+					? [...matched].filter(el => !el.isOmitted)
+					: [...matched];
 				if (exists.length === 0) {
 					const message = t('Require {0}', t('the "{0*}" {1}', query, 'element'));
 					report({
@@ -49,7 +55,9 @@ export default createRule<string[], Options>({
 				return;
 			}
 			for (const query of el.rule.value) {
-				const exists = [...el.children].find(child => child.matches(query));
+				const exists = [...el.children].find(
+					child => !(el.rule.options.ignoreOmittedElements && child.isOmitted) && child.matches(query),
+				);
 				if (!exists) {
 					const message = t('Require {0}', t('the "{0*}" {1}', query, 'element'));
 					report({

--- a/packages/@markuplint/rules/src/required-element/schema.json
+++ b/packages/@markuplint/rules/src/required-element/schema.json
@@ -16,6 +16,12 @@
 					"default": "true",
 					"description": "Ignore if it has mutable child elements in a preprocessor language like _Pug_ or a component library like _Vue_. (If use _Pug_ or _Vue_ need each [@markuplint/pug-parser](https://github.com/markuplint/markuplint/tree/main/packages/%40markuplint/pug-parser) and [@markuplint/vue-parser](https://github.com/markuplint/markuplint/tree/main/packages/%40markuplint/vue-parser))",
 					"description:ja": "*Pug*のようなプリプロセッサ言語や*Vue*のようなコンポーネントライブラリにおけるミュータブルな子要素を含む場合、無視します。（*Pug*も、*Vue*も、それぞれ[@markuplint/pug-parser](https://github.com/markuplint/markuplint/tree/main/packages/%40markuplint/pug-parser)や[@markuplint/vue-parser](https://github.com/markuplint/markuplint/tree/main/packages/%40markuplint/vue-parser)が必要です）"
+				},
+				"ignoreOmittedElements": {
+					"type": "boolean",
+					"default": "false",
+					"description": "Ignore omitted (ghost) elements that are implicitly created by the HTML parser. When true, only explicitly written elements satisfy the requirement.",
+					"description:ja": "HTMLパーサーが暗黙的に生成した省略要素（ゴースト要素）を無視します。trueの場合、明示的に記述された要素のみが要件を満たします。"
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

- Add `ignoreOmittedElements` option to the `required-element` rule
- When `true`, elements implicitly created by the HTML parser (ghost/omitted elements like `<tbody>`) are excluded, ensuring only explicitly written elements satisfy the requirement
- Defaults to `false` for backwards compatibility

## Details

Closes #2066

HTML allows certain tags (e.g., `<tbody>`) to be omitted. The HTML parser (parse5) implicitly creates these as ghost nodes (`isOmitted: true`). Previously, `required-element` counted ghost elements as satisfying the requirement, making it impossible to enforce explicit `<tbody>` tags.

### Changed files

| File | Change |
|------|--------|
| `index.ts` | Add `ignoreOmittedElements` to `Options` type, filter ghost elements in both global and nodeRule paths |
| `schema.json` | Add option definition with EN/JA descriptions |
| `index.spec.ts` | Add 4 test cases covering ghost detection, explicit element pass, backwards compat, and global rule |
| `README.md` | Document the new option with configuration example |
| `README.ja.md` | Japanese translation of the documentation |

### Configuration example

```json
{
  "nodeRules": [
    {
      "selector": "table",
      "rules": {
        "required-element": {
          "value": ["tbody"],
          "options": {
            "ignoreOmittedElements": true
          }
        }
      }
    }
  ]
}
```

## Test plan

- [x] All 13 `required-element` tests pass (9 existing + 4 new)
- [x] Full `yarn test` passes (1412 tests)
- [x] Full `yarn lint` passes
- [x] Full `yarn build` passes (37 packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)