### PR TITLE
Drop Node.js 18 compatibility and modernize codebase

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -203,7 +203,7 @@ jobs:
                     - windows-latest
                 node: [24]
                 include:
-                    - node: 18
+                    - node: 22
                       os: ubuntu-latest
                     - node: 24
                       os: ubuntu-latest
@@ -261,7 +261,7 @@ jobs:
                 node: [24]
                 shard: [1/4, 2/4, 3/4, 4/4]
                 include:
-                    - node: 18
+                    - node: 22
                       os: ubuntu-latest
                       shard: 1/1
                     - node: 24

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
 	"name": "markuplint-packages",
 	"private": true,
 	"type": "module",
+	"engines": {
+		"node": ">=22"
+	},
 	"scripts": {
 		"all": "run-s up lint clean build test site:up",
 		"build": "lerna run build",

--- a/packages/@markuplint-dev/eslint-config/base.js
+++ b/packages/@markuplint-dev/eslint-config/base.js
@@ -85,11 +85,4 @@ export const base = [
 			'import-x/resolver-next': [createTypeScriptImportResolver()],
 		},
 	},
-	// for Node.js v18 — TODO: Re-enable in v5 when dropping Node.js 18 support (#3144)
-	{
-		rules: {
-			'unicorn/no-array-reverse': 0,
-			'unicorn/no-array-sort': 0,
-		},
-	},
 ];

--- a/packages/@markuplint-dev/tsconfig/tsconfig.json
+++ b/packages/@markuplint-dev/tsconfig/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"compilerOptions": {
 		"module": "NodeNext",
-		"target": "ES2020",
+		"target": "ES2022",
 		"strict": true,
 		"strictNullChecks": true,
 		"strictPropertyInitialization": true,

--- a/packages/@markuplint/alpine-parser/package.json
+++ b/packages/@markuplint/alpine-parser/package.json
@@ -5,6 +5,9 @@
 	"repository": "git@github.com:markuplint/markuplint.git",
 	"author": "Yusuke Hirao <yusukehirao@me.com>",
 	"license": "MIT",
+	"engines": {
+		"node": ">=22"
+	},
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/@markuplint/astro-parser/package.json
+++ b/packages/@markuplint/astro-parser/package.json
@@ -5,6 +5,9 @@
 	"repository": "git@github.com:markuplint/markuplint.git",
 	"author": "Yusuke Hirao <yusukehirao@me.com>",
 	"license": "MIT",
+	"engines": {
+		"node": ">=22"
+	},
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/@markuplint/cli-utils/package.json
+++ b/packages/@markuplint/cli-utils/package.json
@@ -5,6 +5,9 @@
 	"repository": "git@github.com:markuplint/markuplint.git",
 	"author": "Yusuke Hirao <yusukehirao@me.com>",
 	"license": "MIT",
+	"engines": {
+		"node": ">=22"
+	},
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/@markuplint/config-presets/package.json
+++ b/packages/@markuplint/config-presets/package.json
@@ -5,6 +5,9 @@
 	"repository": "git@github.com:markuplint/markuplint.git",
 	"author": "Yusuke Hirao <yusukehirao@me.com>",
 	"license": "MIT",
+	"engines": {
+		"node": ">=22"
+	},
 	"publishConfig": {
 		"access": "public"
 	},

--- a/packages/@markuplint/create-rule/package.json
+++ b/packages/@markuplint/create-rule/package.json
@@ -5,6 +5,9 @@
 	"repository": "git@github.com:markuplint/markuplint.git",
 	"author": "Yusuke Hirao <yusukehirao@me.com>",
 	"license": "MIT",
+	"engines": {
+		"node": ">=22"
+	},
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/@markuplint/create-rule/src/create-rule-to-core.spec.ts
+++ b/packages/@markuplint/create-rule/src/create-rule-to-core.spec.ts
@@ -55,7 +55,7 @@ test('create', async () => {
 	});
 	const testDir = await getTestDir(sandboxDirName);
 	const fileList = await readdir(testDir, { encoding: 'utf8' });
-	expect(fileList.sort()).toEqual([
+	expect(fileList.toSorted()).toEqual([
 		'README.ja.md',
 		'README.md',
 		'index.spec.ts',

--- a/packages/@markuplint/create-rule/src/transfer.spec.ts
+++ b/packages/@markuplint/create-rule/src/transfer.spec.ts
@@ -39,7 +39,7 @@ test('transfer', async () => {
 		},
 	});
 	const fileList = await glob(path.resolve(TEST_SANDBOX, '**', '*'));
-	expect(fileList.sort().map(file => path.relative(TEST_SANDBOX, file).split(path.sep).join('/'))).toEqual([
+	expect(fileList.toSorted().map(file => path.relative(TEST_SANDBOX, file).split(path.sep).join('/'))).toEqual([
 		'core',
 		'core/README.ja.md',
 		'core/README.md',

--- a/packages/@markuplint/ejs-parser/package.json
+++ b/packages/@markuplint/ejs-parser/package.json
@@ -5,6 +5,9 @@
 	"repository": "git@github.com:markuplint/markuplint.git",
 	"author": "Yusuke Hirao <yusukehirao@me.com>",
 	"license": "MIT",
+	"engines": {
+		"node": ">=22"
+	},
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/@markuplint/erb-parser/package.json
+++ b/packages/@markuplint/erb-parser/package.json
@@ -5,6 +5,9 @@
 	"repository": "git@github.com:markuplint/markuplint.git",
 	"author": "Yusuke Hirao <yusukehirao@me.com>",
 	"license": "MIT",
+	"engines": {
+		"node": ">=22"
+	},
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/@markuplint/file-resolver/package.json
+++ b/packages/@markuplint/file-resolver/package.json
@@ -5,6 +5,9 @@
 	"repository": "git@github.com:markuplint/markuplint.git",
 	"author": "Yusuke Hirao <yusukehirao@me.com>",
 	"license": "MIT",
+	"engines": {
+		"node": ">=22"
+	},
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/@markuplint/file-resolver/src/config-provider.ts
+++ b/packages/@markuplint/file-resolver/src/config-provider.ts
@@ -123,7 +123,7 @@ export class ConfigProvider {
 		}
 		let configSet = await this._mergeConfigs(keys, cache, targetFile.path);
 
-		const filePath = [...configSet.files].reverse()[0];
+		const filePath = [...configSet.files].toReversed()[0];
 		if (!filePath) {
 			throw new ConfigParserError('Config file not found', {
 				filePath: targetFile.path,

--- a/packages/@markuplint/html-parser/package.json
+++ b/packages/@markuplint/html-parser/package.json
@@ -5,6 +5,9 @@
 	"repository": "git@github.com:markuplint/markuplint.git",
 	"author": "Yusuke Hirao <yusukehirao@me.com>",
 	"license": "MIT",
+	"engines": {
+		"node": ">=22"
+	},
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/@markuplint/html-spec/package.json
+++ b/packages/@markuplint/html-spec/package.json
@@ -5,6 +5,9 @@
 	"repository": "git@github.com:markuplint/markuplint.git",
 	"author": "Yusuke Hirao <yusukehirao@me.com>",
 	"license": "MIT",
+	"engines": {
+		"node": ">=22"
+	},
 	"main": "index.js",
 	"types": "index.d.ts",
 	"exports": {

--- a/packages/@markuplint/htmx-parser/package.json
+++ b/packages/@markuplint/htmx-parser/package.json
@@ -5,6 +5,9 @@
 	"repository": "git@github.com:markuplint/markuplint.git",
 	"author": "Yusuke Hirao <yusukehirao@me.com>",
 	"license": "MIT",
+	"engines": {
+		"node": ">=22"
+	},
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/@markuplint/i18n/package.json
+++ b/packages/@markuplint/i18n/package.json
@@ -5,6 +5,9 @@
 	"repository": "git@github.com:markuplint/markuplint.git",
 	"author": "Yusuke Hirao <yusukehirao@me.com>",
 	"license": "MIT",
+	"engines": {
+		"node": ">=22"
+	},
 	"main": "./cjs/index.js",
 	"types": "./cjs/index.d.ts",
 	"exports": {

--- a/packages/@markuplint/jsx-parser/package.json
+++ b/packages/@markuplint/jsx-parser/package.json
@@ -5,6 +5,9 @@
 	"repository": "git@github.com:markuplint/markuplint.git",
 	"author": "Yusuke Hirao <yusukehirao@me.com>",
 	"license": "BSD-2-Clause",
+	"engines": {
+		"node": ">=22"
+	},
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/@markuplint/liquid-parser/package.json
+++ b/packages/@markuplint/liquid-parser/package.json
@@ -5,6 +5,9 @@
 	"repository": "git@github.com:markuplint/markuplint.git",
 	"author": "Yusuke Hirao <yusukehirao@me.com>",
 	"license": "MIT",
+	"engines": {
+		"node": ">=22"
+	},
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/@markuplint/ml-ast/package.json
+++ b/packages/@markuplint/ml-ast/package.json
@@ -5,6 +5,9 @@
 	"repository": "git@github.com:markuplint/markuplint.git",
 	"author": "Yusuke Hirao <yusukehirao@me.com>",
 	"license": "MIT",
+	"engines": {
+		"node": ">=22"
+	},
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/@markuplint/ml-config/package.json
+++ b/packages/@markuplint/ml-config/package.json
@@ -5,6 +5,9 @@
 	"repository": "git@github.com:markuplint/markuplint.git",
 	"author": "Yusuke Hirao <yusukehirao@me.com>",
 	"license": "MIT",
+	"engines": {
+		"node": ">=22"
+	},
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/@markuplint/ml-core/package.json
+++ b/packages/@markuplint/ml-core/package.json
@@ -5,6 +5,9 @@
 	"repository": "git@github.com:markuplint/markuplint.git",
 	"author": "Yusuke Hirao <yusukehirao@me.com>",
 	"license": "MIT",
+	"engines": {
+		"node": ">=22"
+	},
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/@markuplint/ml-core/src/ml-dom/node/document.ts
+++ b/packages/@markuplint/ml-core/src/ml-dom/node/document.ts
@@ -3121,8 +3121,7 @@ export class MLDocument<T extends RuleConfigValue, O extends PlainData = undefin
 				tokens.push(node.closeTag);
 			}
 		}
-		tokens.sort((a, b) => a.startOffset - b.startOffset);
-		this.#tokenList = Object.freeze(tokens);
+		this.#tokenList = Object.freeze(tokens.toSorted((a, b) => a.startOffset - b.startOffset));
 		return this.#tokenList;
 	}
 

--- a/packages/@markuplint/ml-spec/package.json
+++ b/packages/@markuplint/ml-spec/package.json
@@ -5,6 +5,9 @@
 	"repository": "git@github.com:markuplint/markuplint.git",
 	"author": "Yusuke Hirao <yusukehirao@me.com>",
 	"license": "MIT",
+	"engines": {
+		"node": ">=22"
+	},
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/@markuplint/ml-spec/src/algorithm/aria/get-aria.ts
+++ b/packages/@markuplint/ml-spec/src/algorithm/aria/get-aria.ts
@@ -95,5 +95,5 @@ function optimizePermittedRoles(permittedRoles: ReadonlyDeep<PermittedRoles>) {
 		unique.add('presentation');
 	}
 
-	return [...unique].sort();
+	return [...unique].toSorted();
 }

--- a/packages/@markuplint/ml-spec/src/algorithm/aria/matches-context-role.ts
+++ b/packages/@markuplint/ml-spec/src/algorithm/aria/matches-context-role.ts
@@ -30,7 +30,7 @@ function matchesCondition(
 	specs: MLMLSpec,
 	version: ARIAVersion,
 ) {
-	const conditions = condition.split(/\s+>\s+/).reverse();
+	const conditions = condition.split(/\s+>\s+/).toReversed();
 
 	while (conditions.length > 0) {
 		if (!parentEl) {

--- a/packages/@markuplint/ml-spec/src/algorithm/html/content-model-category-to-tag-names.ts
+++ b/packages/@markuplint/ml-spec/src/algorithm/html/content-model-category-to-tag-names.ts
@@ -18,7 +18,7 @@ export function contentModelCategoryToTagNames(contentModel: Category, def: MLML
 		return cached;
 	}
 	const tags: readonly string[] | undefined = def['#contentModels'][contentModel];
-	const sortedTag = Object.freeze(tags && Array.isArray(tags) ? tags.sort() : []);
+	const sortedTag = Object.freeze(tags && Array.isArray(tags) ? tags.toSorted() : []);
 	cache.set(contentModel, sortedTag);
 	return sortedTag;
 }

--- a/packages/@markuplint/ml-spec/src/utils/get-attr-specs-spec.ts
+++ b/packages/@markuplint/ml-spec/src/utils/get-attr-specs-spec.ts
@@ -85,12 +85,12 @@ export function getAttrSpecs(localName: string, namespace: NamespaceURI | null, 
 		};
 	}
 
-	const attrList = Object.keys(attrs).map<Attribute>(name => {
-		const attr = attrs[name];
-		return { name, type: 'Any', ...attr };
-	});
-
-	attrList.sort(nameCompare);
+	const attrList = Object.keys(attrs)
+		.map<Attribute>(name => {
+			const attr = attrs[name];
+			return { name, type: 'Any', ...attr };
+		})
+		.toSorted(nameCompare);
 
 	cacheMap.set(localNameWithNS, attrList);
 	return attrList;

--- a/packages/@markuplint/mustache-parser/package.json
+++ b/packages/@markuplint/mustache-parser/package.json
@@ -5,6 +5,9 @@
 	"repository": "git@github.com:markuplint/markuplint.git",
 	"author": "Yusuke Hirao <yusukehirao@me.com>",
 	"license": "MIT",
+	"engines": {
+		"node": ">=22"
+	},
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/@markuplint/nunjucks-parser/package.json
+++ b/packages/@markuplint/nunjucks-parser/package.json
@@ -5,6 +5,9 @@
 	"repository": "git@github.com:markuplint/markuplint.git",
 	"author": "Yusuke Hirao <yusukehirao@me.com>",
 	"license": "MIT",
+	"engines": {
+		"node": ">=22"
+	},
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/@markuplint/parser-utils/ARCHITECTURE.ja.md
+++ b/packages/@markuplint/parser-utils/ARCHITECTURE.ja.md
@@ -57,7 +57,7 @@ flowchart TD
         mlAst["@markuplint/ml-ast\n型定義"]
         mlSpec["@markuplint/ml-spec\nvoid 要素"]
         espree["espree\nJS トークナイザ"]
-        uuidLib["uuid\nノード ID"]
+        cryptoLib["node:crypto\nノード ID"]
     end
 
     parser --> attrTokenizer
@@ -79,7 +79,7 @@ flowchart TD
 
     parser --> mlAst
     parser --> mlSpec
-    parser --> uuidLib
+    parser --> cryptoLib
     decision --> mlAst
 ```
 
@@ -157,7 +157,7 @@ ParserError (基底クラス)
 | `@markuplint/ml-ast`  | AST 型定義                         |
 | `@markuplint/ml-spec` | void 要素判定                      |
 | `@markuplint/types`   | カスタム要素名検証                 |
-| `uuid`                | AST ノード UUID 生成               |
+| `node:crypto`         | AST ノード UUID 生成               |
 | `debug`               | パフォーマンスタイミング・ロギング |
 | `espree`              | JavaScript トークン化・パース      |
 | `type-fest`           | TypeScript ユーティリティ型        |

--- a/packages/@markuplint/parser-utils/ARCHITECTURE.md
+++ b/packages/@markuplint/parser-utils/ARCHITECTURE.md
@@ -67,7 +67,7 @@ flowchart TD
         mlSpec["@markuplint/ml-spec\n(void element detection)"]
         mlTypes["@markuplint/types\n(custom element validation)"]
         espree["espree\n(JS tokenization)"]
-        uuidLib["uuid\n(node ID generation)"]
+        cryptoLib["node:crypto\n(node ID generation)"]
         debugLib["debug\n(logging)"]
     end
 
@@ -90,7 +90,7 @@ flowchart TD
     decision --> mlTypes
     parser --> mlAst
     parser --> mlSpec
-    parser --> uuidLib
+    parser --> cryptoLib
     scriptParser --> espree
     debugMod --> debugLib
 ```
@@ -189,7 +189,7 @@ The lookup handles camelCase IDL names, lowercase content attribute names, and h
 | `@markuplint/ml-ast`  | AST type definitions (`MLASTDocument`, `MLASTElement`, `MLASTToken`, etc.) |
 | `@markuplint/ml-spec` | Void element detection (`isVoidElement`) for self-closing tag handling     |
 | `@markuplint/types`   | Custom element name validation (`isCustomElementName`)                     |
-| `uuid`                | AST node UUID generation for unique node identification                    |
+| `node:crypto`         | AST node UUID generation via `crypto.randomUUID()`                         |
 | `debug`               | Performance timing and structured logging                                  |
 | `espree`              | JavaScript tokenization and parsing for embedded script content            |
 | `type-fest`           | TypeScript utility types                                                   |

--- a/packages/@markuplint/parser-utils/package.json
+++ b/packages/@markuplint/parser-utils/package.json
@@ -5,6 +5,9 @@
 	"repository": "git@github.com:markuplint/markuplint.git",
 	"author": "Yusuke Hirao <yusukehirao@me.com>",
 	"license": "MIT",
+	"engines": {
+		"node": ">=22"
+	},
 	"type": "module",
 	"exports": {
 		".": {
@@ -31,11 +34,9 @@
 		"@markuplint/ml-ast": "4.4.11",
 		"@markuplint/ml-spec": "4.10.2",
 		"@markuplint/types": "4.8.2",
-		"@types/uuid": "11.0.0",
 		"debug": "4.4.3",
 		"espree": "11.1.0",
-		"type-fest": "4.41.0",
-		"uuid": "13.0.0"
+		"type-fest": "4.41.0"
 	},
 	"devDependencies": {
 		"@typescript-eslint/typescript-estree": "8.55.0"

--- a/packages/@markuplint/parser-utils/src/ignore-block.ts
+++ b/packages/@markuplint/parser-utils/src/ignore-block.ts
@@ -21,12 +21,10 @@ export function ignoreBlock(source: string, tags: readonly IgnoreTag[], maskChar
 		replaced = text.replaced;
 		stack.push(...text.stack.map(res => ({ ...res, type: tag.type })));
 	}
-	stack.sort((a, b) => a.index - b.index);
-
 	return {
 		source,
 		replaced,
-		stack,
+		stack: stack.toSorted((a, b) => a.index - b.index),
 		maskChar,
 	};
 }

--- a/packages/@markuplint/parser-utils/src/parser.ts
+++ b/packages/@markuplint/parser-utils/src/parser.ts
@@ -34,8 +34,8 @@ import type {
 	MLASTBlockBehavior,
 } from '@markuplint/ml-ast';
 
+import { randomUUID } from 'node:crypto';
 import { isVoidElement as detectVoidElement } from '@markuplint/ml-spec';
-import { v4 as uuid } from 'uuid';
 
 import { attrTokenizer } from './attr-tokenizer.js';
 import { defaultSpaces } from './const.js';
@@ -367,10 +367,7 @@ export abstract class Parser<Node extends {} = {}, State extends unknown = null>
 	 * @returns The node tree sorted by source position
 	 */
 	afterTraverse(nodeTree: readonly MLASTNodeTreeItem[]): readonly MLASTNodeTreeItem[] {
-		return Array.prototype.toSorted == null
-			? // TODO: Use sort instead of toSorted until we end support for Node 18
-				[...nodeTree].sort(sortNodes)
-			: nodeTree.toSorted(sortNodes);
+		return nodeTree.toSorted(sortNodes);
 	}
 
 	/**
@@ -1062,7 +1059,7 @@ export abstract class Parser<Node extends {} = {}, State extends unknown = null>
 				: token;
 
 		return {
-			uuid: uuid().slice(0, 8),
+			uuid: randomUUID().slice(0, 8),
 			...props,
 		};
 	}
@@ -1152,11 +1149,7 @@ export abstract class Parser<Node extends {} = {}, State extends unknown = null>
 		}
 
 		Object.assign(parentNode, {
-			childNodes:
-				Array.prototype.toSorted == null
-					? // TODO: Use sort instead of toSorted until we end support for Node 18
-						[...newChildNodes].sort(sortNodes)
-					: newChildNodes.toSorted(sortNodes),
+			childNodes: newChildNodes.toSorted(sortNodes),
 		});
 	}
 
@@ -1175,13 +1168,6 @@ export abstract class Parser<Node extends {} = {}, State extends unknown = null>
 	) {
 		const index = parentNode.childNodes.findIndex(childNode => childNode.uuid === oldChildNode.uuid);
 		if (index === -1) {
-			return;
-		}
-		if (Array.prototype.toSpliced == null) {
-			const newChildNodes = [...parentNode.childNodes];
-			// TODO: Use splice instead of toSpliced until we end support for Node 18
-			newChildNodes.splice(index, 1, ...replacementChildNodes);
-			Object.assign(parentNode, { childNodes: newChildNodes });
 			return;
 		}
 		const newChildNodes = parentNode.childNodes.toSpliced(index, 1, ...replacementChildNodes);
@@ -1235,7 +1221,7 @@ export abstract class Parser<Node extends {} = {}, State extends unknown = null>
 
 		const textNode: MLASTText = {
 			...firstNode,
-			uuid: uuid().slice(0, 8),
+			uuid: randomUUID().slice(0, 8),
 			raw: nodes.map(n => n.raw).join(''),
 		};
 
@@ -1663,11 +1649,7 @@ export abstract class Parser<Node extends {} = {}, State extends unknown = null>
 		/**
 		 * sorting
 		 */
-		const sorted =
-			Array.prototype.toSorted == null
-				? // TODO: Use sort instead of toSorted until we end support for Node 18
-					[...nodeOrders].sort(sortNodes)
-				: nodeOrders.toSorted(sortNodes);
+		const sorted = nodeOrders.toSorted(sortNodes);
 
 		/**
 		 * remove duplicated node
@@ -1709,12 +1691,6 @@ export abstract class Parser<Node extends {} = {}, State extends unknown = null>
 		const raw = firstNode.raw.slice(offsetOffset);
 
 		if (!raw) {
-			if (Array.prototype.toSpliced == null) {
-				const newNodeList = [...nodeList];
-				// TODO: Use splice instead of toSpliced until we end support for Node 18
-				newNodeList.splice(0, 1);
-				return newNodeList;
-			}
 			return nodeList.toSpliced(0, 1);
 		}
 

--- a/packages/@markuplint/php-parser/package.json
+++ b/packages/@markuplint/php-parser/package.json
@@ -5,6 +5,9 @@
 	"repository": "git@github.com:markuplint/markuplint.git",
 	"author": "Yusuke Hirao <yusukehirao@me.com>",
 	"license": "MIT",
+	"engines": {
+		"node": ">=22"
+	},
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/@markuplint/pretenders/package.json
+++ b/packages/@markuplint/pretenders/package.json
@@ -5,6 +5,9 @@
 	"repository": "git@github.com:markuplint/markuplint.git",
 	"author": "Yusuke Hirao <yusukehirao@me.com>",
 	"license": "MIT",
+	"engines": {
+		"node": ">=22"
+	},
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/@markuplint/pretenders/src/dependency-mapper.ts
+++ b/packages/@markuplint/pretenders/src/dependency-mapper.ts
@@ -96,7 +96,7 @@ export function dependencyMapper(map: Readonly<PretenderDirectorMap>): Pretender
 		linkedPretenders.push(pretender);
 	}
 
-	return linkedPretenders.sort(propSort('selector'));
+	return linkedPretenders.toSorted(propSort('selector'));
 }
 
 function getElName(identity: Identity) {

--- a/packages/@markuplint/pug-parser/package.json
+++ b/packages/@markuplint/pug-parser/package.json
@@ -5,6 +5,9 @@
 	"repository": "git@github.com:markuplint/markuplint.git",
 	"author": "Yusuke Hirao <yusukehirao@me.com>",
 	"license": "MIT",
+	"engines": {
+		"node": ">=22"
+	},
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/@markuplint/react-spec/package.json
+++ b/packages/@markuplint/react-spec/package.json
@@ -5,6 +5,9 @@
 	"repository": "git@github.com:markuplint/markuplint.git",
 	"author": "Yusuke Hirao <yusukehirao@me.com>",
 	"license": "MIT",
+	"engines": {
+		"node": ">=22"
+	},
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/@markuplint/rule-textlint/package.json
+++ b/packages/@markuplint/rule-textlint/package.json
@@ -5,6 +5,9 @@
 	"repository": "git@github.com:markuplint/markuplint.git",
 	"author": "Yusuke Hirao <yusukehirao@me.com>",
 	"license": "MIT",
+	"engines": {
+		"node": ">=22"
+	},
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/@markuplint/rules/package.json
+++ b/packages/@markuplint/rules/package.json
@@ -5,6 +5,9 @@
 	"repository": "git@github.com:markuplint/markuplint.git",
 	"author": "Yusuke Hirao <yusukehirao@me.com>",
 	"license": "MIT",
+	"engines": {
+		"node": ">=22"
+	},
 	"type": "module",
 	"exports": {
 		".": {
@@ -31,7 +34,6 @@
 		"@markuplint/shared": "4.4.13",
 		"@markuplint/types": "4.8.2",
 		"@types/debug": "4.1.12",
-		"@ungap/structured-clone": "1.3.0",
 		"ansi-colors": "4.1.3",
 		"chrono-node": "2.9.0",
 		"debug": "4.4.3",

--- a/packages/@markuplint/rules/src/helpers.ts
+++ b/packages/@markuplint/rules/src/helpers.ts
@@ -5,9 +5,6 @@ import type { Element, RuleConfigValue, Document } from '@markuplint/ml-core';
 import type { Attribute } from '@markuplint/ml-spec';
 import type { WritableDeep } from 'type-fest';
 
-// @ts-ignore
-import structuredClone from '@ungap/structured-clone';
-
 import { attrCheck } from './attr-check.js';
 
 /**

--- a/packages/@markuplint/rules/src/permitted-contents/choice.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/choice.ts
@@ -71,7 +71,7 @@ export function choice(
 		i++;
 	}
 
-	const barelyMatchedResult = unmatchedResults.sort((a, b) => {
+	const barelyMatchedResult = unmatchedResults.toSorted((a, b) => {
 		if (a.type !== b.type) {
 			if (a.type === 'UNEXPECTED_EXTRA_NODE') {
 				return -1;

--- a/packages/@markuplint/rules/src/permitted-contents/count-pattern.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/count-pattern.ts
@@ -251,7 +251,7 @@ function compereResult(
 	}
 
 	const result =
-		[a, b].sort(
+		[a, b].toSorted(
 			(a, b) => (b.hint.missing?.barelyMatchedElements ?? 0) - (a.hint.missing?.barelyMatchedElements ?? 0),
 		)[0] ?? a;
 

--- a/packages/@markuplint/rules/src/permitted-contents/order.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/order.ts
@@ -63,7 +63,7 @@ export function order(
 				continue;
 			}
 
-			const barelyMatchedResult = unmatchedResults.sort((a, b) => b.matched.length - a.matched.length)[0];
+			const barelyMatchedResult = unmatchedResults.toSorted((a, b) => b.matched.length - a.matched.length)[0];
 
 			if (!barelyMatchedResult) {
 				throw new Error('Unreachable code');

--- a/packages/@markuplint/rules/src/permitted-contents/utils.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/utils.ts
@@ -266,7 +266,7 @@ export function mergeHints(
 	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
 	b: Readonly<Hints>,
 ) {
-	const missing = [a.missing, b.missing].sort(
+	const missing = [a.missing, b.missing].toSorted(
 		(a, b) => (b?.barelyMatchedElements ?? 0) - (a?.barelyMatchedElements ?? 0),
 	)[0];
 	return cleanObject({

--- a/packages/@markuplint/rules/src/required-attr/index.ts
+++ b/packages/@markuplint/rules/src/required-attr/index.ts
@@ -95,15 +95,15 @@ export default createRule<RequiredAttributes>({
 					invalid = el.matches(selector) && didntHave;
 				}
 
-				candidate.sort();
+				const sortedCandidate = candidate.toSorted();
 
 				if (invalid) {
 					const expects =
-						candidate.length === 1
+						sortedCandidate.length === 1
 							? t('the "{0*}" {1}', spec.name, 'attribute')
 							: t(
 									'{0} {1}',
-									candidate
+									sortedCandidate
 										.map(attrName => t('the "{0*}"', attrName))
 										// eslint-disable-next-line unicorn/no-array-reduce
 										.reduce((a, b) => t('{0} or {1}', a, b)),

--- a/packages/@markuplint/selector/package.json
+++ b/packages/@markuplint/selector/package.json
@@ -5,6 +5,9 @@
 	"repository": "git@github.com:markuplint/markuplint.git",
 	"author": "Yusuke Hirao <yusukehirao@me.com>",
 	"license": "MIT",
+	"engines": {
+		"node": ">=22"
+	},
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/@markuplint/shared/package.json
+++ b/packages/@markuplint/shared/package.json
@@ -5,6 +5,9 @@
 	"repository": "git@github.com:markuplint/markuplint.git",
 	"author": "Yusuke Hirao <yusukehirao@me.com>",
 	"license": "MIT",
+	"engines": {
+		"node": ">=22"
+	},
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/@markuplint/smarty-parser/package.json
+++ b/packages/@markuplint/smarty-parser/package.json
@@ -5,6 +5,9 @@
 	"repository": "git@github.com:markuplint/markuplint.git",
 	"author": "Yusuke Hirao <yusukehirao@me.com>",
 	"license": "MIT",
+	"engines": {
+		"node": ">=22"
+	},
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/@markuplint/spec-generator/package.json
+++ b/packages/@markuplint/spec-generator/package.json
@@ -5,6 +5,9 @@
 	"repository": "git@github.com:markuplint/markuplint.git",
 	"author": "Yusuke Hirao <yusukehirao@me.com>",
 	"license": "MIT",
+	"engines": {
+		"node": ">=22"
+	},
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/@markuplint/spec-generator/src/aria.ts
+++ b/packages/@markuplint/spec-generator/src/aria.ts
@@ -171,7 +171,7 @@ async function getRoles(version: ARIAVersion, graphicsAria = false) {
 				? false
 				: undefined;
 		const ownedProperties = arrayUnique(
-			[...ownedRequiredProps, ...ownedInheritedProps, ...ownedProps].sort(nameCompare),
+			[...ownedRequiredProps, ...ownedInheritedProps, ...ownedProps].toSorted(nameCompare),
 		);
 		const prohibitedProperties = $features
 			.find('.role-disallowed li code')
@@ -228,9 +228,7 @@ async function getRoles(version: ARIAVersion, graphicsAria = false) {
 		}
 	}
 
-	roles.sort(nameCompare);
-
-	return roles;
+	return roles.toSorted(nameCompare);
 }
 
 /**
@@ -266,7 +264,7 @@ async function getProps(version: ARIAVersion, roles: readonly ARIARoleInSchema[]
 			})
 			.filter((s): s is string => !!s),
 	);
-	const arias = [...ariaNameList].sort().map((name): ARIAProperty => {
+	const arias = [...ariaNameList].toSorted().map((name): ARIAProperty => {
 		const $section = $(`#${name}`);
 		const className = $section.attr('class');
 		const type = className && /property/i.test(className) ? 'property' : 'state';
@@ -356,9 +354,7 @@ async function getProps(version: ARIAVersion, roles: readonly ARIARoleInSchema[]
 		return aria;
 	});
 
-	arias.sort(nameCompare);
-
-	return arias;
+	return arias.toSorted(nameCompare);
 }
 
 /**

--- a/packages/@markuplint/spec-generator/src/fetch.ts
+++ b/packages/@markuplint/spec-generator/src/fetch.ts
@@ -77,5 +77,5 @@ export function getReferences() {
 	current += 1;
 	bar.update(current, { process: '🎉 Finished.' });
 	bar.stop();
-	return [...cache.keys()].sort();
+	return [...cache.keys()].toSorted();
 }

--- a/packages/@markuplint/spec-generator/src/html-elements.ts
+++ b/packages/@markuplint/spec-generator/src/html-elements.ts
@@ -144,6 +144,6 @@ export async function getElements(filePattern: string) {
 	);
 
 	return specs
-		.sort(nameCompare)
-		.sort((a, b) => (a.namespace == b.namespace ? 0 : a.namespace === 'http://www.w3.org/2000/svg' ? 1 : -1));
+		.toSorted(nameCompare)
+		.toSorted((a, b) => (a.namespace == b.namespace ? 0 : a.namespace === 'http://www.w3.org/2000/svg' ? 1 : -1));
 }

--- a/packages/@markuplint/spec-generator/src/utils.ts
+++ b/packages/@markuplint/spec-generator/src/utils.ts
@@ -35,8 +35,7 @@ export function nameCompare(a: HasName | string, b: HasName | string) {
  */
 export function sortObjectByKey<T>(o: T): T {
 	// @ts-ignore
-	const keys = Object.keys(o);
-	keys.sort(nameCompare);
+	const keys = Object.keys(o).toSorted(nameCompare);
 	// @ts-ignore
 	const newObj: T = {};
 	for (const key of keys) {

--- a/packages/@markuplint/svelte-parser/package.json
+++ b/packages/@markuplint/svelte-parser/package.json
@@ -5,6 +5,9 @@
 	"repository": "git@github.com:markuplint/markuplint.git",
 	"author": "Yusuke Hirao <yusukehirao@me.com>",
 	"license": "MIT",
+	"engines": {
+		"node": ">=22"
+	},
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/@markuplint/svelte-spec/package.json
+++ b/packages/@markuplint/svelte-spec/package.json
@@ -5,6 +5,9 @@
 	"repository": "git@github.com:markuplint/markuplint.git",
 	"author": "Yusuke Hirao <yusukehirao@me.com>",
 	"license": "MIT",
+	"engines": {
+		"node": ">=22"
+	},
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/@markuplint/types/gen/types.ts
+++ b/packages/@markuplint/types/gen/types.ts
@@ -26,11 +26,11 @@ fs.writeFileSync(
 		definitions: {
 			'css-syntax': {
 				type: 'string',
-				enum: [...new Set([...props, ...types]), ...Object.keys(cssTokenizers).map(t => `<${t}>`)].sort(),
+				enum: [...new Set([...props, ...types]), ...Object.keys(cssTokenizers).map(t => `<${t}>`)].toSorted(),
 			},
 			'extended-type': {
 				type: 'string',
-				enum: Object.keys({ ...defs, ...cssDefs }).sort(),
+				enum: Object.keys({ ...defs, ...cssDefs }).toSorted(),
 			},
 			'html-attr-requirement': {
 				type: 'string',
@@ -69,6 +69,6 @@ function oneOf(...keys: readonly string[]) {
 				$ref: `#/definitions/${key}`,
 			}))
 			// @ts-ignore Charactor sorting
-			.sort((a, b) => b.$ref - a.$ref),
+			.toSorted((a, b) => b.$ref - a.$ref),
 	};
 }

--- a/packages/@markuplint/types/package.json
+++ b/packages/@markuplint/types/package.json
@@ -5,6 +5,9 @@
 	"repository": "git@github.com:markuplint/markuplint.git",
 	"author": "Yusuke Hirao <yusukehirao@me.com>",
 	"license": "MIT",
+	"engines": {
+		"node": ">=22"
+	},
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/@markuplint/types/src/whatwg/check-autocomplete.ts
+++ b/packages/@markuplint/types/src/whatwg/check-autocomplete.ts
@@ -342,7 +342,7 @@ export const checkAutoComplete: CustomSyntaxChecker = () => value => {
 		}
 	} else if (!hasPartOfAddress) {
 		expects.unshift(
-			...[...partOfAddress].reverse().map(token => ({
+			...[...partOfAddress].toReversed().map(token => ({
 				type: 'const' as const,
 				value: token,
 			})),

--- a/packages/@markuplint/vue-parser/package.json
+++ b/packages/@markuplint/vue-parser/package.json
@@ -5,6 +5,9 @@
 	"repository": "git@github.com:markuplint/markuplint.git",
 	"author": "Yusuke Hirao <yusukehirao@me.com>",
 	"license": "MIT",
+	"engines": {
+		"node": ">=22"
+	},
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/@markuplint/vue-spec/package.json
+++ b/packages/@markuplint/vue-spec/package.json
@@ -5,6 +5,9 @@
 	"repository": "git@github.com:markuplint/markuplint.git",
 	"author": "Yusuke Hirao <yusukehirao@me.com>",
 	"license": "MIT",
+	"engines": {
+		"node": ">=22"
+	},
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/markuplint/README.md
+++ b/packages/markuplint/README.md
@@ -25,7 +25,7 @@
 $ npx markuplint target.html
 ```
 
-Supported for _Node.js_ `v18.18.0` or later.
+Supported for _Node.js_ `v22.0.0` or later.
 
 ## Usage
 

--- a/packages/markuplint/package.json
+++ b/packages/markuplint/package.json
@@ -4,6 +4,9 @@
 	"description": "An HTML linter for all markup developers",
 	"author": "Yusuke Hirao",
 	"license": "MIT",
+	"engines": {
+		"node": ">=22"
+	},
 	"repository": "git@github.com:markuplint/markuplint.git",
 	"type": "module",
 	"exports": {

--- a/packages/markuplint/src/version.ts
+++ b/packages/markuplint/src/version.ts
@@ -1,9 +1,4 @@
-import { createRequire } from 'node:module';
-
-const require = createRequire(import.meta.url);
-
-// TODO: Use import attribute in Node.js v22 and v20.10 or later
-const pkg = require('../package.json');
+import pkg from '../package.json' with { type: 'json' };
 
 /**
  * The current version string of the markuplint package, read from `package.json`.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2726,12 +2726,10 @@ __metadata:
     "@markuplint/ml-ast": "npm:4.4.11"
     "@markuplint/ml-spec": "npm:4.10.2"
     "@markuplint/types": "npm:4.8.2"
-    "@types/uuid": "npm:11.0.0"
     "@typescript-eslint/typescript-estree": "npm:8.55.0"
     debug: "npm:4.4.3"
     espree: "npm:11.1.0"
     type-fest: "npm:4.41.0"
-    uuid: "npm:13.0.0"
   languageName: unknown
   linkType: soft
 
@@ -2801,7 +2799,6 @@ __metadata:
     "@markuplint/shared": "npm:4.4.13"
     "@markuplint/types": "npm:4.8.2"
     "@types/debug": "npm:4.1.12"
-    "@ungap/structured-clone": "npm:1.3.0"
     ansi-colors: "npm:4.1.3"
     chrono-node: "npm:2.9.0"
     debug: "npm:4.4.3"
@@ -4712,15 +4709,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/uuid@npm:11.0.0":
-  version: 11.0.0
-  resolution: "@types/uuid@npm:11.0.0"
-  dependencies:
-    uuid: "npm:*"
-  checksum: 10c0/6ebf1448d8fdc78d348a8a84389b74083f2f58bed75a5a6cf3be8419d33dcf757735c8b2de746b066ff8ef07f4384d02549774dc84195ffa46b24745471e9d8e
-  languageName: node
-  linkType: hard
-
 "@types/vscode@npm:1.99.1":
   version: 1.99.1
   resolution: "@types/vscode@npm:1.99.1"
@@ -4919,13 +4907,6 @@ __metadata:
     https-proxy-agent: "npm:^7.0.0"
     tslib: "npm:^2.6.2"
   checksum: 10c0/fe6121ce9015d32a38755244ecabd7f44ff7e40cc07a5656e84d19a0ea8a644a67b49804c5e851ad768d774194221accf8388ac834e1f9f1e148a03c054355dd
-  languageName: node
-  linkType: hard
-
-"@ungap/structured-clone@npm:1.3.0":
-  version: 1.3.0
-  resolution: "@ungap/structured-clone@npm:1.3.0"
-  checksum: 10c0/0fc3097c2540ada1fc340ee56d58d96b5b536a2a0dab6e3ec17d4bfc8c4c86db345f61a375a8185f9da96f01c69678f836a2b57eeaa9e4b8eeafd26428e57b0a
   languageName: node
   linkType: hard
 
@@ -18287,15 +18268,6 @@ __metadata:
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 10c0/41a5bdd214df2f6c3ecf8622745e4a366c4adced864bc3c833739791aeeeb1838119af7daed4ba36428114b5c67dcda034a79c882e97e43c03e66a4dd7389942
-  languageName: node
-  linkType: hard
-
-"uuid@npm:*, uuid@npm:13.0.0":
-  version: 13.0.0
-  resolution: "uuid@npm:13.0.0"
-  bin:
-    uuid: dist-node/bin/uuid
-  checksum: 10c0/950e4c18d57fef6c69675344f5700a08af21e26b9eff2bf2180427564297368c538ea11ac9fb2e6528b17fc3966a9fd2c5049361b0b63c7d654f3c550c9b3d67
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Update CI test matrix from Node.js 18 to 22
- Remove Node.js 18 polyfills and workarounds (`toSorted`/`toSpliced` fallbacks, `@ungap/structured-clone`, `uuid`)
- Replace `uuid` with native `crypto.randomUUID()` in parser-utils
- Replace `require()` with `import ... with { type: 'json' }` in markuplint
- Re-enable `unicorn/no-array-sort` and `unicorn/no-array-reverse` ESLint rules (#3144)
- Convert all `.sort()` → `.toSorted()` and `.reverse()` → `.toReversed()` across the codebase (25 locations)
- Bump TypeScript target from ES2020 to ES2022
- Add `"engines": { "node": ">=22" }` to root and all 37 published packages
- Update README minimum Node.js version to v22.0.0

## Related Issues

- Closes #3144
- Related: #3147, #3148, #3149, #3150, #3151 (dependency updates now unblocked)

## Test plan

- [x] Full test suite passes (141 test files, 1419 tests)
- [x] Build succeeds for parser-utils, rules, and markuplint
- [ ] CI passes on Node.js 22 and 24

🤖 Generated with [Claude Code](https://claude.com/claude-code)