### PR TITLE
feat: add ruleCommonSettings and change allowWarnings default

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1,6 +1,15 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"definitions": {
+		"ruleCommonSettings": {
+			"additionalProperties": false,
+			"properties": {
+				"ariaVersion": {
+					"type": "string",
+					"enum": ["1.1", "1.2", "1.3"]
+				}
+			}
+		},
 		"rules": {
 			"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/schema.json#/definitions/rules",
 			"additionalProperties": false,
@@ -344,6 +353,7 @@
 				"type": "string"
 			}
 		},
+		"ruleCommonSettings": { "$ref": "#/definitions/ruleCommonSettings" },
 		"plugins": { "$ref": "#/definitions/plugins" },
 		"parser": { "$ref": "#/definitions/parser" },
 		"parserOptions": { "$ref": "#/definitions/parserOptions" },

--- a/docs/migration/v4-v5/cli.ja.md
+++ b/docs/migration/v4-v5/cli.ja.md
@@ -1,0 +1,65 @@
+# CLI 破壊的変更: v4 から v5 への移行ガイド
+
+## 対象読者
+
+- コマンドラインから `markuplint` を実行する **CLI ユーザー**
+- パイプラインに `markuplint` を組み込んでいる **CI/CD メンテナー**
+
+## 変更一覧
+
+| 変更内容 | 影響範囲 |
+|---------|---------|
+| `--allow-warnings` のデフォルトが `true` に変更 | 終了コードの動作 |
+| `--allow-warnings` が `--no-allow-warnings` にリネーム | CLI フラグ名 |
+
+## `--allow-warnings` のデフォルト変更
+
+v4 では、警告があるとデフォルトで非ゼロの終了コードが返されていました。v5 では、警告はデフォルトで許可されます（終了コード 0）。
+
+### v4 の動作
+
+```bash
+# 警告があると終了コード 1
+markuplint index.html
+echo $?  # 1（警告がある場合）
+
+# 明示的に警告を許可
+markuplint --allow-warnings index.html
+echo $?  # 0
+```
+
+### v5 の動作
+
+```bash
+# デフォルトで警告を許可（終了コード 0）
+markuplint index.html
+echo $?  # 0（警告があっても）
+
+# 明示的に警告を禁止
+markuplint --no-allow-warnings index.html
+echo $?  # 1（警告がある場合）
+```
+
+### 移行方法
+
+CI パイプラインが警告を検出するためにデフォルト動作に依存していた場合:
+
+```bash
+# v4
+markuplint index.html
+
+# v5 — 同じ動作を維持するには --no-allow-warnings を追加
+markuplint --no-allow-warnings index.html
+```
+
+CI パイプラインで既に `--allow-warnings` を使用していた場合は、フラグを削除するだけです:
+
+```bash
+# v4
+markuplint --allow-warnings index.html
+
+# v5 — 不要になりました（デフォルト動作）
+markuplint index.html
+```
+
+> **ヒント**: 許容する警告数をより細かく制御するには `--max-warnings=N` を使用してください。

--- a/docs/migration/v4-v5/cli.md
+++ b/docs/migration/v4-v5/cli.md
@@ -1,0 +1,65 @@
+# CLI Breaking Changes: v4 to v5 Migration Guide
+
+## Who This Guide Is For
+
+- **CLI users** who run `markuplint` from the command line
+- **CI/CD maintainers** who have `markuplint` in their pipelines
+
+## Summary of Changes
+
+| Change | Impact |
+|--------|--------|
+| `--allow-warnings` default changed to `true` | Exit code behavior |
+| `--allow-warnings` renamed to `--no-allow-warnings` | CLI flag name |
+
+## `--allow-warnings` Default Changed
+
+In v4, warnings caused a non-zero exit code by default. In v5, warnings are allowed by default (exit code 0).
+
+### v4 Behavior
+
+```bash
+# Warnings cause exit code 1
+markuplint index.html
+echo $?  # 1 (if warnings exist)
+
+# Explicitly allow warnings
+markuplint --allow-warnings index.html
+echo $?  # 0
+```
+
+### v5 Behavior
+
+```bash
+# Warnings are allowed by default (exit code 0)
+markuplint index.html
+echo $?  # 0 (even if warnings exist)
+
+# Explicitly disallow warnings
+markuplint --no-allow-warnings index.html
+echo $?  # 1 (if warnings exist)
+```
+
+### Migration
+
+If your CI pipeline relied on the default behavior to catch warnings:
+
+```bash
+# v4
+markuplint index.html
+
+# v5 — add --no-allow-warnings to preserve the same behavior
+markuplint --no-allow-warnings index.html
+```
+
+If your CI pipeline already used `--allow-warnings`, simply remove the flag:
+
+```bash
+# v4
+markuplint --allow-warnings index.html
+
+# v5 — no longer needed (this is the default)
+markuplint index.html
+```
+
+> **Tip**: Use `--max-warnings=N` for finer control over the allowed number of warnings.

--- a/docs/migration/v4-v5/config.ja.md
+++ b/docs/migration/v4-v5/config.ja.md
@@ -1,0 +1,104 @@
+# Config 破壊的変更: v4 から v5 への移行ガイド
+
+## 対象読者
+
+- `.markuplintrc` や `markuplint.config.*` を作成する**設定ファイル作成者**
+- ルールオプションから `ariaVersion` にアクセスする**カスタムルール作成者**
+
+## 変更一覧
+
+| 変更内容 | 影響範囲 |
+|---------|---------|
+| 新しい `ruleCommonSettings` 設定プロパティ | 設定ファイル |
+| ARIA バージョンの解決優先度の変更 | `ariaVersion` / `version` オプションを使用するルール |
+
+## `ruleCommonSettings`
+
+新しいトップレベルの設定プロパティ `ruleCommonSettings` により、すべてのルールにグローバルに適用される共通オプションを設定できます。現在は `ariaVersion` をサポートしています。
+
+### v4
+
+各ルールに個別に `ariaVersion`（または `version`）オプションを指定する必要がありました:
+
+```json
+{
+  "rules": {
+    "wai-aria": {
+      "options": {
+        "version": "1.2"
+      }
+    },
+    "require-accessible-name": {
+      "options": {
+        "ariaVersion": "1.2"
+      }
+    },
+    "no-refer-to-non-existent-id": {
+      "options": {
+        "ariaVersion": "1.2"
+      }
+    }
+  }
+}
+```
+
+### v5
+
+`ruleCommonSettings` で一度設定すれば、すべての ARIA 関連ルールがフォールバックとして使用します:
+
+```json
+{
+  "ruleCommonSettings": {
+    "ariaVersion": "1.2"
+  },
+  "rules": {
+    "wai-aria": true,
+    "require-accessible-name": true,
+    "no-refer-to-non-existent-id": true
+  }
+}
+```
+
+### 解決優先度
+
+ルールは以下の順序で ARIA バージョンを解決します（優先度の高い順）:
+
+1. **ルールレベルのオプション** — `options.version`（wai-aria）または `options.ariaVersion`（その他のルール）
+2. **`ruleCommonSettings.ariaVersion`** — 設定ファイルからのグローバルフォールバック
+3. **デフォルト** — markuplint に組み込まれた推奨 ARIA バージョン
+
+ルール単位のオプションは引き続き優先されるため、特定のルールで `ruleCommonSettings` をオーバーライドできます:
+
+```json
+{
+  "ruleCommonSettings": {
+    "ariaVersion": "1.2"
+  },
+  "rules": {
+    "wai-aria": {
+      "options": {
+        "version": "1.3"
+      }
+    }
+  }
+}
+```
+
+## カスタムルール作成者向け
+
+カスタムルールで ARIA バージョンにアクセスしている場合は、新しいフォールバックチェーンを使用してください:
+
+```ts
+// v4
+const ariaVersion = el.rule.options.ariaVersion;
+
+// v5
+import { ARIA_RECOMMENDED_VERSION } from '@markuplint/ml-spec';
+
+const ariaVersion =
+  el.rule.options?.ariaVersion
+  ?? document.ruleCommonSettings?.ariaVersion
+  ?? ARIA_RECOMMENDED_VERSION;
+```
+
+`document.ruleCommonSettings` は、ルールの `verify()` コールバックに渡される `MLDocument` インスタンスで利用可能です。

--- a/docs/migration/v4-v5/config.md
+++ b/docs/migration/v4-v5/config.md
@@ -1,0 +1,104 @@
+# Config Breaking Changes: v4 to v5 Migration Guide
+
+## Who This Guide Is For
+
+- **Config authors** who write `.markuplintrc` or `markuplint.config.*` files
+- **Custom rule authors** who access `ariaVersion` from rule options
+
+## Summary of Changes
+
+| Change | Impact |
+|--------|--------|
+| New `ruleCommonSettings` config property | Config files |
+| ARIA version resolution priority changed | Rules using `ariaVersion` / `version` option |
+
+## `ruleCommonSettings`
+
+A new top-level configuration property `ruleCommonSettings` allows you to set common options that apply globally to all rules. Currently, it supports `ariaVersion`.
+
+### v4
+
+Each rule required its own `ariaVersion` (or `version`) option:
+
+```json
+{
+  "rules": {
+    "wai-aria": {
+      "options": {
+        "version": "1.2"
+      }
+    },
+    "require-accessible-name": {
+      "options": {
+        "ariaVersion": "1.2"
+      }
+    },
+    "no-refer-to-non-existent-id": {
+      "options": {
+        "ariaVersion": "1.2"
+      }
+    }
+  }
+}
+```
+
+### v5
+
+Set it once in `ruleCommonSettings` and all ARIA-related rules will use it as a fallback:
+
+```json
+{
+  "ruleCommonSettings": {
+    "ariaVersion": "1.2"
+  },
+  "rules": {
+    "wai-aria": true,
+    "require-accessible-name": true,
+    "no-refer-to-non-existent-id": true
+  }
+}
+```
+
+### Resolution Priority
+
+Rules resolve the ARIA version in the following order (highest priority first):
+
+1. **Rule-level option** — `options.version` (wai-aria) or `options.ariaVersion` (other rules)
+2. **`ruleCommonSettings.ariaVersion`** — Global fallback from config
+3. **Default** — The recommended ARIA version built into markuplint
+
+Per-rule options still take precedence, so you can override `ruleCommonSettings` for specific rules:
+
+```json
+{
+  "ruleCommonSettings": {
+    "ariaVersion": "1.2"
+  },
+  "rules": {
+    "wai-aria": {
+      "options": {
+        "version": "1.3"
+      }
+    }
+  }
+}
+```
+
+## For Custom Rule Authors
+
+If your custom rule accesses the ARIA version, use the new fallback chain:
+
+```ts
+// v4
+const ariaVersion = el.rule.options.ariaVersion;
+
+// v5
+import { ARIA_RECOMMENDED_VERSION } from '@markuplint/ml-spec';
+
+const ariaVersion =
+  el.rule.options?.ariaVersion
+  ?? document.ruleCommonSettings?.ariaVersion
+  ?? ARIA_RECOMMENDED_VERSION;
+```
+
+`document.ruleCommonSettings` is available on the `MLDocument` instance passed to rule `verify()` callbacks.

--- a/packages/@markuplint/ml-config/src/merge-config.md
+++ b/packages/@markuplint/ml-config/src/merge-config.md
@@ -1,16 +1,17 @@
 ## Merge Props
 
-| Options                                                               | Type                   | Merging                      | Path Absolutize |
-| --------------------------------------------------------------------- | ---------------------- | ---------------------------- | --------------- |
-| [plugins](https://markuplint.dev/configuration#plugins)               | Array                  | Add uniquely                 | ✓               |
-| [parser](https://markuplint.dev/configuration#parser)                 | Object                 | Merge                        | ✓               |
-| [parserOptions](https://markuplint.dev/configuration#parserOptions)   | Object                 | Merge                        | ✓               |
-| [specs](https://markuplint.dev/configuration#specs)                   | Object(v2) / Array(v1) | Merge(v2) / Add uniquely(v1) | -               |
-| [extends](https://markuplint.dev/configuration#extends)               | Array                  | Delete after merged          | ✓               |
-| [excludeFiles](https://markuplint.dev/configuration#excludeFiles)     | Array                  | Add uniquely                 | ✓               |
-| [rules](https://markuplint.dev/configuration#rules)                   | Object                 | †1                           | -               |
-| [nodeRules](https://markuplint.dev/configuration#nodeRules)           | Array                  | Add                          | -               |
-| [childNodeRules](https://markuplint.dev/configuration#childNodeRules) | Array                  | Add                          | -               |
+| Options                                                                       | Type                   | Merging                      | Path Absolutize |
+| ----------------------------------------------------------------------------- | ---------------------- | ---------------------------- | --------------- |
+| [ruleCommonSettings](https://markuplint.dev/configuration#ruleCommonSettings) | Object                 | Merge                        | ✓               |
+| [plugins](https://markuplint.dev/configuration#plugins)                       | Array                  | Add uniquely                 | ✓               |
+| [parser](https://markuplint.dev/configuration#parser)                         | Object                 | Merge                        | ✓               |
+| [parserOptions](https://markuplint.dev/configuration#parserOptions)           | Object                 | Merge                        | ✓               |
+| [specs](https://markuplint.dev/configuration#specs)                           | Object(v2) / Array(v1) | Merge(v2) / Add uniquely(v1) | -               |
+| [extends](https://markuplint.dev/configuration#extends)                       | Array                  | Delete after merged          | ✓               |
+| [excludeFiles](https://markuplint.dev/configuration#excludeFiles)             | Array                  | Add uniquely                 | ✓               |
+| [rules](https://markuplint.dev/configuration#rules)                           | Object                 | †1                           | -               |
+| [nodeRules](https://markuplint.dev/configuration#nodeRules)                   | Array                  | Add                          | -               |
+| [childNodeRules](https://markuplint.dev/configuration#childNodeRules)         | Array                  | Add                          | -               |
 
 ## †1 Merge Rules
 

--- a/packages/@markuplint/ml-config/src/merge-config.ts
+++ b/packages/@markuplint/ml-config/src/merge-config.ts
@@ -35,6 +35,7 @@ export function mergeConfig(a: Config, b?: Config): OptimizedConfig {
 	const config: OptimizedConfig = {
 		...a,
 		...b,
+		ruleCommonSettings: mergeObject(a.ruleCommonSettings, b.ruleCommonSettings),
 		plugins: concatArray(a.plugins, b.plugins, true, 'name')?.map(plugin => {
 			if (typeof plugin === 'string') {
 				return {

--- a/packages/@markuplint/ml-config/src/types.ts
+++ b/packages/@markuplint/ml-config/src/types.ts
@@ -27,6 +27,10 @@ export type Config = {
 	readonly overrides?: Readonly<Record<string, OverrideConfig>>;
 };
 
+/**
+ * Common settings applied globally to all rules.
+ * These values serve as fallbacks when individual rules do not specify their own.
+ */
 export type RuleCommonSettings = {
 	readonly ariaVersion?: ARIAVersion;
 };

--- a/packages/@markuplint/ml-config/src/types.ts
+++ b/packages/@markuplint/ml-config/src/types.ts
@@ -1,4 +1,5 @@
 import type { ParserOptions } from '@markuplint/ml-ast';
+import type { ARIAVersion } from '@markuplint/ml-spec';
 import type { RegexSelector } from '@markuplint/selector';
 import type { Nullable } from '@markuplint/shared';
 
@@ -10,6 +11,7 @@ export type { RegexSelector } from '@markuplint/selector';
  */
 export type Config = {
 	readonly $schema?: string;
+	readonly ruleCommonSettings?: RuleCommonSettings;
 	readonly extends?: string | readonly string[];
 	readonly plugins?: readonly (PluginConfig | string)[];
 	readonly parser?: ParserConfig;
@@ -23,6 +25,10 @@ export type Config = {
 	readonly childNodeRules?: readonly ChildNodeRule[];
 	readonly overrideMode?: 'merge' | 'reset';
 	readonly overrides?: Readonly<Record<string, OverrideConfig>>;
+};
+
+export type RuleCommonSettings = {
+	readonly ariaVersion?: ARIAVersion;
 };
 
 /**

--- a/packages/@markuplint/ml-config/tsconfig.json
+++ b/packages/@markuplint/ml-config/tsconfig.json
@@ -8,6 +8,9 @@
 			"path": "../ml-ast"
 		},
 		{
+			"path": "../ml-spec"
+		},
+		{
 			"path": "../selector"
 		},
 		{

--- a/packages/@markuplint/ml-core/docs/linting-pipeline.ja.md
+++ b/packages/@markuplint/ml-core/docs/linting-pipeline.ja.md
@@ -76,7 +76,7 @@ constructor(params: MLCoreParams)
 パースされた AST から `MLDocument` を作成します：
 
 ```typescript
-new Document(ast, ruleset, schemas, {
+new Document(ast, ruleset, schemas, ruleCommonSettings, {
   filename,
   endTag,
   booleanish,

--- a/packages/@markuplint/ml-core/docs/linting-pipeline.ja.md
+++ b/packages/@markuplint/ml-core/docs/linting-pipeline.ja.md
@@ -32,17 +32,18 @@ constructor(params: MLCoreParams)
 
 `MLFabric` 型はリンティング設定全体を定義します：
 
-| フィールド      | 型                                | 説明                                                  |
-| --------------- | --------------------------------- | ----------------------------------------------------- |
-| `parser`        | `MLParser`                        | パーサーインスタンス（例：`@markuplint/html-parser`） |
-| `ruleset`       | `Ruleset`                         | 解決済みルール設定                                    |
-| `rules`         | `readonly MLRule[]`               | ルールインスタンスの配列                              |
-| `locale`        | `LocaleSet`                       | 違反メッセージのロケール                              |
-| `schemas`       | `MLSchema`                        | HTML/ARIA 仕様タプル                                  |
-| `parserOptions` | `ParserOptions`                   | パーサー設定オプション                                |
-| `severity`      | `{ parseError?: SeverityOption }` | 重大度オーバーライド                                  |
-| `pretenders`    | `readonly Pretender[]`            | コンポーネントから HTML へのマッピング                |
-| `configErrors`  | `readonly ConfigError[]`          | 報告する設定エラー                                    |
+| フィールド           | 型                                | 説明                                                  |
+| -------------------- | --------------------------------- | ----------------------------------------------------- |
+| `parser`             | `MLParser`                        | パーサーインスタンス（例：`@markuplint/html-parser`） |
+| `ruleset`            | `Ruleset`                         | 解決済みルール設定                                    |
+| `rules`              | `readonly MLRule[]`               | ルールインスタンスの配列                              |
+| `locale`             | `LocaleSet`                       | 違反メッセージのロケール                              |
+| `schemas`            | `MLSchema`                        | HTML/ARIA 仕様タプル                                  |
+| `parserOptions`      | `ParserOptions`                   | パーサー設定オプション                                |
+| `severity`           | `{ parseError?: SeverityOption }` | 重大度オーバーライド                                  |
+| `pretenders`         | `readonly Pretender[]`            | コンポーネントから HTML へのマッピング                |
+| `ruleCommonSettings` | `RuleCommonSettings`              | すべてのルールにグローバルに適用される共通設定        |
+| `configErrors`       | `readonly ConfigError[]`          | 報告する設定エラー                                    |
 
 ### プロパティ
 

--- a/packages/@markuplint/ml-core/docs/linting-pipeline.md
+++ b/packages/@markuplint/ml-core/docs/linting-pipeline.md
@@ -76,7 +76,7 @@ If the parser throws:
 Creates `MLDocument` from the parsed AST:
 
 ```typescript
-new Document(ast, ruleset, schemas, {
+new Document(ast, ruleset, schemas, ruleCommonSettings, {
   filename,
   endTag,
   booleanish,

--- a/packages/@markuplint/ml-core/docs/linting-pipeline.md
+++ b/packages/@markuplint/ml-core/docs/linting-pipeline.md
@@ -32,17 +32,18 @@ Where `MLCoreParams` extends `MLFabric` with:
 
 The `MLFabric` type defines the full linting configuration:
 
-| Field           | Type                              | Description                                       |
-| --------------- | --------------------------------- | ------------------------------------------------- |
-| `parser`        | `MLParser`                        | Parser instance (e.g., `@markuplint/html-parser`) |
-| `ruleset`       | `Ruleset`                         | Resolved rule configuration                       |
-| `rules`         | `readonly MLRule[]`               | Array of rule instances                           |
-| `locale`        | `LocaleSet`                       | Locale for violation messages                     |
-| `schemas`       | `MLSchema`                        | HTML/ARIA specification tuple                     |
-| `parserOptions` | `ParserOptions`                   | Parser configuration options                      |
-| `severity`      | `{ parseError?: SeverityOption }` | Severity overrides                                |
-| `pretenders`    | `readonly Pretender[]`            | Component-to-HTML mappings                        |
-| `configErrors`  | `readonly ConfigError[]`          | Configuration errors to report                    |
+| Field                | Type                              | Description                                       |
+| -------------------- | --------------------------------- | ------------------------------------------------- |
+| `parser`             | `MLParser`                        | Parser instance (e.g., `@markuplint/html-parser`) |
+| `ruleset`            | `Ruleset`                         | Resolved rule configuration                       |
+| `rules`              | `readonly MLRule[]`               | Array of rule instances                           |
+| `locale`             | `LocaleSet`                       | Locale for violation messages                     |
+| `schemas`            | `MLSchema`                        | HTML/ARIA specification tuple                     |
+| `parserOptions`      | `ParserOptions`                   | Parser configuration options                      |
+| `severity`           | `{ parseError?: SeverityOption }` | Severity overrides                                |
+| `pretenders`         | `readonly Pretender[]`            | Component-to-HTML mappings                        |
+| `ruleCommonSettings` | `RuleCommonSettings`              | Common settings applied globally to all rules     |
+| `configErrors`       | `readonly ConfigError[]`          | Configuration errors to report                    |
 
 ### Properties
 

--- a/packages/@markuplint/ml-core/src/ml-core.ts
+++ b/packages/@markuplint/ml-core/src/ml-core.ts
@@ -3,7 +3,14 @@ import type { Ruleset } from './ruleset/index.js';
 import type { MLFabric, MLSchema } from './types.js';
 import type { LocaleSet } from '@markuplint/i18n';
 import type { MLASTDocument, MLParser, ParserOptions } from '@markuplint/ml-ast';
-import type { PlainData, Pretender, RuleConfigValue, SeverityOptions, Violation } from '@markuplint/ml-config';
+import type {
+	PlainData,
+	Pretender,
+	RuleCommonSettings,
+	RuleConfigValue,
+	SeverityOptions,
+	Violation,
+} from '@markuplint/ml-config';
 
 import { ParserError } from '@markuplint/parser-utils';
 
@@ -43,6 +50,7 @@ export class MLCore {
 	#rules: Readonly<MLRule<RuleConfigValue, PlainData>>[];
 	#ruleset: Ruleset;
 	#schemas: MLSchema;
+	#ruleCommonSettings: RuleCommonSettings;
 	#sourceCode: string;
 	#configErrors: Readonly<Error>[];
 
@@ -53,6 +61,7 @@ export class MLCore {
 		rules,
 		locale,
 		schemas,
+		ruleCommonSettings,
 		parserOptions,
 		severity,
 		pretenders,
@@ -74,6 +83,7 @@ export class MLCore {
 		};
 		this.#locale = locale;
 		this.#schemas = schemas;
+		this.#ruleCommonSettings = ruleCommonSettings;
 		this.#filename = filename;
 		this.#rules = [...rules];
 		this.#severity = severity;
@@ -240,7 +250,7 @@ export class MLCore {
 			return;
 		}
 		try {
-			this.#document = new Document(this.#ast, this.#ruleset, this.#schemas, {
+			this.#document = new Document(this.#ast, this.#ruleset, this.#schemas, this.#ruleCommonSettings, {
 				filename: this.#filename,
 				endTag: this.#parser.endTag,
 				booleanish: this.#parser.booleanish,

--- a/packages/@markuplint/ml-core/src/ml-dom/helper/accname.spec.ts
+++ b/packages/@markuplint/ml-core/src/ml-dom/helper/accname.spec.ts
@@ -1,4 +1,5 @@
 import { parser } from '@markuplint/html-parser';
+import { ARIA_RECOMMENDED_VERSION } from '@markuplint/ml-spec';
 import { test, expect } from 'vitest';
 
 import { convertRuleset } from '../../index.js';
@@ -12,7 +13,7 @@ function c(sourceCode: string) {
 	const ast = parser.parse(sourceCode);
 	const astNode = ast.nodeList[0]!;
 	const ruleset = convertRuleset({});
-	const document = new MLDocument(ast, ruleset, dummySchemas());
+	const document = new MLDocument(ast, ruleset, dummySchemas(), { ariaVersion: ARIA_RECOMMENDED_VERSION });
 	const node = createNode(astNode, document);
 	if (node.is(node.ELEMENT_NODE)) {
 		return node;

--- a/packages/@markuplint/ml-core/src/ml-dom/helper/create-node.spec.ts
+++ b/packages/@markuplint/ml-core/src/ml-dom/helper/create-node.spec.ts
@@ -1,4 +1,5 @@
 import { parser } from '@markuplint/html-parser';
+import { ARIA_RECOMMENDED_VERSION } from '@markuplint/ml-spec';
 import { describe, test, expect } from 'vitest';
 
 import { Document, convertRuleset } from '../../index.js';
@@ -12,7 +13,7 @@ describe('create Node', () => {
 		const ast = parser.parse(sourceCode);
 		const astNode = ast.nodeList[0];
 		const ruleset = convertRuleset({});
-		const document = new Document(ast, ruleset, dummySchemas());
+		const document = new Document(ast, ruleset, dummySchemas(), { ariaVersion: ARIA_RECOMMENDED_VERSION });
 		const node = createNode(astNode!, document);
 		expect(node.raw).toBe('<div>');
 	});

--- a/packages/@markuplint/ml-core/src/ml-dom/node/document.ts
+++ b/packages/@markuplint/ml-core/src/ml-dom/node/document.ts
@@ -11,7 +11,7 @@ import type { MLSchema } from '../../types.js';
 import type { Walker } from '../helper/walkers.js';
 import type { MLToken } from '../token/token.js';
 import type { EndTagType, MLASTDocument, MLASTNodeTreeItem } from '@markuplint/ml-ast';
-import type { PlainData, Pretender, RuleConfigValue } from '@markuplint/ml-config';
+import type { PlainData, Pretender, RuleCommonSettings, RuleConfigValue } from '@markuplint/ml-config';
 import type { ARIAVersion, MLMLSpec } from '@markuplint/ml-spec';
 
 import { exchangeValueOnRule, mergeRule } from '@markuplint/ml-config';
@@ -151,6 +151,8 @@ export class MLDocument<T extends RuleConfigValue, O extends PlainData = undefin
 	 */
 	readonly tagNameCaseSensitive: boolean;
 
+	readonly ruleCommonSettings: RuleCommonSettings;
+
 	#tokenList: ReadonlyArray<MLToken> | null = null;
 
 	/**
@@ -162,6 +164,7 @@ export class MLDocument<T extends RuleConfigValue, O extends PlainData = undefin
 		ast: MLASTDocument,
 		ruleset: Ruleset,
 		schemas: MLSchema,
+		ruleCommonSettings: RuleCommonSettings,
 		options?: {
 			readonly filename?: string;
 			readonly endTag?: 'xml' | 'omittable' | 'never';
@@ -179,6 +182,7 @@ export class MLDocument<T extends RuleConfigValue, O extends PlainData = undefin
 		this.endTag = options?.endTag ?? 'omittable';
 		this.#filename = options?.filename;
 		this.tagNameCaseSensitive = options?.tagNameCaseSensitive ?? false;
+		this.ruleCommonSettings = ruleCommonSettings;
 
 		// console.log(ast.nodeList.map((n, i) => `${i}: ${n.uuid} "${n.raw.trim()}"(${n.type})`));
 		this.nodeList = Object.freeze(

--- a/packages/@markuplint/ml-core/src/ml-dom/node/document.ts
+++ b/packages/@markuplint/ml-core/src/ml-dom/node/document.ts
@@ -151,14 +151,20 @@ export class MLDocument<T extends RuleConfigValue, O extends PlainData = undefin
 	 */
 	readonly tagNameCaseSensitive: boolean;
 
+	/**
+	 * Common settings applied globally to all rules, such as the ARIA version.
+	 * Rules use this as a fallback when their own options do not specify a value.
+	 */
 	readonly ruleCommonSettings: RuleCommonSettings;
 
 	#tokenList: ReadonlyArray<MLToken> | null = null;
 
 	/**
-	 *
 	 * @param ast node list of markuplint AST
 	 * @param ruleset ruleset object
+	 * @param schemas base HTML/ARIA spec with optional framework-specific extensions
+	 * @param ruleCommonSettings common settings applied globally to all rules
+	 * @param options optional configuration for document behavior
 	 */
 	constructor(
 		ast: MLASTDocument,

--- a/packages/@markuplint/ml-core/src/test/index.ts
+++ b/packages/@markuplint/ml-core/src/test/index.ts
@@ -5,6 +5,7 @@ import type { MLASTNode, MLASTToken, MLParser } from '@markuplint/ml-ast';
 import type { Config, PlainData, Pretender, RuleConfigValue } from '@markuplint/ml-config';
 import type { MLMLSpec } from '@markuplint/ml-spec';
 
+import { ARIA_RECOMMENDED_VERSION } from '@markuplint/ml-spec';
 import { parser } from '@markuplint/html-parser';
 import spec from '@markuplint/html-spec';
 
@@ -44,7 +45,9 @@ export function createTestDocument<T extends RuleConfigValue = any, O extends Pl
 			: options.parser.parse(sourceCode, options.config?.parserOptions)
 		: parser.parse(sourceCode, options?.config?.parserOptions);
 	const ruleset = convertRuleset(options?.config);
-	const document = new MLDocument<T, O>(ast, ruleset, [options?.specs ?? ({} as any), {}]);
+	const document = new MLDocument<T, O>(ast, ruleset, [options?.specs ?? ({} as any), {}], {
+		ariaVersion: ARIA_RECOMMENDED_VERSION,
+	});
 	return document;
 }
 

--- a/packages/@markuplint/ml-core/src/types.ts
+++ b/packages/@markuplint/ml-core/src/types.ts
@@ -2,7 +2,7 @@ import type { AnyMLRule } from './ml-rule/index.js';
 import type { Ruleset } from './ruleset/index.js';
 import type { LocaleSet } from '@markuplint/i18n';
 import type { MLParser, ParserOptions } from '@markuplint/ml-ast';
-import type { Pretender, SeverityOptions } from '@markuplint/ml-config';
+import type { Pretender, RuleCommonSettings, SeverityOptions } from '@markuplint/ml-config';
 import type { ExtendedSpec, MLMLSpec } from '@markuplint/ml-spec';
 
 /**
@@ -21,6 +21,7 @@ export type MLFabric = {
 	readonly rules: readonly Readonly<AnyMLRule>[];
 	readonly locale: LocaleSet;
 	readonly schemas: MLSchema;
+	readonly ruleCommonSettings: RuleCommonSettings;
 	readonly parserOptions: ParserOptions;
 	readonly severity: SeverityOptions;
 	readonly pretenders: readonly Pretender[];

--- a/packages/@markuplint/rules/src/neighbor-popovers/index.ts
+++ b/packages/@markuplint/rules/src/neighbor-popovers/index.ts
@@ -1,11 +1,7 @@
 import { createRule } from '@markuplint/ml-core';
-import { mayBeFocusable } from '@markuplint/ml-spec';
+import { ARIA_RECOMMENDED_VERSION, mayBeFocusable } from '@markuplint/ml-spec';
 
 import meta from './meta.js';
-
-// TODO: It will be received from config
-/** The ARIA specification version used for accessible name computation. */
-const ARIA_VERSION = '1.2';
 
 /**
  * Command values from the Invoker Commands API that relate to popover behavior.
@@ -24,6 +20,8 @@ const POPOVER_COMMANDS = new Set(['toggle-popover', 'show-popover', 'hide-popove
 export default createRule({
 	meta: meta,
 	verify({ document, report, t }) {
+		const ariaVersion = document.ruleCommonSettings?.ariaVersion ?? ARIA_RECOMMENDED_VERSION;
+
 		const triggers = document.querySelectorAll('[popovertarget], [commandfor]');
 		Triggers: for (const trigger of triggers) {
 			let targetId: string | null = null;
@@ -58,7 +56,7 @@ export default createRule({
 				if (
 					(node.is(node.ELEMENT_NODE) &&
 						// Element has accessible name
-						(node.getAccessibleName(ARIA_VERSION) ||
+						(node.getAccessibleName(ariaVersion) ||
 							// Element is focusable
 							mayBeFocusable(node, node.ownerMLDocument.specs))) ||
 					(node.is(node.TEXT_NODE) &&

--- a/packages/@markuplint/rules/src/no-refer-to-non-existent-id/index.ts
+++ b/packages/@markuplint/rules/src/no-refer-to-non-existent-id/index.ts
@@ -20,7 +20,7 @@ const HYPERLINK_SELECTOR = 'a[href], area[href]';
 export default createRule({
 	meta: meta,
 	defaultOptions: {
-		ariaVersion: ARIA_RECOMMENDED_VERSION as ARIAVersion,
+		ariaVersion: undefined as ARIAVersion | undefined,
 		fragmentRefersNameAttr: false,
 	},
 	async verify({ document, report, t }) {
@@ -122,7 +122,10 @@ export default createRule({
 				}
 			}
 
-			const { props } = ariaSpecs(document.specs, attr.rule.options.ariaVersion);
+			const { props } = ariaSpecs(
+				document.specs,
+				attr.rule.options.ariaVersion ?? document.ruleCommonSettings?.ariaVersion ?? ARIA_RECOMMENDED_VERSION,
+			);
 
 			const aria = props.find(prop => prop.name === name);
 			if (aria) {

--- a/packages/@markuplint/rules/src/no-refer-to-non-existent-id/schema.json
+++ b/packages/@markuplint/rules/src/no-refer-to-non-existent-id/schema.json
@@ -10,7 +10,7 @@
 			"properties": {
 				"ariaVersion": {
 					"type": "string",
-					"enum": ["1.1", "1.2"],
+					"enum": ["1.1", "1.2", "1.3"],
 					"default": "1.2",
 					"description": "Choose the version of WAI-ARIA to evaluate.",
 					"description:ja": "評価する WAI-ARIA のバージョンを指定します。"

--- a/packages/@markuplint/rules/src/require-accessible-name/index.ts
+++ b/packages/@markuplint/rules/src/require-accessible-name/index.ts
@@ -8,50 +8,40 @@ import { accnameMayBeMutable } from '../helpers.js';
 import meta from './meta.js';
 
 /**
- * Configuration options for the require-accessible-name rule.
- */
-type Option = {
-	/** The ARIA specification version to use for role and accessible name computation. */
-	ariaVersion: ARIAVersion;
-};
-
-/**
  * Rule that requires elements with roles that need accessible names to have one.
  *
  * For each element exposed to the accessibility tree whose computed ARIA role
  * has `accessibleNameRequired` set to `true`, this rule verifies that the element
  * provides a non-empty accessible name.
  */
-export default createRule<boolean, Option>({
+export default createRule({
 	meta: meta,
 	defaultOptions: {
-		ariaVersion: ARIA_RECOMMENDED_VERSION,
+		ariaVersion: undefined as ARIAVersion | undefined,
 	},
 	async verify({ document, report, t }) {
 		await document.walkOn('Element', el => {
+			const ariaVersion =
+				el.rule.options?.ariaVersion ?? document.ruleCommonSettings?.ariaVersion ?? ARIA_RECOMMENDED_VERSION;
+
 			if (accnameMayBeMutable(el, document)) {
 				return;
 			}
 
-			if (!isExposed(el, document.specs, el.rule.options.ariaVersion)) {
+			if (!isExposed(el, document.specs, ariaVersion)) {
 				return;
 			}
 
-			const computed = getComputedRole(document.specs, el, el.rule.options.ariaVersion);
+			const computed = getComputedRole(document.specs, el, ariaVersion);
 			if (!computed.role) {
 				return;
 			}
-			const roleSpec = getRoleSpec(
-				document.specs,
-				computed.role.name,
-				el.namespaceURI,
-				el.rule.options.ariaVersion,
-			);
+			const roleSpec = getRoleSpec(document.specs, computed.role.name, el.namespaceURI, ariaVersion);
 			if (!roleSpec || !roleSpec.accessibleNameRequired) {
 				return;
 			}
 
-			const hasAccessibleName = !!el.getAccessibleName(el.rule.options.ariaVersion).trim();
+			const hasAccessibleName = !!el.getAccessibleName(ariaVersion).trim();
 
 			if (!hasAccessibleName) {
 				report({ scope: el, message: t('Require {0}', 'accessible name') });

--- a/packages/@markuplint/rules/src/require-accessible-name/schema.json
+++ b/packages/@markuplint/rules/src/require-accessible-name/schema.json
@@ -10,7 +10,7 @@
 			"properties": {
 				"ariaVersion": {
 					"type": "string",
-					"enum": ["1.1", "1.2"],
+					"enum": ["1.1", "1.2", "1.3"],
 					"default": "1.2",
 					"description": "Choose the version of WAI-ARIA to evaluate.",
 					"description:ja": "評価するWAI-ARIAのバージョンを指定します。"

--- a/packages/@markuplint/rules/src/wai-aria/checkings/abstract-role.ts
+++ b/packages/@markuplint/rules/src/wai-aria/checkings/abstract-role.ts
@@ -1,7 +1,7 @@
 import type { Options } from '../types.js';
 import type { AttrChecker } from '@markuplint/ml-core';
 
-import { ariaSpecs } from '@markuplint/ml-spec';
+import { ARIA_RECOMMENDED_VERSION, ariaSpecs } from '@markuplint/ml-spec';
 
 /**
  * Checks whether the `role` attribute value refers to an abstract WAI-ARIA role.
@@ -15,7 +15,11 @@ import { ariaSpecs } from '@markuplint/ml-spec';
 export const checkingAbstractRole: AttrChecker<boolean, Options> =
 	({ attr }) =>
 	t => {
-		const { roles } = ariaSpecs(attr.ownerMLDocument.specs, attr.rule.options.version);
+		const ariaVersion =
+			attr.rule.options?.version ??
+			attr.ownerMLDocument.ruleCommonSettings?.ariaVersion ??
+			ARIA_RECOMMENDED_VERSION;
+		const { roles } = ariaSpecs(attr.ownerMLDocument.specs, ariaVersion);
 		const tokens = attr.tokenList?.allTokens();
 		if (!tokens) {
 			return;

--- a/packages/@markuplint/rules/src/wai-aria/checkings/disallowed-prop.ts
+++ b/packages/@markuplint/rules/src/wai-aria/checkings/disallowed-prop.ts
@@ -2,7 +2,7 @@ import type { Options } from '../types.js';
 import type { AttrChecker } from '@markuplint/ml-core';
 import type { ARIAProperty, ARIARole } from '@markuplint/ml-spec';
 
-import { getARIA } from '@markuplint/ml-spec';
+import { ARIA_RECOMMENDED_VERSION, getARIA } from '@markuplint/ml-spec';
 
 /**
  * Checks whether an ARIA property or state is disallowed on the element's computed role.
@@ -35,13 +35,18 @@ export const checkingDisallowedProp: AttrChecker<
 		if (!/^aria-/i.test(attr.name)) {
 			return;
 		}
+
+		const ariaVersion =
+			attr.rule.options?.version ??
+			attr.ownerMLDocument.ruleCommonSettings?.ariaVersion ??
+			ARIA_RECOMMENDED_VERSION;
 		const statesAndProp = role.ownedProperties.find(p => p.name === attr.name);
 		const propSpec = propSpecs.find(p => p.name === attr.name);
 		const elAriaSpec = getARIA(
 			attr.ownerMLDocument.specs,
 			attr.ownerElement.localName,
 			attr.ownerElement.namespaceURI,
-			attr.rule.options.version,
+			ariaVersion,
 			attr.ownerElement.matches.bind(attr.ownerElement),
 		);
 

--- a/packages/@markuplint/rules/src/wai-aria/checkings/implicit-role.ts
+++ b/packages/@markuplint/rules/src/wai-aria/checkings/implicit-role.ts
@@ -1,7 +1,7 @@
 import type { Options } from '../types.js';
 import type { AttrChecker } from '@markuplint/ml-core';
 
-import { getImplicitRoleName } from '@markuplint/ml-spec';
+import { ARIA_RECOMMENDED_VERSION, getImplicitRoleName } from '@markuplint/ml-spec';
 
 /**
  * Checks whether the explicit `role` attribute duplicates the element's implicit (native) role.
@@ -19,11 +19,12 @@ export const checkingImplicitRole: AttrChecker<boolean, Options> =
 		if (!tokens) {
 			return;
 		}
-		const implicitRole = getImplicitRoleName(
-			attr.ownerElement,
-			attr.rule.options.version,
-			attr.ownerMLDocument.specs,
-		);
+
+		const ariaVersion =
+			attr.rule.options?.version ??
+			attr.ownerMLDocument.ruleCommonSettings?.ariaVersion ??
+			ARIA_RECOMMENDED_VERSION;
+		const implicitRole = getImplicitRoleName(attr.ownerElement, ariaVersion, attr.ownerMLDocument.specs);
 		for (const token of tokens) {
 			if (implicitRole === token.raw) {
 				return {

--- a/packages/@markuplint/rules/src/wai-aria/checkings/non-existent-role.ts
+++ b/packages/@markuplint/rules/src/wai-aria/checkings/non-existent-role.ts
@@ -1,7 +1,7 @@
 import type { Options } from '../types.js';
 import type { AttrChecker } from '@markuplint/ml-core';
 
-import { ariaSpecs } from '@markuplint/ml-spec';
+import { ARIA_RECOMMENDED_VERSION, ariaSpecs } from '@markuplint/ml-spec';
 
 /**
  * Checks whether the `role` attribute value refers to a role that does not exist
@@ -16,7 +16,11 @@ import { ariaSpecs } from '@markuplint/ml-spec';
 export const checkingNonExistentRole: AttrChecker<boolean, Options> =
 	({ attr }) =>
 	t => {
-		const { roles, graphicsRoles } = ariaSpecs(attr.ownerMLDocument.specs, attr.rule.options.version);
+		const ariaVersion =
+			attr.rule.options?.version ??
+			attr.ownerMLDocument.ruleCommonSettings?.ariaVersion ??
+			ARIA_RECOMMENDED_VERSION;
+		const { roles, graphicsRoles } = ariaSpecs(attr.ownerMLDocument.specs, ariaVersion);
 		const tokens = attr.tokenList?.allTokens();
 		if (!tokens) {
 			return;

--- a/packages/@markuplint/rules/src/wai-aria/checkings/permitted-roles.ts
+++ b/packages/@markuplint/rules/src/wai-aria/checkings/permitted-roles.ts
@@ -1,7 +1,7 @@
 import type { Options } from '../types.js';
 import type { AttrChecker } from '@markuplint/ml-core';
 
-import { getPermittedRoles } from '@markuplint/ml-spec';
+import { ARIA_RECOMMENDED_VERSION, getPermittedRoles } from '@markuplint/ml-spec';
 
 /**
  * Checks whether the explicit `role` attribute value is permitted on the element
@@ -16,8 +16,12 @@ import { getPermittedRoles } from '@markuplint/ml-spec';
 export const checkingPermittedRoles: AttrChecker<boolean, Options> =
 	({ attr }) =>
 	t => {
+		const ariaVersion =
+			attr.rule.options?.version ??
+			attr.ownerMLDocument.ruleCommonSettings?.ariaVersion ??
+			ARIA_RECOMMENDED_VERSION;
 		const el = attr.ownerElement;
-		const permittedRoles = getPermittedRoles(el, el.rule.options.version, attr.ownerMLDocument.specs);
+		const permittedRoles = getPermittedRoles(el, ariaVersion, attr.ownerMLDocument.specs);
 		if (permittedRoles.length === 0) {
 			return {
 				scope: attr,

--- a/packages/@markuplint/rules/src/wai-aria/checkings/presentational-children.ts
+++ b/packages/@markuplint/rules/src/wai-aria/checkings/presentational-children.ts
@@ -2,7 +2,7 @@ import type { Options } from '../types.js';
 import type { Element, ElementChecker } from '@markuplint/ml-core';
 import type { ComputedRole } from '@markuplint/ml-spec';
 
-import { getComputedRole } from '@markuplint/ml-spec';
+import { ARIA_RECOMMENDED_VERSION, getComputedRole } from '@markuplint/ml-spec';
 
 /**
  * Checks whether ARIA attributes are applied to descendants of an element whose
@@ -73,9 +73,11 @@ function getAncestorHasPresentationalChildren(
 	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
 	el: Element<boolean, Options>,
 ): ComputedRole | null {
+	const ariaVersion =
+		el.rule.options?.version ?? el.ownerMLDocument.ruleCommonSettings?.ariaVersion ?? ARIA_RECOMMENDED_VERSION;
 	let current: Element<boolean, Options> | null = el.parentElement;
 	while (current) {
-		const computed = getComputedRole(el.ownerMLDocument.specs, current, el.rule.options.version);
+		const computed = getComputedRole(el.ownerMLDocument.specs, current, ariaVersion);
 		if (computed.role?.childrenPresentational) {
 			return computed;
 		}

--- a/packages/@markuplint/rules/src/wai-aria/checkings/required-owned-elements.ts
+++ b/packages/@markuplint/rules/src/wai-aria/checkings/required-owned-elements.ts
@@ -2,7 +2,7 @@ import type { Options } from '../types.js';
 import type { Element, ElementChecker, Block } from '@markuplint/ml-core';
 import type { ARIARole } from '@markuplint/ml-spec';
 
-import { getComputedRole, isRequiredOwnedElement } from '@markuplint/ml-spec';
+import { ARIA_RECOMMENDED_VERSION, getComputedRole, isRequiredOwnedElement } from '@markuplint/ml-spec';
 
 /**
  * Represents a classified child node when checking required owned elements.
@@ -67,7 +67,12 @@ export const checkingRequiredOwnedElements: ElementChecker<
 				if (child.matches('[aria-busy="true" i]')) {
 					return [child, 'BUSY'];
 				}
-				const computedChild = getComputedRole(child.ownerMLDocument.specs, child, child.rule.options.version);
+
+				const ariaVersion =
+					child.rule.options?.version ??
+					child.ownerMLDocument.ruleCommonSettings?.ariaVersion ??
+					ARIA_RECOMMENDED_VERSION;
+				const computedChild = getComputedRole(child.ownerMLDocument.specs, child, ariaVersion);
 				if (
 					role.requiredOwnedElements.some(ownedRole =>
 						isRequiredOwnedElement(
@@ -75,7 +80,7 @@ export const checkingRequiredOwnedElements: ElementChecker<
 							computedChild.role,
 							ownedRole,
 							child.ownerMLDocument.specs,
-							child.rule.options.version,
+							ariaVersion,
 						),
 					)
 				) {

--- a/packages/@markuplint/rules/src/wai-aria/checkings/required-prop.ts
+++ b/packages/@markuplint/rules/src/wai-aria/checkings/required-prop.ts
@@ -1,7 +1,7 @@
 import type { Options } from '../types.js';
 import type { ElementChecker } from '@markuplint/ml-core';
 
-import { getARIA, type ARIAProperty, type ARIARole } from '@markuplint/ml-spec';
+import { ARIA_RECOMMENDED_VERSION, getARIA, type ARIAProperty, type ARIARole } from '@markuplint/ml-spec';
 
 /**
  * Checks whether all required ARIA properties for the element's computed role are present.
@@ -38,11 +38,16 @@ export const checkingRequiredProp: ElementChecker<
 			if (!has) {
 				const propSpec = propSpecs.find(p => p.name === requiredProp);
 
+				const ariaVersion =
+					el.rule.options?.version ??
+					el.ownerMLDocument.ruleCommonSettings?.ariaVersion ??
+					ARIA_RECOMMENDED_VERSION;
+
 				const elAriaSpec = getARIA(
 					el.ownerMLDocument.specs,
 					el.localName,
 					el.namespaceURI,
-					el.rule.options.version,
+					ariaVersion,
 					el.matches.bind(el),
 				);
 

--- a/packages/@markuplint/rules/src/wai-aria/index.ts
+++ b/packages/@markuplint/rules/src/wai-aria/index.ts
@@ -1,6 +1,7 @@
 import type { Options } from './types.js';
 
 import { createRule, getAttrSpecs, getComputedRole, ariaSpecs, getSpec } from '@markuplint/ml-core';
+import type { ARIAVersion } from '@markuplint/ml-spec';
 import { ARIA_RECOMMENDED_VERSION } from '@markuplint/ml-spec';
 
 import { Collection } from '../helpers.js';
@@ -45,7 +46,7 @@ export default createRule<boolean, Options>({
 		disallowSetImplicitRole: true,
 		disallowSetImplicitProps: true,
 		disallowDefaultValue: false,
-		version: ARIA_RECOMMENDED_VERSION,
+		version: undefined as ARIAVersion | undefined,
 	},
 	async verify({ document, report, t }) {
 		await document.walkOn('Element', el => {
@@ -69,8 +70,11 @@ export default createRule<boolean, Options>({
 				return;
 			}
 
-			const computed = getComputedRole(document.specs, el, el.rule.options.version);
-			const { props: propSpecs } = ariaSpecs(document.specs, el.rule.options.version);
+			const ariaVersion =
+				el.rule.options?.version ?? document.ruleCommonSettings?.ariaVersion ?? ARIA_RECOMMENDED_VERSION;
+
+			const computed = getComputedRole(document.specs, el, ariaVersion);
+			const { props: propSpecs } = ariaSpecs(document.specs, ariaVersion);
 
 			if (roleAttr) {
 				if (report(checkingNonExistentRole({ attr: roleAttr }))) {

--- a/packages/@markuplint/rules/src/wai-aria/schema.json
+++ b/packages/@markuplint/rules/src/wai-aria/schema.json
@@ -52,7 +52,7 @@
 				},
 				"version": {
 					"type": "string",
-					"enum": ["1.1", "1.2"],
+					"enum": ["1.1", "1.2", "1.3"],
 					"default": "1.2",
 					"description": "Choose the version of WAI-ARIA to evaluate.",
 					"description:ja": "評価するWAI-ARIAのバージョンを指定します。"

--- a/packages/@markuplint/rules/src/wai-aria/types.ts
+++ b/packages/@markuplint/rules/src/wai-aria/types.ts
@@ -28,5 +28,5 @@ export type Options = {
 	/** Whether to disallow explicitly setting an ARIA property to its default value. */
 	disallowDefaultValue: boolean;
 	/** The WAI-ARIA specification version to validate against. */
-	version: ARIAVersion;
+	version?: ARIAVersion;
 };

--- a/packages/markuplint/README.md
+++ b/packages/markuplint/README.md
@@ -81,7 +81,7 @@ Options
 	--locale                               Locale of the message of violation. Default is an OS setting.
 	--no-color,                            Output no color.
 	--problem-only,          -p            Output only problems, without passeds.
-	--allow-warnings                       Return status code 0 even if there are warnings.
+	--no-allow-warnings                    Return status code 1 even if there are warnings.
 	--allow-empty-input                    Return status code 1 even if there are no input files.
 	--show-config                          Output computed configuration of the target file. Supports "details" and empty. Default: empty.
 	--verbose                              Output with detailed information.

--- a/packages/markuplint/src/api/ml-engine.ts
+++ b/packages/markuplint/src/api/ml-engine.ts
@@ -346,6 +346,8 @@ export class MLEngine extends Emitter<MLEngineEventMap> {
 
 		const locale = await i18n(this.#options?.locale);
 
+		const ruleCommonSettings = configSet.config.ruleCommonSettings ?? {};
+
 		if (fileLog.enabled) {
 			fileLog(
 				'Loaded %d rules: %O',
@@ -363,6 +365,7 @@ export class MLEngine extends Emitter<MLEngineEventMap> {
 			schemas,
 			rules,
 			locale,
+			ruleCommonSettings,
 			configErrors: configSet.errs,
 		};
 	}

--- a/packages/markuplint/src/cli/bootstrap.ts
+++ b/packages/markuplint/src/cli/bootstrap.ts
@@ -21,7 +21,7 @@ Options
 	--locale                               Locale of the message of violation. Default is an OS setting.
 	--no-color,                            Output no color.
 	--problem-only,          -p            Output only problems, without passeds.
-	--allow-warnings                       Return status code 0 even if there are warnings.
+	--no-allow-warnings                    Return status code 1 even if there are warnings.
 	--allow-empty-input                    Return status code 1 even if there are no input files.
 	--show-config                          Output computed configuration of the target file. Supports "details" and empty. Default: empty.
 	--verbose                              Output with detailed information.
@@ -87,8 +87,7 @@ export const cli = meow(help, {
 		},
 		allowWarnings: {
 			type: 'boolean',
-			// TODO: It will be changed to `true` in the next major version.
-			default: false,
+			default: true,
 		},
 		allowEmptyInput: {
 			type: 'boolean',

--- a/packages/markuplint/src/cli/index.spec.ts
+++ b/packages/markuplint/src/cli/index.spec.ts
@@ -68,17 +68,21 @@ describe('STDOUT Test', () => {
 		});
 		expect(stdout).toBe('');
 		expect(stderr.split('\n').length).toBe(30);
-		expect(exitCode).toBe(1);
+		expect(exitCode).toBe(0);
 	});
 
 	test('allow warnings', async () => {
 		const targetFilePath = path.resolve(__dirname, '../../../../test/fixture/002.html');
-		const { stdout, stderr, exitCode } = await execa(entryFilePath, ['--allow-warnings', escape(targetFilePath)], {
-			reject: false,
-		});
+		const { stdout, stderr, exitCode } = await execa(
+			entryFilePath,
+			['--no-allow-warnings', escape(targetFilePath)],
+			{
+				reject: false,
+			},
+		);
 		expect(stdout).toBe('');
 		expect(stderr.split('\n').length).toBe(24);
-		expect(exitCode).toBe(0);
+		expect(exitCode).toBe(1);
 	});
 
 	test('format', async () => {
@@ -139,7 +143,7 @@ describe('STDOUT Test', () => {
 		const { exitCode } = await execa(entryFilePath, ['--severity-parse-error', 'warning', escape(targetFilePath)], {
 			reject: false,
 		});
-		expect(exitCode).toBe(1);
+		expect(exitCode).toBe(0);
 	});
 
 	test('--severity-parse-error off', async () => {
@@ -188,7 +192,7 @@ describe('STDOUT Test', () => {
 		const violationCount = stderr.split('\n').filter(line => line.includes('<markuplint>')).length;
 
 		expect(violationCount).toBe(1);
-		expect(exitCode).toBe(1); // Still should exit with error
+		expect(exitCode).toBe(0); // allowWarnings defaults to true, so warnings-only exits with 0
 	});
 
 	test('--max-count=0 (no limit)', async () => {
@@ -328,8 +332,8 @@ describe('--max-warnings option', () => {
 			reject: false,
 		});
 
-		// Should behave same as without --max-warnings
-		expect(exitCode).toBe(1); // Has violations, so exit code 1
+		// Should behave same as without --max-warnings (allowWarnings defaults to true)
+		expect(exitCode).toBe(0);
 	});
 
 	test('--max-warnings=0 exits with code 1 when warnings exist', async () => {
@@ -389,15 +393,15 @@ describe('--max-warnings option', () => {
 		expect(exitCode3).toBe(1);
 	});
 
-	test('--max-warnings with errors still returns exit code 1', async () => {
-		// Use a file that has both errors and warnings
+	test('--max-warnings with warnings-only file still returns exit code 0', async () => {
+		// Use a file that has warnings only (allowWarnings defaults to true)
 		const targetFilePath = path.resolve(__dirname, '../../../../test/fixture/002.html');
 
 		const { exitCode } = await execa(entryFilePath, ['--max-warnings=100', escape(targetFilePath)], {
 			reject: false,
 		});
 
-		// Errors take precedence, so should still be exit code 1
-		expect(exitCode).toBe(1);
+		// allowWarnings defaults to true, and 6 warnings < 100 limit
+		expect(exitCode).toBe(0);
 	});
 });

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -84,10 +84,11 @@
 				},
 				"markuplint.hover.accessibility.ariaVersion": {
 					"type": "string",
-					"markdownDescription": "Set `1.1` or `1.2` WAI-ARIA version; Default is `1.2`.",
+					"markdownDescription": "Set WAI-ARIA version; Default is `1.2`.",
 					"enum": [
 						"1.1",
-						"1.2"
+						"1.2",
+						"1.3"
 					],
 					"default": "1.2"
 				}

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -25,6 +25,7 @@ import {
 	warningToPopup,
 } from './lsp.js';
 import { StatusBar } from './status-bar.js';
+import { ARIA_RECOMMENDED_VERSION } from '@markuplint/ml-spec';
 
 let client: LanguageClient;
 let logger: Logger;
@@ -77,7 +78,7 @@ export function activate(
 			hover: {
 				accessibility: {
 					enable: true,
-					ariaVersion: '1.2',
+					ariaVersion: ARIA_RECOMMENDED_VERSION,
 				},
 			},
 		};

--- a/vscode/src/server/get-module.ts
+++ b/vscode/src/server/get-module.ts
@@ -1,5 +1,5 @@
 import type { Log } from '../types.js';
-import type { ARIAVersion } from '@markuplint/ml-spec';
+import { ARIA_RECOMMENDED_VERSION, type ARIAVersion } from '@markuplint/ml-spec';
 
 import path from 'node:path';
 
@@ -53,7 +53,7 @@ export async function getModule(log: Log): Promise<Module> {
 		version,
 		moduleType,
 		markuplint,
-		ariaRecommendedVersion: '1.2',
+		ariaRecommendedVersion: ARIA_RECOMMENDED_VERSION,
 	};
 }
 

--- a/vscode/tsconfig.json
+++ b/vscode/tsconfig.json
@@ -6,6 +6,9 @@
 	},
 	"references": [
 		{
+			"path": "../packages/@markuplint/ml-spec"
+		},
+		{
 			"path": "../packages/markuplint"
 		}
 	]


### PR DESCRIPTION
## Summary

- Add `ruleCommonSettings.ariaVersion` config option as a global ARIA version fallback for all rules
- Change `--allow-warnings` CLI flag default to `true` (breaking: warnings no longer cause exit code 1)
- Use `ARIA_RECOMMENDED_VERSION` constant in VS Code extension instead of hardcoded value
- Add ARIA 1.3 to version enums across rules and VS Code config

## Breaking Change

`allowWarnings` now defaults to `true`. Warnings no longer cause a non-zero exit code.
To preserve the v4 behavior, use `--no-allow-warnings`.

## Resolution Priority (ariaVersion)

1. Rule-level option (`options.version` / `options.ariaVersion`)
2. `ruleCommonSettings.ariaVersion` (global config fallback)
3. `ARIA_RECOMMENDED_VERSION` (built-in default)

## Commits (9)

1. `feat(ml-config)`: add `ruleCommonSettings.ariaVersion` option
2. `feat(ml-core)`: wire `ruleCommonSettings` through MLCore to Document
3. `feat(rules)`: use `ruleCommonSettings.ariaVersion` fallback in ARIA rules
4. `feat(markuplint)!`: wire `ruleCommonSettings` and set `allowWarnings` default to `true`
5. `feat(vscode)`: use `ARIA_RECOMMENDED_VERSION` constant and add 1.3 to enum
6. `chore`: add `ruleCommonSettings` to `config.schema.json`
7. `docs(ml-config)`: add JSDoc to `RuleCommonSettings` type
8. `docs(ml-core)`: add JSDoc and document `ruleCommonSettings`
9. `docs`: add v4-to-v5 migration guides for CLI and config

## Test plan

- [x] `yarn build` — 37 projects all pass
- [x] `yarn lint-check:eslint` — clean
- [x] `npx vitest run` — 141 test files, 1419 tests pass
- [x] CLI tests updated for new `allowWarnings` default

🤖 Generated with [Claude Code](https://claude.com/claude-code)