### PR TITLE
Make i18n function synchronous and upgrade os-locale

### DIFF
--- a/packages/@markuplint/rules/src/attr-check.spec.ts
+++ b/packages/@markuplint/rules/src/attr-check.spec.ts
@@ -8,8 +8,8 @@ import { valueCheck } from './attr-check.js';
 
 let t: Translator;
 
-beforeAll(async () => {
-	const locale = await i18n('en');
+beforeAll(() => {
+	const locale = i18n('en');
 	t = translator(locale);
 });
 

--- a/packages/@markuplint/rules/src/create-message.spec.ts
+++ b/packages/@markuplint/rules/src/create-message.spec.ts
@@ -8,8 +8,8 @@ import { __createMessageValueExpected } from './create-message.js';
 
 let t: Translator;
 
-beforeAll(async () => {
-	const locale = await i18n('en');
+beforeAll(() => {
+	const locale = i18n('en');
 	t = translator(locale);
 });
 

--- a/packages/markuplint/package.json
+++ b/packages/markuplint/package.json
@@ -41,7 +41,7 @@
 		"chokidar": "5.0.0",
 		"debug": "4.4.3",
 		"meow": "14.0.0",
-		"os-locale": "6.0.2",
+		"os-locale": "8.0.0",
 		"strict-event-emitter": "0.5.1",
 		"strip-ansi": "7.1.2",
 		"type-fest": "4.41.0"

--- a/packages/markuplint/src/api/ml-engine.ts
+++ b/packages/markuplint/src/api/ml-engine.ts
@@ -240,8 +240,8 @@ export class MLEngine extends Emitter<MLEngineEventMap> {
 		return core;
 	}
 
-	private async i18n() {
-		const i18nSettings = await i18n(this.#options?.locale);
+	private i18n() {
+		const i18nSettings = i18n(this.#options?.locale);
 		this.emit('i18n', this.#file.path, i18nSettings);
 		return i18nSettings;
 	}
@@ -344,7 +344,7 @@ export class MLEngine extends Emitter<MLEngineEventMap> {
 		const rules = await this.resolveRules(configSet.plugins, ruleset);
 		fileLog('Resolved rules: %O', rules);
 
-		const locale = await i18n(this.#options?.locale);
+		const locale = i18n(this.#options?.locale);
 
 		if (fileLog.enabled) {
 			fileLog(

--- a/packages/markuplint/src/i18n.spec.ts
+++ b/packages/markuplint/src/i18n.spec.ts
@@ -2,24 +2,24 @@ import { test, expect } from 'vitest';
 
 import { i18n } from './i18n.js';
 
-test('ja', async () => {
-	const locale = await i18n('ja');
+test('ja', () => {
+	const locale = i18n('ja');
 
 	expect(locale.locale).toBe('ja');
 	expect(locale.keywords).toBeTruthy();
 	expect(locale.sentences).toBeTruthy();
 });
 
-test('en', async () => {
-	const locale = await i18n('en');
+test('en', () => {
+	const locale = i18n('en');
 
 	expect(locale.locale).toBe('en');
 	expect(locale.keywords).toBeTruthy();
 	expect(locale.sentences).toBeFalsy();
 });
 
-test('fallback', async () => {
-	const locale = await i18n('foo');
+test('fallback', () => {
+	const locale = i18n('foo');
 
 	expect(locale.locale).toBe('en');
 	expect(locale.keywords).toBeTruthy();

--- a/packages/markuplint/src/i18n.ts
+++ b/packages/markuplint/src/i18n.ts
@@ -1,17 +1,8 @@
 import type { LocaleSet } from '@markuplint/i18n';
 
-import { osLocale } from 'os-locale';
+import osLocale from 'os-locale';
 
 import { getJsonModule } from './get-json-module.js';
-
-let cachedLocale: string | null = null;
-
-async function getLocale() {
-	if (!cachedLocale) {
-		cachedLocale = await osLocale({ spawn: true });
-	}
-	return cachedLocale;
-}
 
 /**
  * Loads the locale-specific message set for use in violation messages.
@@ -23,7 +14,7 @@ async function getLocale() {
  * @returns The loaded locale set containing translated messages and the resolved locale code.
  */
 export async function i18n(locale?: string): Promise<LocaleSet> {
-	locale = locale ?? (await getLocale()) ?? 'en';
+	locale = locale ?? osLocale() ?? 'en';
 	const langCode = locale.split('-')[0] ?? locale;
 	const loadLocaleSet = getJsonModule<LocaleSet>(`@markuplint/i18n/locales/${langCode}.json`);
 	const localeSet: LocaleSet = loadLocaleSet ?? getJsonModule('@markuplint/i18n/locales/en.json')!;

--- a/packages/markuplint/src/i18n.ts
+++ b/packages/markuplint/src/i18n.ts
@@ -13,7 +13,7 @@ import { getJsonModule } from './get-json-module.js';
  * @param locale - An optional BCP 47 locale string (e.g., `"ja"`, `"en-US"`).
  * @returns The loaded locale set containing translated messages and the resolved locale code.
  */
-export async function i18n(locale?: string): Promise<LocaleSet> {
+export function i18n(locale?: string): LocaleSet {
 	locale = locale ?? osLocale() ?? 'en';
 	const langCode = locale.split('-')[0] ?? locale;
 	const loadLocaleSet = getJsonModule<LocaleSet>(`@markuplint/i18n/locales/${langCode}.json`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -10678,13 +10678,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"invert-kv@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "invert-kv@npm:3.0.1"
-  checksum: 10c0/a3d90951a635e35dea9c9a5fd749e981e9c54e8a362ad80b2253dad03b9257314b7c4e4d250d61bcd79698ccd5f4c6b0c750cd991bb5ce16352bf830e77ea64b
-  languageName: node
-  linkType: hard
-
 "ip-address@npm:10.0.1, ip-address@npm:^10.0.1":
   version: 10.0.1
   resolution: "ip-address@npm:10.0.1"
@@ -11891,15 +11884,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lcid@npm:^3.1.1":
-  version: 3.1.1
-  resolution: "lcid@npm:3.1.1"
-  dependencies:
-    invert-kv: "npm:^3.0.0"
-  checksum: 10c0/43a39c39d92d756b9671691bb36ac2667c44c4a7e30f55403dc9c98ca4e7bba8c2b35599e8d7967163d65c1697e0d136596e9a9b9bccbd2292caf915c77416a4
-  languageName: node
-  linkType: hard
-
 "lcov-parse@npm:^1.0.0":
   version: 1.0.0
   resolution: "lcov-parse@npm:1.0.0"
@@ -12643,7 +12627,7 @@ __metadata:
     chokidar: "npm:5.0.0"
     debug: "npm:4.4.3"
     meow: "npm:14.0.0"
-    os-locale: "npm:6.0.2"
+    os-locale: "npm:8.0.0"
     strict-event-emitter: "npm:0.5.1"
     strip-ansi: "npm:7.1.2"
     type-fest: "npm:4.41.0"
@@ -14130,12 +14114,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"os-locale@npm:6.0.2":
-  version: 6.0.2
-  resolution: "os-locale@npm:6.0.2"
-  dependencies:
-    lcid: "npm:^3.1.1"
-  checksum: 10c0/15778a074367ff91ab7a3701f374fca8897cdea39e5c542c4df58a6ada0b811f0e98eb0e3a5401ca7dcf29bd20f37c9786864dbe051b363c56ecd2f481f90254
+"os-locale@npm:8.0.0":
+  version: 8.0.0
+  resolution: "os-locale@npm:8.0.0"
+  checksum: 10c0/5e7bea7afcbfb70c8b36424aadf85f7f170aabc7b50735f73ebe45046082a346f354bc9b79718bd304c0d7f2439825258617b67c7d9440cff7e88131b5426329
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #???

## What is the purpose of this PR?

- [x] Improve or refactor core features
- [x] Update specs

### Description

This PR refactors the `i18n` function to be synchronous instead of asynchronous by upgrading `os-locale` from v6 to v8, which now provides a synchronous API.

**Changes:**
- Changed `i18n()` function from async to sync by calling `osLocale()` synchronously instead of `await osLocale()`
- Removed the `getLocale()` helper function and its caching mechanism, as they are no longer needed
- Updated the import statement for `os-locale` to use default export syntax
- Updated all call sites to remove `await` keywords:
  - `MLEngine.i18n()` method
  - `MLEngine.lint()` method
  - Test files in `attr-check.spec.ts` and `create-message.spec.ts`
- Upgraded `os-locale` dependency from `6.0.2` to `8.0.0` in `package.json`

This simplification removes unnecessary async complexity while maintaining the same functionality.

## Checklist

- [x] Improve or refactor core features
  - [x] Updated tests to reflect synchronous behavior

https://claude.ai/code/session_01JoUKT8EMJqA83TsTtxUowv