### PR TITLE
feat(ml-core): flatten each/end block child nodes

### DIFF
--- a/packages/@markuplint/ml-core/src/index.spec.ts
+++ b/packages/@markuplint/ml-core/src/index.spec.ts
@@ -911,6 +911,24 @@ describe('Conditional Child Nodes', () => {
 	});
 });
 
+describe('ChildNode with blockBehavior', () => {
+	test('each', async () => {
+		const dom = createTestDocument(
+			`
+<dl>
+  {#each collection.items as item}
+    <dt>{item.name}</dt>
+  {/each}
+</dl>
+`.replaceAll(/\t|\n/g, ''),
+			{ parser: await import('@markuplint/svelte-parser') },
+		);
+
+		expect(dom.nodeList[0]?.nodeName).toEqual('DL');
+		expect(dom.nodeList[0]?.children[0]?.nodeName).toEqual('DT');
+	});
+});
+
 describe('Fix', () => {
 	test('HTML', () => {
 		const doc = createTestDocument(

--- a/packages/@markuplint/ml-core/src/ml-dom/node/node.ts
+++ b/packages/@markuplint/ml-core/src/ml-dom/node/node.ts
@@ -226,7 +226,11 @@ export abstract class MLNode<
 		const pureChildNodes = [...this.getPureChildNodes()];
 
 		const childNodes = pureChildNodes.flatMap(node => {
-			if (node.isFragment) {
+			if (
+				node.isFragment ||
+				(node.is(node.MARKUPLINT_PREPROCESSOR_BLOCK) &&
+					['each', 'end'].includes(node.blockBehavior?.type ?? ''))
+			) {
 				return [...node.childNodes];
 			}
 			return [node];

--- a/packages/@markuplint/ml-core/src/ml-dom/node/node.ts
+++ b/packages/@markuplint/ml-core/src/ml-dom/node/node.ts
@@ -217,6 +217,8 @@ export abstract class MLNode<
 
 	/**
 	 * The list of child nodes that contains `Element`, `Text`, and `Comment`.
+	 * Fragment nodes and preprocessor blocks with `each` or `end` block behavior
+	 * are transparent — their child nodes are flattened into this list.
 	 *
 	 * @readonly
 	 * @implements DOM API: `Node`


### PR DESCRIPTION
## Summary

- `childNodes` getter now flattens child nodes of preprocessor blocks with `each` or `end` block behavior, similar to how fragment nodes are already flattened
- Added test case for Svelte `{#each}` block verifying child node visibility
- Updated JSDoc for `childNodes` to document the flattening behavior

## Test plan

- [ ] Verify `yarn test --scope @markuplint/ml-core` passes
- [ ] Confirm Svelte `{#each}` block children are visible as direct child nodes of the parent element

🤖 Generated with [Claude Code](https://claude.com/claude-code)