### PR TITLE
test(rules): add loop block and namespace detection tests

### DIFF
--- a/packages/@markuplint/ml-core/ARCHITECTURE.md
+++ b/packages/@markuplint/ml-core/ARCHITECTURE.md
@@ -349,7 +349,7 @@ Template engines (Pug, EJS, Nunjucks, etc.) produce preprocessor-specific blocks
 | `'switch:default'`   | `{% case %}`       | Switch case                |
 | `'end'`              | `{% endswitch %}`  | End of switch              |
 
-`MLNode.conditionalChildNodes()` returns an array of `NodeListOf` arrays — one per conditional branch — so rules can analyze each branch independently.
+`MLNode.conditionalChildNodes()` returns an array of `NodeListOf` arrays — one per conditional branch — so rules can analyze each branch independently. Note that `'each'` blocks do not start a new conditional mode (`'if'` or `'switch'`); they are flattened into `childNodes` and their content is treated as always-present rather than as an alternative branch. Only `'if'`/`'if:elseif'` and `'switch:case'` start new modes that generate null sentinels for the "empty branch" case.
 
 ## Plugin System
 

--- a/packages/@markuplint/ml-core/docs/ml-dom/block.md
+++ b/packages/@markuplint/ml-core/docs/ml-dom/block.md
@@ -45,7 +45,7 @@ Blocks with a recognized `blockBehavior.type` form conditional groups. Each grou
 | `'if:else'`          | Default (else) branch                                      | Branch within current group                                                       |
 | `'switch:case'`      | Switch case branch                                         | Starts a new conditional group                                                    |
 | `'switch:default'`   | Switch default branch                                      | Branch within current group                                                       |
-| `'each'`             | Start of iteration (loop) block                            | Starts a new conditional group                                                    |
+| `'each'`             | Start of iteration (loop) block                            | Continues in current mode (no new mode set); flattened into `childNodes`          |
 | `'each:empty'`       | Empty state for an iteration block                         | Branch within current group                                                       |
 | `'await'`            | Asynchronous block (pending state)                         | Branch within current group                                                       |
 | `'await:then'`       | Resolved state of async block                              | Branch within current group                                                       |
@@ -205,7 +205,7 @@ The inner `{#if b}` block recursively generates its patterns `[<span>X</span>]`,
 
 `MLElement.hasMutableChildren()` uses `blockBehavior` to distinguish between two categories of MLBlock:
 
-- **Blocks WITH `blockBehavior`** (e.g., type `'if'`, `'each'`, `'switch:case'`): Skipped (`continue`) — these are handled by `conditionalChildNodes()` which enumerates all possible patterns
+- **Blocks WITH `blockBehavior`** (e.g., type `'if'`, `'switch:case'`): Skipped (`continue`) — these are handled by `conditionalChildNodes()` which enumerates all possible patterns. Note that `'each'` and `'end'` blocks are flattened into `childNodes` (their children are inlined), so they do not reach `hasMutableChildren()` as blocks
 - **Blocks WITHOUT `blockBehavior`** (`null`): Return `true` immediately — these represent expression outputs like `{value}` or other non-conditional template constructs whose content cannot be statically determined
 
 ```typescript

--- a/packages/@markuplint/rules/src/permitted-contents/index.spec.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/index.spec.ts
@@ -1897,4 +1897,23 @@ describe('Issues', () => {
 			).violations,
 		).toStrictEqual([]);
 	});
+
+	test('#2302', async () => {
+		const sourceCode = `
+<svg>
+	{list.map(item => (
+		<path />
+	))}
+</svg>
+`;
+		expect(
+			(
+				await mlRuleTest(rule, sourceCode, {
+					parser: {
+						'.*': '@markuplint/jsx-parser',
+					},
+				})
+			).violations,
+		).toStrictEqual([]);
+	});
 });

--- a/packages/@markuplint/rules/src/permitted-contents/index.spec.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/index.spec.ts
@@ -1324,6 +1324,242 @@ body
 	});
 });
 
+describe('Loop blocks', () => {
+	test('Svelte', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					`
+<dl>
+	{#each items as item}
+		<dt>{item.key}</dt>
+	{/each}
+</dl>
+<dl>
+	{#each items as item}
+		<dt>{item.key}</dt>
+		<dd>{item.value}</dd>
+	{/each}
+</dl>
+		`,
+					{
+						parser: {
+							'.*': '@markuplint/svelte-parser',
+						},
+					},
+				)
+			).violations,
+		).toStrictEqual([
+			{
+				severity: 'error',
+				line: 2,
+				col: 1,
+				message: 'Require one or more elements. (Need "dd")',
+				raw: '<dl>',
+			},
+		]);
+	});
+
+	test('Vue', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					`
+<template>
+	<dl v-for="item in items">
+		<dt>{item.key}</dt>
+	</dl>
+	<dl v-for="item in items">
+		<dt>{item.key}</dt>
+		<dd>{item.value}</dd>
+	</dl>
+</template>
+		`,
+					{
+						parser: {
+							'.*': '@markuplint/vue-parser',
+						},
+					},
+				)
+			).violations,
+		).toStrictEqual([
+			{
+				severity: 'error',
+				line: 3,
+				col: 2,
+				message: 'Require one or more elements. (Need "dd")',
+				raw: '<dl v-for="item in items">',
+			},
+		]);
+	});
+
+	test('Pug', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					`
+dl
+	each item in items
+		dt= item.key
+dl
+	each item in items
+		dt= item.key
+		dd= item.value
+		`,
+					{
+						parser: {
+							'.*': '@markuplint/pug-parser',
+						},
+					},
+				)
+			).violations,
+		).toStrictEqual([
+			{
+				severity: 'error',
+				line: 2,
+				col: 1,
+				message: 'Require one or more elements. (Need "dd")',
+				raw: 'dl',
+			},
+		]);
+	});
+
+	test('Alpine', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					`
+<dl>
+	<template x-for="color in items" :key="color.id">
+		<dt>{item.key}</dt>
+	</template>
+</dl>
+<dl>
+	<template x-for="color in items" :key="color.id">
+		<dt>{item.key}</dt>
+		<dd>{item.value}</dd>
+	</template>
+</dl>
+		`,
+					{
+						parser: {
+							'.*': '@markuplint/alpine-parser',
+						},
+					},
+				)
+			).violations,
+		).toStrictEqual([
+			{
+				severity: 'error',
+				line: 2,
+				col: 1,
+				message: 'Require one or more elements. (Need "dd")',
+				raw: '<dl>',
+			},
+		]);
+	});
+
+	test('JSX', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					`
+<>
+	<dl>
+		{items.map(item => (
+			<dt>{item}</dt>
+		))}
+	</dl>
+	<dl>
+		{items.map(item => (
+			<>
+				<dt>{item.key}</dt>
+				<dd>{item.value}</dd>
+			</>
+		))}
+	</dl>
+	<dl>
+		{/* No rendering loop */}
+		{items.forEach(item => (
+			<>
+				<dt>{item.key}</dt>
+			</>
+		))}
+	</dl>
+</>
+		`,
+					{
+						parser: {
+							'.*': '@markuplint/jsx-parser',
+						},
+					},
+				)
+			).violations,
+		).toStrictEqual([
+			{
+				severity: 'error',
+				line: 3,
+				col: 2,
+				message: 'Require one or more elements. (Need "dd")',
+				raw: '<dl>',
+			},
+		]);
+	});
+
+	test('Astro', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					`
+<>
+	<dl>
+		{items.map(item => (
+			<dt>{item}</dt>
+		))}
+	</dl>
+	<dl>
+		{items.map(item => (
+			<>
+				<dt>{item.key}</dt>
+				<dd>{item.value}</dd>
+			</>
+		))}
+	</dl>
+	<dl>
+		{/* No rendering loop */}
+		{items.forEach(item => (
+			<>
+				<dt>{item.key}</dt>
+			</>
+		))}
+	</dl>
+</>
+		`,
+					{
+						parser: {
+							'.*': '@markuplint/astro-parser',
+						},
+					},
+				)
+			).violations,
+		).toStrictEqual([
+			{
+				severity: 'error',
+				line: 3,
+				col: 2,
+				message: 'Require one or more elements. (Need "dd")',
+				raw: '<dl>',
+			},
+		]);
+	});
+});
+
 describe('Issues', () => {
 	test('#396', async () => {
 		expect(


### PR DESCRIPTION
## Summary
- Add tests for loop blocks in `permitted-contents` rule (Svelte, Vue, Pug, Alpine, JSX, Astro)
- Add namespace detection test for SVG inside JSX (fix #2302)
- Fix inaccurate documentation about `'each'` block behavior in ml-core

## Details

Cherry-picked from v5 branch:
- `f8aa35cfe` test(rules): add tests for loop blocks (+236 lines)
- `d88903578` test(rules): add a test for detection of namespace (+19 lines, fix #2302)

Parser changes for loop blocks were already merged to dev. These commits add the corresponding rule tests.

Also fixed documentation in `@markuplint/ml-core` where `'each'` blocks were incorrectly described as "starting a new conditional group" — in reality they don't set a new mode and are flattened into `childNodes`.

## Test plan
- [x] `permitted-contents` tests pass (56/56)
- [x] Full ESLint check passes
- [x] Build passes (existing `markuplint` build errors are pre-existing)
- [x] Full test suite — failures are pre-existing and unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)