### PR TITLE
Upgrade type-fest to 5.4.4 and add return type annotation

### DIFF
--- a/packages/@markuplint/html-parser/package.json
+++ b/packages/@markuplint/html-parser/package.json
@@ -30,6 +30,6 @@
 		"@markuplint/ml-ast": "4.4.11",
 		"@markuplint/parser-utils": "4.8.11",
 		"parse5": "8.0.0",
-		"type-fest": "4.41.0"
+		"type-fest": "5.4.4"
 	}
 }

--- a/packages/@markuplint/ml-config/package.json
+++ b/packages/@markuplint/ml-config/package.json
@@ -35,6 +35,6 @@
 		"deepmerge": "4.3.1",
 		"is-plain-object": "5.0.0",
 		"mustache": "4.2.0",
-		"type-fest": "4.41.0"
+		"type-fest": "5.4.4"
 	}
 }

--- a/packages/@markuplint/ml-core/package.json
+++ b/packages/@markuplint/ml-core/package.json
@@ -43,6 +43,6 @@
 		"@types/debug": "4.1.12",
 		"debug": "4.4.3",
 		"is-plain-object": "5.0.0",
-		"type-fest": "4.41.0"
+		"type-fest": "5.4.4"
 	}
 }

--- a/packages/@markuplint/ml-spec/package.json
+++ b/packages/@markuplint/ml-spec/package.json
@@ -38,7 +38,7 @@
 		"@markuplint/types": "4.8.2",
 		"dom-accessibility-api": "0.7.1",
 		"is-plain-object": "5.0.0",
-		"type-fest": "4.41.0"
+		"type-fest": "5.4.4"
 	},
 	"devDependencies": {
 		"@markuplint/test-tools": "4.5.23",

--- a/packages/@markuplint/ml-spec/src/algorithm/html/get-content-model.ts
+++ b/packages/@markuplint/ml-spec/src/algorithm/html/get-content-model.ts
@@ -21,7 +21,7 @@ export function getContentModel(
 	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
 	el: Element,
 	specs: Specs,
-) {
+): ReadonlyDeep<PermittedContentPattern[]> | boolean | null {
 	const cacheByEl = cachesBySpecs.get(specs) ?? new Map<Element, PermittedContentPattern[] | boolean>();
 	const cached = cacheByEl.get(el);
 	if (cached !== undefined) {

--- a/packages/@markuplint/parser-utils/package.json
+++ b/packages/@markuplint/parser-utils/package.json
@@ -36,7 +36,7 @@
 		"@markuplint/types": "4.8.2",
 		"debug": "4.4.3",
 		"espree": "11.1.0",
-		"type-fest": "4.41.0"
+		"type-fest": "5.4.4"
 	},
 	"devDependencies": {
 		"@typescript-eslint/typescript-estree": "8.55.0"

--- a/packages/@markuplint/rules/package.json
+++ b/packages/@markuplint/rules/package.json
@@ -37,6 +37,6 @@
 		"ansi-colors": "4.1.3",
 		"chrono-node": "2.9.0",
 		"debug": "4.4.3",
-		"type-fest": "4.41.0"
+		"type-fest": "5.4.4"
 	}
 }

--- a/packages/@markuplint/selector/package.json
+++ b/packages/@markuplint/selector/package.json
@@ -31,7 +31,7 @@
 		"@types/debug": "4.1.12",
 		"debug": "4.4.3",
 		"postcss-selector-parser": "7.1.1",
-		"type-fest": "4.41.0"
+		"type-fest": "5.4.4"
 	},
 	"devDependencies": {
 		"@types/jsdom": "27.0.0",

--- a/packages/@markuplint/spec-generator/package.json
+++ b/packages/@markuplint/spec-generator/package.json
@@ -36,6 +36,6 @@
 		"@markuplint/ml-spec": "4.10.2",
 		"@markuplint/test-tools": "4.5.23",
 		"@types/cli-progress": "3.11.6",
-		"type-fest": "4.41.0"
+		"type-fest": "5.4.4"
 	}
 }

--- a/packages/@markuplint/test-tools/package.json
+++ b/packages/@markuplint/test-tools/package.json
@@ -33,7 +33,7 @@
 		"jsdom": "28.0.0",
 		"strip-json-comments": "5.0.3",
 		"textlint-rule-prh": "6.1.0",
-		"type-fest": "4.41.0",
+		"type-fest": "5.4.4",
 		"vitest": "4.0.18"
 	},
 	"optionalDependencies": {

--- a/packages/@markuplint/types/package.json
+++ b/packages/@markuplint/types/package.json
@@ -39,7 +39,7 @@
 		"css-tree": "3.1.0",
 		"debug": "4.4.3",
 		"leven": "4.1.0",
-		"type-fest": "4.41.0",
+		"type-fest": "5.4.4",
 		"whatwg-mimetype": "5.0.0"
 	}
 }

--- a/packages/markuplint/package.json
+++ b/packages/markuplint/package.json
@@ -44,6 +44,6 @@
 		"os-locale": "8.0.0",
 		"strict-event-emitter": "0.5.1",
 		"strip-ansi": "7.1.2",
-		"type-fest": "4.41.0"
+		"type-fest": "5.4.4"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2646,7 +2646,7 @@ __metadata:
     "@markuplint/ml-ast": "npm:4.4.11"
     "@markuplint/parser-utils": "npm:4.8.11"
     parse5: "npm:8.0.0"
-    type-fest: "npm:4.41.0"
+    type-fest: "npm:5.4.4"
   languageName: unknown
   linkType: soft
 
@@ -2715,7 +2715,7 @@ __metadata:
     deepmerge: "npm:4.3.1"
     is-plain-object: "npm:5.0.0"
     mustache: "npm:4.2.0"
-    type-fest: "npm:4.41.0"
+    type-fest: "npm:5.4.4"
   languageName: unknown
   linkType: soft
 
@@ -2736,7 +2736,7 @@ __metadata:
     "@types/debug": "npm:4.1.12"
     debug: "npm:4.4.3"
     is-plain-object: "npm:5.0.0"
-    type-fest: "npm:4.41.0"
+    type-fest: "npm:5.4.4"
   languageName: unknown
   linkType: soft
 
@@ -2750,7 +2750,7 @@ __metadata:
     dom-accessibility-api: "npm:0.7.1"
     is-plain-object: "npm:5.0.0"
     json-schema-to-typescript: "npm:15.0.4"
-    type-fest: "npm:4.41.0"
+    type-fest: "npm:5.4.4"
   languageName: unknown
   linkType: soft
 
@@ -2782,7 +2782,7 @@ __metadata:
     "@typescript-eslint/typescript-estree": "npm:8.55.0"
     debug: "npm:4.4.3"
     espree: "npm:11.1.0"
-    type-fest: "npm:4.41.0"
+    type-fest: "npm:5.4.4"
   languageName: unknown
   linkType: soft
 
@@ -2855,7 +2855,7 @@ __metadata:
     ansi-colors: "npm:4.1.3"
     chrono-node: "npm:2.9.0"
     debug: "npm:4.4.3"
-    type-fest: "npm:4.41.0"
+    type-fest: "npm:5.4.4"
   languageName: unknown
   linkType: soft
 
@@ -2869,7 +2869,7 @@ __metadata:
     debug: "npm:4.4.3"
     jsdom: "npm:28.0.0"
     postcss-selector-parser: "npm:7.1.1"
-    type-fest: "npm:4.41.0"
+    type-fest: "npm:5.4.4"
   languageName: unknown
   linkType: soft
 
@@ -2904,7 +2904,7 @@ __metadata:
     fast-xml-parser: "npm:5.3.5"
     glob: "npm:13.0.3"
     strip-json-comments: "npm:5.0.3"
-    type-fest: "npm:4.41.0"
+    type-fest: "npm:5.4.4"
   languageName: unknown
   linkType: soft
 
@@ -2942,7 +2942,7 @@ __metadata:
     jsdom: "npm:28.0.0"
     strip-json-comments: "npm:5.0.3"
     textlint-rule-prh: "npm:6.1.0"
-    type-fest: "npm:4.41.0"
+    type-fest: "npm:5.4.4"
     vitest: "npm:4.0.18"
   dependenciesMeta:
     "@esbuild/linux-x64":
@@ -2965,7 +2965,7 @@ __metadata:
     css-tree: "npm:3.1.0"
     debug: "npm:4.4.3"
     leven: "npm:4.1.0"
-    type-fest: "npm:4.41.0"
+    type-fest: "npm:5.4.4"
     whatwg-mimetype: "npm:5.0.0"
   languageName: unknown
   linkType: soft
@@ -12622,7 +12622,7 @@ __metadata:
     os-locale: "npm:8.0.0"
     strict-event-emitter: "npm:0.5.1"
     strip-ansi: "npm:7.1.2"
-    type-fest: "npm:4.41.0"
+    type-fest: "npm:5.4.4"
   bin:
     markuplint: ./bin/markuplint.mjs
   languageName: unknown
@@ -16788,6 +16788,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tagged-tag@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "tagged-tag@npm:1.0.0"
+  checksum: 10c0/91d25c9ffb86a91f20522cefb2cbec9b64caa1febe27ad0df52f08993ff60888022d771e868e6416cf2e72dab68449d2139e8709ba009b74c6c7ecd4000048d1
+  languageName: node
+  linkType: hard
+
 "tapable@npm:^2.2.0":
   version: 2.2.2
   resolution: "tapable@npm:2.2.2"
@@ -17768,10 +17775,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:4.41.0, type-fest@npm:^4.39.1, type-fest@npm:^4.6.0":
-  version: 4.41.0
-  resolution: "type-fest@npm:4.41.0"
-  checksum: 10c0/f5ca697797ed5e88d33ac8f1fec21921839871f808dc59345c9cf67345bfb958ce41bd821165dbf3ae591cedec2bf6fe8882098dfdd8dc54320b859711a2c1e4
+"type-fest@npm:5.4.4":
+  version: 5.4.4
+  resolution: "type-fest@npm:5.4.4"
+  dependencies:
+    tagged-tag: "npm:^1.0.0"
+  checksum: 10c0/bf9c6d7df5383fd720aac71da8ce8690ff1c554459d19cf3c72d61eac98255dba57abe20c628f91f4116f66211791462fdafa90b2be2d7405a5a4c295e4d849d
   languageName: node
   linkType: hard
 
@@ -17807,6 +17816,13 @@ __metadata:
   version: 0.8.1
   resolution: "type-fest@npm:0.8.1"
   checksum: 10c0/dffbb99329da2aa840f506d376c863bd55f5636f4741ad6e65e82f5ce47e6914108f44f340a0b74009b0cb5d09d6752ae83203e53e98b1192cf80ecee5651636
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^4.39.1, type-fest@npm:^4.6.0":
+  version: 4.41.0
+  resolution: "type-fest@npm:4.41.0"
+  checksum: 10c0/f5ca697797ed5e88d33ac8f1fec21921839871f808dc59345c9cf67345bfb958ce41bd821165dbf3ae591cedec2bf6fe8882098dfdd8dc54320b859711a2c1e4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #???

## What is the purpose of this PR?

- [ ] Fix bug
- [ ] Fix typo
- [ ] Update specs
- [ ] Add new rule
- [ ] Add new parser
- [ ] Improve or refactor rules
- [ ] Add a new core feature
- [x] Improve or refactor core features
- [ ] Update documents
- [ ] Others

### Description

This PR upgrades the `type-fest` dependency from version 4.41.0 to 5.4.4 across all packages in the monorepo. Additionally, it adds an explicit return type annotation to the `getContentModel` function in `@markuplint/ml-spec` to leverage the improved type utilities from the newer version of `type-fest`.

**Changes:**
- Updated `type-fest` dependency to 5.4.4 in 11 packages
- Added return type `ReadonlyDeep<PermittedContentPattern[]> | boolean | null` to `getContentModel()` function in `packages/@markuplint/ml-spec/src/algorithm/html/get-content-model.ts`

The return type annotation uses `ReadonlyDeep` from `type-fest` to ensure immutability of the returned content model patterns, improving type safety and consistency with the codebase's type standards.

## Checklist

- [x] Improve or refactor core features
  - [x] Existing tests pass (no new tests needed for dependency upgrade and type annotation)

https://claude.ai/code/session_0139UVec6cd6G8PwuwE3degP