### PR TITLE
feat(rules)!: change ignoreOmittedElements default to true

### DIFF
--- a/docs/migration/v4-v5/rules/required-element.ja.md
+++ b/docs/migration/v4-v5/rules/required-element.ja.md
@@ -1,0 +1,73 @@
+# `required-element` 破壊的変更: v4 から v5 への移行ガイド
+
+## 対象読者
+
+- `required-element` ルールを使用する**設定ファイル作成者**
+
+## 変更一覧
+
+| 変更内容 | 影響範囲 |
+|---------|---------|
+| `ignoreOmittedElements` のデフォルト値が `false` から `true` に変更 | ゴースト要素で要件を満たしていた設定 |
+
+## `ignoreOmittedElements` のデフォルト値
+
+HTML では特定のタグを省略できます（例: `<tbody>`）。HTML パーサーはこれらの省略された要素をゴーストノードとして暗黙的に生成します。
+
+v4 では、ゴースト要素もデフォルトで `required-element` の要件を満たしていました。v5 では、ゴースト要素はデフォルトで**無視**されます。ソースコードに明示的に記述された要素のみが要件を満たします。
+
+### v4
+
+ゴースト `<tbody>` が要件を満たす（デフォルト `ignoreOmittedElements: false`）:
+
+```html
+<!-- v4 では違反なし -->
+<table>
+  <tr><td>Text</td></tr>
+</table>
+```
+
+```json
+{
+  "nodeRules": [
+    {
+      "selector": "table",
+      "rules": {
+        "required-element": ["tbody"]
+      }
+    }
+  ]
+}
+```
+
+### v5
+
+同じ設定でゴースト `<tbody>` は無視されるため、違反が報告されます（デフォルト `ignoreOmittedElements: true`）。`<tbody>` を明示的に記述するか:
+
+```html
+<table>
+  <tbody>
+    <tr><td>Text</td></tr>
+  </tbody>
+</table>
+```
+
+または、オプションを `false` に明示的に設定して v4 の動作を復元してください:
+
+```json
+{
+  "nodeRules": [
+    {
+      "selector": "table",
+      "rules": {
+        "required-element": {
+          "value": ["tbody"],
+          "options": {
+            "ignoreOmittedElements": false
+          }
+        }
+      }
+    }
+  ]
+}
+```

--- a/docs/migration/v4-v5/rules/required-element.md
+++ b/docs/migration/v4-v5/rules/required-element.md
@@ -1,0 +1,73 @@
+# `required-element` Breaking Changes: v4 to v5 Migration Guide
+
+## Who This Guide Is For
+
+- **Config authors** who use the `required-element` rule
+
+## Summary of Changes
+
+| Change | Impact |
+|--------|--------|
+| `ignoreOmittedElements` default changed from `false` to `true` | Configs relying on ghost elements to satisfy requirements |
+
+## `ignoreOmittedElements` Default Value
+
+HTML allows certain tags to be omitted (e.g., `<tbody>`). The HTML parser implicitly creates these omitted elements as ghost nodes.
+
+In v4, ghost elements satisfied the `required-element` requirement by default. In v5, ghost elements are **ignored** by default — only elements explicitly written in the source satisfy the requirement.
+
+### v4
+
+Ghost `<tbody>` satisfies the requirement (default `ignoreOmittedElements: false`):
+
+```html
+<!-- No violation in v4 -->
+<table>
+  <tr><td>Text</td></tr>
+</table>
+```
+
+```json
+{
+  "nodeRules": [
+    {
+      "selector": "table",
+      "rules": {
+        "required-element": ["tbody"]
+      }
+    }
+  ]
+}
+```
+
+### v5
+
+The same config now reports a violation because ghost `<tbody>` is ignored (default `ignoreOmittedElements: true`). Either write `<tbody>` explicitly:
+
+```html
+<table>
+  <tbody>
+    <tr><td>Text</td></tr>
+  </tbody>
+</table>
+```
+
+Or restore the v4 behavior by explicitly setting the option to `false`:
+
+```json
+{
+  "nodeRules": [
+    {
+      "selector": "table",
+      "rules": {
+        "required-element": {
+          "value": ["tbody"],
+          "options": {
+            "ignoreOmittedElements": false
+          }
+        }
+      }
+    }
+  ]
+}
+```

--- a/packages/@markuplint/rules/src/required-element/README.ja.md
+++ b/packages/@markuplint/rules/src/required-element/README.ja.md
@@ -66,7 +66,7 @@ h1要素が必要な場合は[`required-h1`](../required-h1/)ルールを使用�
 
 ### `ignoreOmittedElements`オプションの設定 {#setting-ignore-omitted-elements}
 
-HTMLでは特定のタグを省略できます（例：`<tbody>`）。HTMLパーサーはこれらの省略された要素をゴーストノードとして暗黙的に生成します。デフォルトでは、これらのゴースト要素も要件を満たすものとして扱われます。`ignoreOmittedElements`を`true`に設定すると、ソースコードに明示的に記述された要素のみが要件を満たすようになります。
+HTMLでは特定のタグを省略できます（例：`<tbody>`）。HTMLパーサーはこれらの省略された要素をゴーストノードとして暗黙的に生成します。デフォルトでは、これらのゴースト要素は**無視**されます。つまり、ソースコードに明示的に記述された要素のみが要件を満たします。ゴースト要素も要件を満たすものとして扱いたい場合は、`ignoreOmittedElements`を`false`に設定してください。
 
 ```json class=config
 {
@@ -77,7 +77,7 @@ HTMLでは特定のタグを省略できます（例：`<tbody>`）。HTMLパー
         "required-element": {
           "value": ["tbody"],
           "options": {
-            "ignoreOmittedElements": true
+            "ignoreOmittedElements": false
           }
         }
       }

--- a/packages/@markuplint/rules/src/required-element/README.md
+++ b/packages/@markuplint/rules/src/required-element/README.md
@@ -65,7 +65,7 @@ If specified to `nodeRules` or `childNodeRules`, It searches the element from ch
 
 ### Setting `ignoreOmittedElements` option {#setting-ignore-omitted-elements}
 
-HTML allows certain tags to be omitted (e.g., `<tbody>`). The HTML parser implicitly creates these omitted elements as ghost nodes. By default, these ghost elements satisfy the requirement. Set `ignoreOmittedElements` to `true` to require that elements are explicitly written in the source.
+HTML allows certain tags to be omitted (e.g., `<tbody>`). The HTML parser implicitly creates these omitted elements as ghost nodes. By default, these ghost elements are **ignored** — only elements explicitly written in the source satisfy the requirement. Set `ignoreOmittedElements` to `false` if you want ghost elements to count as satisfying the requirement.
 
 ```json class=config
 {
@@ -76,7 +76,7 @@ HTML allows certain tags to be omitted (e.g., `<tbody>`). The HTML parser implic
         "required-element": {
           "value": ["tbody"],
           "options": {
-            "ignoreOmittedElements": true
+            "ignoreOmittedElements": false
           }
         }
       }

--- a/packages/@markuplint/rules/src/required-element/index.spec.ts
+++ b/packages/@markuplint/rules/src/required-element/index.spec.ts
@@ -103,7 +103,7 @@ describe('React', () => {
 });
 
 describe('ghost/omitted elements', () => {
-	test('ghost tbody should not satisfy the requirement with ignoreOmittedElements', async () => {
+	test('ignoreOmittedElements: true — ghost tbody does not satisfy the requirement', async () => {
 		const { violations } = await mlRuleTest(rule, '<table><tr><th>Heading</th><td>Text</td></tr></table>', {
 			nodeRule: [
 				{
@@ -116,7 +116,7 @@ describe('ghost/omitted elements', () => {
 		expect(violations[0].message).toBe('Require the "tbody" element');
 	});
 
-	test('explicit tbody should satisfy the requirement', async () => {
+	test('ignoreOmittedElements: true — explicit tbody satisfies the requirement', async () => {
 		const { violations } = await mlRuleTest(
 			rule,
 			'<table><tbody><tr><th>Heading</th><td>Text</td></tr></tbody></table>',
@@ -132,7 +132,19 @@ describe('ghost/omitted elements', () => {
 		expect(violations).toStrictEqual([]);
 	});
 
-	test('ghost tbody should satisfy the requirement by default (backwards compat)', async () => {
+	test('ignoreOmittedElements: false — ghost tbody satisfies the requirement', async () => {
+		const { violations } = await mlRuleTest(rule, '<table><tr><th>Heading</th><td>Text</td></tr></table>', {
+			nodeRule: [
+				{
+					selector: 'table',
+					rule: { value: ['tbody'], options: { ignoreOmittedElements: false } },
+				},
+			],
+		});
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('no option (default) — ghost tbody does not satisfy the requirement', async () => {
 		const { violations } = await mlRuleTest(rule, '<table><tr><th>Heading</th><td>Text</td></tr></table>', {
 			nodeRule: [
 				{
@@ -141,7 +153,7 @@ describe('ghost/omitted elements', () => {
 				},
 			],
 		});
-		expect(violations).toStrictEqual([]);
+		expect(violations.length).toBe(1);
 	});
 
 	test('global rule: ghost tbody ignored with option', async () => {

--- a/packages/@markuplint/rules/src/required-element/index.ts
+++ b/packages/@markuplint/rules/src/required-element/index.ts
@@ -25,7 +25,7 @@ export default createRule<string[], Options>({
 	defaultValue: [],
 	defaultOptions: {
 		ignoreHasMutableContents: true,
-		ignoreOmittedElements: false,
+		ignoreOmittedElements: true,
 	},
 	async verify({ document, report, t }) {
 		const hasMutableContent = document.nodeList.some(n => n.is(n.ELEMENT_NODE) && n.hasMutableChildren());

--- a/packages/@markuplint/rules/src/required-element/schema.json
+++ b/packages/@markuplint/rules/src/required-element/schema.json
@@ -19,7 +19,7 @@
 				},
 				"ignoreOmittedElements": {
 					"type": "boolean",
-					"default": "false",
+					"default": "true",
 					"description": "Ignore omitted (ghost) elements that are implicitly created by the HTML parser. When true, only explicitly written elements satisfy the requirement.",
 					"description:ja": "HTMLパーサーが暗黙的に生成した省略要素（ゴースト要素）を無視します。trueの場合、明示的に記述された要素のみが要件を満たします。"
 				}


### PR DESCRIPTION
## Summary

- Change `ignoreOmittedElements` default from `false` to `true` in the `required-element` rule
- Ghost (omitted) elements are now ignored by default — only explicitly written elements satisfy the requirement
- Update tests to cover all three cases: explicit `true`, explicit `false`, and no option (default)
- Update rule README (EN/JA) to reflect the new default behavior
- Add v4-to-v5 migration guide for this breaking change (EN/JA)

Closes #3136

## Test plan

- [x] `ignoreOmittedElements: true` — ghost tbody does not satisfy the requirement
- [x] `ignoreOmittedElements: false` — ghost tbody satisfies the requirement
- [x] No option (default) — ghost tbody does not satisfy the requirement
- [x] All 14 tests pass in `required-element/index.spec.ts`
- [x] `@markuplint/rules` builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)