### PR TITLE
Refactor selector engine to use pure data interfaces instead of DOM types

### DIFF
--- a/packages/@markuplint/selector/ARCHITECTURE.ja.md
+++ b/packages/@markuplint/selector/ARCHITECTURE.ja.md
@@ -4,7 +4,7 @@
 
 `@markuplint/selector` は markuplint のための拡張 [W3C Selectors Level 4](https://www.w3.org/TR/selectors-4/) マッチャーです。2 つの独立したマッチングシステムを提供します:
 
-1. **CSS セレクタマッチング** -- `postcss-selector-parser` を使用して標準 CSS セレクタをパースし、DOM ノードに対して完全な詳細度追跡付きでマッチングします。
+1. **CSS セレクタマッチング** -- `postcss-selector-parser` を使用して標準 CSS セレクタをパースし、要素に対して完全な詳細度追跡付きでマッチングします。
 2. **Regex セレクタマッチング** -- ノード名と属性に対する正規表現パターンでマッチングし、キャプチャグループデータを抽出します。
 
 また、markuplint 固有の拡張擬似クラス（`:aria()`、`:role()`、`:model()`）を定義し、HTML/ARIA 仕様データをセレクタマッチングに統合します。
@@ -14,13 +14,13 @@
 ```
 src/
 ├── index.ts                                — エクスポートエントリーポイント
-├── types.ts                                — 型定義（Specificity, SelectorResult, RegexSelector 等）
+├── types.ts                                — 型定義（SelectorElement, SelectorNode, SelectorAttr, Specificity, SelectorResult 等）
 ├── selector.ts                             — コア Selector/Ruleset/StructuredSelector/SelectorTarget クラス
 ├── create-selector.ts                      — インスタンスキャッシュと拡張擬似クラス登録を持つ Selector ファクトリ
 ├── match-selector.ts                       — CSS/Regex セレクタマッチング公開関数
 ├── compare-specificity.ts                  — 詳細度比較ユーティリティ
 ├── regex-selector-matches.ts               — 正規表現パターンマッチングヘルパー
-├── is.ts                                   — DOM ノード型ガード
+├── is.ts                                   — ノード型ガード（SelectorNode/SelectorElement）
 ├── invalid-selector-error.ts               — 無効セレクタ用カスタムエラークラス
 ├── debug.ts                                — デバッグログ設定（debug パッケージ使用）
 └── extended-selector/
@@ -81,13 +81,13 @@ flowchart TD
 | モジュール                      | 役割                     | 主要エクスポート                                                                                                               |
 | ------------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
 | `index.ts`                      | エントリーポイント       | 全公開 API の再エクスポート                                                                                                    |
-| `types.ts`                      | 型定義                   | `Specificity`, `SelectorResult`, `RegexSelector`, `RegexSelectorCombinator`                                                    |
-| `selector.ts`                   | CSS セレクタエンジン     | `Selector` クラス（エントリーポイントからは再エクスポートされない）、`Ruleset`, `StructuredSelector`, `SelectorTarget`（内部） |
+| `types.ts`                      | 型定義                   | `Specificity`, `SelectorResult`, `RegexSelector`, `RegexSelectorCombinator`, `SelectorAttr`, `SelectorNode`, `SelectorElement` |
+| `selector.ts`                   | CSS セレクタエンジン     | `Selector` クラス、`ExtendedPseudoClass` 型、`Ruleset`, `StructuredSelector`, `SelectorTarget`（内部）                         |
 | `create-selector.ts`            | キャッシュ付きファクトリ | `createSelector()`                                                                                                             |
 | `match-selector.ts`             | 統合マッチング           | `matchSelector()`, `SelectorMatches`                                                                                           |
 | `compare-specificity.ts`        | 詳細度比較               | `compareSpecificity()`                                                                                                         |
 | `regex-selector-matches.ts`     | Regex マッチングヘルパー | `regexSelectorMatches()`                                                                                                       |
-| `is.ts`                         | DOM 型ガード             | `isElement()`, `isNonDocumentTypeChildNode()`, `isPureHTMLElement()`                                                           |
+| `is.ts`                         | ノード型ガード           | `isElement()`, `isNonDocumentTypeChildNode()`, `isPureHTMLElement()`                                                           |
 | `invalid-selector-error.ts`     | エラークラス             | `InvalidSelectorError`                                                                                                         |
 | `debug.ts`                      | デバッグログ             | `log`（debug インスタンス）, `enableDebug()`                                                                                   |
 | `aria-pseudo-class.ts`          | `:aria()` ハンドラ       | `ariaPseudoClass()`                                                                                                            |
@@ -102,7 +102,7 @@ flowchart TD
 
 ### `matchSelector(el, selector, scope?, specs?)`
 
-CSS セレクタ文字列または `RegexSelector` オブジェクトの両方を受け付ける統合マッチング関数です。`{ matched: true, selector, specificity, data? }` または `{ matched: false }` を返します。
+CSS セレクタ文字列または `RegexSelector` オブジェクトの両方を受け付ける統合マッチング関数です。`el` および `scope` パラメータは任意の `SelectorNode` を受け取ります。`{ matched: true, selector, specificity, data? }` または `{ matched: false }` を返します。
 
 ### `compareSpecificity(a, b)`
 
@@ -115,6 +115,20 @@ CSS セレクタ文字列または `RegexSelector` オブジェクトの両方�
 ### `InvalidSelectorError`
 
 CSS セレクタ文字列がパースできない場合にスローされるカスタムエラーです。
+
+## 純粋データインターフェース
+
+セレクタエンジンは DOM `Element`/`Node` を直接使用せず、純粋なデータインターフェース上で動作します。これにより、マッチングロジックが約200プロパティの DOM API から分離され、移植性（例: Rust/WASM）とプレーンオブジェクトによるテストが可能になります。
+
+| インターフェース  | 継承元         | 用途                                                   |
+| ----------------- | -------------- | ------------------------------------------------------ |
+| `SelectorAttr`    | —              | 最小属性: `name`, `localName`, `value`, `namespaceURI` |
+| `SelectorNode`    | —              | 最小ノード: `nodeType`, `nodeName`, `parentNode`       |
+| `SelectorElement` | `SelectorNode` | エンジンが実際に読み取る約12のプロパティを持つ要素     |
+
+DOM `Element`、JSDOM 要素、`MLElement` はすべて構造的型付けにより `SelectorElement` を満たします — アダプタコードは不要です。
+
+拡張擬似クラス（`:aria()`、`:role()`、`:model()`）は `SelectorElement` を受け取り、完全な DOM API が必要な `@markuplint/ml-spec` 境界で `Element` にキャストします。
 
 ## コア内部クラス
 
@@ -136,7 +150,7 @@ Selector
 
 ### CSS セレクタマッチング
 
-標準 CSS セレクタは `postcss-selector-parser` により AST にパースされ、DOM ノードに対してマッチングされます:
+標準 CSS セレクタは `postcss-selector-parser` により AST にパースされ、`SelectorNode`/`SelectorElement` インスタンスに対してマッチングされます:
 
 1. `createSelector()` がキャッシュされた `Selector` インスタンスを作成または取得
 2. `Selector.match()` が `Ruleset.match()` に委譲
@@ -161,7 +175,7 @@ Regex セレクタは `RegexSelector` 型を使用してパターンで要素を
 拡張擬似クラスは `ExtendedPseudoClass` 型を通じて登録されます:
 
 ```typescript
-type ExtendedPseudoClass = Record<string, (content: string) => (el: Element) => SelectorResult>;
+type ExtendedPseudoClass = Record<string, (content: string) => (el: SelectorElement) => SelectorResult>;
 ```
 
 3 つの擬似クラスが組み込まれています:

--- a/packages/@markuplint/selector/ARCHITECTURE.md
+++ b/packages/@markuplint/selector/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 
 `@markuplint/selector` is an extended [W3C Selectors Level 4](https://www.w3.org/TR/selectors-4/) matcher for markuplint. It provides two independent matching systems:
 
-1. **CSS Selector Matching** -- Parses standard CSS selectors via `postcss-selector-parser` and matches them against DOM nodes with full specificity tracking.
+1. **CSS Selector Matching** -- Parses standard CSS selectors via `postcss-selector-parser` and matches them against elements with full specificity tracking.
 2. **Regex Selector Matching** -- Matches elements using regular expression patterns on node names and attributes, with captured group data extraction.
 
 The package also defines markuplint-specific extended pseudo-classes (`:aria()`, `:role()`, `:model()`) that integrate HTML/ARIA specification data into selector matching.
@@ -14,13 +14,13 @@ The package also defines markuplint-specific extended pseudo-classes (`:aria()`,
 ```
 src/
 ├── index.ts                                — Export entry point
-├── types.ts                                — Type definitions (Specificity, SelectorResult, RegexSelector, etc.)
+├── types.ts                                — Type definitions (SelectorElement, SelectorNode, SelectorAttr, Specificity, SelectorResult, etc.)
 ├── selector.ts                             — Core Selector/Ruleset/StructuredSelector/SelectorTarget classes
 ├── create-selector.ts                      — Selector factory with instance caching and extended pseudo-class registration
 ├── match-selector.ts                       — CSS/Regex selector matching public function
 ├── compare-specificity.ts                  — Specificity comparison utility
 ├── regex-selector-matches.ts               — Regex pattern matching helper
-├── is.ts                                   — DOM node type guards
+├── is.ts                                   — Node type guards (SelectorNode/SelectorElement)
 ├── invalid-selector-error.ts               — Custom error class for invalid selectors
 ├── debug.ts                                — Debug log configuration (using debug package)
 └── extended-selector/
@@ -78,21 +78,21 @@ flowchart TD
 
 ## Module Overview
 
-| Module                          | Role                   | Key Exports                                                                                                       |
-| ------------------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `index.ts`                      | Entry point            | Re-exports all public API                                                                                         |
-| `types.ts`                      | Type definitions       | `Specificity`, `SelectorResult`, `RegexSelector`, `RegexSelectorCombinator`                                       |
-| `selector.ts`                   | CSS selector engine    | `Selector` class (not re-exported from entry point), `Ruleset`, `StructuredSelector`, `SelectorTarget` (internal) |
-| `create-selector.ts`            | Factory with caching   | `createSelector()`                                                                                                |
-| `match-selector.ts`             | Unified matching       | `matchSelector()`, `SelectorMatches`                                                                              |
-| `compare-specificity.ts`        | Specificity comparison | `compareSpecificity()`                                                                                            |
-| `regex-selector-matches.ts`     | Regex matching helper  | `regexSelectorMatches()`                                                                                          |
-| `is.ts`                         | DOM type guards        | `isElement()`, `isNonDocumentTypeChildNode()`, `isPureHTMLElement()`                                              |
-| `invalid-selector-error.ts`     | Error class            | `InvalidSelectorError`                                                                                            |
-| `debug.ts`                      | Debug logging          | `log` (debug instance), `enableDebug()`                                                                           |
-| `aria-pseudo-class.ts`          | `:aria()` handler      | `ariaPseudoClass()`                                                                                               |
-| `aria-role-pseudo-class.ts`     | `:role()` handler      | `ariaRolePseudoClass()`                                                                                           |
-| `content-model-pseudo-class.ts` | `:model()` handler     | `contentModelPseudoClass()`                                                                                       |
+| Module                          | Role                   | Key Exports                                                                                                                    |
+| ------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `index.ts`                      | Entry point            | Re-exports all public API                                                                                                      |
+| `types.ts`                      | Type definitions       | `Specificity`, `SelectorResult`, `RegexSelector`, `RegexSelectorCombinator`, `SelectorAttr`, `SelectorNode`, `SelectorElement` |
+| `selector.ts`                   | CSS selector engine    | `Selector` class, `ExtendedPseudoClass` type, `Ruleset`, `StructuredSelector`, `SelectorTarget` (internal)                     |
+| `create-selector.ts`            | Factory with caching   | `createSelector()`                                                                                                             |
+| `match-selector.ts`             | Unified matching       | `matchSelector()`, `SelectorMatches`                                                                                           |
+| `compare-specificity.ts`        | Specificity comparison | `compareSpecificity()`                                                                                                         |
+| `regex-selector-matches.ts`     | Regex matching helper  | `regexSelectorMatches()`                                                                                                       |
+| `is.ts`                         | Node type guards       | `isElement()`, `isNonDocumentTypeChildNode()`, `isPureHTMLElement()`                                                           |
+| `invalid-selector-error.ts`     | Error class            | `InvalidSelectorError`                                                                                                         |
+| `debug.ts`                      | Debug logging          | `log` (debug instance), `enableDebug()`                                                                                        |
+| `aria-pseudo-class.ts`          | `:aria()` handler      | `ariaPseudoClass()`                                                                                                            |
+| `aria-role-pseudo-class.ts`     | `:role()` handler      | `ariaRolePseudoClass()`                                                                                                        |
+| `content-model-pseudo-class.ts` | `:model()` handler     | `contentModelPseudoClass()`                                                                                                    |
 
 ## Public API
 
@@ -102,7 +102,7 @@ Creates a cached `Selector` instance. When `specs` is provided, the extended pse
 
 ### `matchSelector(el, selector, scope?, specs?)`
 
-Unified matching function that accepts either a CSS selector string or a `RegexSelector` object. Returns `{ matched: true, selector, specificity, data? }` or `{ matched: false }`.
+Unified matching function that accepts either a CSS selector string or a `RegexSelector` object. The `el` and `scope` parameters accept any `SelectorNode`. Returns `{ matched: true, selector, specificity, data? }` or `{ matched: false }`.
 
 ### `compareSpecificity(a, b)`
 
@@ -115,6 +115,20 @@ Union type for selector match results: `{ matched: true, selector, specificity, 
 ### `InvalidSelectorError`
 
 Custom error thrown when a CSS selector string cannot be parsed.
+
+## Pure Data Interfaces
+
+The selector engine operates on pure data interfaces rather than DOM `Element`/`Node` directly. This decouples the matching logic from the ~200-property DOM API, making it portable (e.g., to Rust/WASM) and testable with plain objects.
+
+| Interface         | Extends        | Purpose                                                         |
+| ----------------- | -------------- | --------------------------------------------------------------- |
+| `SelectorAttr`    | —              | Minimal attribute: `name`, `localName`, `value`, `namespaceURI` |
+| `SelectorNode`    | —              | Minimal node: `nodeType`, `nodeName`, `parentNode`              |
+| `SelectorElement` | `SelectorNode` | Element with the ~12 properties the engine actually reads       |
+
+DOM `Element`, JSDOM elements, and `MLElement` all satisfy `SelectorElement` via structural typing — no adapter code is needed.
+
+Extended pseudo-classes (`:aria()`, `:role()`, `:model()`) receive a `SelectorElement` and cast to `Element` at the `@markuplint/ml-spec` boundary where full DOM APIs are required.
 
 ## Core Internal Classes
 
@@ -136,7 +150,7 @@ Selector
 
 ### CSS Selector Matching
 
-Standard CSS selectors are parsed by `postcss-selector-parser` into an AST, then matched against DOM nodes. The matching process:
+Standard CSS selectors are parsed by `postcss-selector-parser` into an AST, then matched against `SelectorNode`/`SelectorElement` instances. The matching process:
 
 1. `createSelector()` creates or retrieves a cached `Selector` instance
 2. `Selector.match()` delegates to `Ruleset.match()`
@@ -161,7 +175,7 @@ See [Selector Matching](docs/matching.md) for detailed algorithm documentation.
 Extended pseudo-classes are registered through the `ExtendedPseudoClass` type:
 
 ```typescript
-type ExtendedPseudoClass = Record<string, (content: string) => (el: Element) => SelectorResult>;
+type ExtendedPseudoClass = Record<string, (content: string) => (el: SelectorElement) => SelectorResult>;
 ```
 
 Three pseudo-classes are built in:

--- a/packages/@markuplint/selector/SKILL.md
+++ b/packages/@markuplint/selector/SKILL.md
@@ -40,7 +40,7 @@ Add a new markuplint-specific extended pseudo-class. Follow recipe #1 in `docs/m
 2. Create `src/extended-selector/<name>-pseudo-class.ts`
 3. Implement the handler following the `ExtendedPseudoClass` signature:
    ```typescript
-   (content: string) => (el: Element) => SelectorResult;
+   (content: string) => (el: SelectorElement) => SelectorResult;
    ```
 4. Return specificity `[0, 1, 0]` for consistency with other extended pseudo-classes
 

--- a/packages/@markuplint/selector/docs/maintenance.ja.md
+++ b/packages/@markuplint/selector/docs/maintenance.ja.md
@@ -41,12 +41,14 @@ yarn workspace @markuplint/selector run vitest run src/selector.spec.ts
 1. `src/extended-selector/custom-pseudo-class.ts` を作成:
 
    ```typescript
-   import type { SelectorResult } from '../types.js';
+   import type { SelectorElement, SelectorResult } from '../types.js';
 
    export function customPseudoClass() {
      return (content: string) =>
-       (el: Element): SelectorResult => {
+       (el: SelectorElement): SelectorResult => {
          // content 文字列をパースして el に対してマッチング
+         // 完全な DOM API（例: @markuplint/ml-spec）が必要な場合は、
+         // その境界で `el as Element` とキャストしてください。
          const matched = /* マッチングロジック */;
          return {
            specificity: [0, 1, 0],
@@ -206,4 +208,4 @@ Regex セレクタに新しいコンビネータを追加するには:
 ### jsdom（開発）
 
 - テストで DOM 環境を作成するための `JSDOM` を提供
-- `jsdom` で作成された要素はセレクタマッチングロジックが使用する標準 DOM API を持つ
+- `jsdom` で作成された要素はセレクタマッチングロジックが使用する `SelectorElement` インターフェースを満たす

--- a/packages/@markuplint/selector/docs/maintenance.md
+++ b/packages/@markuplint/selector/docs/maintenance.md
@@ -41,12 +41,14 @@ To add a new markuplint-specific pseudo-class (e.g., `:custom()`):
 1. Create `src/extended-selector/custom-pseudo-class.ts`:
 
    ```typescript
-   import type { SelectorResult } from '../types.js';
+   import type { SelectorElement, SelectorResult } from '../types.js';
 
    export function customPseudoClass() {
      return (content: string) =>
-       (el: Element): SelectorResult => {
+       (el: SelectorElement): SelectorResult => {
          // Parse content string and match against el
+         // If you need full DOM APIs (e.g., from @markuplint/ml-spec),
+         // cast with `el as Element` at that boundary.
          const matched = /* your matching logic */;
          return {
            specificity: [0, 1, 0],
@@ -206,4 +208,4 @@ To add a new combinator for regex selectors:
 ### jsdom (dev)
 
 - Provides `JSDOM` for creating DOM environments in tests
-- Elements created via `jsdom` have standard DOM APIs used by the selector matching logic
+- Elements created via `jsdom` satisfy the `SelectorElement` interface used by the selector matching logic

--- a/packages/@markuplint/selector/docs/matching.ja.md
+++ b/packages/@markuplint/selector/docs/matching.ja.md
@@ -9,7 +9,7 @@
 1. **CSS セレクタマッチング** -- `postcss-selector-parser` でパースされる標準 CSS セレクタ
 2. **Regex セレクタマッチング** -- 正規表現を使用したパターンベースのマッチング
 
-両システムとも詳細度情報を返し、統合関数 `matchSelector()` を通じて使用できます。
+両システムとも DOM `Element` ではなく純粋データインターフェース（`SelectorNode`/`SelectorElement`）上で動作し、詳細度情報を返し、統合関数 `matchSelector()` を通じて使用できます。
 
 ## CSS セレクタマッチングフロー
 
@@ -83,7 +83,7 @@ div > .class:not(.other) span
 
 ### 拡張擬似クラス
 
-拡張擬似クラスは `ExtendedPseudoClass` レジストリを通じてディスパッチされます:
+拡張擬似クラスは `ExtendedPseudoClass` レジストリを通じてディスパッチされます。ハンドラは `SelectorElement` を受け取り、`@markuplint/ml-spec` API を呼び出す際に `Element` にキャストします:
 
 #### `:aria(syntax)`
 

--- a/packages/@markuplint/selector/docs/matching.md
+++ b/packages/@markuplint/selector/docs/matching.md
@@ -9,7 +9,7 @@ The package provides two independent matching systems:
 1. **CSS Selector Matching** -- Standard CSS selectors parsed via `postcss-selector-parser`
 2. **Regex Selector Matching** -- Pattern-based matching using regular expressions
 
-Both systems return specificity information and can be used through the unified `matchSelector()` function.
+Both systems operate on pure data interfaces (`SelectorNode`/`SelectorElement`) rather than DOM `Element` directly, return specificity information, and can be used through the unified `matchSelector()` function.
 
 ## CSS Selector Matching Flow
 
@@ -83,7 +83,7 @@ Walks up the ancestor chain and matches if any ancestor matches the inner select
 
 ### Extended Pseudo-Classes
 
-Extended pseudo-classes are dispatched through the `ExtendedPseudoClass` registry:
+Extended pseudo-classes are dispatched through the `ExtendedPseudoClass` registry. Handlers receive a `SelectorElement` and cast to `Element` when calling `@markuplint/ml-spec` APIs:
 
 #### `:aria(syntax)`
 

--- a/packages/@markuplint/selector/src/extended-selector/aria-pseudo-class.ts
+++ b/packages/@markuplint/selector/src/extended-selector/aria-pseudo-class.ts
@@ -1,4 +1,4 @@
-import type { SelectorResult } from '../types.js';
+import type { SelectorElement, SelectorResult } from '../types.js';
 import type { ARIAVersion } from '@markuplint/ml-spec';
 
 import { validateAriaVersion, ARIA_RECOMMENDED_VERSION, getAccname } from '@markuplint/ml-spec';
@@ -16,10 +16,10 @@ export function ariaPseudoClass() {
 	return (content: string) =>
 		(
 			// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-			el: Element,
+			el: SelectorElement,
 		): SelectorResult => {
 			const aria = ariaPseudoClassParser(content);
-			const name = getAccname(el);
+			const name = getAccname(el as Element);
 			switch (aria.type) {
 				case 'hasName': {
 					if (name) {

--- a/packages/@markuplint/selector/src/extended-selector/aria-role-pseudo-class.ts
+++ b/packages/@markuplint/selector/src/extended-selector/aria-role-pseudo-class.ts
@@ -1,4 +1,4 @@
-import type { SelectorResult } from '../types.js';
+import type { SelectorElement, SelectorResult } from '../types.js';
 import type { ARIAVersion, MLMLSpec } from '@markuplint/ml-spec';
 
 import { validateAriaVersion, ARIA_RECOMMENDED_VERSION, getComputedRole } from '@markuplint/ml-spec';
@@ -16,11 +16,11 @@ export function ariaRolePseudoClass(specs: MLMLSpec) {
 	return (content: string) =>
 		(
 			// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-			el: Element,
+			el: SelectorElement,
 		): SelectorResult => {
 			const aria = ariaPseudoClassParser(content);
 
-			const computed = getComputedRole(specs, el, aria.version ?? ARIA_RECOMMENDED_VERSION);
+			const computed = getComputedRole(specs, el as Element, aria.version ?? ARIA_RECOMMENDED_VERSION);
 
 			if (computed.role?.name === aria.role) {
 				return {

--- a/packages/@markuplint/selector/src/extended-selector/content-model-pseudo-class.ts
+++ b/packages/@markuplint/selector/src/extended-selector/content-model-pseudo-class.ts
@@ -1,4 +1,4 @@
-import type { SelectorMatchedResult, SelectorResult } from '../types.js';
+import type { SelectorElement, SelectorMatchedResult, SelectorResult } from '../types.js';
 import type { Category, MLMLSpec } from '@markuplint/ml-spec';
 
 import { contentModelCategoryToTagNames } from '@markuplint/ml-spec';
@@ -18,7 +18,7 @@ export function contentModelPseudoClass(specs: MLMLSpec) {
 	return (category: string) =>
 		(
 			// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-			el: Element,
+			el: SelectorElement,
 		): SelectorResult => {
 			category = category.trim().toLowerCase();
 

--- a/packages/@markuplint/selector/src/index.ts
+++ b/packages/@markuplint/selector/src/index.ts
@@ -1,5 +1,7 @@
 export { compareSpecificity } from './compare-specificity.js';
 export { matchSelector, SelectorMatches } from './match-selector.js';
 export { createSelector } from './create-selector.js';
+export { Selector } from './selector.js';
+export type { ExtendedPseudoClass } from './selector.js';
 export { InvalidSelectorError } from './invalid-selector-error.js';
 export * from './types.js';

--- a/packages/@markuplint/selector/src/is.ts
+++ b/packages/@markuplint/selector/src/is.ts
@@ -29,8 +29,8 @@ export function isNonDocumentTypeChildNode(node: SelectorNode): node is Selector
  * If a pure HTML element, `localName` returns lowercase,
  * `nodeName` returns uppercase.
  *
- * @param el The element to check.
- * @returns Returns true if the element is a pure HTML element, otherwise returns false.
+ * @param el - The element to check
+ * @returns `true` if the element is a pure HTML element, `false` otherwise
  */
 export function isPureHTMLElement(
 	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types

--- a/packages/@markuplint/selector/src/is.ts
+++ b/packages/@markuplint/selector/src/is.ts
@@ -1,27 +1,25 @@
+import type { SelectorElement, SelectorNode } from './types.js';
+
+const ELEMENT_NODE = 1;
+
 /**
  * Checks whether the given node is an Element node.
  *
- * @param node - The DOM node to check
+ * @param node - The node to check
  * @returns `true` if the node is an Element
  */
-export function isElement(
-	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-	node: Node,
-): node is Element {
-	return node.nodeType === node.ELEMENT_NODE;
+export function isElement(node: SelectorNode): node is SelectorElement {
+	return node.nodeType === ELEMENT_NODE;
 }
 
 /**
  * Checks whether the given node is a non-DocumentType child node
  * (i.e., has `previousElementSibling` and `nextElementSibling` properties).
  *
- * @param node - The DOM node to check
+ * @param node - The node to check
  * @returns `true` if the node is an Element or CharacterData
  */
-export function isNonDocumentTypeChildNode(
-	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-	node: Node,
-): node is Element | CharacterData {
+export function isNonDocumentTypeChildNode(node: SelectorNode): node is SelectorElement {
 	return 'previousElementSibling' in node && 'nextElementSibling' in node;
 }
 
@@ -36,7 +34,7 @@ export function isNonDocumentTypeChildNode(
  */
 export function isPureHTMLElement(
 	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-	el: Element,
+	el: SelectorElement,
 ) {
 	return el.localName !== el.nodeName;
 }

--- a/packages/@markuplint/selector/src/match-selector.ts
+++ b/packages/@markuplint/selector/src/match-selector.ts
@@ -1,4 +1,10 @@
-import type { Specificity, RegexSelector, RegexSelectorCombinator, RegexSelectorWithoutCombination } from './types.js';
+import type {
+	SelectorNode,
+	Specificity,
+	RegexSelector,
+	RegexSelectorCombinator,
+	RegexSelectorWithoutCombination,
+} from './types.js';
 import type { Writable } from 'type-fest';
 import type { MLMLSpec } from '@markuplint/ml-spec';
 
@@ -24,23 +30,21 @@ type SelectorUnmatched = {
 };
 
 /**
- * Matches a CSS selector or regex selector against a DOM node.
+ * Matches a CSS selector or regex selector against a node.
  *
  * Supports both standard CSS selectors (as strings) and markuplint's
  * {@link RegexSelector} for pattern-based matching with captured groups.
  *
- * @param el - The DOM node to test
+ * @param el - The node to test
  * @param selector - A CSS selector string, a regex selector object, or `undefined`
  * @param scope - The scope element for `:scope` pseudo-class resolution
  * @param specs - The HTML/ARIA specification data for extended pseudo-classes
  * @returns A match result with specificity and captured data, or `{ matched: false }`
  */
 export function matchSelector(
-	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-	el: Node,
+	el: SelectorNode,
 	selector: string | RegexSelector | undefined,
-	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-	scope?: ParentNode | null,
+	scope?: SelectorNode | null,
 	specs?: MLMLSpec,
 ): SelectorMatches {
 	if (selector == null || selector === '') {
@@ -67,11 +71,7 @@ export function matchSelector(
 	return regexSelect(el, selector);
 }
 
-function regexSelect(
-	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-	el: Node,
-	selector: RegexSelector,
-): SelectorMatches {
+function regexSelect(el: SelectorNode, selector: RegexSelector): SelectorMatches {
 	let edge = new SelectorTarget(selector);
 	let edgeSelector = selector.combination;
 	while (edgeSelector) {
@@ -100,10 +100,7 @@ class SelectorTarget {
 		this.#combinedFrom = { target, combinator };
 	}
 
-	match(
-		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-		el: Node,
-	): SelectorMatches {
+	match(el: SelectorNode): SelectorMatches {
 		const unitCheck = this._matchWithoutCombineChecking(el);
 		if (!unitCheck.matched) {
 			return unitCheck;
@@ -194,19 +191,12 @@ class SelectorTarget {
 		}
 	}
 
-	private _matchWithoutCombineChecking(
-		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-		el: Node,
-	) {
+	private _matchWithoutCombineChecking(el: SelectorNode) {
 		return uncombinedRegexSelect(el, this.#selector);
 	}
 }
 
-function uncombinedRegexSelect(
-	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-	el: Node,
-	selector: RegexSelectorWithoutCombination,
-): SelectorMatches {
+function uncombinedRegexSelect(el: SelectorNode, selector: RegexSelectorWithoutCombination): SelectorMatches {
 	if (!isElement(el)) {
 		return {
 			matched: false,
@@ -288,14 +278,14 @@ function uncombinedRegexSelect(
 
 	if (matched) {
 		return {
-			matched,
+			matched: true,
 			selector: `${tagSelector}${attrSelector}`,
 			specificity,
 			data,
 		};
 	}
 
-	return { matched };
+	return { matched: false };
 }
 
 function mergeMatches(a: SelectorMatched, b: SelectorMatched, sep: string, close = false): SelectorMatched {

--- a/packages/@markuplint/selector/src/selector.ts
+++ b/packages/@markuplint/selector/src/selector.ts
@@ -12,6 +12,13 @@ import { isElement, isNonDocumentTypeChildNode, isPureHTMLElement } from './is.j
 const selLog = coreLog.extend('selector');
 const resLog = coreLog.extend('result');
 
+/**
+ * Registry of extended pseudo-class handlers keyed by pseudo-class name.
+ *
+ * Each handler is a curried function: given the pseudo-class content string,
+ * it returns a matcher that tests a {@link SelectorElement} and produces
+ * a {@link SelectorResult}.
+ */
 export type ExtendedPseudoClass = Readonly<
 	Record<
 		string,
@@ -30,6 +37,10 @@ export type ExtendedPseudoClass = Readonly<
 export class Selector {
 	#ruleset: Ruleset;
 
+	/**
+	 * @param selector - The CSS selector string to parse
+	 * @param extended - Extended pseudo-class handlers to register
+	 */
 	constructor(selector: string, extended: ExtendedPseudoClass = {}) {
 		this.#ruleset = Ruleset.parse(selector, extended);
 	}

--- a/packages/@markuplint/selector/src/selector.ts
+++ b/packages/@markuplint/selector/src/selector.ts
@@ -1,4 +1,4 @@
-import type { SelectorMatchedResult, SelectorResult, Specificity } from './types.js';
+import type { SelectorElement, SelectorMatchedResult, SelectorNode, SelectorResult, Specificity } from './types.js';
 import type { ReadonlyDeep, Writable } from 'type-fest';
 
 import { resolveNamespace } from '@markuplint/ml-spec';
@@ -12,18 +12,18 @@ import { isElement, isNonDocumentTypeChildNode, isPureHTMLElement } from './is.j
 const selLog = coreLog.extend('selector');
 const resLog = coreLog.extend('result');
 
-type ExtendedPseudoClass = Readonly<
+export type ExtendedPseudoClass = Readonly<
 	Record<
 		string,
 		(content: string) => (
 			// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-			el: Element,
+			el: SelectorElement,
 		) => SelectorResult
 	>
 >;
 
 /**
- * CSS selector matcher that parses a selector string and matches it against DOM nodes.
+ * CSS selector matcher that parses a selector string and matches it against nodes.
  *
  * Use {@link createSelector} to create cached instances with extended pseudo-class support.
  */
@@ -34,12 +34,14 @@ export class Selector {
 		this.#ruleset = Ruleset.parse(selector, extended);
 	}
 
-	match(
-		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-		el: Node,
-		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-		scope?: ParentNode | null,
-	): Specificity | false {
+	/**
+	 * Tests whether the given node matches this selector.
+	 *
+	 * @param el - The node to test
+	 * @param scope - The scope node for `:scope` pseudo-class resolution
+	 * @returns The specificity of the first matching selector, or `false` if none matched
+	 */
+	match(el: SelectorNode, scope?: SelectorNode | null): Specificity | false {
 		scope = scope ?? (isElement(el) ? el : null);
 		const results = this.search(el, scope);
 		for (const result of results) {
@@ -50,12 +52,15 @@ export class Selector {
 		return false;
 	}
 
-	search(
-		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-		el: Node,
-		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-		scope?: ParentNode | null,
-	) {
+	/**
+	 * Evaluates all comma-separated selectors against the given node
+	 * and returns each result (matched or unmatched).
+	 *
+	 * @param el - The node to test
+	 * @param scope - The scope node for `:scope` pseudo-class resolution
+	 * @returns An array of results, one per comma-separated selector alternative
+	 */
+	search(el: SelectorNode, scope?: SelectorNode | null) {
 		scope = scope ?? (isElement(el) ? el : null);
 		return this.#ruleset.match(el, scope);
 	}
@@ -93,12 +98,7 @@ class Ruleset {
 		}
 	}
 
-	match(
-		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-		el: Node,
-		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-		scope: ParentNode | null,
-	): SelectorResult[] {
+	match(el: SelectorNode, scope: SelectorNode | null): SelectorResult[] {
 		if (coreLog.enabled) {
 			coreLog(
 				'<%s> (%s)',
@@ -162,12 +162,7 @@ class StructuredSelector {
 		return this.#selector.nodes.join('');
 	}
 
-	match(
-		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-		el: Node,
-		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-		scope: ParentNode | null,
-	): SelectorResult {
+	match(el: SelectorNode, scope: SelectorNode | null): SelectorResult {
 		return this.#edge.match(el, scope, 0);
 	}
 }
@@ -231,13 +226,7 @@ class SelectorTarget {
 		this.#combinedFrom = { target, combinator };
 	}
 
-	match(
-		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-		el: Node,
-		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-		scope: ParentNode | null,
-		count: number,
-	): SelectorResult {
+	match(el: SelectorNode, scope: SelectorNode | null, count: number): SelectorResult {
 		const result = this._match(el, scope, count);
 		if (selLog.enabled) {
 			const nodeName = el.nodeName;
@@ -263,10 +252,8 @@ class SelectorTarget {
 	}
 
 	private _match(
-		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-		el: Node,
-		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-		scope: ParentNode | null,
+		el: SelectorNode,
+		scope: SelectorNode | null,
 		count: number,
 	): SelectorResult & { combinator?: string } {
 		const unitCheck = this._matchWithoutCombineChecking(el, scope);
@@ -283,7 +270,7 @@ class SelectorTarget {
 		switch (combinator.value) {
 			// Descendant combinator
 			case ' ': {
-				const matchedNodes: (Element | Text)[] = [];
+				const matchedNodes: SelectorElement[] = [];
 				const has: SelectorMatchedResult[] = [];
 				const not: SelectorMatchedResult[] = [];
 				let ancestor = el.parentElement;
@@ -333,7 +320,7 @@ class SelectorTarget {
 			}
 			// Child combinator
 			case '>': {
-				const matchedNodes: (Element | Text)[] = [];
+				const matchedNodes: SelectorElement[] = [];
 				const has: SelectorMatchedResult[] = [];
 				const not: SelectorMatchedResult[] = [];
 				const specificity: Writable<Specificity> = [...unitCheck.specificity];
@@ -376,7 +363,7 @@ class SelectorTarget {
 			}
 			// Next-sibling combinator
 			case '+': {
-				const matchedNodes: (Element | Text)[] = [];
+				const matchedNodes: SelectorElement[] = [];
 				const has: SelectorMatchedResult[] = [];
 				const not: SelectorMatchedResult[] = [];
 				const specificity: Writable<Specificity> = [...unitCheck.specificity];
@@ -418,7 +405,7 @@ class SelectorTarget {
 			}
 			// Subsequent-sibling combinator
 			case '~': {
-				const matchedNodes: (Element | Text)[] = [];
+				const matchedNodes: SelectorElement[] = [];
 				const has: SelectorMatchedResult[] = [];
 				const not: SelectorMatchedResult[] = [];
 				let prev = el.previousElementSibling;
@@ -486,12 +473,7 @@ class SelectorTarget {
 	 * @param scope
 	 * @private
 	 */
-	private _matchWithoutCombineChecking(
-		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-		el: Node,
-		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-		scope: ParentNode | null,
-	): SelectorResult {
+	private _matchWithoutCombineChecking(el: SelectorNode, scope: SelectorNode | null): SelectorResult {
 		const specificity: Writable<Specificity> = [0, 0, 0];
 
 		if (!isElement(el)) {
@@ -583,7 +565,7 @@ class SelectorTarget {
 		if (matched) {
 			return {
 				specificity,
-				matched,
+				matched: true,
 				nodes: [el],
 				has,
 			};
@@ -591,7 +573,7 @@ class SelectorTarget {
 
 		return {
 			specificity,
-			matched,
+			matched: false,
 			not,
 		};
 	}
@@ -600,7 +582,7 @@ class SelectorTarget {
 function attrMatch(
 	attr: ReadonlyDeep<parser.Attribute>,
 	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-	el: Element,
+	el: SelectorElement,
 ) {
 	return [...el.attributes].some(attrOfEl => {
 		if (attr.attribute !== attrOfEl.localName) {
@@ -665,9 +647,8 @@ function attrMatch(
 function pseudoMatch(
 	pseudo: ReadonlyDeep<parser.Pseudo>,
 	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-	el: Element,
-	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-	scope: ParentNode | null,
+	el: SelectorElement,
+	scope: SelectorNode | null,
 	extended: ExtendedPseudoClass,
 	depth: number,
 ): SelectorResult {
@@ -888,25 +869,24 @@ function pseudoMatch(
 
 function isScope(
 	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-	el: Element,
-	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-	scope: ParentNode | null,
+	el: SelectorElement,
+	scope: SelectorNode | null,
 ) {
 	return el === scope || el.parentNode === null;
 }
 
 function getDescendants(
 	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-	el: Element,
+	el: SelectorElement,
 	includeSelf = false,
-): Element[] {
+): SelectorElement[] {
 	return [...[...el.children].flatMap(child => getDescendants(child, true)), ...(includeSelf ? [el] : [])];
 }
 
 function getSiblings(
 	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-	el: Element,
-) {
+	el: SelectorElement,
+): SelectorElement[] {
 	return [...(el.parentElement?.children ?? [])];
 }
 

--- a/packages/@markuplint/selector/src/types.ts
+++ b/packages/@markuplint/selector/src/types.ts
@@ -1,4 +1,51 @@
 /**
+ * Minimal attribute representation for selector matching.
+ * Pure data — no methods, no class instances.
+ *
+ * In Rust this maps directly to a struct.
+ */
+export interface SelectorAttr {
+	readonly name: string;
+	readonly localName: string;
+	readonly value: string;
+	readonly namespaceURI: string | null;
+}
+
+/**
+ * Minimal node representation for selector matching.
+ * Pure data with tree-navigation references.
+ *
+ * In Rust this maps to a trait backed by arena indices.
+ */
+export interface SelectorNode {
+	readonly nodeType: number;
+	readonly nodeName: string;
+	readonly parentNode: SelectorNode | null;
+}
+
+/**
+ * Minimal element representation for CSS selector matching.
+ * Captures **only** the properties the selector engine actually reads.
+ *
+ * DOM `Element` and `MLElement` both satisfy this interface,
+ * but plain objects can satisfy it too — enabling Rust interop
+ * and unit-testing without a full DOM.
+ *
+ * In Rust this maps to a struct + trait.
+ */
+export interface SelectorElement extends SelectorNode {
+	readonly localName: string;
+	readonly id: string;
+	readonly namespaceURI: string | null;
+	readonly classList: { contains(className: string): boolean };
+	readonly attributes: Iterable<SelectorAttr>;
+	readonly parentElement: SelectorElement | null;
+	readonly previousElementSibling: SelectorElement | null;
+	readonly nextElementSibling: SelectorElement | null;
+	readonly children: Iterable<SelectorElement>;
+}
+
+/**
  * A CSS specificity tuple: `[id, class, type]`.
  * Each component counts selectors of the corresponding category.
  */
@@ -17,8 +64,8 @@ export type SelectorMatchedResult = {
 	/** The computed specificity of the matched selector */
 	readonly specificity: Specificity;
 	readonly matched: true;
-	/** The DOM nodes that were matched */
-	readonly nodes: readonly (Element | Text)[];
+	/** The elements that were matched */
+	readonly nodes: readonly SelectorElement[];
 	/** Results from `:has()` pseudo-class sub-matches */
 	readonly has: readonly SelectorMatchedResult[];
 };


### PR DESCRIPTION
Fixes #???

## What is the purpose of this PR?

- [x] Improve or refactor core features
- [x] Update documents

### Description

This PR refactors the `@markuplint/selector` package to decouple the selector matching engine from concrete DOM types (`Element`, `Node`, `ParentNode`). Instead, it introduces minimal pure data interfaces (`SelectorNode`, `SelectorElement`, `SelectorAttr`) that capture only the properties the selector engine actually reads.

**Key changes:**

1. **New type interfaces in `types.ts`:**
   - `SelectorAttr`: Minimal attribute representation (name, localName, value, namespaceURI)
   - `SelectorNode`: Minimal node representation (nodeType, nodeName, parentNode)
   - `SelectorElement`: Minimal element representation extending SelectorNode (localName, id, namespaceURI, classList, attributes, parentElement, siblings, children)

2. **Updated selector engine (`selector.ts`, `match-selector.ts`):**
   - All matching functions now accept `SelectorNode`/`SelectorElement` instead of DOM `Node`/`Element`/`ParentNode`
   - Removed `@typescript-eslint/prefer-readonly-parameter-types` eslint-disable comments where types are now properly readonly
   - Updated `ExtendedPseudoClass` type to be exported and use `SelectorElement`
   - Added comprehensive JSDoc comments to public methods

3. **Updated type guards (`is.ts`):**
   - `isElement()` now returns `SelectorElement` type guard
   - `isNonDocumentTypeChildNode()` now works with `SelectorNode` and returns `SelectorElement`
   - Replaced `node.ELEMENT_NODE` with constant `ELEMENT_NODE = 1`

4. **Updated extended pseudo-classes:**
   - `aria-pseudo-class.ts`, `aria-role-pseudo-class.ts`, `content-model-pseudo-class.ts` now accept `SelectorElement`
   - Added casts to `Element` at boundaries where full DOM APIs are needed (e.g., `getAccname(el as Element)`)

5. **Updated documentation:**
   - `ARCHITECTURE.md` and `ARCHITECTURE.ja.md`: Updated to reflect new type interfaces and their purpose
   - `maintenance.md` and `maintenance.ja.md`: Updated examples to use `SelectorElement` and document casting at boundaries
   - `matching.md` and `matching.ja.md`: Clarified that the engine operates on pure data interfaces

6. **Updated exports (`index.ts`):**
   - Now exports `Selector` class and `SelectorElement`, `SelectorNode`, `SelectorAttr` types

**Benefits:**

- Enables Rust interop by allowing the selector engine to work with non-DOM data structures
- Improves testability by allowing unit tests without a full DOM
- Maintains backward compatibility: DOM `Element` and `MLElement` both satisfy the `SelectorElement` interface
- Clearer separation of concerns: selector matching logic is now independent of DOM implementation details

## Checklist

- [x] Improve or refactor core features
  - [x] Existing tests pass (selector matching behavior unchanged)
  - [x] Updated documentation to reflect new architecture
  - [x] Added JSDoc comments to public APIs

https://claude.ai/code/session_01SwpQSdqSkPMCWZT6abcEsJ