### PR TITLE
Add /issue slash command for GitHub Issue analysis

### DIFF
--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -1,0 +1,45 @@
+---
+description: Analyze a GitHub Issue and create a resolution plan
+---
+
+You are given a GitHub Issue URL as input: $ARGUMENTS
+
+Follow these steps in order:
+
+## Step 1: Fetch Issue Information
+
+1. Extract owner/repo/number from the Issue URL
+2. Run `gh issue view <URL> --json number,title,body,labels,comments,assignees,state` to retrieve all Issue details
+
+## Step 2: Create a Worktree
+
+1. Generate a slug from the Issue title (lowercase, spaces to hyphens, alphanumeric and hyphens only, strip leading/trailing hyphens, truncate to 50 chars)
+2. Branch name: `issue/<number>-<slug>`
+3. Worktree path: `../<branch name with slashes replaced by hyphens>` (under the parent directory of the current repository)
+4. Execute:
+   ```bash
+   git worktree add ../<worktree-dir> -b issue/<number>-<slug> dev
+   cd ../<worktree-dir>
+   yarn install && yarn build
+   ```
+
+## Step 3: Analyze the Problem
+
+Read through the Issue body and comments carefully, then organize the following:
+
+1. **Summary**: What is happening / what is being requested
+2. **Reproduction**: For bugs, reproduction steps and environment
+3. **Related Code**: Identify files, functions, and rules mentioned in the Issue and explore the codebase
+4. **Impact Scope**: Packages and features potentially affected by the fix
+
+## Step 4: Propose a Resolution Plan
+
+Based on the analysis, present a resolution plan:
+
+1. **Approach**: The chosen solution and rationale
+2. **Files to Change**: List of files to modify or add
+3. **Implementation Steps**: Concrete steps in dependency order
+4. **Testing Strategy**: Test cases and validation methods to add
+5. **Risks**: Side effects and caveats
+
+Present the plan to the user and wait for approval before proceeding with implementation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ Use the following skills and commands for common tasks. **Always invoke the appr
 | `/pr`      | Create and push a pull request via `gh pr create`      | [pr.md](.claude/commands/pr.md)           |
 | `/doc`     | Update documentation (README, ARCHITECTURE, JSDoc)     | [doc.md](.claude/commands/doc.md)         |
 | `/release` | Create GitHub Release notes                            | [release.md](.claude/commands/release.md) |
+| `/issue`   | Analyze a GitHub Issue and create a resolution plan    | [issue.md](.claude/commands/issue.md)     |
 
 ## Skills
 


### PR DESCRIPTION
## Summary
- Add `/issue` slash command that takes a GitHub Issue URL and automates the analysis workflow
- Creates a worktree, fetches issue details via `gh`, analyzes the problem, and proposes a resolution plan
- Register the command in `CLAUDE.md` commands table

## Test plan
- [ ] Run `/issue <URL>` with a valid GitHub Issue URL
- [ ] Verify issue information is fetched correctly
- [ ] Verify worktree is created at the expected path
- [ ] Verify problem analysis and resolution plan are presented

🤖 Generated with [Claude Code](https://claude.com/claude-code)