### PR TITLE
fix(svelte): allow IDL property attributes on form elements

### DIFF
--- a/packages/@markuplint/svelte-parser/ARCHITECTURE.ja.md
+++ b/packages/@markuplint/svelte-parser/ARCHITECTURE.ja.md
@@ -335,6 +335,12 @@ export function svelteParse(template: string): SvelteNode[] {
 
 `super.visitAttr()` が `type: 'spread'` の属性を返した場合、追加処理なしでそのまま返されます。
 
+### IDL 属性マッピング
+
+すべてのディレクティブ・省略形処理の後、パーサーは `@markuplint/parser-utils` の `searchIDLAttribute()` を適用して、camelCase の IDL プロパティ名を対応するコンテンツ属性名にマッピングします。例えば、`tabIndex` は `tabindex` に、`contentEditable` は `contenteditable` にマッピングされます。このマッピングは通常の属性と `bind:` ディレクティブのサブ名の両方に適用されます。
+
+マッピングはコンテンツ属性名がルックアップ名と異なる場合にのみ `potentialName` を更新するため、すでにコンテンツ属性形式と一致している属性（例: `value`、`class`）は影響を受けません。対応するコンテンツ属性を持たない IDL 専用プロパティ（例: `defaultValue`、`indeterminate`）はマッピングに含まれず、対となる `@markuplint/svelte-spec` パッケージで処理されます。
+
 ## SvelteKit パーサー
 
 ### アーキテクチャ上の区別
@@ -421,7 +427,7 @@ class SvelteKitTemplateParser extends HtmlParser {
 | 依存パッケージ             | 用途                                                                    |
 | -------------------------- | ----------------------------------------------------------------------- |
 | `@markuplint/ml-ast`       | AST 型定義（`MLASTPreprocessorSpecificBlock` 等）                       |
-| `@markuplint/parser-utils` | 抽象 `Parser` クラス、`ChildToken`、`Token`、`AttrState`、`ParserError` |
+| `@markuplint/parser-utils` | 抽象 `Parser` クラス、`ChildToken`、`Token`、`AttrState`、`ParserError`、`searchIDLAttribute` |
 | `@markuplint/html-parser`  | `HtmlParser`（SvelteKit パーサーの基底）、`getNamespace()`              |
 | `svelte`                   | `svelte/compiler` の `parse()` 関数（トークン化用）                     |
 

--- a/packages/@markuplint/svelte-parser/ARCHITECTURE.ja.md
+++ b/packages/@markuplint/svelte-parser/ARCHITECTURE.ja.md
@@ -424,12 +424,12 @@ class SvelteKitTemplateParser extends HtmlParser {
 
 ## 外部依存
 
-| 依存パッケージ             | 用途                                                                    |
-| -------------------------- | ----------------------------------------------------------------------- |
-| `@markuplint/ml-ast`       | AST 型定義（`MLASTPreprocessorSpecificBlock` 等）                       |
+| 依存パッケージ             | 用途                                                                                          |
+| -------------------------- | --------------------------------------------------------------------------------------------- |
+| `@markuplint/ml-ast`       | AST 型定義（`MLASTPreprocessorSpecificBlock` 等）                                             |
 | `@markuplint/parser-utils` | 抽象 `Parser` クラス、`ChildToken`、`Token`、`AttrState`、`ParserError`、`searchIDLAttribute` |
-| `@markuplint/html-parser`  | `HtmlParser`（SvelteKit パーサーの基底）、`getNamespace()`              |
-| `svelte`                   | `svelte/compiler` の `parse()` 関数（トークン化用）                     |
+| `@markuplint/html-parser`  | `HtmlParser`（SvelteKit パーサーの基底）、`getNamespace()`                                    |
+| `svelte`                   | `svelte/compiler` の `parse()` 関数（トークン化用）                                           |
 
 ## ドキュメントマップ
 

--- a/packages/@markuplint/svelte-parser/ARCHITECTURE.md
+++ b/packages/@markuplint/svelte-parser/ARCHITECTURE.md
@@ -424,12 +424,12 @@ These Svelte 5 constructs are handled by the parser: `SnippetBlock` has dedicate
 
 ## External Dependencies
 
-| Dependency                 | Purpose                                                                    |
-| -------------------------- | -------------------------------------------------------------------------- |
-| `@markuplint/ml-ast`       | AST type definitions (`MLASTPreprocessorSpecificBlock`, etc.)              |
+| Dependency                 | Purpose                                                                                          |
+| -------------------------- | ------------------------------------------------------------------------------------------------ |
+| `@markuplint/ml-ast`       | AST type definitions (`MLASTPreprocessorSpecificBlock`, etc.)                                    |
 | `@markuplint/parser-utils` | Abstract `Parser` class, `ChildToken`, `Token`, `AttrState`, `ParserError`, `searchIDLAttribute` |
-| `@markuplint/html-parser`  | `HtmlParser` (base for SvelteKit parser), `getNamespace()`                 |
-| `svelte`                   | `svelte/compiler` `parse()` function for tokenization                      |
+| `@markuplint/html-parser`  | `HtmlParser` (base for SvelteKit parser), `getNamespace()`                                       |
+| `svelte`                   | `svelte/compiler` `parse()` function for tokenization                                            |
 
 ## Documentation Map
 

--- a/packages/@markuplint/svelte-parser/ARCHITECTURE.md
+++ b/packages/@markuplint/svelte-parser/ARCHITECTURE.md
@@ -335,6 +335,12 @@ When an attribute is a shorthand expression like `{items}`:
 
 When `super.visitAttr()` returns an attribute with `type: 'spread'`, it is returned directly without further processing.
 
+### IDL Attribute Mapping
+
+After all directive and shorthand processing, the parser applies `searchIDLAttribute()` from `@markuplint/parser-utils` to map camelCase IDL property names to their corresponding content attribute names. For example, `tabIndex` is mapped to `tabindex` and `contentEditable` to `contenteditable`. This mapping applies to both regular attributes and `bind:` directive sub-names.
+
+The mapping only updates `potentialName` when the content attribute name differs from the looked-up name, so attributes that already match their content attribute form (e.g., `value`, `class`) are unaffected. IDL-only properties that have no corresponding content attribute (e.g., `defaultValue`, `indeterminate`) are not in the mapping and are instead handled by the paired `@markuplint/svelte-spec` package.
+
 ## SvelteKit Parser
 
 ### Architectural Distinction
@@ -421,7 +427,7 @@ These Svelte 5 constructs are handled by the parser: `SnippetBlock` has dedicate
 | Dependency                 | Purpose                                                                    |
 | -------------------------- | -------------------------------------------------------------------------- |
 | `@markuplint/ml-ast`       | AST type definitions (`MLASTPreprocessorSpecificBlock`, etc.)              |
-| `@markuplint/parser-utils` | Abstract `Parser` class, `ChildToken`, `Token`, `AttrState`, `ParserError` |
+| `@markuplint/parser-utils` | Abstract `Parser` class, `ChildToken`, `Token`, `AttrState`, `ParserError`, `searchIDLAttribute` |
 | `@markuplint/html-parser`  | `HtmlParser` (base for SvelteKit parser), `getNamespace()`                 |
 | `svelte`                   | `svelte/compiler` `parse()` function for tokenization                      |
 

--- a/packages/@markuplint/svelte-parser/src/parser.ts
+++ b/packages/@markuplint/svelte-parser/src/parser.ts
@@ -358,7 +358,8 @@ export class SvelteParser extends Parser<SvelteNode> {
 	/**
 	 * Visits an attribute token, handling Svelte-specific syntax including
 	 * curly-brace expression values, shorthand attributes (`{name}`),
-	 * `bind:` / `class:` directives, and duplicatable class attributes.
+	 * `bind:` / `class:` directives, duplicatable class attributes,
+	 * and IDL-to-content attribute name mapping via `searchIDLAttribute`.
 	 *
 	 * @param token - The token representing the attribute
 	 * @returns The parsed attribute node with Svelte-specific metadata

--- a/packages/@markuplint/svelte-parser/src/parser.ts
+++ b/packages/@markuplint/svelte-parser/src/parser.ts
@@ -7,7 +7,7 @@ import type {
 } from '@markuplint/ml-ast';
 import type { ChildToken, ParseOptions, Token } from '@markuplint/parser-utils';
 
-import { ParserError, Parser, AttrState } from '@markuplint/parser-utils';
+import { ParserError, Parser, AttrState, searchIDLAttribute } from '@markuplint/parser-utils';
 
 import { parseBlock } from './parse-block.js';
 import { svelteParse } from './svelte-parser/index.js';
@@ -412,6 +412,12 @@ export class SvelteParser extends Parser<SvelteNode> {
 
 		if (attr.startQuote.raw === '{' && attr.endQuote.raw === '}') {
 			isDynamicValue = true;
+		}
+
+		const nameForLookup = potentialName ?? attr.name.raw;
+		const { contentAttrName } = searchIDLAttribute(nameForLookup);
+		if (contentAttrName && contentAttrName !== nameForLookup) {
+			potentialName = contentAttrName;
 		}
 
 		return {

--- a/packages/@markuplint/svelte-spec/ARCHITECTURE.ja.md
+++ b/packages/@markuplint/svelte-spec/ARCHITECTURE.ja.md
@@ -2,7 +2,7 @@
 
 ## 概要
 
-`@markuplint/svelte-spec` は markuplint 向けの Svelte 固有の拡張仕様を提供します。Svelte のフォーム要素における双方向バインディング動作に対応するため、要素レベルの属性オーバーライドを定義する `ExtendedSpec` オブジェクトをエクスポートします。具体的には、`<select>` と `<textarea>` 要素の `value` 属性の型を `Any` に拡張し、文字列だけでなく任意の型のバインド変数を許容します。
+`@markuplint/svelte-spec` は markuplint 向けの Svelte 固有の拡張仕様を提供します。Svelte のフォーム要素における双方向バインディング動作と IDL プロパティ属性に対応するため、要素レベルの属性オーバーライドを定義する `ExtendedSpec` オブジェクトをエクスポートします。`<select>` と `<textarea>` 要素の `value` 属性の型を `Any` に拡張するほか、`<input>`、`<select>`、`<textarea>` 要素で `defaultValue`、`defaultChecked`、`indeterminate` などの IDL プロパティ属性をサポートします。
 
 ## ExtendedSpec の内容
 
@@ -10,10 +10,15 @@
 
 ### 要素固有のオーバーライド
 
-| 要素         | 属性    | 型オーバーライド | 理由                                                    |
-| ------------ | ------- | ---------------- | ------------------------------------------------------- |
-| `<select>`   | `value` | `Any`            | Svelte の `bind:value` は文字列だけでなく任意の型を許容 |
-| `<textarea>` | `value` | `Any`            | Svelte の `bind:value` は文字列だけでなく任意の型を許容 |
+| 要素         | 属性             | 型オーバーライド | 理由                                                           |
+| ------------ | ---------------- | ---------------- | -------------------------------------------------------------- |
+| `<input>`    | `defaultChecked` | `Boolean`        | チェックボックス/ラジオの非制御初期状態を表す IDL プロパティ   |
+| `<input>`    | `defaultValue`   | `Any`            | 入力要素の非制御初期値を表す IDL プロパティ                    |
+| `<input>`    | `indeterminate`  | `Boolean`        | チェックボックスの不定状態を表す IDL プロパティ                |
+| `<select>`   | `value`          | `Any`            | Svelte の `bind:value` は文字列だけでなく任意の型を許容        |
+| `<select>`   | `defaultValue`   | `Any`            | セレクト要素の非制御初期値を表す IDL プロパティ                |
+| `<textarea>` | `value`          | `Any`            | Svelte の `bind:value` は文字列だけでなく任意の型を許容        |
+| `<textarea>` | `defaultValue`   | `Any`            | テキストエリアの非制御初期値を表す IDL プロパティ              |
 
 これらのオーバーライドにより、markuplint が Svelte 固有の属性使用を不正としてフラグ付けすることなく、標準 HTML 仕様を拡張します。
 
@@ -40,7 +45,7 @@ flowchart TD
     end
 
     subgraph pkg ["@markuplint/svelte-spec"]
-        spec["ExtendedSpec オブジェクト\n(select, textarea オーバーライド)"]
+        spec["ExtendedSpec オブジェクト\n(input, select, textarea オーバーライド)"]
     end
 
     subgraph downstream ["下流"]

--- a/packages/@markuplint/svelte-spec/ARCHITECTURE.ja.md
+++ b/packages/@markuplint/svelte-spec/ARCHITECTURE.ja.md
@@ -10,15 +10,15 @@
 
 ### 要素固有のオーバーライド
 
-| 要素         | 属性             | 型オーバーライド | 理由                                                           |
-| ------------ | ---------------- | ---------------- | -------------------------------------------------------------- |
-| `<input>`    | `defaultChecked` | `Boolean`        | チェックボックス/ラジオの非制御初期状態を表す IDL プロパティ   |
-| `<input>`    | `defaultValue`   | `Any`            | 入力要素の非制御初期値を表す IDL プロパティ                    |
-| `<input>`    | `indeterminate`  | `Boolean`        | チェックボックスの不定状態を表す IDL プロパティ                |
-| `<select>`   | `value`          | `Any`            | Svelte の `bind:value` は文字列だけでなく任意の型を許容        |
-| `<select>`   | `defaultValue`   | `Any`            | セレクト要素の非制御初期値を表す IDL プロパティ                |
-| `<textarea>` | `value`          | `Any`            | Svelte の `bind:value` は文字列だけでなく任意の型を許容        |
-| `<textarea>` | `defaultValue`   | `Any`            | テキストエリアの非制御初期値を表す IDL プロパティ              |
+| 要素         | 属性             | 型オーバーライド | 理由                                                         |
+| ------------ | ---------------- | ---------------- | ------------------------------------------------------------ |
+| `<input>`    | `defaultChecked` | `Boolean`        | チェックボックス/ラジオの非制御初期状態を表す IDL プロパティ |
+| `<input>`    | `defaultValue`   | `Any`            | 入力要素の非制御初期値を表す IDL プロパティ                  |
+| `<input>`    | `indeterminate`  | `Boolean`        | チェックボックスの不定状態を表す IDL プロパティ              |
+| `<select>`   | `value`          | `Any`            | Svelte の `bind:value` は文字列だけでなく任意の型を許容      |
+| `<select>`   | `defaultValue`   | `Any`            | セレクト要素の非制御初期値を表す IDL プロパティ              |
+| `<textarea>` | `value`          | `Any`            | Svelte の `bind:value` は文字列だけでなく任意の型を許容      |
+| `<textarea>` | `defaultValue`   | `Any`            | テキストエリアの非制御初期値を表す IDL プロパティ            |
 
 これらのオーバーライドにより、markuplint が Svelte 固有の属性使用を不正としてフラグ付けすることなく、標準 HTML 仕様を拡張します。
 

--- a/packages/@markuplint/svelte-spec/ARCHITECTURE.md
+++ b/packages/@markuplint/svelte-spec/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-`@markuplint/svelte-spec` provides Svelte-specific extended specifications for markuplint. It exports an `ExtendedSpec` object that defines element-level attribute overrides to accommodate Svelte's two-way binding behavior on form elements. Specifically, the `<select>` and `<textarea>` elements have their `value` attribute type broadened to `Any`, allowing bound variables of any type rather than only strings.
+`@markuplint/svelte-spec` provides Svelte-specific extended specifications for markuplint. It exports an `ExtendedSpec` object that defines element-level attribute overrides to accommodate Svelte's two-way binding behavior and IDL property attributes on form elements. The `<select>` and `<textarea>` elements have their `value` attribute type broadened to `Any`, and the `<input>`, `<select>`, and `<textarea>` elements support IDL property attributes such as `defaultValue`, `defaultChecked`, and `indeterminate`.
 
 ## ExtendedSpec Content
 
@@ -10,10 +10,15 @@ The package exports a single `ExtendedSpec` object with element-specific overrid
 
 ### Element-Specific Overrides
 
-| Element      | Attribute | Type Override | Reason                                                  |
-| ------------ | --------- | ------------- | ------------------------------------------------------- |
-| `<select>`   | `value`   | `Any`         | Svelte's `bind:value` allows any type, not just strings |
-| `<textarea>` | `value`   | `Any`         | Svelte's `bind:value` allows any type, not just strings |
+| Element      | Attribute        | Type Override | Reason                                                         |
+| ------------ | ---------------- | ------------- | -------------------------------------------------------------- |
+| `<input>`    | `defaultChecked` | `Boolean`     | IDL property for uncontrolled checkbox/radio initial state      |
+| `<input>`    | `defaultValue`   | `Any`         | IDL property for uncontrolled input initial value               |
+| `<input>`    | `indeterminate`  | `Boolean`     | IDL property for checkbox indeterminate state                   |
+| `<select>`   | `value`          | `Any`         | Svelte's `bind:value` allows any type, not just strings        |
+| `<select>`   | `defaultValue`   | `Any`         | IDL property for uncontrolled select initial value              |
+| `<textarea>` | `value`          | `Any`         | Svelte's `bind:value` allows any type, not just strings        |
+| `<textarea>` | `defaultValue`   | `Any`         | IDL property for uncontrolled textarea initial value            |
 
 These overrides extend the standard HTML spec so that markuplint does not flag Svelte-specific attribute usage as invalid.
 
@@ -40,7 +45,7 @@ flowchart TD
     end
 
     subgraph pkg ["@markuplint/svelte-spec"]
-        spec["ExtendedSpec object\n(select, textarea overrides)"]
+        spec["ExtendedSpec object\n(input, select, textarea overrides)"]
     end
 
     subgraph downstream ["Downstream"]

--- a/packages/@markuplint/svelte-spec/ARCHITECTURE.md
+++ b/packages/@markuplint/svelte-spec/ARCHITECTURE.md
@@ -10,15 +10,15 @@ The package exports a single `ExtendedSpec` object with element-specific overrid
 
 ### Element-Specific Overrides
 
-| Element      | Attribute        | Type Override | Reason                                                         |
-| ------------ | ---------------- | ------------- | -------------------------------------------------------------- |
-| `<input>`    | `defaultChecked` | `Boolean`     | IDL property for uncontrolled checkbox/radio initial state      |
-| `<input>`    | `defaultValue`   | `Any`         | IDL property for uncontrolled input initial value               |
-| `<input>`    | `indeterminate`  | `Boolean`     | IDL property for checkbox indeterminate state                   |
-| `<select>`   | `value`          | `Any`         | Svelte's `bind:value` allows any type, not just strings        |
-| `<select>`   | `defaultValue`   | `Any`         | IDL property for uncontrolled select initial value              |
-| `<textarea>` | `value`          | `Any`         | Svelte's `bind:value` allows any type, not just strings        |
-| `<textarea>` | `defaultValue`   | `Any`         | IDL property for uncontrolled textarea initial value            |
+| Element      | Attribute        | Type Override | Reason                                                     |
+| ------------ | ---------------- | ------------- | ---------------------------------------------------------- |
+| `<input>`    | `defaultChecked` | `Boolean`     | IDL property for uncontrolled checkbox/radio initial state |
+| `<input>`    | `defaultValue`   | `Any`         | IDL property for uncontrolled input initial value          |
+| `<input>`    | `indeterminate`  | `Boolean`     | IDL property for checkbox indeterminate state              |
+| `<select>`   | `value`          | `Any`         | Svelte's `bind:value` allows any type, not just strings    |
+| `<select>`   | `defaultValue`   | `Any`         | IDL property for uncontrolled select initial value         |
+| `<textarea>` | `value`          | `Any`         | Svelte's `bind:value` allows any type, not just strings    |
+| `<textarea>` | `defaultValue`   | `Any`         | IDL property for uncontrolled textarea initial value       |
 
 These overrides extend the standard HTML spec so that markuplint does not flag Svelte-specific attribute usage as invalid.
 

--- a/packages/@markuplint/svelte-spec/src/index.ts
+++ b/packages/@markuplint/svelte-spec/src/index.ts
@@ -3,9 +3,8 @@
  *
  * Provides Svelte-specific extended specifications for markuplint.
  * Defines element-level attribute overrides for Svelte's two-way
- * binding behavior on form elements (`<select>` and `<textarea>`),
- * where the `value` attribute accepts any type to support bound
- * variables.
+ * binding behavior on form elements and IDL property attributes
+ * such as `defaultValue`, `defaultChecked`, and `indeterminate`.
  */
 
 import type { ExtendedSpec } from '@markuplint/ml-spec';
@@ -14,17 +13,39 @@ import type { ExtendedSpec } from '@markuplint/ml-spec';
  * The Svelte framework extended specification.
  *
  * Provides per-element attribute definitions that accommodate
- * Svelte's two-way binding (`bind:value`) on `<select>` and
- * `<textarea>` elements, allowing the `value` attribute to accept
- * any type rather than only strings.
+ * Svelte's two-way binding (`bind:value`) and IDL property
+ * attributes on form elements.
  */
 const spec: ExtendedSpec = {
 	specs: [
+		{
+			name: 'input',
+			attributes: {
+				defaultChecked: {
+					type: 'Boolean',
+					caseSensitive: true,
+					condition: ['[type=checkbox]', '[type=radio]'],
+				},
+				defaultValue: {
+					type: 'Any',
+					caseSensitive: true,
+				},
+				indeterminate: {
+					type: 'Boolean',
+					caseSensitive: true,
+					condition: '[type=checkbox]',
+				},
+			},
+		},
 		{
 			name: 'select',
 			attributes: {
 				value: {
 					type: 'Any',
+				},
+				defaultValue: {
+					type: 'Any',
+					caseSensitive: true,
 				},
 			},
 		},
@@ -33,6 +54,10 @@ const spec: ExtendedSpec = {
 			attributes: {
 				value: {
 					type: 'Any',
+				},
+				defaultValue: {
+					type: 'Any',
+					caseSensitive: true,
 				},
 			},
 		},


### PR DESCRIPTION
## Summary

- Add `defaultValue`, `defaultChecked`, and `indeterminate` to `@markuplint/svelte-spec` for `<input>`, `<select>`, and `<textarea>` elements
- Add `searchIDLAttribute` mapping in `@markuplint/svelte-parser` to convert camelCase IDL names to content attribute names (e.g., `tabIndex` → `tabindex`)
- Update ARCHITECTURE docs and JSDoc to reflect the new IDL attribute handling

Closes #2590

## Test plan

- [x] `yarn build` passes (all 37 projects)
- [x] `yarn test` passes (1469 tests, 141 files)
- [x] `yarn lint-check:eslint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)