### PR TITLE
fix(html-spec): update as attribute enum values based on link type

### DIFF
--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -39057,27 +39057,18 @@
 					"description": "This attribute is required when rel=\"preload\" has been set on the <link> element, optional when rel=\"modulepreload\" has been set, and otherwise should not be used. It specifies the type of content being loaded by the <link>, which is necessary for request matching, application of correct content security policy, and setting of correct Accept request header. Furthermore, rel=\"preload\" uses this as a signal for request prioritization. The table below lists the valid values for this attribute and the elements or resources they apply to. Value Applies To audio <audio> elements document <iframe> and <frame> elements embed <embed> elements fetch fetch, XHR Note: This value also requires <link> to contain the crossorigin attribute, see CORS-enabled fetches. font CSS @font-face Note: This value also requires <link> to contain the crossorigin attribute, see CORS-enabled fetches. image <img> and <picture> elements with srcset or imageset attributes, SVG <image> elements, CSS *-image rules object <object> elements script <script> elements, Worker importScripts style <link rel=stylesheet> elements, CSS @import track <track> elements video <video> elements worker Worker, SharedWorker",
 					"type": {
 						"enum": [
-							"fetch",
-							"audio",
 							"audioworklet",
-							"document",
-							"embed",
+							"fetch",
 							"font",
-							"frame",
-							"iframe",
 							"image",
-							"manifest",
-							"object",
+							"json",
 							"paintworklet",
-							"report",
 							"script",
 							"serviceworker",
 							"sharedworker",
 							"style",
 							"track",
-							"video",
-							"worker",
-							"xslt"
+							"worker"
 						]
 					},
 					"condition": ["[rel='preload' i]", "[rel='modulepreload' i]"]

--- a/packages/@markuplint/html-spec/src/spec.link.json
+++ b/packages/@markuplint/html-spec/src/spec.link.json
@@ -58,33 +58,28 @@
 			"required": "[imagesrcset]"
 		},
 		// https://html.spec.whatwg.org/multipage/semantics.html#attr-link-as
+		// https://html.spec.whatwg.org/multipage/links.html#link-type-preload
+		// https://html.spec.whatwg.org/multipage/links.html#link-type-modulepreload
+		// The enumerated values are the union of preload destinations and module preload destinations.
+		// Preload destinations: fetch, font, image, script, style, track
+		// Module preload destinations: json, style, and script-like destinations (audioworklet, paintworklet, script, serviceworker, sharedworker, worker)
 		"as": {
 			"type": {
 				"enum": [
-					"fetch",
-					"audio",
 					"audioworklet",
-					"document",
-					"embed",
+					"fetch",
 					"font",
-					"frame",
-					"iframe",
 					"image",
-					"manifest",
-					"object",
+					"json",
 					"paintworklet",
-					"report",
 					"script",
 					"serviceworker",
 					"sharedworker",
 					"style",
 					"track",
-					"video",
-					"worker",
-					"xslt"
+					"worker"
 				]
 			},
-			// If the rel attribute is modulepreload, invalidValueDefault and missingValueDefault will be `script`
 			"condition": ["[rel='preload' i]", "[rel='modulepreload' i]"]
 		},
 		// https://html.spec.whatwg.org/multipage/urls-and-fetching.html#blocking-attributes

--- a/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
@@ -1590,6 +1590,77 @@ describe('Issues', () => {
 		).toStrictEqual([]);
 	});
 
+	// https://github.com/markuplint/markuplint/issues/1987
+	test('#1987', async () => {
+		// Valid preload destinations
+		expect((await mlRuleTest(rule, '<link rel="preload" as="fetch" href="/api" />')).violations).toStrictEqual([]);
+		expect(
+			(await mlRuleTest(rule, '<link rel="preload" as="font" href="/font.woff2" />')).violations,
+		).toStrictEqual([]);
+		expect((await mlRuleTest(rule, '<link rel="preload" as="script" href="/app.js" />')).violations).toStrictEqual(
+			[],
+		);
+		expect((await mlRuleTest(rule, '<link rel="preload" as="style" href="/app.css" />')).violations).toStrictEqual(
+			[],
+		);
+		expect((await mlRuleTest(rule, '<link rel="preload" as="track" href="/sub.vtt" />')).violations).toStrictEqual(
+			[],
+		);
+
+		// Valid module preload destinations
+		expect(
+			(await mlRuleTest(rule, '<link rel="modulepreload" as="script" href="/mod.js" />')).violations,
+		).toStrictEqual([]);
+		expect(
+			(await mlRuleTest(rule, '<link rel="modulepreload" as="worker" href="/worker.js" />')).violations,
+		).toStrictEqual([]);
+		expect(
+			(await mlRuleTest(rule, '<link rel="modulepreload" as="json" href="/data.json" />')).violations,
+		).toStrictEqual([]);
+		expect(
+			(await mlRuleTest(rule, '<link rel="modulepreload" as="style" href="/mod.css" />')).violations,
+		).toStrictEqual([]);
+		expect(
+			(await mlRuleTest(rule, '<link rel="modulepreload" as="audioworklet" href="/audio.js" />')).violations,
+		).toStrictEqual([]);
+
+		// Invalid: values removed from the spec (no longer valid for either preload or modulepreload)
+		expect(
+			(await mlRuleTest(rule, '<link rel="preload" as="audio" href="/audio.mp3" />')).violations,
+		).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 25,
+				message:
+					'The "as" attribute expects either "audioworklet", "fetch", "font", "image", "json", "paintworklet", "script", "serviceworker", "sharedworker", "style", "track", "worker"',
+				raw: 'audio',
+			},
+		]);
+		expect(
+			(await mlRuleTest(rule, '<link rel="preload" as="video" href="/video.mp4" />')).violations,
+		).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 25,
+				message:
+					'The "as" attribute expects either "audioworklet", "fetch", "font", "image", "json", "paintworklet", "script", "serviceworker", "sharedworker", "style", "track", "worker"',
+				raw: 'video',
+			},
+		]);
+		expect((await mlRuleTest(rule, '<link rel="preload" as="document" href="/page" />')).violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 25,
+				message:
+					'The "as" attribute expects either "audioworklet", "fetch", "font", "image", "json", "paintworklet", "script", "serviceworker", "sharedworker", "style", "track", "worker"',
+				raw: 'document',
+			},
+		]);
+	});
+
 	test('#564', async () => {
 		expect((await mlRuleTest(rule, '<div class="md:flex"></div>')).violations).toStrictEqual([]);
 		expect((await mlRuleTest(rule, '<svg><rect class="md:flex"/></svg>')).violations).toStrictEqual([]);


### PR DESCRIPTION
## Summary

- Update the enumerated values of the `as` attribute on `<link>` to the union of preload destinations and module preload destinations per WHATWG HTML spec changes
- **Preload destinations**: `fetch`, `font`, `image`, `script`, `style`, `track`
- **Module preload destinations**: `json`, `style`, `audioworklet`, `paintworklet`, `script`, `serviceworker`, `sharedworker`, `worker`
- Removed values no longer valid for either context: `audio`, `document`, `embed`, `frame`, `iframe`, `manifest`, `object`, `report`, `video`, `xslt`

Refs:
- whatwg/html#10212
- whatwg/html#11981
- whatwg/html#11727

Closes #1987

## Test plan

- [x] Valid preload destination values pass (`fetch`, `font`, `script`, `style`, `track`, `image`)
- [x] Valid module preload destination values pass (`script`, `worker`, `json`, `style`, `audioworklet`)
- [x] Removed values (`audio`, `video`, `document`) are reported as errors
- [x] Existing tests (`#553` imagesrcset + `as="image"`) still pass
- [x] Full test suite passes (141 files, 1513 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)