### PR TITLE
feat!: stop loading default config when --config is specified

### DIFF
--- a/docs/migration/v4-v5/cli.ja.md
+++ b/docs/migration/v4-v5/cli.ja.md
@@ -11,6 +11,7 @@
 |---------|---------|
 | `--allow-warnings` のデフォルトが `true` に変更 | 終了コードの動作 |
 | `--allow-warnings` が `--no-allow-warnings` にリネーム | CLI フラグ名 |
+| `--config` 指定時にデフォルト設定ファイルの自動読み込みを停止 | 設定ファイルの読み込み動作 |
 
 ## `--allow-warnings` のデフォルト変更
 
@@ -63,3 +64,34 @@ markuplint index.html
 ```
 
 > **ヒント**: 許容する警告数をより細かく制御するには `--max-warnings=N` を使用してください。
+
+## `--config` 指定時のデフォルト設定ファイル自動読み込みの停止
+
+v4 では、`--config` で設定ファイルを指定しても、デフォルトの設定ファイル（`.markuplintrc` など）が自動検索・読み込みされ、マージされていました。v5 では、`--config` を指定すると `--no-search-config` と同じ動作になり、指定したファイルのみが使用されます。
+
+### v4 の動作
+
+```bash
+# custom.json と .markuplintrc の両方が読み込まれてマージされる
+markuplint --config custom.json index.html
+```
+
+### v5 の動作
+
+```bash
+# custom.json のみ読み込まれ、.markuplintrc は無視される
+markuplint --config custom.json index.html
+```
+
+### 移行方法
+
+`--config` で指定したファイルとプロジェクトの `.markuplintrc` のマージに依存していた場合、設定ファイルの `extends` フィールドを使用してください:
+
+```json
+{
+  "extends": ["./.markuplintrc"],
+  "rules": {
+    "your-custom-rule": true
+  }
+}
+```

--- a/docs/migration/v4-v5/cli.md
+++ b/docs/migration/v4-v5/cli.md
@@ -11,6 +11,7 @@
 |--------|--------|
 | `--allow-warnings` default changed to `true` | Exit code behavior |
 | `--allow-warnings` renamed to `--no-allow-warnings` | CLI flag name |
+| `--config` no longer merges with auto-discovered config | Config loading behavior |
 
 ## `--allow-warnings` Default Changed
 
@@ -63,3 +64,34 @@ markuplint index.html
 ```
 
 > **Tip**: Use `--max-warnings=N` for finer control over the allowed number of warnings.
+
+## `--config` No Longer Merges with Auto-Discovered Config
+
+In v4, using `--config` to specify a config file still loaded the default config file (e.g., `.markuplintrc`) and merged them. In v5, `--config` now implies `--no-search-config` — only the specified file is used.
+
+### v4 Behavior
+
+```bash
+# Both custom.json AND .markuplintrc are loaded and merged
+markuplint --config custom.json index.html
+```
+
+### v5 Behavior
+
+```bash
+# Only custom.json is loaded; .markuplintrc is ignored
+markuplint --config custom.json index.html
+```
+
+### Migration
+
+If you relied on merging your `--config` file with the project's `.markuplintrc`, use the `extends` field in your config file instead:
+
+```json
+{
+  "extends": ["./.markuplintrc"],
+  "rules": {
+    "your-custom-rule": true
+  }
+}
+```

--- a/docs/migration/v4-v5/config.ja.md
+++ b/docs/migration/v4-v5/config.ja.md
@@ -15,6 +15,7 @@
 | ルールの配列値が連結から上書きに変更 | `extends` で配列ルール値を使用する設定ファイル |
 | ルール options が deep merge から shallow merge に変更 | `extends` でネストされた options を使用する設定ファイル |
 | Pretender の `data` 配列が上書きから追加に変更 | `extends` で pretenders を使用する設定ファイル |
+| `--config` 指定時にデフォルト設定ファイルの自動読み込みを停止 | `--config` を指定する CLI ユーザー |
 
 ## `ruleCommonSettings`
 
@@ -172,6 +173,37 @@ v5 ではマージアルゴリズムが変更されました。これらの変�
 | `data`     | 上書き    | 追加      |
 
 **移行方法:** これは一般的に非破壊的な改善です。pretender データを完全に置き換える必要がある場合は、`extends` を使用せず、単一の設定ですべての pretenders を定義してください。
+
+## `--config` 指定時のデフォルト設定ファイル自動読み込みの停止
+
+v4 では、CLI の `--config` オプションで設定ファイルを指定しても、デフォルトの設定ファイル（`.markuplintrc` など）が自動検索・読み込みされ、マージされていました。v5 では、`--config` を指定するとデフォルト設定ファイルの検索がスキップされ、指定したファイルのみが使用されます。
+
+**v4:** 両方の設定が読み込まれてマージされる。
+
+```bash
+# custom.json と .markuplintrc の両方が読み込まれてマージされる
+markuplint --config custom.json index.html
+```
+
+**v5:** 指定した設定のみが読み込まれる。
+
+```bash
+# custom.json のみ読み込まれ、.markuplintrc は無視される
+markuplint --config custom.json index.html
+```
+
+**移行方法:** `--config` で指定したファイルとプロジェクトの `.markuplintrc` のマージに依存していた場合、設定ファイルの `extends` を使用してください:
+
+```json
+{
+  "extends": ["./.markuplintrc"],
+  "rules": {
+    "your-custom-rule": true
+  }
+}
+```
+
+CLI フラグの変更の詳細は [CLI 移行ガイド](./cli.ja.md)を参照してください。
 
 ## ARIA 1.3 サポート
 

--- a/docs/migration/v4-v5/config.md
+++ b/docs/migration/v4-v5/config.md
@@ -15,6 +15,7 @@
 | Rule array values now override instead of concatenate | Config files using `extends` with array rule values |
 | Rule options now use shallow merge instead of deep merge | Config files using `extends` with nested option objects |
 | Pretender `data` arrays now append instead of override | Config files using `extends` with pretenders |
+| `--config` no longer merges with auto-discovered config | CLI users specifying `--config` |
 
 ## `ruleCommonSettings`
 
@@ -172,6 +173,37 @@ The merge algorithm has changed in v5. These changes affect how configurations a
 | `data`    | Override    | Append      |
 
 **Migration:** This is generally a non-breaking improvement. If you need to replace pretender data entirely, avoid using `extends` and define all pretenders in a single config.
+
+## `--config` No Longer Merges with Auto-Discovered Config
+
+In v4, using the CLI `--config` option to specify a config file still searched for and loaded the default config file (e.g., `.markuplintrc`) and merged them together. In v5, specifying `--config` now implicitly skips the default config file search — only the specified file is used.
+
+**v4:** Both configs loaded and merged.
+
+```bash
+# Loads custom.json AND .markuplintrc, then merges
+markuplint --config custom.json index.html
+```
+
+**v5:** Only the specified config is loaded.
+
+```bash
+# Loads only custom.json; .markuplintrc is ignored
+markuplint --config custom.json index.html
+```
+
+**Migration:** If you relied on merging your `--config` file with the project's `.markuplintrc`, use `extends` in your config file:
+
+```json
+{
+  "extends": ["./.markuplintrc"],
+  "rules": {
+    "your-custom-rule": true
+  }
+}
+```
+
+See the [CLI migration guide](./cli.md) for more details on CLI flag changes.
 
 ## ARIA 1.3 Support
 

--- a/packages/markuplint/src/api/ml-engine.spec.ts
+++ b/packages/markuplint/src/api/ml-engine.spec.ts
@@ -207,6 +207,53 @@ describe('Config Priority', () => {
 	});
 });
 
+describe('#1862 configFile skips default config search', () => {
+	it('configFile only — default config file is not loaded', async () => {
+		const filePath = path.resolve(__dirname, '../../test/issue1862/index.html');
+		const configFilePath = path.resolve(__dirname, '../../test/issue1862/config.json');
+		const file = await MLEngine.toMLFile(filePath);
+		const engine = new MLEngine(file!, {
+			configFile: configFilePath,
+		});
+
+		let configSet: ConfigSet | null = null;
+		engine.once('config', (_, _configSet) => {
+			configSet = _configSet;
+		});
+		await engine.exec();
+
+		// configFile rule should be applied
+		// @ts-ignore
+		expect(configSet?.config.rules?.['__test-rule']).toBe(true);
+		// Default .markuplintrc should NOT be loaded
+		// @ts-ignore
+		expect(configSet?.config.rules?.['wai-aria']).toBe(undefined);
+	});
+
+	it('configFile + noSearchConfig — consistent behavior', async () => {
+		const filePath = path.resolve(__dirname, '../../test/issue1862/index.html');
+		const configFilePath = path.resolve(__dirname, '../../test/issue1862/config.json');
+		const file = await MLEngine.toMLFile(filePath);
+		const engine = new MLEngine(file!, {
+			configFile: configFilePath,
+			noSearchConfig: true,
+		});
+
+		let configSet: ConfigSet | null = null;
+		engine.once('config', (_, _configSet) => {
+			configSet = _configSet;
+		});
+		await engine.exec();
+
+		// configFile rule should be applied
+		// @ts-ignore
+		expect(configSet?.config.rules?.['__test-rule']).toBe(true);
+		// Default .markuplintrc should NOT be loaded
+		// @ts-ignore
+		expect(configSet?.config.rules?.['wai-aria']).toBe(undefined);
+	});
+});
+
 describe('Parse Error Severity', () => {
 	it('from config', async () => {
 		const file = await MLEngine.toMLFile({

--- a/packages/markuplint/src/api/ml-engine.ts
+++ b/packages/markuplint/src/api/ml-engine.ts
@@ -382,9 +382,10 @@ export class MLEngine extends Emitter<MLEngineEventMap> {
 		const targetConfig = await this.#configProvider.search(this.#file);
 		this.emit('log', 'targetConfig', targetConfig ?? 'N/A');
 
-		const configFilePathsFromTarget = this.#options?.noSearchConfig
-			? (defaultConfigKey ?? null)
-			: (targetConfig ?? defaultConfigKey);
+		const configFilePathsFromTarget =
+			this.#options?.noSearchConfig || this.#options?.configFile
+				? (defaultConfigKey ?? null)
+				: (targetConfig ?? defaultConfigKey);
 		configLog('configFilePathsFromTarget: %s', configFilePathsFromTarget ?? 'N/A');
 		this.emit('log', 'configFilePathsFromTarget', configFilePathsFromTarget ?? 'N/A');
 
@@ -393,7 +394,7 @@ export class MLEngine extends Emitter<MLEngineEventMap> {
 		this.emit('log', 'option.config', configFilePathsFromTarget ?? 'N/A');
 
 		let defaultRecommended: string | null = null;
-		if (!defaultConfigKey && !configFilePathsFromTarget && !configKey) {
+		if (!defaultConfigKey && !configFilePathsFromTarget && !configKey && !this.#options?.configFile) {
 			// No configured
 			// Default: set recommended
 			defaultRecommended = this.#configProvider.set({ extends: ['markuplint:recommended'] });

--- a/packages/markuplint/test/issue1862/.markuplintrc
+++ b/packages/markuplint/test/issue1862/.markuplintrc
@@ -1,0 +1,6 @@
+{
+	"extends": ["markuplint:recommended"],
+	"rules": {
+		"wai-aria": true
+	}
+}

--- a/packages/markuplint/test/issue1862/config.json
+++ b/packages/markuplint/test/issue1862/config.json
@@ -1,0 +1,5 @@
+{
+	"rules": {
+		"__test-rule": true
+	}
+}

--- a/packages/markuplint/test/issue1862/index.html
+++ b/packages/markuplint/test/issue1862/index.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+<head>
+	<title>test</title>
+</head>
+<body>
+	<div></div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- `--config` 指定時にデフォルト設定ファイル（`.markuplintrc` 等）の自動検索をスキップするように変更
- `--config` の動作を `--no-search-config` と一貫させた
- v4-v5 migration guide (cli, config) に変更内容と移行方法を追記

Closes #1862

## BREAKING CHANGE

`--config` で設定ファイルを指定した場合、自動検出された設定ファイルとのマージが行われなくなります。従来の動作が必要な場合は、設定ファイル内で `"extends": ["./.markuplintrc"]` を使用してください。

## Test plan

- [x] `configFile` 指定時にデフォルト設定がマージされないことを検証するテスト追加
- [x] `configFile` + `noSearchConfig` の組み合わせテスト追加
- [x] 既存テスト全 61 件パス
- [x] `yarn lint` パス（ESLint + Prettier + CSpell）
- [x] `yarn build --scope markuplint` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)