### PR TITLE
docs: add mandatory lint and pre-flight checks to skill commands

### DIFF
--- a/.claude/commands/doc.md
+++ b/.claude/commands/doc.md
@@ -26,3 +26,7 @@ Thoroughly identify any omissions or inconsistencies in the documentation. **The
   - `@returns` — description of the return value is mandatory
   - `@template` — for each type parameter; include a description
 - Do not add redundant type annotations that TypeScript already provides — focus on describing the purpose and semantics
+
+# Final Step (MANDATORY)
+
+After all documentation changes are complete, **always run `yarn lint`** to verify formatting, spelling, and style. Fix any errors before committing.

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -3,5 +3,8 @@ description: Create and push a pull request
 ---
 
 1. Ensure that you are on a topic branch that is not `dev` or `main`.
-2. Review the changes on the current topic branch using appropriate `git` commands.
-3. Generate and execute a one-liner `gh pr create` command to create a pull request.
+2. **Pre-flight checks (MANDATORY — do NOT skip):**
+   - If `yarn lint-check`, `yarn build`, and `yarn test` have not already been run and passed in this session, run them **now** before proceeding.
+   - All three must pass. Fix any failures before continuing.
+3. Review the changes on the current topic branch using appropriate `git` commands.
+4. Generate and execute a one-liner `gh pr create` command to create a pull request.


### PR DESCRIPTION
## Summary

- `/doc` skill: ドキュメント変更後に `yarn lint` の実行を必須化
- `/pr` skill: PR作成前に `yarn lint-check`・`yarn build`・`yarn test` の実行を必須化

## Test plan

- [x] `yarn lint-check` passed
- [x] `yarn build` passed
- [x] `yarn test` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)