### PR TITLE
fix(vscode): fix extension activation and refactor config retrieval

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -49,6 +49,12 @@
 			"matchPackageNames": ["node"],
 			"matchManagers": ["dockerfile"],
 			"enabled": false
+		},
+		{
+			"description": "Do not update engines.vscode — must stay pinned for Cursor and other forks",
+			"matchPackageNames": ["vscode"],
+			"matchDepTypes": ["engines"],
+			"enabled": false
 		}
 	]
 }

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -13,7 +13,7 @@
 		"theme": "dark"
 	},
 	"engines": {
-		"vscode": "1.99.1"
+		"vscode": "^1.99.1"
 	},
 	"categories": [
 		"Programming Languages",

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -94,7 +94,8 @@ export function activate(
 		langConfigs[languageId] = {
 			enable: langConfig.get('enable') ?? true,
 			debug: langConfig.get('debug') ?? false,
-			defaultConfig: structuredClone(defaultConfig),
+			// eslint-disable-next-line unicorn/prefer-structured-clone
+			defaultConfig: JSON.parse(JSON.stringify(defaultConfig)),
 			hover: {
 				accessibility: {
 					enable: langConfig.get('hover.accessibility.enable') ?? true,

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -74,11 +74,14 @@ export function activate(
 		langConfigs[languageId] = {
 			enable: langConfig.get('enable') ?? true,
 			debug: langConfig.get('debug') ?? false,
-			defaultConfig: JSON.parse(JSON.stringify(defaultConfig)),
+			defaultConfig: structuredClone(defaultConfig),
 			hover: {
 				accessibility: {
 					enable: langConfig.get('hover.accessibility.enable') ?? true,
-					ariaVersion: langConfig.get<Config['hover']['accessibility']['ariaVersion']>('hover.accessibility.ariaVersion') ?? ARIA_RECOMMENDED_VERSION,
+					ariaVersion:
+						langConfig.get<Config['hover']['accessibility']['ariaVersion']>(
+							'hover.accessibility.ariaVersion',
+						) ?? ARIA_RECOMMENDED_VERSION,
 				},
 			},
 		};

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -62,17 +62,19 @@ export function activate(
 		},
 	};
 
-	const customLanguageList: string[] = config.get('targetLanguages') ?? [];
+	const customLanguageList: string[] = config.get('targetLanguages') ?? ['html'];
 	const languageList = [...new Set(customLanguageList)];
 
 	const langConfigs: LangConfigs = {};
 	for (const languageId of languageList) {
 		const langConfig = workspace.getConfiguration(ID, { languageId });
 
+		const defaultConfig = langConfig.get('defaultConfig') ?? { extends: ['markuplint:recommended'] };
+
 		langConfigs[languageId] = {
 			enable: langConfig.get('enable') ?? true,
 			debug: langConfig.get('debug') ?? false,
-			defaultConfig: langConfig.get('defaultConfig') ?? {},
+			defaultConfig: JSON.parse(JSON.stringify(defaultConfig)),
 			hover: {
 				accessibility: {
 					enable: langConfig.get('hover.accessibility.enable') ?? true,

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -67,18 +67,16 @@ export function activate(
 
 	const langConfigs: LangConfigs = {};
 	for (const languageId of languageList) {
-		const workspaceConfig = workspace.getConfiguration('', { languageId }).get(ID);
-		// eslint-disable-next-line unicorn/prefer-structured-clone
-		const config: Config = JSON.parse(JSON.stringify(workspaceConfig));
+		const langConfig = workspace.getConfiguration(ID, { languageId });
 
-		langConfigs[languageId] = config ?? {
-			enable: true,
-			debug: false,
-			defaultConfig: {},
+		langConfigs[languageId] = {
+			enable: langConfig.get('enable') ?? true,
+			debug: langConfig.get('debug') ?? false,
+			defaultConfig: langConfig.get('defaultConfig') ?? {},
 			hover: {
 				accessibility: {
-					enable: true,
-					ariaVersion: ARIA_RECOMMENDED_VERSION,
+					enable: langConfig.get('hover.accessibility.enable') ?? true,
+					ariaVersion: langConfig.get<Config['hover']['accessibility']['ariaVersion']>('hover.accessibility.ariaVersion') ?? ARIA_RECOMMENDED_VERSION,
 				},
 			},
 		};

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -35,6 +35,26 @@ export function activate(
 	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
 	context: ExtensionContext,
 ) {
+	const openLogCommand = commands.registerCommand(COMMAND_NAME_OPEN_LOG_COMMAND, () => {
+		logger?.show();
+	});
+	context.subscriptions.push(openLogCommand);
+
+	const restartServerCommand = commands.registerCommand(COMMAND_NAME_RESTART_SERVER, async () => {
+		if (client === undefined) {
+			return;
+		}
+		try {
+			void window.showInformationMessage('Restarting Markuplint language server...');
+			await client.stop();
+			await client.start();
+			void window.showInformationMessage('Markuplint language server restarted successfully.');
+		} catch (error) {
+			void window.showErrorMessage(`Failed to restart Markuplint language server: ${String(error)}`);
+		}
+	});
+	context.subscriptions.push(restartServerCommand);
+
 	const config = workspace.getConfiguration(ID);
 
 	if (config.get('enable') === false) {
@@ -135,23 +155,6 @@ export function activate(
 			void window.showInformationMessage(message);
 		});
 	});
-
-	const openLogCommand = commands.registerCommand(COMMAND_NAME_OPEN_LOG_COMMAND, () => {
-		logger.show();
-	});
-	context.subscriptions.push(openLogCommand);
-
-	const restartServerCommand = commands.registerCommand(COMMAND_NAME_RESTART_SERVER, async () => {
-		try {
-			void window.showInformationMessage('Restarting Markuplint language server...');
-			await client.stop();
-			await client.start();
-			void window.showInformationMessage('Markuplint language server restarted successfully.');
-		} catch (error) {
-			void window.showErrorMessage(`Failed to restart Markuplint language server: ${String(error)}`);
-		}
-	});
-	context.subscriptions.push(restartServerCommand);
 }
 
 export function deactivate() {

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -37,7 +37,7 @@ export function activate(
 ) {
 	const config = workspace.getConfiguration(ID);
 
-	if (!config.get('enable')) {
+	if (config.get('enable') === false) {
 		return;
 	}
 

--- a/vscode/test/config.spec.ts
+++ b/vscode/test/config.spec.ts
@@ -5,43 +5,35 @@ import * as vscode from 'vscode';
 
 suite('Config Tests', () => {
 	test('config', () => {
-		const config = vscode.workspace.getConfiguration();
+		const config = vscode.workspace.getConfiguration('markuplint');
 
-		const mlConfig = config.get('markuplint');
-
-		assert.deepStrictEqual(mlConfig, {
-			debug: true,
-			defaultConfig: {
-				extends: ['markuplint:recommended'],
-			},
-			enable: true,
-			hover: {
-				accessibility: {
-					ariaVersion: '1.2',
-					enable: true,
-				},
-			},
-			targetLanguages: [
-				'astro',
-				'ejs',
-				'haml',
-				'handlebars',
-				'html',
-				'jade',
-				'javascript',
-				'javascriptreact',
-				'jstl',
-				'liquid',
-				'mustache',
-				'nunjucks',
-				'php',
-				'ruby',
-				'smarty',
-				'svelte',
-				'typescript',
-				'typescriptreact',
-				'vue',
-			],
+		assert.strictEqual(config.get('debug'), true);
+		assert.strictEqual(config.get('enable'), true);
+		assert.deepStrictEqual(config.get('defaultConfig'), {
+			extends: ['markuplint:recommended'],
 		});
+		assert.deepStrictEqual(config.get('hover.accessibility.enable'), true);
+		assert.deepStrictEqual(config.get('hover.accessibility.ariaVersion'), '1.2');
+		assert.deepStrictEqual(config.get('targetLanguages'), [
+			'astro',
+			'ejs',
+			'haml',
+			'handlebars',
+			'html',
+			'jade',
+			'javascript',
+			'javascriptreact',
+			'jstl',
+			'liquid',
+			'mustache',
+			'nunjucks',
+			'php',
+			'ruby',
+			'smarty',
+			'svelte',
+			'typescript',
+			'typescriptreact',
+			'vue',
+		]);
 	});
 });

--- a/vscode/test/config.spec.ts
+++ b/vscode/test/config.spec.ts
@@ -36,4 +36,42 @@ suite('Config Tests', () => {
 			'vue',
 		]);
 	});
+
+	test('per-language scoped config resolves defaults', () => {
+		const languages = ['html', 'javascript', 'vue'];
+
+		for (const languageId of languages) {
+			const langConfig = vscode.workspace.getConfiguration('markuplint', { languageId });
+
+			const config = {
+				enable: langConfig.get('enable'),
+				debug: langConfig.get('debug'),
+				defaultConfig: langConfig.get('defaultConfig'),
+				hover: {
+					accessibility: {
+						enable: langConfig.get('hover.accessibility.enable'),
+						ariaVersion: langConfig.get('hover.accessibility.ariaVersion'),
+					},
+				},
+			};
+
+			assert.deepStrictEqual(
+				config,
+				{
+					enable: true,
+					debug: true,
+					defaultConfig: {
+						extends: ['markuplint:recommended'],
+					},
+					hover: {
+						accessibility: {
+							enable: true,
+							ariaVersion: '1.2',
+						},
+					},
+				},
+				`Config for language "${languageId}" should have all defaults resolved`,
+			);
+		}
+	});
 });

--- a/vscode/test/extension.spec.ts
+++ b/vscode/test/extension.spec.ts
@@ -1,9 +1,16 @@
 import assert from 'node:assert';
 
-import { suite, test } from 'mocha';
+import { suite, suiteSetup, test } from 'mocha';
 import * as vscode from 'vscode';
 
 suite('Extension Tests', () => {
+	suiteSetup(async () => {
+		const extension = vscode.extensions.getExtension('yusukehirao.vscode-markuplint');
+		if (extension && !extension.isActive) {
+			await extension.activate();
+		}
+	});
+
 	suite('Command Registration', () => {
 		test('markuplint.restartServer command should be registered', async () => {
 			const commands = await vscode.commands.getCommands(true);

--- a/vscode/test/extension.spec.ts
+++ b/vscode/test/extension.spec.ts
@@ -3,12 +3,27 @@ import assert from 'node:assert';
 import { suite, suiteSetup, test } from 'mocha';
 import * as vscode from 'vscode';
 
-suite('Extension Tests', () => {
-	suiteSetup(async () => {
-		const extension = vscode.extensions.getExtension('yusukehirao.vscode-markuplint');
-		if (extension && !extension.isActive) {
-			await extension.activate();
+const EXTENSION_ID = 'yusukehirao.vscode-markuplint';
+
+async function waitForExtension(timeout = 5000): Promise<vscode.Extension<unknown>> {
+	const start = Date.now();
+	while (Date.now() - start < timeout) {
+		const extension = vscode.extensions.getExtension(EXTENSION_ID);
+		if (extension) {
+			if (!extension.isActive) {
+				await extension.activate();
+			}
+			return extension;
 		}
+		await new Promise(resolve => setTimeout(resolve, 100));
+	}
+	throw new Error(`Extension ${EXTENSION_ID} not found within ${timeout}ms`);
+}
+
+suite('Extension Tests', () => {
+	suiteSetup(async function () {
+		this.timeout(10_000);
+		await waitForExtension();
 	});
 
 	suite('Command Registration', () => {
@@ -25,56 +40,44 @@ suite('Extension Tests', () => {
 
 	suite('Restart Server Command', () => {
 		test('should execute without throwing error', async () => {
-			// Open an HTML file to activate the extension
 			const doc = await vscode.workspace.openTextDocument({
 				language: 'html',
 				content: '<html><body><h1>Test</h1></body></html>',
 			});
 			await vscode.window.showTextDocument(doc);
 
-			// Wait for extension activation
 			await new Promise(resolve => setTimeout(resolve, 1000));
 
-			// Execute restart command - should not throw an error
 			await vscode.commands.executeCommand('markuplint.restartServer');
 
-			// Clean up
 			await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
 		});
 
 		test('should work after restart', async function () {
-			// Increase timeout for this test
 			this.timeout(10_000);
 
-			// Open an HTML file
 			const doc = await vscode.workspace.openTextDocument({
 				language: 'html',
 				content: '<html><body><h1>Test</h1></body></html>',
 			});
 			await vscode.window.showTextDocument(doc);
 
-			// Wait for extension activation
 			await new Promise(resolve => setTimeout(resolve, 1000));
 
-			// Execute restart command
 			await vscode.commands.executeCommand('markuplint.restartServer');
 
-			// Wait for restart to complete
 			await new Promise(resolve => setTimeout(resolve, 3000));
 
-			// Verify diagnostics still work after restart
-			// Note: This is a basic check that the extension is still functional
 			const diagnostics = vscode.languages.getDiagnostics(doc.uri);
 			assert.ok(Array.isArray(diagnostics), 'Diagnostics should be available after restart');
 
-			// Clean up
 			await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
 		});
 	});
 
 	suite('Extension Activation', () => {
 		test('extension should be active', () => {
-			const extension = vscode.extensions.getExtension('yusukehirao.vscode-markuplint');
+			const extension = vscode.extensions.getExtension(EXTENSION_ID);
 			assert.ok(extension, 'Extension should be installed');
 			assert.strictEqual(extension.isActive, true, 'Extension should be active');
 		});


### PR DESCRIPTION
## What is the purpose of this PR?

- [x] Fix bug
- [x] Improve or refactor core features

### Description

Fixes multiple issues preventing the VSCode extension from loading, and refactors the configuration retrieval logic.

**Bug fixes:**

1. **Missing caret in `engines.vscode`** — Changed `"1.99.1"` to `"^1.99.1"`. Without the caret, VS Code required an exact version match, causing `Extension is not compatible` errors on newer versions (e.g., 1.110.0-insider).
2. **`structuredClone` DataCloneError** — VS Code config objects are proxies that cannot be structurally cloned. Reverted to `JSON.parse(JSON.stringify(...))`.
3. **Renovate auto-updating `engines.vscode`** — Added a packageRule with `matchDepTypes: ["engines"]` to disable automatic updates. The engine version must be managed manually to maintain compatibility with Cursor and other VS Code forks.

**Refactoring:**

4. **Scoped Configuration API** — Use `workspace.getConfiguration(ID, { languageId })` to properly resolve language-specific settings with consistent default values.
5. **Command registration moved to top of `activate()`** — Ensures restart/log commands are registered even when `enable` is `false`.
6. **Test improvements** — Added scoped config test, added extension activation polling before tests.

## Checklist

- [x] Fix bug
  - [x] `engines.vscode` forward compatibility
  - [x] `structuredClone` DataCloneError
  - [x] Renovate `engines.vscode` auto-update prevention
- [x] Improve or refactor core features
  - [x] Scoped configuration API
  - [x] Command registration order
  - [x] Test improvements