### PR TITLE
docs: add TDD workflow and verification commands

### DIFF
--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -34,12 +34,13 @@ Read through the Issue body and comments carefully, then organize the following:
 
 ## Step 4: Propose a Resolution Plan
 
-Based on the analysis, present a resolution plan:
+Based on the analysis, present a resolution plan following **TDD (Test-Driven Development)**:
 
 1. **Approach**: The chosen solution and rationale
 2. **Files to Change**: List of files to modify or add
-3. **Implementation Steps**: Concrete steps in dependency order
-4. **Testing Strategy**: Test cases and validation methods to add
-5. **Risks**: Side effects and caveats
+3. **Implementation Steps**: Follow the **Red-Green** cycle for each behavior unit:
+   1. **Red**: Write failing tests first that define the expected behavior
+   2. **Green**: Implement the minimal code to make the tests pass
+4. **Risks**: Side effects and caveats
 
 Present the plan to the user and wait for approval before proceeding with implementation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,25 @@ Each package has a `SKILL.md` with package-specific maintenance guidance.
 | `@markuplint/php-parser`      | Maintenance tasks for php-parser                                      | [SKILL.md](packages/@markuplint/php-parser/SKILL.md)      |
 | `@markuplint/smarty-parser`   | Maintenance tasks for smarty-parser                                   | [SKILL.md](packages/@markuplint/smarty-parser/SKILL.md)   |
 
+## Verification Commands
+
+### Test
+
+- **Full test**: `yarn test` (no arguments)
+- **Single file/directory**: `npx vitest run <path>`
+- **NEVER use**: `npx lerna run test`, `yarn test --scope @markuplint/*`, or any other variant
+
+### Lint
+
+- **Full lint check**: `yarn lint-check` (no arguments) — runs ESLint, Prettier, and CSpell
+- **Full lint with auto-fix**: `yarn lint` (no arguments) — same linters with auto-fix enabled
+- **NEVER run linters individually** (e.g., `npx eslint ...` alone) — always use the root scripts to ensure all linters run
+
+### Build
+
+- **Full build**: `yarn build` (no arguments)
+- **Single package**: `yarn build --scope @markuplint/<package>`
+
 ## Worktree Usage
 
 When working on feature branches that involve multiple PRs or long-running tasks,


### PR DESCRIPTION
## Summary

- `/issue` skill: resolution plan に TDD Red-Green サイクルを追加（テストを先に書く → 実装で通す）
- `CLAUDE.md`: Verification Commands セクションを追加
  - test: `yarn test` or `npx vitest run <path>` のみ許可
  - lint: `yarn lint-check` / `yarn lint` のみ許可（個別リンター実行禁止）
  - build: `yarn build` / `yarn build --scope` のみ許可

## Test plan

- [x] `yarn lint-check` passed
- [x] `yarn build` passed (37 packages)
- [x] `yarn test` — flaky test in `index.spec.ts` (parallel execution race condition, passes in isolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)