### PR TITLE
fix: treat orphaned end tags as bogus to prevent false positives

### DIFF
--- a/packages/@markuplint/ml-core/docs/ml-dom/others.ja.md
+++ b/packages/@markuplint/ml-core/docs/ml-dom/others.ja.md
@@ -27,8 +27,9 @@ MLBlock のドキュメントは専用の [MLBlock](./block.ja.md) リファレ�
 - `nodeName`: `'#text'`
 - `nodeType`: `3`（`TEXT_NODE`）
 
-| メソッド                    | 戻り値    | 説明                                               |
+| プロパティ / メソッド       | 戻り値    | 説明                                               |
 | --------------------------- | --------- | -------------------------------------------------- |
+| `isBogus`                   | `boolean` | 不正な AST ノードから生成されたノードの場合 `true` |
 | `isWhitespace()`            | `boolean` | テキストが `/^\s+$/` にマッチする場合 `true`       |
 | `isRawTextElementContent()` | `boolean` | 親要素が `<script>` または `<style>` の場合 `true` |
 

--- a/packages/@markuplint/ml-core/docs/ml-dom/others.md
+++ b/packages/@markuplint/ml-core/docs/ml-dom/others.md
@@ -27,10 +27,11 @@ Text node. Extends `MLCharacterData` and implements DOM `Text`.
 - `nodeName`: `'#text'`
 - `nodeType`: `3` (`TEXT_NODE`)
 
-| Method                      | Returns   | Description                                         |
-| --------------------------- | --------- | --------------------------------------------------- |
-| `isWhitespace()`            | `boolean` | `true` if text matches `/^\s+$/`                    |
-| `isRawTextElementContent()` | `boolean` | `true` if parent element is `<script>` or `<style>` |
+| Property / Method           | Returns   | Description                                             |
+| --------------------------- | --------- | ------------------------------------------------------- |
+| `isBogus`                   | `boolean` | `true` if this node originated from an invalid AST node |
+| `isWhitespace()`            | `boolean` | `true` if text matches `/^\s+$/`                        |
+| `isRawTextElementContent()` | `boolean` | `true` if parent element is `<script>` or `<style>`     |
 
 ## MLComment
 

--- a/packages/@markuplint/ml-core/src/ml-dom/helper/create-node.spec.ts
+++ b/packages/@markuplint/ml-core/src/ml-dom/helper/create-node.spec.ts
@@ -17,4 +17,24 @@ describe('create Node', () => {
 		const node = createNode(astNode!, document);
 		expect(node.raw).toBe('<div>');
 	});
+
+	test('Invalid node (orphaned end tag) has isBogus', () => {
+		const sourceCode = '<div></p></div>';
+		const ast = parser.parse(sourceCode);
+		const ruleset = convertRuleset({});
+		const document = new Document(ast, ruleset, dummySchemas(), { ariaVersion: ARIA_RECOMMENDED_VERSION });
+		const invalidNode = document.nodeList.find(n => n.raw === '</p>');
+		expect(invalidNode).toBeDefined();
+		expect((invalidNode as any).isBogus).toBe(true);
+	});
+
+	test('Normal text node has isBogus false', () => {
+		const sourceCode = '<div>hello</div>';
+		const ast = parser.parse(sourceCode);
+		const ruleset = convertRuleset({});
+		const document = new Document(ast, ruleset, dummySchemas(), { ariaVersion: ARIA_RECOMMENDED_VERSION });
+		const textNode = document.nodeList.find(n => n.raw === 'hello');
+		expect(textNode).toBeDefined();
+		expect((textNode as any).isBogus).toBe(false);
+	});
 });

--- a/packages/@markuplint/ml-core/src/ml-dom/node/text.ts
+++ b/packages/@markuplint/ml-core/src/ml-dom/node/text.ts
@@ -35,6 +35,16 @@ export class MLText<T extends RuleConfigValue, O extends PlainData = undefined>
 	}
 
 	/**
+	 * Returns `true` if this text node originated from an invalid (bogus) AST
+	 * node, such as an orphaned end tag.
+	 *
+	 * @implements `@markuplint/ml-core` API: `MLText`
+	 */
+	get isBogus(): boolean {
+		return (this._astToken as MLASTText & { readonly isBogus?: boolean }).isBogus ?? false;
+	}
+
+	/**
 	 * Returns a string appropriate for the type of node as `Text`
 	 *
 	 * @see https://dom.spec.whatwg.org/#ref-for-attr%E2%91%A4

--- a/packages/@markuplint/rules/src/character-reference/index.spec.ts
+++ b/packages/@markuplint/rules/src/character-reference/index.spec.ts
@@ -58,6 +58,11 @@ test('in EJS', async () => {
 });
 
 describe('Issues', () => {
+	test('#1575: no false positive on orphaned end tag', async () => {
+		const { violations } = await mlRuleTest(rule, '<div></p></div>');
+		expect(violations).toStrictEqual([]);
+	});
+
 	test('#1074', async () => {
 		const { violations } = await mlRuleTest(rule, '<span>&#9660;</span><span>&#x25BC;</span><span>&x25BC;</span>');
 		expect(violations).toStrictEqual([

--- a/packages/@markuplint/rules/src/character-reference/index.ts
+++ b/packages/@markuplint/rules/src/character-reference/index.ts
@@ -22,7 +22,8 @@ const ignoreParentElement = new Set(['script', 'style']);
  *
  * Scans text nodes and attribute values for the characters `"`, `&`, `<`,
  * and `>` that are not already part of a valid character reference. Text
- * inside `<script>` and `<style>` elements is excluded.
+ * inside `<script>` and `<style>` elements is excluded, as are bogus
+ * text nodes (e.g., orphaned end tags).
  */
 export default createRule({
 	meta: meta,

--- a/packages/@markuplint/rules/src/character-reference/index.ts
+++ b/packages/@markuplint/rules/src/character-reference/index.ts
@@ -30,6 +30,9 @@ export default createRule({
 		const targetNodes: Report<RuleConfigValue>[] = [];
 
 		await document.walkOn('Text', node => {
+			if (node.isBogus) {
+				return;
+			}
 			if (node.parentNode && ignoreParentElement.has(node.parentNode.nodeName.toLowerCase())) {
 				return;
 			}

--- a/packages/@markuplint/rules/src/no-orphaned-end-tag/index.spec.ts
+++ b/packages/@markuplint/rules/src/no-orphaned-end-tag/index.spec.ts
@@ -29,3 +29,16 @@ test('It is test', async () => {
 		},
 	]);
 });
+
+test('#1575: orphaned end tag with newlines', async () => {
+	const { violations } = await mlRuleTest(rule, '<div>\n  </p>\n</div>');
+	expect(violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 2,
+			col: 3,
+			raw: '</p>',
+			message: 'Orphaned end tag detected',
+		},
+	]);
+});

--- a/packages/@markuplint/rules/src/no-orphaned-end-tag/index.ts
+++ b/packages/@markuplint/rules/src/no-orphaned-end-tag/index.ts
@@ -13,8 +13,7 @@ export default createRule<boolean, null>({
 	meta,
 	async verify({ document, report, t }) {
 		await document.walkOn('Text', text => {
-			const raw = text.raw.trim();
-			if (/^<\//.test(raw)) {
+			if (text.isBogus) {
 				report({
 					scope: text,
 					message: t('{0} detected', t('Orphaned end tag')),

--- a/packages/@markuplint/rules/src/no-orphaned-end-tag/index.ts
+++ b/packages/@markuplint/rules/src/no-orphaned-end-tag/index.ts
@@ -5,8 +5,8 @@ import meta from './meta.js';
 /**
  * Rule that detects orphaned end tags with no matching start tag.
  *
- * Scans text nodes for content that looks like a closing tag (starts with
- * `</`) which indicates a stray end tag that the parser could not match
+ * Scans text nodes and reports any that originated from invalid (bogus) AST
+ * nodes, which indicates a stray end tag that the parser could not match
  * to an opening element.
  */
 export default createRule<boolean, null>({


### PR DESCRIPTION
## Summary

Fixes #1575

- Add `isBogus` getter to `MLText` that reads the bogus flag preserved from invalid AST nodes through the spread in `create-node.ts`
- Skip bogus text nodes in `character-reference` rule to prevent false positive "escape `<` and `>`" warnings on orphaned end tags
- Replace regex-based detection in `no-orphaned-end-tag` rule with `isBogus` flag check for more accurate detection

## Test plan

- [x] `create-node.spec.ts`: verify `isBogus` is `true` for orphaned end tag nodes and `false` for normal text nodes
- [x] `character-reference/index.spec.ts`: verify no false positive on `<div></p></div>`
- [x] `no-orphaned-end-tag/index.spec.ts`: verify orphaned end tag with newlines is detected
- [x] Full test suite passes (1519 tests)
- [x] `yarn lint` passes
- [x] `yarn build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)