### PR TITLE
fix: support Bun runtime

### DIFF
--- a/packages/@markuplint/cli-utils/src/index.ts
+++ b/packages/@markuplint/cli-utils/src/index.ts
@@ -10,7 +10,8 @@ export { default as font } from 'picocolors';
 
 export { xterm } from './color.js';
 export { input, confirm, confirmSequence, select, multiSelect } from './prompt.js';
-export { installModule, InstallModuleResult } from './install-module.js';
+export { installModule } from './install-module.js';
+export type { InstallModuleResult } from './install-module.js';
 export { getWidth } from './get-width.js';
 export { header } from './header.js';
 export { invisibleSpace } from './invisible-space.js';

--- a/packages/@markuplint/i18n/src/index.ts
+++ b/packages/@markuplint/i18n/src/index.ts
@@ -1,2 +1,2 @@
 export { translator } from './translator.js';
-export { Translator, LocaleSet } from './types.js';
+export type { Translator, LocaleSet } from './types.js';

--- a/packages/@markuplint/jsx-parser/ARCHITECTURE.ja.md
+++ b/packages/@markuplint/jsx-parser/ARCHITECTURE.ja.md
@@ -105,7 +105,7 @@ JSX 式とその包含要素間の親子関係を追跡するプライベート 
 | メソッド              | 用途                                                                                                     |
 | --------------------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
 | `tokenize()`          | `jsxParser()` を呼び出して TypeScript ESTree 経由でソースをパースし、コメントを state に抽出             |
-| `parseError()`        | TypeScript ESTree のパースエラー（`lineNumber`/`column` 付き）を `ParserError` に変換                    |
+| `parseError()`        | TypeScript ESTree のパースエラーを `error.location.start` を使って `ParserError` に変換（下記注記参照）  |
 | `nodeize()`           | JSX AST ノードを markuplint ノードに変換。コメント、テキスト、要素、フラグメント、psblock を処理         |
 | `afterTraverse()`     | `#parentIdMap` を使用して psblock ノードの親子関係を再構築                                               |
 | `afterFlattenNodes()` | `exposeWhiteSpace: false` と `exposeInvalidNode: false` で親メソッドを呼び出す                           |
@@ -113,6 +113,12 @@ JSX 式とその包含要素間の親子関係を追跡するプライベート 
 | `visitAttr()`         | JSX 固有のクォート（`{}`）、IDL 属性マッピング、動的値検出を処理                                         |
 | `parseCodeFragment()` | `namelessFragment: true` で親メソッドに委譲                                                              |
 | `detectElementType()` | `/^[A-Z]                                                                                                 | \./` 正規表現でコンポーネント vs HTML 要素を検出 |
+
+### 注記: `parseError()` と TSError の getter プロパティ
+
+`@typescript-eslint/typescript-estree` の `TSError` は `lineNumber` と `column` を自身のプロパティではなく **prototype の getter プロパティ** として公開しています。一部のランタイム（例: Bun）ではこれらの getter に対する `'lineNumber' in error` チェックが失敗し、`super.parseError()` にフォールバックして `col` がデフォルト値 `0` になってしまいます。
+
+これを回避するため、`parseError()` は `error.location.start` を直接参照しています。これは `TSError` の own property であり、全ランタイムで確実に `{ line, column }` を提供します。
 
 ## JSX AST 抽出（jsx.ts）
 

--- a/packages/@markuplint/jsx-parser/ARCHITECTURE.md
+++ b/packages/@markuplint/jsx-parser/ARCHITECTURE.md
@@ -105,7 +105,7 @@ A private `WeakMap` that tracks the parent-child relationships between JSX expre
 | Method                | Purpose                                                                                                     |
 | --------------------- | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
 | `tokenize()`          | Invokes `jsxParser()` to parse source via TypeScript ESTree, extracts comments into state                   |
-| `parseError()`        | Converts TypeScript ESTree parse errors (with `lineNumber`/`column`) to `ParserError`                       |
+| `parseError()`        | Converts TypeScript ESTree parse errors to `ParserError` using `error.location.start` (see note below)      |
 | `nodeize()`           | Converts JSX AST nodes to markuplint nodes, handling comments, text, elements, fragments, and psblock nodes |
 | `afterTraverse()`     | Rebuilds parent-child relationships for psblock nodes using `#parentIdMap`                                  |
 | `afterFlattenNodes()` | Calls parent with `exposeWhiteSpace: false` and `exposeInvalidNode: false`                                  |
@@ -113,6 +113,12 @@ A private `WeakMap` that tracks the parent-child relationships between JSX expre
 | `visitAttr()`         | Handles JSX-specific quoting (`{}`), IDL attribute mapping, and dynamic value detection                     |
 | `parseCodeFragment()` | Delegates to parent with `namelessFragment: true`                                                           |
 | `detectElementType()` | Uses `/^[A-Z]                                                                                               | \./` regex to detect component vs HTML element |
+
+### Note: `parseError()` and TSError getter properties
+
+`TSError` from `@typescript-eslint/typescript-estree` exposes `lineNumber` and `column` as **prototype getter properties** rather than own properties. Some runtimes (e.g. Bun) fail the `'lineNumber' in error` check for these getters, which would cause a fallback to `super.parseError()` and default `col` to `0`.
+
+To avoid this, `parseError()` reads `error.location.start` directly -- an own property on `TSError` that reliably provides `{ line, column }` across all runtimes.
 
 ## JSX AST Extraction (jsx.ts)
 

--- a/packages/@markuplint/jsx-parser/src/parser.ts
+++ b/packages/@markuplint/jsx-parser/src/parser.ts
@@ -43,12 +43,14 @@ class JSXParser extends Parser<JSXNode, State> {
 	}
 
 	parseError(error: any) {
-		if (error instanceof Error && 'location' in error && error.location?.start) {
-			const { line, column } = error.location.start;
-			return new ParserError(error.message, {
-				line,
-				col: column,
-			});
+		if (error instanceof Error && 'location' in error) {
+			const loc = error.location as { start?: { line: number; column: number } };
+			if (loc.start) {
+				return new ParserError(error.message, {
+					line: loc.start.line,
+					col: loc.start.column,
+				});
+			}
 		}
 		return super.parseError(error);
 	}

--- a/packages/@markuplint/jsx-parser/src/parser.ts
+++ b/packages/@markuplint/jsx-parser/src/parser.ts
@@ -43,6 +43,11 @@ class JSXParser extends Parser<JSXNode, State> {
 	}
 
 	parseError(error: any) {
+		// TSError from @typescript-eslint/typescript-estree exposes
+		// `lineNumber` and `column` as prototype getter properties.
+		// Some runtimes (e.g. Bun) may fail the `in` check for these
+		// getters, so we read `error.location.start` (an own property
+		// on TSError) directly instead.
 		if (error instanceof Error && 'location' in error) {
 			const loc = error.location as { start?: { line: number; column: number } };
 			if (loc.start) {

--- a/packages/@markuplint/jsx-parser/src/parser.ts
+++ b/packages/@markuplint/jsx-parser/src/parser.ts
@@ -43,10 +43,11 @@ class JSXParser extends Parser<JSXNode, State> {
 	}
 
 	parseError(error: any) {
-		if (error instanceof Error && 'lineNumber' in error && 'column' in error) {
+		if (error instanceof Error && 'location' in error && error.location?.start) {
+			const { line, column } = error.location.start;
 			return new ParserError(error.message, {
-				line: error.lineNumber as number,
-				col: error.column as number,
+				line,
+				col: column,
 			});
 		}
 		return super.parseError(error);

--- a/packages/@markuplint/ml-config/src/index.ts
+++ b/packages/@markuplint/ml-config/src/index.ts
@@ -1,3 +1,3 @@
 export * from './merge-config.js';
 export * from './utils.js';
-export * from './types.js';
+export type * from './types.js';

--- a/packages/@markuplint/ml-core/src/index.ts
+++ b/packages/@markuplint/ml-core/src/index.ts
@@ -1,4 +1,4 @@
-export { RuleInfo, RuleConfig, RuleConfigValue } from '@markuplint/ml-config';
+export type { RuleInfo, RuleConfig, RuleConfigValue } from '@markuplint/ml-config';
 export {
 	ariaSpecs,
 	contentModelCategoryToTagNames,
@@ -19,8 +19,8 @@ export * from './ml-dom/index.js';
 export * from './ml-rule/index.js';
 export * from './plugin/index.js';
 export * from './test/index.js';
-export * from './types.js';
+export type * from './types.js';
 export * from './utils/index.js';
 export * from './violation-collector.js';
 
-export { AccessibilityProperties } from './ml-dom/node/types.js';
+export type { AccessibilityProperties } from './ml-dom/node/types.js';

--- a/packages/@markuplint/parser-utils/src/index.ts
+++ b/packages/@markuplint/parser-utils/src/index.ts
@@ -5,4 +5,4 @@ export * from './idl-attributes.js';
 export * from './parser-error.js';
 export * from './parser.js';
 export * from './script-parser.js';
-export * from './types.js';
+export type * from './types.js';

--- a/packages/@markuplint/selector/src/index.ts
+++ b/packages/@markuplint/selector/src/index.ts
@@ -1,7 +1,8 @@
 export { compareSpecificity } from './compare-specificity.js';
-export { matchSelector, SelectorMatches } from './match-selector.js';
+export { matchSelector } from './match-selector.js';
+export type { SelectorMatches } from './match-selector.js';
 export { createSelector } from './create-selector.js';
 export { Selector } from './selector.js';
 export type { ExtendedPseudoClass } from './selector.js';
 export { InvalidSelectorError } from './invalid-selector-error.js';
-export * from './types.js';
+export type * from './types.js';

--- a/packages/@markuplint/shared/src/index.ts
+++ b/packages/@markuplint/shared/src/index.ts
@@ -1,2 +1,2 @@
 export * from './functions.js';
-export * from './types.js';
+export type * from './types.js';

--- a/packages/@markuplint/types/src/index.ts
+++ b/packages/@markuplint/types/src/index.ts
@@ -8,4 +8,4 @@
 export * from './whatwg/is-custom-element-name.js';
 export * from './check.js';
 export * from './check-base.js';
-export * from './types.js';
+export type * from './types.js';


### PR DESCRIPTION
## Summary

Fix markuplint to work under the Bun runtime.

### 1. Use explicit `export type` for type-only re-exports (8 packages)

Bun validates ESM named exports statically at import time. Type-only exports (`type`, `interface`) re-exported via plain `export { ... }` or `export * from` don't exist in compiled `.js`, causing Bun to crash at startup:

```
SyntaxError: export 'SelectorMatches' not found in './match-selector.js'
```

Fixed by using `export type { ... }` and `export type * from`. Node.js is unaffected — `export type` is semantically correct and produces identical compiled output.

**Affected packages:** `@markuplint/selector`, `@markuplint/i18n`, `@markuplint/cli-utils`, `@markuplint/ml-core`, `@markuplint/ml-config`, `@markuplint/shared`, `@markuplint/parser-utils`, `@markuplint/types`

### 2. Fix jsx-parser `parseError` to use `error.location` (own property)

`TSError` from `@typescript-eslint/typescript-estree` exposes `lineNumber` and `column` as prototype getter properties. Under Bun, the `in` check for these getters returns `false`, causing fallback to `super.parseError()` which defaults `col` to `0`.

Fixed by reading `error.location.start` directly — an own property on `TSError` that works reliably across both Node.js and Bun.

Cherry-picked from #3200 (implementation changes only, CI workflow excluded).

## Test plan

- [x] `yarn build` passes
- [x] All 1520 tests pass on Node.js
- [ ] Bun runtime compatibility verified via #3200 CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)