### PR TITLE
ci: add Deno runtime testing workflow

### DIFF
--- a/.github/workflows/test-deno.yml
+++ b/.github/workflows/test-deno.yml
@@ -1,0 +1,162 @@
+name: Test Deno
+
+on:
+    pull_request:
+        branches:
+            - dev
+            - v3
+            - next
+        paths:
+            - '.github/workflows/test-deno.yml'
+            - 'vitest.config.ts'
+            - 'packages/**'
+            - '!**/*.md'
+            - 'packages/@markuplint/config-presets/src/README.md'
+            - 'test/**'
+            - 'yarn.lock'
+            - '.yarnrc.yml'
+
+env:
+    NODE_BUILD_VERSION: 24
+    NX_DISABLE_DB: true
+
+jobs:
+    setup-and-build:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+              with:
+                  # SEE: https://github.com/lerna/lerna/issues/2542
+                  fetch-depth: '0'
+
+            - name: Use Node.js ${{ env.NODE_BUILD_VERSION }}
+              uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+              with:
+                  node-version: ${{ env.NODE_BUILD_VERSION }}
+
+            - name: Enable Corepack and setup Yarn v4
+              run: |
+                  corepack enable
+                  yarn --version
+
+            - name: Get yarn cache directory path
+              id: yarn-cache-dir-path
+              run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
+
+            - name: Cache Restore devDependencies
+              id: cache-restore-dev-depends
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
+              with:
+                  path: |
+                      '**/node_modules'
+                      ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                  key: dev-depends-ubuntu-latest-node${{ env.NODE_BUILD_VERSION }}-${{ hashFiles('yarn.lock', '.yarnrc.yml') }}
+
+            - name: Install dependencies
+              if: steps.cache-restore-dev-depends.outputs.cache-hit != 'true'
+              run: yarn install --immutable
+
+            - name: Cache Save devDependencies
+              if: steps.cache-restore-dev-depends.outputs.cache-hit != 'true'
+              uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
+              with:
+                  path: |
+                      '**/node_modules'
+                      ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                  key: dev-depends-ubuntu-latest-node${{ env.NODE_BUILD_VERSION }}-${{ hashFiles('yarn.lock', '.yarnrc.yml') }}
+
+            - name: Cache Restore Production
+              id: cache-restore-prod
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
+              with:
+                  path: |
+                      packages/**/lib
+                      packages/**/cjs
+                      packages/**/esm
+                      packages/@markuplint/config-presets/preset.*.json
+                      packages/@markuplint/html-spec/index.js
+                      packages/@markuplint/html-spec/index.json
+                  key: prod-node${{ env.NODE_BUILD_VERSION }}-${{ github.sha }}
+
+            - name: Install dependencies
+              run: yarn install --immutable
+
+            - name: Build
+              if: steps.cache-restore-prod.outputs.cache-hit != 'true'
+              run: yarn run build
+
+            - name: Cache Save Production
+              if: steps.cache-restore-prod.outputs.cache-hit != 'true'
+              uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
+              with:
+                  enableCrossOsArchive: true
+                  path: |
+                      packages/**/lib
+                      packages/**/cjs
+                      packages/**/esm
+                      packages/@markuplint/config-presets/preset.*.json
+                      packages/@markuplint/html-spec/index.js
+                      packages/@markuplint/html-spec/index.json
+                  key: prod-node${{ env.NODE_BUILD_VERSION }}-${{ github.sha }}
+
+    test-deno:
+        needs: setup-and-build
+        runs-on: ubuntu-latest
+        continue-on-error: true
+        strategy:
+            fail-fast: false
+            matrix:
+                deno-version: [latest]
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+              with:
+                  fetch-depth: '0'
+
+            - name: Use Node.js ${{ env.NODE_BUILD_VERSION }}
+              uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+              with:
+                  node-version: ${{ env.NODE_BUILD_VERSION }}
+
+            - name: Enable Corepack and setup Yarn v4
+              run: |
+                  corepack enable
+                  yarn --version
+
+            - name: Setup Deno ${{ matrix.deno-version }}
+              uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2
+              with:
+                  deno-version: ${{ matrix.deno-version }}
+
+            - name: Get yarn cache directory path
+              id: yarn-cache-dir-path
+              run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
+
+            - name: Cache Restore devDependencies
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
+              with:
+                  path: |
+                      '**/node_modules'
+                      ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                  key: dev-depends-ubuntu-latest-node${{ env.NODE_BUILD_VERSION }}-${{ hashFiles('yarn.lock', '.yarnrc.yml') }}
+
+            - name: Cache Restore Production
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
+              with:
+                  enableCrossOsArchive: true
+                  path: |
+                      packages/**/lib
+                      packages/**/cjs
+                      packages/**/esm
+                      packages/@markuplint/config-presets/preset.*.json
+                      packages/@markuplint/html-spec/index.js
+                      packages/@markuplint/html-spec/index.json
+                  key: prod-node${{ env.NODE_BUILD_VERSION }}-${{ github.sha }}
+
+            - name: Install dependencies
+              run: yarn install --immutable
+
+            - name: Print Deno version
+              run: deno --version
+
+            - name: Test with Deno
+              run: deno run -A --node-modules-dir npm:vitest run

--- a/cspell.json
+++ b/cspell.json
@@ -34,6 +34,7 @@
 		"attributionsrc",
 		"bday",
 		"bunx",
+		"deno",
 		"biblioentry",
 		"biblioref",
 		"checkings",


### PR DESCRIPTION
Add a GitHub Actions workflow to run tests under the Deno runtime,
mirroring the existing Bun test workflow (PR #3200).

Closes #1536

https://claude.ai/code/session_01RenZ4kQmBRYUTQSWGPk8MC