### PR TITLE
fix(types): use instanceof TypeError for URL validation error handling for Deno

### DIFF
--- a/packages/@markuplint/types/src/whatwg/is-abs-url.ts
+++ b/packages/@markuplint/types/src/whatwg/is-abs-url.ts
@@ -20,12 +20,7 @@ export const isAbsURL: FormattedPrimitiveTypeCreator = () => {
 		try {
 			new URL(value);
 		} catch (error: unknown) {
-			if (
-				error &&
-				typeof error === 'object' &&
-				'code' in error && // @ts-ignore
-				error.code === 'ERR_INVALID_URL'
-			) {
+			if (error instanceof TypeError) {
 				return false;
 			}
 			throw error;


### PR DESCRIPTION
Replace Node.js-specific error.code === 'ERR_INVALID_URL' check with
error instanceof TypeError for cross-runtime compatibility (Node.js/Deno).
Per the WHATWG URL spec, the URL constructor throws TypeError for invalid URLs.

https://claude.ai/code/session_011yoWG6AqWkp3iSE8GREtVW