### PR TITLE
fix: prevent a11y preset from bypassing noUse on dialog tabindex

### DIFF
--- a/packages/@markuplint/config-presets/README.md
+++ b/packages/@markuplint/config-presets/README.md
@@ -26,7 +26,6 @@ Ruleset|Description|`recommended`|`recommended-vue`|`recommended-svelte`|`recomm
 ---|---|---|---|---|---|---|---|---|---|---|---|---|
 [Must not duplicate **ID**](https://www.w3.org/WAI/WCAG21/Techniques/html/H93.html)|Be able to avoid problems in assistive technologies from the viewpoint of machine readability.|✅|✅|✅|✅|✅|✅|❌|✅|❌|❌|❌|
 [Disallow `accesskey` attr](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/accesskey#accessibility_concerns)| |✅|✅|✅|✅|✅|✅|❌|❌|❌|❌|❌|
-[`tabindex` attr only `-1` or `0`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex#accessibility_concerns)| |✅|✅|✅|✅|✅|✅|❌|❌|❌|❌|❌|
 `<label>` should have control| |✅|✅|✅|✅|✅|✅|❌|❌|❌|❌|❌|
 [Use **landmark**](https://www.w3.org/TR/wai-aria-practices/examples/landmarks/)| |✅|✅|✅|✅|✅|✅|❌|❌|❌|❌|❌|
 **Popover** trigger and target must be adjacent| |✅|✅|✅|✅|✅|✅|❌|❌|❌|❌|❌|
@@ -45,6 +44,7 @@ Require `<video muted>`| |✅|✅|✅|✅|✅|✅|❌|❌|❌|❌|❌|
 No merge cells| |✅|✅|✅|✅|✅|✅|❌|❌|❌|❌|❌|
 [`<summary>` no contains interactive contents](https://github.com/whatwg/html/issues/2272#issuecomment-1242415594)|There is a case where an assistive technology can't access contents, or contents don't propagate a mouse event to `<summary>`.|✅|✅|✅|✅|✅|✅|❌|❌|❌|❌|❌|
 [Disallow `autofocus` attr to except in the dialog scope](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autofocus#accessibility_considerations)|Don't take away a focus to forced. However,  the `dialog` element and its descendants allow it.|✅|✅|✅|✅|✅|✅|❌|❌|❌|❌|❌|
+[`tabindex` attr only `-1` or `0`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex#accessibility_concerns)|Scoped to non-dialog elements because the HTML spec disallows `tabindex` on `<dialog>` (`noUse`).|✅|✅|✅|✅|✅|✅|❌|❌|❌|❌|❌|
 [No duplicate attr](https://html.spec.whatwg.org/multipage/parsing.html#parse-error-duplicate-attribute)|The parser ignores all such duplicate occurrences of the attribute.|✅|✅|✅|✅|✅|❌|❌|✅|❌|❌|❌|
 No use deprecated attr|You should not use deprecated attributes from the viewpoint of compatibility.|✅|✅|✅|✅|✅|❌|❌|✅|❌|❌|❌|
 No use deprecated element|You should not use deprecated elements from the viewpoint of compatibility.|✅|✅|✅|✅|✅|❌|❌|✅|❌|❌|❌|

--- a/packages/@markuplint/config-presets/src/preset.a11y.json
+++ b/packages/@markuplint/config-presets/src/preset.a11y.json
@@ -18,19 +18,6 @@
 					 * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/accesskey#accessibility_concerns
 					 */
 					"accesskey"
-				],
-				"allowAttrs": [
-					{
-						/**
-						 * `tabindex` attr only `-1` or `0`
-						 *
-						 * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex#accessibility_concerns
-						 */
-						"name": "tabindex",
-						"value": {
-							"enum": ["-1", "0"]
-						}
-					}
 				]
 			}
 		},
@@ -187,6 +174,31 @@
 							 * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autofocus#accessibility_considerations
 							 */
 							"autofocus"
+						]
+					}
+				}
+			}
+		},
+		{
+			"selector": ":where(:not(dialog))",
+			"rules": {
+				"invalid-attr": {
+					"options": {
+						"allowAttrs": [
+							{
+								/**
+								 * `tabindex` attr only `-1` or `0`
+								 *
+								 * Scoped to non-dialog elements because the HTML spec
+								 * disallows `tabindex` on `<dialog>` (`noUse`).
+								 *
+								 * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex#accessibility_concerns
+								 */
+								"name": "tabindex",
+								"value": {
+									"enum": ["-1", "0"]
+								}
+							}
 						]
 					}
 				}

--- a/packages/@markuplint/rules/src/invalid-attr/README.ja.md
+++ b/packages/@markuplint/rules/src/invalid-attr/README.ja.md
@@ -46,6 +46,12 @@ const Component = (props) => {
 
 ### `allowAttrs`オプションの設定 {#setting-allow-attrs-option}
 
+:::caution
+`allowAttrs`は仕様レベルの制約（`noUse`など）を上書きできます。
+プリセットや共有設定を作成する際は、`nodeRules`でスコープを絞り、
+HTML仕様が特定の要素で禁止している属性を意図せず許可しないよう注意してください。
+:::
+
 **配列**もしくは**オブジェクト**を受け取ります。
 
 #### 配列形式 {#allow-attrs-array-format}

--- a/packages/@markuplint/rules/src/invalid-attr/README.md
+++ b/packages/@markuplint/rules/src/invalid-attr/README.md
@@ -45,6 +45,13 @@ const Component = (props) => {
 
 ### Setting `allowAttrs` option {#setting-allow-attrs-option}
 
+:::caution
+`allowAttrs` can override spec-level restrictions (such as `noUse`).
+When writing presets or shared configurations, use `nodeRules` to
+scope `allowAttrs` so it does not unintentionally allow attributes
+that the HTML specification disallows on specific elements.
+:::
+
 It accepts an **array** or an **object**.
 
 #### Array format {#allow-attrs-array-format}

--- a/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
@@ -647,6 +647,19 @@ test('noUse flag', async () => {
 	]);
 });
 
+test('noUse flag with allowAttrs (allowAttrs overrides noUse)', async () => {
+	const { violations } = await mlRuleTest(rule, '<dialog tabindex="0"></dialog>', {
+		rule: {
+			options: {
+				allowAttrs: [{ name: 'tabindex', value: { enum: ['-1', '0'] } }],
+			},
+		},
+	});
+	// allowAttrs intentionally overrides spec-level noUse — users can opt in.
+	// Presets should use nodeRules to scope allowAttrs and avoid this.
+	expect(violations).toStrictEqual([]);
+});
+
 test('svg', async () => {
 	expect(
 		(

--- a/packages/@markuplint/rules/src/invalid-attr/index.ts
+++ b/packages/@markuplint/rules/src/invalid-attr/index.ts
@@ -15,11 +15,16 @@ const log = ruleLog.extend('invalid-attr');
  */
 type Option = {
 	/**
+	 * Attributes to allow beyond what the spec permits.
+	 * Can override spec-level restrictions such as `noUse`.
+	 *
 	 * @since 3.7.0
 	 */
 	allowAttrs?: (string | Attr)[] | Record<string, ValueRule>;
 
 	/**
+	 * Attributes to disallow in addition to spec restrictions.
+	 *
 	 * @since 3.7.0
 	 */
 	disallowAttrs?: (string | Attr)[] | Record<string, ValueRule>;


### PR DESCRIPTION
## Summary

- Move `tabindex` `allowAttrs` from global rules to `nodeRules` with `:where(:not(dialog))` selector in `preset.a11y.json`, preventing it from overriding the spec-level `noUse` restriction on `<dialog tabindex>`
- Document that `allowAttrs` can override spec-level restrictions like `noUse`, recommending `nodeRules` to scope it in presets and shared configurations
- Add JSDoc descriptions for `allowAttrs` and `disallowAttrs` options

## Context

`<dialog tabindex="0">` is disallowed by the HTML spec (`noUse: true`), but the `markuplint:a11y` preset's global `allowAttrs: [{ name: "tabindex", value: { enum: ["-1", "0"] } }]` matched first and bypassed the `noUse` check.

Rather than changing the rule implementation to prioritize `noUse` over `allowAttrs` (which would reduce user configuration freedom), this fix scopes the preset's `tabindex` `allowAttrs` to non-dialog elements using `nodeRules`, following the existing `autofocus` pattern (`:not(dialog, dialog *)`).

Closes #1734

## Test plan

- [x] `npx vitest run packages/@markuplint/rules/src/invalid-attr/index.spec.ts` — all 74 tests pass (1 skipped)
- [x] `yarn test` — all 1653 tests pass
- [x] `yarn build` — all 37 projects build successfully
- [x] `yarn lint-check` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)