### PR TITLE
fix(html-spec): add aria-valuenow restrictions and missing alt fields

### DIFF
--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -51502,7 +51502,33 @@
 						"permittedRoles": false,
 						"properties": {
 							"global": true,
-							"role": "spinbutton"
+							"role": "spinbutton",
+							"without": [
+								{
+									"type": "should-not",
+									"name": "aria-valuemax",
+									"alt": {
+										"method": "set-attr",
+										"target": "max"
+									}
+								},
+								{
+									"type": "should-not",
+									"name": "aria-valuemin",
+									"alt": {
+										"method": "set-attr",
+										"target": "min"
+									}
+								},
+								{
+									"type": "should-not",
+									"name": "aria-valuenow",
+									"alt": {
+										"method": "set-attr",
+										"target": "value"
+									}
+								}
+							]
 						}
 					},
 					"[type='password' i]": {
@@ -51540,11 +51566,27 @@
 							"without": [
 								{
 									"type": "should-not",
-									"name": "aria-valuemax"
+									"name": "aria-valuemax",
+									"alt": {
+										"method": "set-attr",
+										"target": "max"
+									}
 								},
 								{
 									"type": "should-not",
-									"name": "aria-valuemin"
+									"name": "aria-valuemin",
+									"alt": {
+										"method": "set-attr",
+										"target": "min"
+									}
+								},
+								{
+									"type": "should-not",
+									"name": "aria-valuenow",
+									"alt": {
+										"method": "set-attr",
+										"target": "value"
+									}
 								}
 							]
 						}
@@ -51735,7 +51777,33 @@
 							"permittedRoles": false,
 							"properties": {
 								"global": true,
-								"role": "spinbutton"
+								"role": "spinbutton",
+								"without": [
+									{
+										"type": "should-not",
+										"name": "aria-valuemax",
+										"alt": {
+											"method": "set-attr",
+											"target": "max"
+										}
+									},
+									{
+										"type": "should-not",
+										"name": "aria-valuemin",
+										"alt": {
+											"method": "set-attr",
+											"target": "min"
+										}
+									},
+									{
+										"type": "should-not",
+										"name": "aria-valuenow",
+										"alt": {
+											"method": "set-attr",
+											"target": "value"
+										}
+									}
+								]
 							}
 						},
 						"[type='password' i]": {
@@ -51773,11 +51841,27 @@
 								"without": [
 									{
 										"type": "should-not",
-										"name": "aria-valuemax"
+										"name": "aria-valuemax",
+										"alt": {
+											"method": "set-attr",
+											"target": "max"
+										}
 									},
 									{
 										"type": "should-not",
-										"name": "aria-valuemin"
+										"name": "aria-valuemin",
+										"alt": {
+											"method": "set-attr",
+											"target": "min"
+										}
+									},
+									{
+										"type": "should-not",
+										"name": "aria-valuenow",
+										"alt": {
+											"method": "set-attr",
+											"target": "value"
+										}
 									}
 								]
 							}
@@ -52945,11 +53029,27 @@
 					"without": [
 						{
 							"type": "should-not",
-							"name": "aria-valuemax"
+							"name": "aria-valuemax",
+							"alt": {
+								"method": "set-attr",
+								"target": "max"
+							}
 						},
 						{
 							"type": "should-not",
-							"name": "aria-valuemin"
+							"name": "aria-valuemin",
+							"alt": {
+								"method": "set-attr",
+								"target": "min"
+							}
+						},
+						{
+							"type": "should-not",
+							"name": "aria-valuenow",
+							"alt": {
+								"method": "set-attr",
+								"target": "value"
+							}
 						}
 					]
 				},
@@ -53371,7 +53471,11 @@
 							"without": [
 								{
 									"type": "should-not",
-									"name": "aria-selected"
+									"name": "aria-selected",
+									"alt": {
+										"method": "set-attr",
+										"target": "selected"
+									}
 								}
 							]
 						}
@@ -53630,7 +53734,19 @@
 					"without": [
 						{
 							"type": "should-not",
-							"name": "aria-valuemax"
+							"name": "aria-valuemax",
+							"alt": {
+								"method": "set-attr",
+								"target": "max"
+							}
+						},
+						{
+							"type": "should-not",
+							"name": "aria-valuenow",
+							"alt": {
+								"method": "set-attr",
+								"target": "value"
+							}
 						}
 					]
 				}
@@ -54091,7 +54207,11 @@
 					"without": [
 						{
 							"type": "should-not",
-							"name": "aria-multiselectable"
+							"name": "aria-multiselectable",
+							"alt": {
+								"method": "set-attr",
+								"target": "multiple"
+							}
 						}
 					]
 				},
@@ -54105,7 +54225,11 @@
 							"without": [
 								{
 									"type": "should-not",
-									"name": "aria-multiselectable"
+									"name": "aria-multiselectable",
+									"alt": {
+										"method": "set-attr",
+										"target": "multiple"
+									}
 								}
 							]
 						}

--- a/packages/@markuplint/html-spec/src/spec.input.json
+++ b/packages/@markuplint/html-spec/src/spec.input.json
@@ -470,7 +470,34 @@
 				"permittedRoles": false,
 				"properties": {
 					"global": true,
-					"role": "spinbutton"
+					"role": "spinbutton",
+					// Authors SHOULD NOT use the aria-valuemax, aria-valuemin, or aria-valuenow attributes on input type=number.
+					"without": [
+						{
+							"type": "should-not",
+							"name": "aria-valuemax",
+							"alt": {
+								"method": "set-attr",
+								"target": "max"
+							}
+						},
+						{
+							"type": "should-not",
+							"name": "aria-valuemin",
+							"alt": {
+								"method": "set-attr",
+								"target": "min"
+							}
+						},
+						{
+							"type": "should-not",
+							"name": "aria-valuenow",
+							"alt": {
+								"method": "set-attr",
+								"target": "value"
+							}
+						}
+					]
 				}
 			},
 			"[type='password' i]": {
@@ -507,15 +534,31 @@
 				"properties": {
 					"global": true,
 					"role": "slider",
-					// Authors SHOULD NOT use the aria-valuemax or aria-valuemin attributes on input type=range.
+					// Authors SHOULD NOT use the aria-valuemax, aria-valuemin, or aria-valuenow attributes on input type=range.
 					"without": [
 						{
 							"type": "should-not",
-							"name": "aria-valuemax"
+							"name": "aria-valuemax",
+							"alt": {
+								"method": "set-attr",
+								"target": "max"
+							}
 						},
 						{
 							"type": "should-not",
-							"name": "aria-valuemin"
+							"name": "aria-valuemin",
+							"alt": {
+								"method": "set-attr",
+								"target": "min"
+							}
+						},
+						{
+							"type": "should-not",
+							"name": "aria-valuenow",
+							"alt": {
+								"method": "set-attr",
+								"target": "value"
+							}
 						}
 					]
 				}
@@ -709,7 +752,34 @@
 					"permittedRoles": false,
 					"properties": {
 						"global": true,
-						"role": "spinbutton"
+						"role": "spinbutton",
+						// Authors SHOULD NOT use the aria-valuemax, aria-valuemin, or aria-valuenow attributes on input type=number.
+						"without": [
+							{
+								"type": "should-not",
+								"name": "aria-valuemax",
+								"alt": {
+									"method": "set-attr",
+									"target": "max"
+								}
+							},
+							{
+								"type": "should-not",
+								"name": "aria-valuemin",
+								"alt": {
+									"method": "set-attr",
+									"target": "min"
+								}
+							},
+							{
+								"type": "should-not",
+								"name": "aria-valuenow",
+								"alt": {
+									"method": "set-attr",
+									"target": "value"
+								}
+							}
+						]
 					}
 				},
 				"[type='password' i]": {
@@ -746,15 +816,31 @@
 					"properties": {
 						"global": true,
 						"role": "slider",
-						// Authors SHOULD NOT use the aria-valuemax or aria-valuemin attributes on input type=range.
+						// Authors SHOULD NOT use the aria-valuemax, aria-valuemin, or aria-valuenow attributes on input type=range.
 						"without": [
 							{
 								"type": "should-not",
-								"name": "aria-valuemax"
+								"name": "aria-valuemax",
+								"alt": {
+									"method": "set-attr",
+									"target": "max"
+								}
 							},
 							{
 								"type": "should-not",
-								"name": "aria-valuemin"
+								"name": "aria-valuemin",
+								"alt": {
+									"method": "set-attr",
+									"target": "min"
+								}
+							},
+							{
+								"type": "should-not",
+								"name": "aria-valuenow",
+								"alt": {
+									"method": "set-attr",
+									"target": "value"
+								}
 							}
 						]
 					}

--- a/packages/@markuplint/html-spec/src/spec.meter.json
+++ b/packages/@markuplint/html-spec/src/spec.meter.json
@@ -45,15 +45,31 @@
 		"permittedRoles": false,
 		"properties": {
 			"global": true,
-			// Authors SHOULD NOT use the aria-valuemax or aria-valuemin attributes on meter elements.
+			// Authors SHOULD NOT use the aria-valuemax, aria-valuemin, or aria-valuenow attributes on meter elements.
 			"without": [
 				{
 					"type": "should-not",
-					"name": "aria-valuemax"
+					"name": "aria-valuemax",
+					"alt": {
+						"method": "set-attr",
+						"target": "max"
+					}
 				},
 				{
 					"type": "should-not",
-					"name": "aria-valuemin"
+					"name": "aria-valuemin",
+					"alt": {
+						"method": "set-attr",
+						"target": "min"
+					}
+				},
+				{
+					"type": "should-not",
+					"name": "aria-valuenow",
+					"alt": {
+						"method": "set-attr",
+						"target": "value"
+					}
 				}
 			]
 		},

--- a/packages/@markuplint/html-spec/src/spec.option.json
+++ b/packages/@markuplint/html-spec/src/spec.option.json
@@ -62,10 +62,17 @@
 					"global": true,
 					"role": "option",
 					// Authors SHOULD NOT use the aria-selected attribute on the option element.
+					// Note: This without check is currently non-functional because
+					// getComputedRole() returns null for option inside select
+					// (Required Context Role mismatch). See #3214.
 					"without": [
 						{
 							"type": "should-not",
-							"name": "aria-selected"
+							"name": "aria-selected",
+							"alt": {
+								"method": "set-attr",
+								"target": "selected"
+							}
 						}
 					]
 				}

--- a/packages/@markuplint/html-spec/src/spec.progress.json
+++ b/packages/@markuplint/html-spec/src/spec.progress.json
@@ -31,11 +31,23 @@
 		"properties": {
 			"global": true,
 			"role": "progressbar",
-			// Authors SHOULD NOT use the aria-valuemax attribute on progress elements.
+			// Authors SHOULD NOT use the aria-valuemax or aria-valuenow attributes on progress elements.
 			"without": [
 				{
 					"type": "should-not",
-					"name": "aria-valuemax"
+					"name": "aria-valuemax",
+					"alt": {
+						"method": "set-attr",
+						"target": "max"
+					}
+				},
+				{
+					"type": "should-not",
+					"name": "aria-valuenow",
+					"alt": {
+						"method": "set-attr",
+						"target": "value"
+					}
 				}
 			]
 		}

--- a/packages/@markuplint/html-spec/src/spec.select.json
+++ b/packages/@markuplint/html-spec/src/spec.select.json
@@ -39,7 +39,11 @@
 			"without": [
 				{
 					"type": "should-not",
-					"name": "aria-multiselectable"
+					"name": "aria-multiselectable",
+					"alt": {
+						"method": "set-attr",
+						"target": "multiple"
+					}
 				}
 			]
 		},
@@ -55,7 +59,11 @@
 					"without": [
 						{
 							"type": "should-not",
-							"name": "aria-multiselectable"
+							"name": "aria-multiselectable",
+							"alt": {
+								"method": "set-attr",
+								"target": "multiple"
+							}
 						}
 					]
 				}

--- a/packages/@markuplint/rules/src/wai-aria/index.spec.ts
+++ b/packages/@markuplint/rules/src/wai-aria/index.spec.ts
@@ -1641,3 +1641,175 @@ describe('ARIA 1.3 — image/img synonym in permitted roles', () => {
 		).toStrictEqual([]);
 	});
 });
+
+describe('Issue #2465 — aria-valuenow restrictions and missing alt fields', () => {
+	test('input[type=range] with value and aria-valuenow', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="range" value="50" aria-valuenow="50">');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 32,
+				message:
+					'The "aria-valuenow" ARIA property should not use on the "input" element. As its state is already provided by the "value" attribute',
+				raw: 'aria-valuenow="50"',
+			},
+		]);
+	});
+
+	test('input[type=range] with aria-valuenow but no value attr', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="range" aria-valuenow="50">');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 21,
+				message:
+					'The "aria-valuenow" ARIA property should not use on the "input" element. Add the "value" attribute if you use the ARIA property',
+				raw: 'aria-valuenow="50"',
+			},
+		]);
+	});
+
+	test('input[type=range] with value and aria-valuemax', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="range" value="50" aria-valuemax="100">');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 32,
+				message:
+					'The "aria-valuemax" ARIA property should not use on the "input" element. Add the "max" attribute if you use the ARIA property',
+				raw: 'aria-valuemax="100"',
+			},
+		]);
+	});
+
+	test('input[type=range] with aria-valuemax but no max attr', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="range" aria-valuemax="100">');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 21,
+				message:
+					'The "aria-valuemax" ARIA property should not use on the "input" element. Add the "max" attribute if you use the ARIA property',
+				raw: 'aria-valuemax="100"',
+			},
+		]);
+	});
+
+	test('input[type=number] with value and aria-valuenow', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="number" value="5" aria-valuenow="5">');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 32,
+				message:
+					'The "aria-valuenow" ARIA property should not use on the "input" element. As its state is already provided by the "value" attribute',
+				raw: 'aria-valuenow="5"',
+			},
+		]);
+	});
+
+	test('input[type=number] with aria-valuemax', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="number" aria-valuemax="10">');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 22,
+				message:
+					'The "aria-valuemax" ARIA property should not use on the "input" element. Add the "max" attribute if you use the ARIA property',
+				raw: 'aria-valuemax="10"',
+			},
+		]);
+	});
+
+	test('meter with value and aria-valuenow', async () => {
+		const { violations } = await mlRuleTest(rule, '<meter value="0.6" aria-valuenow="0.6"></meter>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 20,
+				message:
+					'The "aria-valuenow" ARIA property should not use on the "meter" element. As its state is already provided by the "value" attribute',
+				raw: 'aria-valuenow="0.6"',
+			},
+		]);
+	});
+
+	test('meter with value and aria-valuemax', async () => {
+		const { violations } = await mlRuleTest(rule, '<meter value="0.6" aria-valuemax="1"></meter>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 20,
+				message:
+					'The "aria-valuemax" ARIA property should not use on the "meter" element. Add the "max" attribute if you use the ARIA property',
+				raw: 'aria-valuemax="1"',
+			},
+		]);
+	});
+
+	test('progress with value and aria-valuenow', async () => {
+		const { violations } = await mlRuleTest(rule, '<progress value="70" max="100" aria-valuenow="70"></progress>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 32,
+				message:
+					'The "aria-valuenow" ARIA property should not use on the "progress" element. As its state is already provided by the "value" attribute',
+				raw: 'aria-valuenow="70"',
+			},
+		]);
+	});
+
+	test('progress with value and aria-valuemax', async () => {
+		const { violations } = await mlRuleTest(rule, '<progress value="70" max="100" aria-valuemax="100"></progress>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 32,
+				message:
+					'The "aria-valuemax" ARIA property should not use on the "progress" element. As its state is already provided by the "max" attribute',
+				raw: 'aria-valuemax="100"',
+			},
+			{
+				severity: 'error',
+				line: 1,
+				col: 32,
+				message:
+					'The "aria-valuemax" ARIA property has the same semantics as the current "max" attribute or the implicit "max" attribute',
+				raw: 'aria-valuemax="100"',
+			},
+		]);
+	});
+
+	// Note: option[aria-selected] test is skipped because getComputedRole() returns
+	// null for option inside select due to Required Context Role mismatch (combobox
+	// is not recognized as a valid parent for the option role). This prevents the
+	// without check from being reached. See #3214.
+
+	test('select with multiple and aria-multiselectable', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<select multiple aria-multiselectable="true"><option>A</option></select>',
+		);
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 18,
+				message:
+					'The "aria-multiselectable" ARIA property should not use on the "select" element. As its state is already provided by the "multiple" attribute',
+				raw: 'aria-multiselectable="true"',
+			},
+		]);
+	});
+});


### PR DESCRIPTION
## Summary

- Add `should-not` restrictions for `aria-valuenow` on `input[type=range]`, `input[type=number]`, `<meter>`, and `<progress>` per ARIA in HTML spec
- Add missing `alt` fields (native HTML attribute alternatives) to existing `should-not` entries for `aria-valuemax`, `aria-valuemin`, `aria-selected`, `aria-multiselectable`
- Add new `should-not` entries for `aria-valuemax` and `aria-valuemin` on `input[type=number]`
- Add wai-aria rule tests for all new restrictions

> **Note:** The `without` check for `aria-selected` on `<option>` is non-functional due to #3214 (`getComputedRole()` returns null for option inside select). The spec schema is correct and will work once #3214 is resolved.

Closes #2465

## Test plan

- [x] `yarn test` — 1664 passed, 1 skipped
- [x] `yarn lint-check` — 0 errors, 0 warnings
- [x] `yarn build` — 37 projects OK
- [x] `yarn up:gen` idempotency verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)