### PR TITLE
docs: enforce mandatory worktree usage and improve command instructions

### DIFF
--- a/.claude/commands/doc.md
+++ b/.claude/commands/doc.md
@@ -18,6 +18,21 @@ Thoroughly identify any omissions or inconsistencies in the documentation. **The
 - **NEVER include specific dependency version numbers** (e.g., `postcss-selector-parser 7.1.1`) in documentation — versions change frequently and cause maintenance burden. Refer to `package.json` as the source of truth. Note: specification versions like ARIA 1.3 are not dependencies and may be mentioned.
 - If the intent of code or documentation is unclear, ask the user rather than guessing
 
+# Localized Documents (MANDATORY)
+
+**CRITICAL: Many documents have localized variants (e.g., `README.ja.md` alongside `README.md`). You MUST update ALL localized versions when editing a document.**
+
+Before editing any `.md` file, ALWAYS check for sibling files matching the pattern `<basename>.<lang>.md`:
+
+```bash
+# Example: when editing README.md, check for localized versions
+ls README*.md
+```
+
+- If `foo.md` exists alongside `foo.ja.md`, `foo.zh.md`, etc., update **every** localized file with equivalent changes
+- Each localized file must be written in its respective language (e.g., `.ja.md` in Japanese)
+- Do NOT skip this step. Forgetting to update localized docs is a recurring mistake — always verify
+
 # JSDoc
 
 - Every exported function and type must have a JSDoc comment

--- a/.claude/commands/git.md
+++ b/.claude/commands/git.md
@@ -2,6 +2,19 @@
 description: Git manipulation rules
 ---
 
+# Worktree Guard (MUST RUN FIRST)
+
+**Before doing ANYTHING else, check that you are in a worktree (NOT the main working directory):**
+
+```bash
+git rev-parse --show-toplevel
+```
+
+- If the result is the main repository path (e.g., ends with `/markuplint`), **STOP immediately**
+- Warn the user: "You are in the main working directory. Commits must be made in a worktree."
+- Do NOT proceed with any git operations — create or switch to a worktree first
+- Only continue if you are confirmed to be inside a worktree
+
 # Commit creation
 
 - When asked to "commit":

--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -2,30 +2,48 @@
 description: Analyze a GitHub Issue and create a resolution plan
 ---
 
-You are given a GitHub Issue URL as input: $ARGUMENTS
+Input: $ARGUMENTS
 
 Follow these steps in order:
 
-## Step 1: Fetch Issue Information
+## Step 1: Understand the Problem
+
+**If a GitHub Issue URL is provided:**
 
 1. Extract owner/repo/number from the Issue URL
 2. Run `gh issue view <URL> --json number,title,body,labels,comments,assignees,state` to retrieve all Issue details
 
+**If NO URL is provided (or input is empty/a keyword):**
+
+1. Ask the user to describe the problem using AskUserQuestion or conversation:
+   - What is happening? (bug, feature request, refactoring, etc.)
+   - How to reproduce? (for bugs)
+   - What is the expected behavior?
+   - Which packages or rules are affected? (if known)
+2. Gather enough context to form a clear problem statement before proceeding
+3. Do NOT skip this step — do NOT guess or assume the problem
+
 ## Step 2: Create a Worktree
 
-1. Generate a slug from the Issue title (lowercase, spaces to hyphens, alphanumeric and hyphens only, strip leading/trailing hyphens, truncate to 50 chars)
-2. Branch name: `issue/<number>-<slug>`
-3. Worktree path: `../<branch name with slashes replaced by hyphens>` (under the parent directory of the current repository)
+**CRITICAL: ALWAYS create a worktree. NEVER work in the main directory.**
+
+1. Generate a branch name:
+   - With Issue URL: `issue/<number>-<slug>` (slug from title, lowercase, hyphens, max 50 chars)
+   - Without Issue URL: `fix/<short-description>` or `feat/<short-description>` as appropriate
+2. Check for existing worktrees: `git worktree list`
+   - If a worktree for this branch already exists, use it
+3. Worktree path: `../markuplint-worktree-<short-name>` (under the parent directory of the current repository)
 4. Execute:
    ```bash
-   git worktree add ../<worktree-dir> -b issue/<number>-<slug> dev
-   cd ../<worktree-dir>
+   git worktree add ../markuplint-worktree-<short-name> -b <branch-name> dev
+   cd ../markuplint-worktree-<short-name>
    yarn install && yarn build
    ```
+5. **All subsequent work (analysis, edits, commits) MUST happen in the worktree**
 
 ## Step 3: Analyze the Problem
 
-Read through the Issue body and comments carefully, then organize the following:
+Read through the Issue body and comments (or user description) carefully, then organize the following:
 
 1. **Summary**: What is happening / what is being requested
 2. **Reproduction**: For bugs, reproduction steps and environment

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,24 +77,36 @@ Each package has a `SKILL.md` with package-specific maintenance guidance.
 - **Full build**: `yarn build` (no arguments)
 - **Single package**: `yarn build --scope @markuplint/<package>`
 
-## Worktree Usage
+## Worktree Usage (MANDATORY)
 
-When working on feature branches that involve multiple PRs or long-running tasks,
-**proactively use `git worktree`** to avoid blocking the user's main working directory.
+**CRITICAL: Direct commits to `dev` are BLOCKED. All work requires a feature branch.**
+**CRITICAL: NEVER create a feature branch in the main working directory. ALWAYS use `git worktree`.**
 
-```bash
-git worktree add /tmp/markuplint-worktree -b <branch-name> dev
-cd /tmp/markuplint-worktree
-yarn install
-yarn build   # Required before yarn up:gen works
-```
+The main working directory MUST stay on `dev` at all times. Any feature branch work — no matter how small (even a single-file docs change) — MUST be done in a worktree.
+
+### Procedure
+
+1. **Check for existing worktrees first**: `git worktree list`
+   - If the target branch already has a worktree, work there
+2. **Create a new worktree** for new branches:
+   ```bash
+   git worktree add ../markuplint-worktree-<short-name> -b <branch-name> dev
+   ```
+3. **Install and build** in the worktree before any work:
+   ```bash
+   cd ../markuplint-worktree-<short-name>
+   yarn install
+   yarn build
+   ```
+4. **Do all edits, commits, and pushes** from within the worktree
+5. **Clean up** when done:
+   ```bash
+   git worktree remove ../markuplint-worktree-<short-name>
+   git branch -D <branch-name>   # only if branch was merged
+   ```
 
 ### Important Notes
 
-- **Always run `yarn install && yarn build`** in the worktree before any generation or test commands
-- **Husky hooks do NOT run in worktrees** — run `yarn lint` manually before committing
-- Clean up worktrees when done:
-  ```bash
-  git worktree remove /tmp/markuplint-worktree
-  git branch -D <temp-branch-name>
-  ```
+- **Husky hooks do NOT run in worktrees** — run `yarn lint` manually before every commit
+- **NEVER run `git checkout <branch>` or `git switch` in the main working directory** — use worktrees instead
+- If you catch yourself about to create a branch in the main repo, STOP and use a worktree


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: Upgrade "Worktree Usage" section to MANDATORY — all feature branch work must use `git worktree`, no exceptions
- **git.md**: Add "Worktree Guard" at the top — stops all git operations if not inside a worktree
- **issue.md**: Add user interview flow when no GitHub Issue URL is provided; enforce worktree creation
- **doc.md**: Add "Localized Documents" rule — always check for and update `foo.<lang>.md` siblings when editing any `.md` file

## Test plan

- [ ] Verify `/git` command detects and warns when run in main working directory
- [ ] Verify `/issue` without URL argument prompts user for problem description
- [ ] Verify `/doc` reminds to update localized document variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)