### PR TITLE
feat(vscode): show specific warning for Node.js 22+ import assertion incompatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"release:canary": "lerna publish --preid dev --canary --exact --force-publish",
 		"prerelease": "run-s build test",
 		"check:build": "find . -type f -name \"*.d.ts\" -print | xargs grep \"packages/@markuplint\"",
+		"vscode:build": "cd vscode && npx run-p vscode:build:extension vscode:build:server",
 		"vscode:dev": "cd vscode && yarn install && yarn run vscode:dev",
 		"vscode:login": "cd vscode && yarn run vscode:login",
 		"vscode:package": "node vscode/scripts/install.mjs",

--- a/vscode/locales/en.json
+++ b/vscode/locales/en.json
@@ -1,5 +1,6 @@
 {
 	"sentences": {
-		"since markuplint could not be found in the node_modules of the workspace, this use the version (v{0}) installed in vs code extension": "Since markuplint could not be found in the node_modules of the workspace, this use the version (v{0}) installed in VS Code Extension"
+		"since markuplint could not be found in the node_modules of the workspace, this use the version (v{0}) installed in vs code extension": "Since markuplint could not be found in the node_modules of the workspace, this use the version (v{0}) installed in VS Code Extension",
+		"your local markuplint is incompatible with node.js 22+ due to import assertion syntax. the bundled version (v{0}) is used instead. to use your local version, upgrade to markuplint@4.10.0 or later. see: https://github.com/markuplint/markuplint/issues/2837": "Your local markuplint is incompatible with Node.js 22+ due to import assertion syntax. The bundled version (v{0}) is used instead. To use your local version, upgrade to markuplint@4.10.0 or later. See: https://github.com/markuplint/markuplint/issues/2837"
 	}
 }

--- a/vscode/locales/ja.json
+++ b/vscode/locales/ja.json
@@ -11,6 +11,7 @@
 		"undefined": "未定義"
 	},
 	"sentences": {
-		"since markuplint could not be found in the node_modules of the workspace, this use the version (v{0}) installed in vs code extension": "ワークスペースのnode_modulesにmarkuplintが発見できなかったためVS Code拡張にインストールされているバージョン(v{0})を利用します"
+		"since markuplint could not be found in the node_modules of the workspace, this use the version (v{0}) installed in vs code extension": "ワークスペースのnode_modulesにmarkuplintが発見できなかったためVS Code拡張にインストールされているバージョン(v{0})を利用します",
+		"your local markuplint is incompatible with node.js 22+ due to import assertion syntax. the bundled version (v{0}) is used instead. to use your local version, upgrade to markuplint@4.10.0 or later. see: https://github.com/markuplint/markuplint/issues/2837": "ローカルのmarkuplintはimport assertion構文のためNode.js 22+と互換性がありません。代わりにバンドル版(v{0})を使用しています。ローカル版を使用するにはmarkuplint@4.10.0以降にアップグレードしてください。詳細: https://github.com/markuplint/markuplint/issues/2837"
 	}
 }

--- a/vscode/src/const.ts
+++ b/vscode/src/const.ts
@@ -15,5 +15,20 @@ export const WEBSITE_URL = 'https://markuplint.dev';
 export const WEBSITE_URL_RULE_PAGE = `${WEBSITE_URL}/docs/rules/` as const;
 
 // Messages
+
+/**
+ * Warning message shown when markuplint is not found in the workspace's node_modules.
+ * Displayed in the status bar tooltip. Placeholder `{0}` is replaced with the bundled version number.
+ */
 export const NO_INSTALL_WARNING =
 	'since markuplint could not be found in the node_modules of the workspace, this use the version (v{0}) installed in VS Code Extension';
+
+/**
+ * Warning message shown when the local markuplint (v4.0.0–4.9.x) fails to load on Node.js 22+
+ * due to the removed `assert { type: 'json' }` syntax (import assertions).
+ * Displayed as a popup via `warningToPopup`. Placeholder `{0}` is replaced with the bundled version number.
+ *
+ * @see https://github.com/markuplint/markuplint/issues/2837
+ */
+export const IMPORT_ASSERTION_COMPAT_WARNING =
+	'your local markuplint is incompatible with Node.js 22+ due to import assertion syntax. The bundled version (v{0}) is used instead. To use your local version, upgrade to markuplint@4.10.0 or later. See: https://github.com/markuplint/markuplint/issues/2837';

--- a/vscode/src/server/get-module.ts
+++ b/vscode/src/server/get-module.ts
@@ -5,10 +5,21 @@ import path from 'node:path';
 
 import { Files } from 'vscode-languageserver/node.js';
 
+/**
+ * Resolve and load the markuplint module.
+ *
+ * Attempts to load a locally installed markuplint from the workspace first.
+ * If the local module fails to load (e.g., due to import assertion incompatibility
+ * on Node.js 22+), falls back to the bundled version shipped with the VS Code extension.
+ *
+ * @param log - Logger function for diagnostic output
+ * @returns The resolved module metadata including version, type, and optional fallback reason
+ */
 export async function getModule(log: Log): Promise<Module> {
 	let markuplint: any;
 	let isLocalModule = false;
 	let pkg: any;
+	let fallbackReason: Module['fallbackReason'];
 	try {
 		log('Getting module', 'debug');
 		const modPath = await fileResolve(message => log(message));
@@ -21,7 +32,12 @@ export async function getModule(log: Log): Promise<Module> {
 		pkg = pkg.default ?? pkg;
 		isLocalModule = true;
 	} catch (error: unknown) {
-		log(`Failed to resolve local package: ${error}`, 'error');
+		if (isImportAssertionError(error)) {
+			log(`Local markuplint is incompatible with Node.js 22+ (import assertion syntax): ${error}`, 'warn');
+			fallbackReason = 'import-assertion-compat';
+		} else {
+			log(`Failed to resolve local package: ${error}`, 'error');
+		}
 
 		try {
 			markuplint = await import('markuplint');
@@ -54,16 +70,42 @@ export async function getModule(log: Log): Promise<Module> {
 		moduleType,
 		markuplint,
 		ariaRecommendedVersion: ARIA_RECOMMENDED_VERSION,
+		fallbackReason,
 	};
 }
 
+/**
+ * Metadata for the resolved markuplint module.
+ */
 export type Module = {
+	/** Whether the module was loaded from the workspace's local node_modules */
 	isLocalModule: boolean;
+	/** The semver version string of the loaded module */
 	version: string;
+	/** The module system type declared in package.json */
 	moduleType: 'commonjs' | 'module';
+	/** The loaded markuplint module exports */
 	markuplint: any;
+	/** The ARIA specification version recommended by the loaded module */
 	ariaRecommendedVersion: ARIAVersion;
+	/**
+	 * Reason the local module was skipped in favor of the bundled version.
+	 * Set to `'import-assertion-compat'` when the local markuplint uses
+	 * `assert { type: 'json' }` syntax that was removed in Node.js 22.
+	 */
+	fallbackReason?: 'import-assertion-compat';
 };
+
+/**
+ * Check whether the error is a SyntaxError caused by the `assert { type: 'json' }`
+ * import assertion syntax that was removed in Node.js 22.
+ *
+ * @param error - The caught error to inspect
+ * @returns `true` if the error matches the import assertion SyntaxError pattern
+ */
+function isImportAssertionError(error: unknown): boolean {
+	return error instanceof SyntaxError && /Unexpected identifier 'assert'/.test(error.message);
+}
 
 async function fileResolve(log: (message: string) => void) {
 	try {

--- a/vscode/src/server/server.ts
+++ b/vscode/src/server/server.ts
@@ -5,9 +5,9 @@ import type { InitializeResult } from 'vscode-languageserver/node.js';
 import { createConnection, TextDocuments, TextDocumentSyncKind, ProposedFeatures } from 'vscode-languageserver/node.js';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 
-import { NO_INSTALL_WARNING } from '../const.js';
+import { IMPORT_ASSERTION_COMPAT_WARNING, NO_INSTALL_WARNING } from '../const.js';
 import { t } from '../i18n.js';
-import { errorToPopup, logToDiagnosticsChannel, logToPrimaryChannel, status } from '../lsp.js';
+import { errorToPopup, logToDiagnosticsChannel, logToPrimaryChannel, status, warningToPopup } from '../lsp.js';
 
 import { verbosely } from './debug.js';
 import { createEventHandlers } from './document-events.js';
@@ -15,6 +15,13 @@ import { getModule } from './get-module.js';
 
 const DEBUG = false;
 
+/**
+ * Bootstrap the LSP language server.
+ *
+ * Creates the LSP connection, sets up logging handlers, resolves the markuplint module,
+ * registers document event handlers, and starts listening. If the local markuplint module
+ * is unavailable or incompatible, displays appropriate warnings to the user.
+ */
 export function bootServer() {
 	const connection = createConnection(ProposedFeatures.all);
 
@@ -74,6 +81,12 @@ export function bootServer() {
 
 					if (message) {
 						void connection.sendNotification(logToPrimaryChannel, [message, 'warn']);
+					}
+
+					if (mod.fallbackReason === 'import-assertion-compat') {
+						const compatMessage = t(IMPORT_ASSERTION_COMPAT_WARNING, mod.version);
+						void connection.sendNotification(warningToPopup, compatMessage);
+						void connection.sendNotification(logToPrimaryChannel, [compatMessage, 'warn']);
 					}
 				},
 			});


### PR DESCRIPTION
## Summary

- Detect `SyntaxError: Unexpected identifier 'assert'` when loading local markuplint v4.0.0–4.9.x on Node.js 22+ and display an actionable warning popup instead of the generic "markuplint not found" message
- Add `fallbackReason` field to `Module` type to distinguish import assertion incompatibility from other load failures
- Add i18n translations (en/ja) for the compatibility warning message
- Add `vscode:build` script to root `package.json`

## Test plan

- [ ] Install markuplint v4.0.0–4.9.x locally in a workspace
- [ ] Open VS Code with Node.js 22+ runtime
- [ ] Open an HTML file and verify the warning popup appears with the upgrade message
- [ ] Verify the Output channel logs the compatibility warning at `warn` level
- [ ] Verify that with markuplint v4.10.0+ the warning does not appear

Closes #2838

🤖 Generated with [Claude Code](https://claude.com/claude-code)