### PR TITLE
feat: suggest similar attribute names for typos in invalid-attr

### DIFF
--- a/packages/@markuplint/rules/src/attr-check.ts
+++ b/packages/@markuplint/rules/src/attr-check.ts
@@ -3,7 +3,7 @@ import type { Attribute as AttrSpec, AttributeType } from '@markuplint/ml-spec';
 import type { ReadonlyDeep } from 'type-fest';
 
 import { toNonNullableArrayFromItemOrArray } from '@markuplint/shared';
-import { check } from '@markuplint/types';
+import { check, getCandidate } from '@markuplint/types';
 
 import { createMessageValueExpected } from './create-message.js';
 import { log } from './debug.js';
@@ -59,6 +59,7 @@ export function attrCheck(
 	value: string,
 	isCustomRule: boolean,
 	spec?: AttrSpec,
+	allAttrNames?: readonly string[],
 ): Invalid | Invalid<'invalid-value'>[] | false {
 	if (!isCustomRule) {
 		if (/^data-.+$/.test(name)) {
@@ -82,9 +83,17 @@ export function attrCheck(
 	// Existence
 	if (!spec) {
 		log('The "%s" attribute DOES\'NT EXIST in the spec', name);
+		const baseMessage = t('{0} is {1:c}', t('the "{0*}" {1}', name, 'attribute'), 'disallowed');
+		const candidate = allAttrNames ? getCandidate(name, allAttrNames) : undefined;
+		if (candidate) {
+			return {
+				invalidType: 'non-existent',
+				message: baseMessage + t('. ') + t('Did you mean "{0*}"?', candidate),
+			};
+		}
 		return {
 			invalidType: 'non-existent',
-			message: t('{0} is {1:c}', t('the "{0*}" {1}', name, 'attribute'), 'disallowed'),
+			message: baseMessage,
 		};
 	}
 

--- a/packages/@markuplint/rules/src/attr-check.ts
+++ b/packages/@markuplint/rules/src/attr-check.ts
@@ -50,6 +50,8 @@ type Loc = {
  * @param value - The attribute value to validate
  * @param isCustomRule - When `true`, skips the built-in bypass for `data-*`, `aria-*`, and `adapt-*` attributes
  * @param spec - The attribute specification to validate against; if absent, the attribute is considered non-existent
+ * @param allAttrNames - Optional list of all valid attribute names for the element;
+ *   used to suggest a similar attribute name via Levenshtein distance when the attribute is non-existent
  * @returns `false` if the attribute is valid, a single `Invalid` object for existence/disallowed errors,
  *   or an array of `Invalid<'invalid-value'>` objects for value validation failures
  */

--- a/packages/@markuplint/rules/src/helpers.ts
+++ b/packages/@markuplint/rules/src/helpers.ts
@@ -116,7 +116,8 @@ export function isValidAttr(
 ) {
 	const spec = attrSpecs.find(s => s.name.toLowerCase() === name.toLowerCase());
 	log?.('Spec of the %s attr: %o', name, spec);
-	let invalid: ReturnType<typeof attrCheck> = attrCheck(t, name, value, false, spec);
+	const allAttrNames = attrSpecs.map(s => s.name);
+	let invalid: ReturnType<typeof attrCheck> = attrCheck(t, name, value, false, spec, allAttrNames);
 	if (
 		invalid === false &&
 		spec &&

--- a/packages/@markuplint/rules/src/invalid-attr/README.ja.md
+++ b/packages/@markuplint/rules/src/invalid-attr/README.ja.md
@@ -8,6 +8,8 @@ description: 属性が仕様上（あるいは独自に指定したルール上�
 
 [HTML Living Standard](https://momdo.github.io/html/)に準拠します。[`@markuplint/html-spec`](https://github.com/markuplint/markuplint/tree/main/packages/%40markuplint/html-spec/src)に設定値を持っています。
 
+存在しない属性名がその要素の有効な属性名に類似している場合、タイプミスの修正を助けるために「もしかして ...？」という候補がエラーメッセージに含まれます。
+
 <!-- textlint-disable ja-technical-writing/ja-no-mixed-period -->
 
 ❌ 間違ったコード例

--- a/packages/@markuplint/rules/src/invalid-attr/README.md
+++ b/packages/@markuplint/rules/src/invalid-attr/README.md
@@ -9,6 +9,8 @@ Warn if an attribute is a non-existent attribute or an invalid type value due to
 
 This rule according to [HTML Living Standard](https://html.spec.whatwg.org/). It has settings in [`@markuplint/html-spec`](https://github.com/markuplint/markuplint/tree/main/packages/%40markuplint/html-spec/src).
 
+When a non-existent attribute name is similar to a valid attribute for the element, the error message includes a "Did you mean ...?" suggestion to help fix typos.
+
 ❌ Examples of **incorrect** code for this rule
 
 ```html

--- a/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
@@ -455,14 +455,14 @@ test('prefix attribute', async () => {
 			severity: 'error',
 			line: 1,
 			col: 27,
-			message: 'The ":class" attribute is disallowed',
+			message: 'The ":class" attribute is disallowed. Did you mean "class"?',
 			raw: ':class',
 		},
 		{
 			severity: 'error',
 			col: 44,
 			line: 1,
-			message: 'The "@click" attribute is disallowed',
+			message: 'The "@click" attribute is disallowed. Did you mean "onclick"?',
 			raw: '@click',
 		},
 	]);
@@ -680,7 +680,7 @@ test('svg', async () => {
 			severity: 'error',
 			line: 2,
 			col: 30,
-			message: 'The "cz" attribute is disallowed',
+			message: 'The "cz" attribute is disallowed. Did you mean "cx"?',
 			raw: 'cz',
 		},
 	]);
@@ -918,7 +918,7 @@ test('React with spread attribute', async () => {
 			severity: 'error',
 			line: 1,
 			col: 6,
-			message: 'The "invalid" attribute is disallowed',
+			message: 'The "invalid" attribute is disallowed. Did you mean "oninvalid"?',
 			raw: 'invalid',
 		},
 	]);
@@ -936,7 +936,7 @@ test('React with spread attribute', async () => {
 			severity: 'error',
 			line: 1,
 			col: 17,
-			message: 'The "invalid" attribute is disallowed',
+			message: 'The "invalid" attribute is disallowed. Did you mean "oninvalid"?',
 			raw: 'invalid',
 		},
 	]);
@@ -1573,7 +1573,7 @@ describe('Deprecated options', () => {
 				severity: 'error',
 				line: 1,
 				col: 4,
-				message: 'The "as" attribute is disallowed',
+				message: 'The "as" attribute is disallowed. Did you mean "is"?',
 				raw: 'as',
 			},
 		]);
@@ -1825,6 +1825,48 @@ describe('button command attribute', () => {
 				message:
 					'The "command" attribute expects either "toggle-popover", "show-popover", "hide-popover", "close", "request-close", "show-modal". Or, the "command" attribute expects the custom command format. Did you mean "--invalid-value"? (https://html.spec.whatwg.org/multipage/form-elements.html#valid-custom-command)',
 				raw: 'invalid-value',
+			},
+		]);
+	});
+});
+
+describe('Attribute name suggestion (#1487)', () => {
+	test('suggests similar attribute name for typo', async () => {
+		const { violations } = await mlRuleTest(rule, '<input nama="test">');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 8,
+				message: 'The "nama" attribute is disallowed. Did you mean "name"?',
+				raw: 'nama',
+			},
+		]);
+	});
+
+	// cspell:ignore clss
+	test('suggests similar attribute name for class typo', async () => {
+		const { violations } = await mlRuleTest(rule, '<div clss="test"></div>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 6,
+				message: 'The "clss" attribute is disallowed. Did you mean "class"?',
+				raw: 'clss',
+			},
+		]);
+	});
+
+	test('no suggestion for completely unrelated attribute', async () => {
+		const { violations } = await mlRuleTest(rule, '<div xyz="test"></div>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 6,
+				message: 'The "xyz" attribute is disallowed',
+				raw: 'xyz',
 			},
 		]);
 	});

--- a/packages/@markuplint/types/ARCHITECTURE.ja.md
+++ b/packages/@markuplint/types/ARCHITECTURE.ja.md
@@ -224,6 +224,7 @@ flowchart LR
     subgraph pkg ["@markuplint/types"]
         defs["defs レジストリ"]
         check["check()"]
+        getCandidate["getCandidate()"]
         types["型定義"]
     end
 
@@ -234,6 +235,7 @@ flowchart LR
     mlSpec -->|"Defs を提供\n(型定義)"| defs
     mlSpec -->|"Type 共用体を使用\n(属性仕様の記述)"| types
     rules -->|"check() を呼び出し\n属性値を検証"| check
+    rules -->|"getCandidate() を呼び出し\nタイプミス候補を提示"| getCandidate
 ```
 
 ### 上流: `@markuplint/ml-spec`
@@ -243,6 +245,8 @@ flowchart LR
 ### 下流: `@markuplint/rules`
 
 `@markuplint/rules` は、パース済み HTML ドキュメント中の属性値を検証するために `check(value, type)` を呼び出します。`Result` 型がエラー報告を駆動し、`UnmatchedResult` に含まれるオフセット・行・列・理由・期待値・修正候補の情報を、ルールがリント診断メッセージに変換します。
+
+また、`@markuplint/rules` は存在しない属性が検出された際に類似する属性名を提案するため `getCandidate()` も呼び出します。属性値の候補提示と同じレーベンシュタイン距離ベースの類似度閾値（50%以上）が属性名の候補提示にも適用されます。
 
 ## ドキュメントマップ
 

--- a/packages/@markuplint/types/ARCHITECTURE.md
+++ b/packages/@markuplint/types/ARCHITECTURE.md
@@ -224,6 +224,7 @@ flowchart LR
     subgraph pkg ["@markuplint/types"]
         defs["defs registry"]
         check["check()"]
+        getCandidate["getCandidate()"]
         types["Type definitions"]
     end
 
@@ -234,6 +235,7 @@ flowchart LR
     mlSpec -->|"provides Defs\n(type definitions)"| defs
     mlSpec -->|"uses Type union\nfor attribute specs"| types
     rules -->|"calls check()\nto validate attribute values"| check
+    rules -->|"calls getCandidate()\nfor typo suggestions"| getCandidate
 ```
 
 ### Upstream: `@markuplint/ml-spec`
@@ -243,6 +245,8 @@ flowchart LR
 ### Downstream: `@markuplint/rules`
 
 `@markuplint/rules` calls `check(value, type)` to validate attribute values found in parsed HTML documents. The `Result` type drives error reporting: an `UnmatchedResult` provides the offset, line, column, reason, expected values, and candidate corrections that rules translate into lint diagnostics.
+
+`@markuplint/rules` also calls `getCandidate()` to suggest similar attribute names when a non-existent attribute is detected. The same Levenshtein-based similarity threshold (≥50%) used for attribute value suggestions applies to attribute name suggestions.
 
 ## Documentation Map
 

--- a/packages/@markuplint/types/src/index.ts
+++ b/packages/@markuplint/types/src/index.ts
@@ -8,4 +8,5 @@
 export * from './whatwg/is-custom-element-name.js';
 export * from './check.js';
 export * from './check-base.js';
+export { getCandidate } from './get-candidate.js';
 export type * from './types.js';


### PR DESCRIPTION
## Summary

- Export `getCandidate()` from `@markuplint/types` for Levenshtein-based attribute name suggestion
- When `invalid-attr` reports a non-existent attribute, suggest a similar valid attribute name with "Did you mean ...?" if the similarity is ≥50%
- Update documentation (README.md/README.ja.md, ARCHITECTURE.md/ARCHITECTURE.ja.md, JSDoc)

Closes #1487

## Test plan

- [x] New tests: typo detection (`nama` → `name`, `clss` → `class`), no suggestion for unrelated names (`xyz`)
- [x] Updated existing tests to include suggestion messages (`:class` → `class`, `@click` → `onclick`, `cz` → `cx`, etc.)
- [x] All 1667 tests pass
- [x] `yarn lint-check` passes with 0 errors, 0 warnings
- [x] `yarn build` succeeds for all 37 packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)