### PR TITLE
docs(website): add tagged template literal parser to docs and homepage

### DIFF
--- a/website/docs/configuration/properties.md
+++ b/website/docs/configuration/properties.md
@@ -145,6 +145,7 @@ The regex should be specify it matches the target file (ex., the extension part)
     "\\.[jt]sx?$": "@markuplint/jsx-parser",
     "\\.vue$": "@markuplint/vue-parser",
     "\\.svelte$": "@markuplint/svelte-parser",
+    "\\.ts$": "@markuplint/tagged-template-literal-parser",
     "\\.ext$": "./path/to/custom-parser/any-lang.js"
   }
 }
@@ -701,7 +702,7 @@ const MyComponent = props => {
 <div>
   {/* Evaluate as rendered div element has aria-live="polite"  */}
   <MyComponent aria-live="polite">Lorem Ipsam</MyComponent>
-</div>;
+</div>
 ```
 
 #### `as.attrs`
@@ -740,7 +741,7 @@ const MyPicture = () => {
 <div>
   {/* Evaluate as rendered img element has the src attribute and alt="Lorem ipsam"  */}
   <MyComponent />
-</div>;
+</div>
 ```
 
 #### `as.attrs[].name`
@@ -793,7 +794,7 @@ const MyIcon = ({ label }) => {
 <div>
   {/* Evaluate as the accessible name is "my icon name" */}
   <MyIcon label="my icon name" />
-</div>;
+</div>
 ```
 
 #### Interface {#pretenders/interface}

--- a/website/docs/guides/besides-html.md
+++ b/website/docs/guides/besides-html.md
@@ -10,6 +10,12 @@ Install the **parser plugin** through npm or Yarn:
 npm install -D @markuplint/pug-parser
 ```
 
+If your code uses tagged template literals containing HTML (e.g., [lit-html](https://lit.dev/)), install the **tagged template literal parser**:
+
+```shell npm2yarn
+npm install -D @markuplint/tagged-template-literal-parser
+```
+
 If a syntax has its own specification you should install the **spec plugin** with the parser plugin:
 
 ```shell npm2yarn
@@ -22,23 +28,24 @@ npm install -D @markuplint/vue-parser @markuplint/vue-spec
 
 ### Supported syntaxes
 
-| Template or syntax                                                                         | Parser                          | Spec                             |
-| ------------------------------------------------------------------------------------------ | ------------------------------- | -------------------------------- |
-| [**JSX**](https://react.dev/learn/writing-markup-with-jsx)                                 | `@markuplint/jsx-parser`        | `@markuplint/react-spec`         |
-| [**Vue**](https://vuejs.org/)                                                              | `@markuplint/vue-parser`        | `@markuplint/vue-spec`           |
-| [**Svelte**](https://svelte.dev/)                                                          | `@markuplint/svelte-parser`     | `@markuplint/svelte-spec`        |
-| [**SvelteKit**](https://kit.svelte.dev/)                                                   | `@markuplint/svelte-parser/kit` | -                                |
-| [**Astro**](https://astro.build/)                                                          | `@markuplint/astro-parser`      | -                                |
-| [**Alpine.js**](https://alpinejs.dev)                                                      | `@markuplint/alpine-parser`     | `@markuplint/alpine-parser/spec` |
-| [**HTMX**](https://htmx.org)                                                               | `@markuplint/htmx-parser`       | `@markuplint/htmx-parser/spec`   |
-| [**Pug**](https://pugjs.org/)                                                              | `@markuplint/pug-parser`        | -                                |
-| [**PHP**](https://www.php.net/)                                                            | `@markuplint/php-parser`        | -                                |
-| [**Smarty**](https://www.smarty.net/)                                                      | `@markuplint/smarty-parser`     | -                                |
-| [**eRuby**](https://docs.ruby-lang.org/en/master/ERB.html)                                 | `@markuplint/erb-parser`        | -                                |
-| [**EJS**](https://ejs.co/)                                                                 | `@markuplint/ejs-parser`        | -                                |
-| [**Mustache**](https://mustache.github.io/) or [**Handlebars**](https://handlebarsjs.com/) | `@markuplint/mustache-parser`   | -                                |
-| [**Nunjucks**](https://mozilla.github.io/nunjucks/)                                        | `@markuplint/nunjucks-parser`   | -                                |
-| [**Liquid**](https://liquidjs.com/)                                                        | `@markuplint/liquid-parser`     | -                                |
+| Template or syntax                                                                         | Parser                                       | Spec                             |
+| ------------------------------------------------------------------------------------------ | -------------------------------------------- | -------------------------------- |
+| [**JSX**](https://react.dev/learn/writing-markup-with-jsx)                                 | `@markuplint/jsx-parser`                     | `@markuplint/react-spec`         |
+| [**Vue**](https://vuejs.org/)                                                              | `@markuplint/vue-parser`                     | `@markuplint/vue-spec`           |
+| [**Svelte**](https://svelte.dev/)                                                          | `@markuplint/svelte-parser`                  | `@markuplint/svelte-spec`        |
+| [**SvelteKit**](https://kit.svelte.dev/)                                                   | `@markuplint/svelte-parser/kit`              | -                                |
+| [**Astro**](https://astro.build/)                                                          | `@markuplint/astro-parser`                   | -                                |
+| [**Alpine.js**](https://alpinejs.dev)                                                      | `@markuplint/alpine-parser`                  | `@markuplint/alpine-parser/spec` |
+| [**HTMX**](https://htmx.org)                                                               | `@markuplint/htmx-parser`                    | `@markuplint/htmx-parser/spec`   |
+| [**Tagged template literals**](https://lit.dev/) (lit-html etc.)                           | `@markuplint/tagged-template-literal-parser` | -                                |
+| [**Pug**](https://pugjs.org/)                                                              | `@markuplint/pug-parser`                     | -                                |
+| [**PHP**](https://www.php.net/)                                                            | `@markuplint/php-parser`                     | -                                |
+| [**Smarty**](https://www.smarty.net/)                                                      | `@markuplint/smarty-parser`                  | -                                |
+| [**eRuby**](https://docs.ruby-lang.org/en/master/ERB.html)                                 | `@markuplint/erb-parser`                     | -                                |
+| [**EJS**](https://ejs.co/)                                                                 | `@markuplint/ejs-parser`                     | -                                |
+| [**Mustache**](https://mustache.github.io/) or [**Handlebars**](https://handlebarsjs.com/) | `@markuplint/mustache-parser`                | -                                |
+| [**Nunjucks**](https://mozilla.github.io/nunjucks/)                                        | `@markuplint/nunjucks-parser`                | -                                |
+| [**Liquid**](https://liquidjs.com/)                                                        | `@markuplint/liquid-parser`                  | -                                |
 
 :::note
 There is `@markuplint/html-parser` package but the core package includes it.
@@ -111,6 +118,14 @@ Set a regular expression that can identify the target file name to the `parser` 
   },
   "specs": {
     "\\.vue$": "@markuplint/vue-spec"
+  }
+}
+```
+
+```json class=config title="Use lit-html"
+{
+  "parser": {
+    "\\.ts$": "@markuplint/tagged-template-literal-parser"
   }
 }
 ```

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/configuration/properties.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/configuration/properties.md
@@ -137,6 +137,7 @@ interface Config {
     "\\.[jt]sx?$": "@markuplint/jsx-parser",
     "\\.vue$": "@markuplint/vue-parser",
     "\\.svelte$": "@markuplint/svelte-parser",
+    "\\.ts$": "@markuplint/tagged-template-literal-parser",
     "\\.ext$": "./path/to/custom-parser/any-lang.js"
   }
 }
@@ -685,7 +686,7 @@ const MyComponent = props => {
 <div>
   {/* レンダリングされたdiv要素がaria-live="polite"を持つものとして評価します。  */}
   <MyComponent aria-live="polite">Lorem Ipsam</MyComponent>
-</div>;
+</div>
 ```
 
 #### `as.attrs`
@@ -724,7 +725,7 @@ const MyPicture = () => {
 <div>
   {/* レンダリングされたimg要素がsrc属性とalt="Lorem ipsam"を持つものとして評価されます。*/}
   <MyComponent />
-</div>;
+</div>
 ```
 
 #### `as.attrs[].name`
@@ -775,7 +776,7 @@ const MyIcon = ({ label }) => {
 <div>
   {/* アクセシブルな名前が「my icon name」であるとして評価します。 */}
   <MyIcon label="my icon name" />
-</div>;
+</div>
 ```
 
 #### インターフェイス {#pretenders/interface}

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/besides-html.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/besides-html.md
@@ -10,6 +10,12 @@ npmもしくはYarnで**パーサプラグイン**をインストールします
 npm install -D @markuplint/pug-parser
 ```
 
+HTMLを含むタグ付きテンプレートリテラル（[lit-html](https://lit.dev/)など）を使用する場合は、**タグ付きテンプレートリテラルパーサ**をインストールします。
+
+```shell npm2yarn
+npm install -D @markuplint/tagged-template-literal-parser
+```
+
 構文に独自の仕様がある場合は、パーサプラグインと一緒に**スペックプラグイン**をインストールする必要があります。
 
 ```shell npm2yarn
@@ -22,23 +28,24 @@ npm install -D @markuplint/vue-parser @markuplint/vue-spec
 
 ### サポートしている構文 {#supported-syntaxes}
 
-| テンプレートエンジンまたは構文                                                             | パーサ                          | スペック                         |
-| ------------------------------------------------------------------------------------------ | ------------------------------- | -------------------------------- |
-| [**JSX**](https://react.dev/learn/writing-markup-with-jsx)                                 | `@markuplint/jsx-parser`        | `@markuplint/react-spec`         |
-| [**Vue**](https://vuejs.org/)                                                              | `@markuplint/vue-parser`        | `@markuplint/vue-spec`           |
-| [**Svelte**](https://svelte.dev/)                                                          | `@markuplint/svelte-parser`     | `@markuplint/svelte-spec`        |
-| [**SvelteKit**](https://kit.svelte.dev/)                                                   | `@markuplint/svelte-parser/kit` | -                                |
-| [**Astro**](https://astro.build/)                                                          | `@markuplint/astro-parser`      | -                                |
-| [**Alpine.js**](https://alpinejs.dev)                                                      | `@markuplint/alpine-parser`     | `@markuplint/alpine-parser/spec` |
-| [**HTMX**](https://htmx.org)                                                               | `@markuplint/htmx-parser`       | `@markuplint/htmx-parser/spec`   |
-| [**Pug**](https://pugjs.org/)                                                              | `@markuplint/pug-parser`        | -                                |
-| [**PHP**](https://www.php.net/)                                                            | `@markuplint/php-parser`        | -                                |
-| [**Smarty**](https://www.smarty.net/)                                                      | `@markuplint/smarty-parser`     | -                                |
-| [**eRuby**](https://docs.ruby-lang.org/en/master/ERB.html)                                 | `@markuplint/erb-parser`        | -                                |
-| [**EJS**](https://ejs.co/)                                                                 | `@markuplint/ejs-parser`        | -                                |
-| [**Mustache**](https://mustache.github.io/) or [**Handlebars**](https://handlebarsjs.com/) | `@markuplint/mustache-parser`   | -                                |
-| [**Nunjucks**](https://mozilla.github.io/nunjucks/)                                        | `@markuplint/nunjucks-parser`   | -                                |
-| [**Liquid**](https://liquidjs.com/)                                                        | `@markuplint/liquid-parser`     | -                                |
+| テンプレートエンジンまたは構文                                                             | パーサ                                       | スペック                         |
+| ------------------------------------------------------------------------------------------ | -------------------------------------------- | -------------------------------- |
+| [**JSX**](https://react.dev/learn/writing-markup-with-jsx)                                 | `@markuplint/jsx-parser`                     | `@markuplint/react-spec`         |
+| [**Vue**](https://vuejs.org/)                                                              | `@markuplint/vue-parser`                     | `@markuplint/vue-spec`           |
+| [**Svelte**](https://svelte.dev/)                                                          | `@markuplint/svelte-parser`                  | `@markuplint/svelte-spec`        |
+| [**SvelteKit**](https://kit.svelte.dev/)                                                   | `@markuplint/svelte-parser/kit`              | -                                |
+| [**Astro**](https://astro.build/)                                                          | `@markuplint/astro-parser`                   | -                                |
+| [**Alpine.js**](https://alpinejs.dev)                                                      | `@markuplint/alpine-parser`                  | `@markuplint/alpine-parser/spec` |
+| [**HTMX**](https://htmx.org)                                                               | `@markuplint/htmx-parser`                    | `@markuplint/htmx-parser/spec`   |
+| [**タグ付きテンプレートリテラル**](https://lit.dev/)（lit-html等）                         | `@markuplint/tagged-template-literal-parser` | -                                |
+| [**Pug**](https://pugjs.org/)                                                              | `@markuplint/pug-parser`                     | -                                |
+| [**PHP**](https://www.php.net/)                                                            | `@markuplint/php-parser`                     | -                                |
+| [**Smarty**](https://www.smarty.net/)                                                      | `@markuplint/smarty-parser`                  | -                                |
+| [**eRuby**](https://docs.ruby-lang.org/en/master/ERB.html)                                 | `@markuplint/erb-parser`                     | -                                |
+| [**EJS**](https://ejs.co/)                                                                 | `@markuplint/ejs-parser`                     | -                                |
+| [**Mustache**](https://mustache.github.io/) or [**Handlebars**](https://handlebarsjs.com/) | `@markuplint/mustache-parser`                | -                                |
+| [**Nunjucks**](https://mozilla.github.io/nunjucks/)                                        | `@markuplint/nunjucks-parser`                | -                                |
+| [**Liquid**](https://liquidjs.com/)                                                        | `@markuplint/liquid-parser`                  | -                                |
 
 :::note
 
@@ -110,6 +117,14 @@ npm install -D @markuplint/vue-parser @markuplint/vue-spec
   },
   "specs": {
     "\\.vue$": "@markuplint/vue-spec"
+  }
+}
+```
+
+```json class=config title="lit-htmlでつかう"
+{
+  "parser": {
+    "\\.ts$": "@markuplint/tagged-template-literal-parser"
   }
 }
 ```

--- a/website/i18n/ja/docusaurus-plugin-content-pages/index.tsx
+++ b/website/i18n/ja/docusaurus-plugin-content-pages/index.tsx
@@ -63,8 +63,8 @@ export default function Home(): JSX.Element {
               description: (
                 <>
                   Markuplintは、プラグインを通じてHTML以外の構文やテンプレートエンジンについても評価することができます。Pug,
-                  JSX(React), Vue, Svelte, Astro, Alpine.js, HTMX, PHP, Smarty, eRuby, EJS, Mustache/Handlebars,
-                  Nunjucks,
+                  JSX(React), Vue, Svelte, Astro, Alpine.js, HTMX, タグ付きテンプレートリテラル(lit-html), PHP, Smarty,
+                  eRuby, EJS, Mustache/Handlebars, Nunjucks,
                   Liquid用のプラグインが用意されています。また、欲しい構文に対応したプラグインを作成するAPIも提供します。
                 </>
               ),

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -64,9 +64,9 @@ export default function Home(): JSX.Element {
               description: (
                 <>
                   Markuplint can evaluate it for syntaxes and template engines besides HTML through plugins. There are
-                  plugins for Pug, JSX(React), Vue, Svelte, Astro, Alpine.js, HTMX, PHP, Smarty, eRuby, EJS,
-                  Mustache/Handlebars, Nunjucks, and Liquid. And it also provides the API that creates the plugin for
-                  the syntax you want.
+                  plugins for Pug, JSX(React), Vue, Svelte, Astro, Alpine.js, HTMX, Tagged Template Literals (lit-html),
+                  PHP, Smarty, eRuby, EJS, Mustache/Handlebars, Nunjucks, and Liquid. And it also provides the API that
+                  creates the plugin for the syntax you want.
                 </>
               ),
             },


### PR DESCRIPTION
## Summary

- Add `@markuplint/tagged-template-literal-parser` to the supported syntaxes table (en/ja)
- Add install example and configuration example for lit-html usage (en/ja)
- Add parser entry to `properties.md` parser examples (en/ja)
- Add Tagged Template Literals (lit-html) to homepage feature list (en/ja)

Follow-up to #3221.

## Test plan

- [x] `yarn lint-check` passes (0 errors, 0 issues)
- [x] `yarn build` passes
- [x] `yarn test` — 1 pre-existing worktree-specific failure (symlink resolution, unrelated)
- [ ] Visual check via `yarn site:start`

🤖 Generated with [Claude Code](https://claude.com/claude-code)