### PR TITLE
feat(rules): add redundant-accessible-name rule

### DIFF
--- a/packages/@markuplint/config-presets/README.md
+++ b/packages/@markuplint/config-presets/README.md
@@ -32,6 +32,7 @@ Ruleset|Description|`recommended`|`recommended-vue`|`recommended-svelte`|`recomm
 [No ambiguous **Navigable Target Names**](https://html.spec.whatwg.org/multipage/document-sequences.html#navigable-target-names)| |✅|✅|✅|✅|✅|✅|❌|❌|❌|❌|❌|❌|
 No consecutive `<br>`| |✅|✅|✅|✅|✅|✅|❌|❌|❌|❌|❌|❌|
 No refer to no existent **ID**| |✅|✅|✅|✅|✅|✅|❌|❌|✅|❌|❌|❌|
+No redundant **accessible name** sources| |✅|✅|✅|✅|✅|✅|❌|❌|❌|❌|❌|❌|
 Require **accessible name**| |✅|✅|✅|✅|✅|✅|❌|❌|❌|❌|❌|❌|
 Require `<h1>`| |✅|✅|✅|✅|✅|✅|❌|❌|❌|❌|❌|❌|
 Align row and column| |✅|✅|✅|✅|✅|✅|❌|❌|❌|❌|❌|❌|

--- a/packages/@markuplint/config-presets/src/preset.a11y.json
+++ b/packages/@markuplint/config-presets/src/preset.a11y.json
@@ -59,6 +59,11 @@
 		"no-refer-to-non-existent-id": true,
 
 		/**
+		 * No redundant **accessible name** sources
+		 */
+		"redundant-accessible-name": true,
+
+		/**
 		 * Require **accessible name**
 		 */
 		"require-accessible-name": true,

--- a/packages/@markuplint/rules/schema.json
+++ b/packages/@markuplint/rules/schema.json
@@ -99,6 +99,9 @@
 				"placeholder-label-option": {
 					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/placeholder-label-option/schema.json"
 				},
+				"redundant-accessible-name": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/redundant-accessible-name/schema.json"
+				},
 				"require-accessible-name": {
 					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/require-accessible-name/schema.json"
 				},

--- a/packages/@markuplint/rules/src/helpers.ts
+++ b/packages/@markuplint/rules/src/helpers.ts
@@ -204,7 +204,7 @@ export function accnameMayBeMutable(
 	return false;
 }
 
-const labelable = ['button', 'input:not([type=hidden])', 'meter', 'output', 'progress', 'select', 'textarea'];
+export const labelable = ['button', 'input:not([type=hidden])', 'meter', 'output', 'progress', 'select', 'textarea'];
 /**
  * Finds the `<label>` element associated with a labelable form element.
  * First checks for an ancestor `<label>`, then looks for a `<label>` whose

--- a/packages/@markuplint/rules/src/index.ts
+++ b/packages/@markuplint/rules/src/index.ts
@@ -40,6 +40,7 @@ import NoUnsupportedFeatures from './no-unsupported-features/index.js';
 import NoUseEventHandlerAttr from './no-use-event-handler-attr/index.js';
 import PermittedContents from './permitted-contents/index.js';
 import PlaceholderLabelOption from './placeholder-label-option/index.js';
+import RedundantAccessibleName from './redundant-accessible-name/index.js';
 import RequireAccessibleName from './require-accessible-name/index.js';
 import RequireDatetime from './require-datetime/index.js';
 import RequiredAttr from './required-attr/index.js';
@@ -85,6 +86,7 @@ const rules = {
 	'no-use-event-handler-attr': NoUseEventHandlerAttr,
 	'permitted-contents': PermittedContents,
 	'placeholder-label-option': PlaceholderLabelOption,
+	'redundant-accessible-name': RedundantAccessibleName,
 	'require-accessible-name': RequireAccessibleName,
 	'require-datetime': RequireDatetime,
 	'required-attr': RequiredAttr,

--- a/packages/@markuplint/rules/src/redundant-accessible-name/README.ja.md
+++ b/packages/@markuplint/rules/src/redundant-accessible-name/README.ja.md
@@ -1,0 +1,168 @@
+# `redundant-accessible-name`
+
+[Accessible Name and Description Computation (AccName) 1.2](https://www.w3.org/TR/accname-1.2/) アルゴリズムに基づき、**複数のアクセシブル名ソース**が存在し、高優先度のソースが低優先度のソースを上書きしている要素を検出します。
+
+1つの要素に複数の命名メカニズムが存在する場合、最も優先度の高いソースのみが使用されます。上書きされたソースはデッドコードとなり、開発者がその要素のアクセシブル名を提供していると誤解する可能性があります。
+
+例えば、`<label>` に「名前」と記載しつつ `aria-labelledby` で別の要素を参照した場合、目の見えるユーザーには「名前」と表示されますが、スクリーンリーダーには別の名前が伝わります。この不一致は [WCAG 2.5.3: Label in Name](https://www.w3.org/WAI/WCAG21/Understanding/label-in-name.html) 違反となり、支援技術のユーザーに混乱を引き起こします。
+
+> [!WARNING]
+> デフォルトの重大度は `warning` です。
+
+## 優先順位
+
+AccName 1.2 アルゴリズムは以下の優先順位でアクセシブル名を解決します:
+
+| 優先度 | ソース             | AccName ステップ                                                  | 例                                 |
+| ------ | ------------------ | ----------------------------------------------------------------- | ---------------------------------- |
+| 1      | `aria-labelledby`  | [2B](https://www.w3.org/TR/accname-1.2/#comp_labelledby)          | `<input aria-labelledby="ref">`    |
+| 2      | `aria-label`       | [2C](https://www.w3.org/TR/accname-1.2/#comp_aria_label)          | `<input aria-label="Name">`        |
+| 3      | `<label>`          | [2D](https://www.w3.org/TR/accname-1.2/#comp_host_language_label) | `<label for="x">Name</label>`      |
+| 4      | `alt`              | [2D](https://www.w3.org/TR/accname-1.2/#comp_host_language_label) | `<img alt="Photo">`                |
+| 5      | テキストコンテンツ | [2F](https://www.w3.org/TR/accname-1.2/#comp_name_from_content)   | `<button>Click</button>`           |
+| 6      | `value`            | [2D](https://www.w3.org/TR/accname-1.2/#comp_host_language_label) | `<input type="submit" value="Go">` |
+| 7      | `<legend>`         | [2D](https://www.w3.org/TR/accname-1.2/#comp_host_language_label) | `<fieldset><legend>Group</legend>` |
+| 8      | `<caption>`        | [2D](https://www.w3.org/TR/accname-1.2/#comp_host_language_label) | `<table><caption>Title</caption>`  |
+| 9\*    | `title`            | [2I](https://www.w3.org/TR/accname-1.2/#comp_tooltip)             | `<input title="Hint">`             |
+| 10\*   | `placeholder`      | [2I](https://www.w3.org/TR/accname-1.2/#comp_tooltip)             | `<input placeholder="Hint">`       |
+
+\* 対応するオプションが有効な場合のみチェックされます。
+
+> **注意:** このテーブルは本ルールの検出優先度を示しています。同じ AccName ステップに属するソース（例: `label`、`alt`、`legend`、`caption` はすべて Step 2D）は、典型的な適用範囲に基づいて順序付けされており、アルゴリズムの厳密な優先順位とは異なります。
+
+## ルール詳細
+
+### :x: 不正
+
+```html
+<!-- aria-labelledby が label を上書き -->
+<label for="name">名前</label>
+<span id="other-label">別の名前</span>
+<input id="name" type="text" aria-labelledby="other-label" />
+
+<!-- aria-label がボタンのテキストコンテンツを上書き -->
+<button aria-label="ダイアログを閉じる"><img src="x.svg" alt="" /> 閉じる</button>
+
+<!-- aria-label が alt を上書き -->
+<img alt="夕焼けの写真" aria-label="装飾画像" />
+
+<!-- aria-label が legend を上書き -->
+<fieldset aria-label="上書き">
+  <legend>連絡先情報</legend>
+</fieldset>
+```
+
+### :o: 正しい
+
+```html
+<!-- 単一ソース: label のみ -->
+<label for="name">名前</label>
+<input id="name" type="text" />
+
+<!-- 単一ソース: コンテンツのみ -->
+<button>送信</button>
+
+<!-- 単一ソース: alt のみ -->
+<img alt="夕焼けの写真" />
+
+<!-- 単一ソース: aria-label のみ（他のソースなし） -->
+<input type="text" aria-label="検索" />
+```
+
+## WCAG 2.5.3: Label in Name との関連
+
+`aria-label` が視覚的なラベルと異なる文字列を提供する場合、[WCAG 2.5.3: Label in Name](https://www.w3.org/WAI/WCAG21/Understanding/label-in-name.html) 違反となる可能性があります。この達成基準では、アクセシブル名に視覚的なラベルテキストを含めることが求められます。不一致する文字列による冗長な上書きはこの要件を破ります。
+
+本ルールは上書き自体を検出することで、このような不一致を早期に発見する助けとなります。
+
+## オプション
+
+### `checkTitleFallback`
+
+型: `boolean`
+デフォルト: `false`
+
+`true` の場合、`title` 属性を冗長性チェックに含めます。デフォルトでは、`title` は AccName アルゴリズムにおける最終手段のフォールバックであるため無視されます。
+
+```json
+{
+  "redundant-accessible-name": {
+    "options": {
+      "checkTitleFallback": true
+    }
+  }
+}
+```
+
+### `checkPlaceholderFallback`
+
+型: `boolean`
+デフォルト: `false`
+
+`true` の場合、`placeholder` 属性を冗長性チェックに含めます。デフォルトでは、`placeholder` は最終手段のフォールバックであるため無視されます。
+
+```json
+{
+  "redundant-accessible-name": {
+    "options": {
+      "checkPlaceholderFallback": true
+    }
+  }
+}
+```
+
+## 特定の要素を除外する
+
+アイコンボタンなど、`aria-label` で意図的に名前を提供する正当なパターンの場合:
+
+```json
+{
+  "nodeRules": [
+    {
+      "selector": "button:has(svg)",
+      "rules": {
+        "redundant-accessible-name": false
+      }
+    }
+  ]
+}
+```
+
+### `aria-labelledby` による意図的な上書き
+
+`aria-labelledby` を使って `<label>` に追加コンテキストを組み合わせるパターンはよくある正当な用法です:
+
+```html
+<label for="email" id="lbl">メール</label>
+<input id="email" aria-labelledby="lbl hint" />
+<span id="hint">（必須）</span>
+```
+
+本ルールは `aria-labelledby` が `label` を上書きするため違反として報告します。このパターンの警告を抑制するには:
+
+```json
+{
+  "nodeRules": [
+    {
+      "selector": "input[aria-labelledby]",
+      "rules": {
+        "redundant-accessible-name": false
+      }
+    }
+  ]
+}
+```
+
+## 既知の制限事項
+
+- **CSS 生成コンテンツ**: `::before` / `::after` 疑似要素からのコンテンツは静的解析では検出できず、名前ソースのチェックに含まれません。
+- **SVG `<title>`**: SVG の `<title>` 子要素は SVG 要素のアクセシブル名を提供しますが、HTML の `title` 属性とは異なり、本ルールでは現在対象外です。
+- **`aria-describedby`**: 本ルールはアクセシブル「名前」ソースのみをチェックします。アクセシブル「説明」（`aria-describedby`）は別の概念であり、対象外です。
+
+## 関連
+
+- [Issue #1478](https://github.com/markuplint/markuplint/issues/1478)
+- [`require-accessible-name`](../require-accessible-name/README.md)
+- [`wai-aria`](../wai-aria/README.md)
+- [Accessible Name and Description Computation 1.2](https://www.w3.org/TR/accname-1.2/)
+- [WCAG 2.5.3: Label in Name](https://www.w3.org/WAI/WCAG21/Understanding/label-in-name.html)

--- a/packages/@markuplint/rules/src/redundant-accessible-name/README.md
+++ b/packages/@markuplint/rules/src/redundant-accessible-name/README.md
@@ -1,0 +1,168 @@
+# `redundant-accessible-name`
+
+Detects elements with **multiple accessible name sources** where a higher-priority source overrides a lower-priority one according to the [Accessible Name and Description Computation (AccName) 1.2](https://www.w3.org/TR/accname-1.2/) algorithm.
+
+When multiple naming mechanisms are present on a single element, only the highest-priority source is used. The overridden sources are dead code that may mislead developers into thinking they provide the element's accessible name.
+
+For example, if a `<label>` says "Name" but an `aria-labelledby` attribute references a different element, sighted users see "Name" while screen reader users hear something else — a discrepancy that violates [WCAG 2.5.3: Label in Name](https://www.w3.org/WAI/WCAG21/Understanding/label-in-name.html) and creates a confusing experience for assistive technology users.
+
+> [!WARNING]
+> Default severity is `warning`.
+
+## Priority Order
+
+The AccName 1.2 algorithm resolves the accessible name in this priority order:
+
+| Priority | Source            | AccName Step                                                      | Example                            |
+| -------- | ----------------- | ----------------------------------------------------------------- | ---------------------------------- |
+| 1        | `aria-labelledby` | [2B](https://www.w3.org/TR/accname-1.2/#comp_labelledby)          | `<input aria-labelledby="ref">`    |
+| 2        | `aria-label`      | [2C](https://www.w3.org/TR/accname-1.2/#comp_aria_label)          | `<input aria-label="Name">`        |
+| 3        | `<label>`         | [2D](https://www.w3.org/TR/accname-1.2/#comp_host_language_label) | `<label for="x">Name</label>`      |
+| 4        | `alt`             | [2D](https://www.w3.org/TR/accname-1.2/#comp_host_language_label) | `<img alt="Photo">`                |
+| 5        | Text content      | [2F](https://www.w3.org/TR/accname-1.2/#comp_name_from_content)   | `<button>Click</button>`           |
+| 6        | `value`           | [2D](https://www.w3.org/TR/accname-1.2/#comp_host_language_label) | `<input type="submit" value="Go">` |
+| 7        | `<legend>`        | [2D](https://www.w3.org/TR/accname-1.2/#comp_host_language_label) | `<fieldset><legend>Group</legend>` |
+| 8        | `<caption>`       | [2D](https://www.w3.org/TR/accname-1.2/#comp_host_language_label) | `<table><caption>Title</caption>`  |
+| 9\*      | `title`           | [2I](https://www.w3.org/TR/accname-1.2/#comp_tooltip)             | `<input title="Hint">`             |
+| 10\*     | `placeholder`     | [2I](https://www.w3.org/TR/accname-1.2/#comp_tooltip)             | `<input placeholder="Hint">`       |
+
+\* Only checked when the corresponding option is enabled.
+
+> **Note:** This table reflects the detection priority used by this rule. Sources at the same AccName step (e.g., `label`, `alt`, `legend`, and `caption` are all Step 2D) are ordered by their typical applicability scope, not by strict algorithm precedence.
+
+## Rule Details
+
+### :x: Incorrect
+
+```html
+<!-- aria-labelledby overrides label -->
+<label for="name">Your name</label>
+<span id="other-label">Different name</span>
+<input id="name" type="text" aria-labelledby="other-label" />
+
+<!-- aria-label overrides button text content -->
+<button aria-label="Close dialog"><img src="x.svg" alt="" /> Close</button>
+
+<!-- aria-label overrides alt -->
+<img alt="Photo of sunset" aria-label="Decorative image" />
+
+<!-- aria-label overrides legend -->
+<fieldset aria-label="Overridden">
+  <legend>Contact Information</legend>
+</fieldset>
+```
+
+### :o: Correct
+
+```html
+<!-- Single source: label only -->
+<label for="name">Your name</label>
+<input id="name" type="text" />
+
+<!-- Single source: content only -->
+<button>Submit</button>
+
+<!-- Single source: alt only -->
+<img alt="Photo of sunset" />
+
+<!-- Single source: aria-label only (no other source) -->
+<input type="text" aria-label="Search" />
+```
+
+## WCAG 2.5.3: Label in Name
+
+When `aria-label` provides a different string from the visible text, it can violate [WCAG 2.5.3: Label in Name](https://www.w3.org/WAI/WCAG21/Understanding/label-in-name.html). This success criterion requires that the accessible name includes the visible label text. A redundant override with a mismatched string breaks this requirement.
+
+This rule helps catch such mismatches by flagging the override itself.
+
+## Options
+
+### `checkTitleFallback`
+
+Type: `boolean`
+Default: `false`
+
+When `true`, the `title` attribute is included in the redundancy check. By default, `title` is ignored because it is a last-resort fallback in the AccName algorithm.
+
+```json
+{
+  "redundant-accessible-name": {
+    "options": {
+      "checkTitleFallback": true
+    }
+  }
+}
+```
+
+### `checkPlaceholderFallback`
+
+Type: `boolean`
+Default: `false`
+
+When `true`, the `placeholder` attribute is included in the redundancy check. By default, `placeholder` is ignored because it is a last-resort fallback.
+
+```json
+{
+  "redundant-accessible-name": {
+    "options": {
+      "checkPlaceholderFallback": true
+    }
+  }
+}
+```
+
+## Excluding Specific Elements
+
+For legitimate patterns such as icon buttons where `aria-label` intentionally provides the name:
+
+```json
+{
+  "nodeRules": [
+    {
+      "selector": "button:has(svg)",
+      "rules": {
+        "redundant-accessible-name": false
+      }
+    }
+  ]
+}
+```
+
+### Intentional Override with `aria-labelledby`
+
+A common legitimate pattern is using `aria-labelledby` to combine a `<label>` with additional context:
+
+```html
+<label for="email" id="lbl">Email</label>
+<input id="email" aria-labelledby="lbl hint" />
+<span id="hint">(required)</span>
+```
+
+This rule reports this as a violation because `aria-labelledby` overrides `label`. To suppress the warning for this pattern:
+
+```json
+{
+  "nodeRules": [
+    {
+      "selector": "input[aria-labelledby]",
+      "rules": {
+        "redundant-accessible-name": false
+      }
+    }
+  ]
+}
+```
+
+## Known Limitations
+
+- **CSS generated content**: Content from `::before` / `::after` pseudo-elements is not detectable by static analysis and is not included in the naming source check.
+- **SVG `<title>`**: The `<title>` child element of SVG provides an accessible name for SVG elements, but this is distinct from the HTML `title` attribute and is not currently covered by this rule.
+- **`aria-describedby`**: This rule only checks accessible _name_ sources. The accessible _description_ (`aria-describedby`) is a separate concept and is not in scope.
+
+## See Also
+
+- [Issue #1478](https://github.com/markuplint/markuplint/issues/1478)
+- [`require-accessible-name`](../require-accessible-name/README.md)
+- [`wai-aria`](../wai-aria/README.md)
+- [Accessible Name and Description Computation 1.2](https://www.w3.org/TR/accname-1.2/)
+- [WCAG 2.5.3: Label in Name](https://www.w3.org/WAI/WCAG21/Understanding/label-in-name.html)

--- a/packages/@markuplint/rules/src/redundant-accessible-name/index.spec.ts
+++ b/packages/@markuplint/rules/src/redundant-accessible-name/index.spec.ts
@@ -1,0 +1,307 @@
+import { mlRuleTest } from 'markuplint';
+import { describe, test, expect } from 'vitest';
+
+import rule from './index.js';
+
+describe('No violations (single source)', () => {
+	test('label only (explicit)', async () => {
+		const { violations } = await mlRuleTest(rule, '<input id="x" type="text"><label for="x">Label</label>');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('content only (button)', async () => {
+		const { violations } = await mlRuleTest(rule, '<button>Click</button>');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('alt only (img)', async () => {
+		const { violations } = await mlRuleTest(rule, '<img alt="Photo">');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('aria-label only', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="text" aria-label="X">');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('aria-labelledby only', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="text" aria-labelledby="y"><span id="y">Y</span>');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('hidden input is skipped', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="hidden">');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('aria-hidden element is skipped', async () => {
+		const { violations } = await mlRuleTest(rule, '<div aria-hidden="true" aria-label="X">Text</div>');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('no accessible name at all', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="text">');
+		expect(violations).toStrictEqual([]);
+	});
+});
+
+describe('Violations (override detected)', () => {
+	test('aria-labelledby + explicit label', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<input id="x" type="text" aria-labelledby="y"><label for="x">L</label><span id="y">Y</span>',
+		);
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.severity).toBe('warning');
+		expect(violations[0]?.message).toContain('aria-labelledby');
+		expect(violations[0]?.message).toContain('label');
+	});
+
+	test('aria-labelledby + implicit label', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<label><input type="text" aria-labelledby="y">L</label><span id="y">Y</span>',
+		);
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.message).toContain('aria-labelledby');
+		expect(violations[0]?.message).toContain('label');
+	});
+
+	test('aria-label + explicit label', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<input id="x" type="text" aria-label="X"><label for="x">L</label>',
+		);
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.message).toContain('aria-label');
+		expect(violations[0]?.message).toContain('label');
+	});
+
+	test('aria-label + implicit label', async () => {
+		const { violations } = await mlRuleTest(rule, '<label><input type="text" aria-label="X">L</label>');
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.message).toContain('aria-label');
+		expect(violations[0]?.message).toContain('label');
+	});
+
+	test('aria-label + content (button) — full match', async () => {
+		const { violations } = await mlRuleTest(rule, '<button aria-label="X">Click</button>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'warning',
+				line: 1,
+				col: 1,
+				raw: '<button aria-label="X">',
+				message: 'The accessible name from "aria-label" overrides "content"',
+			},
+		]);
+	});
+
+	test('aria-labelledby + content (button)', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<button aria-labelledby="y">Click</button><span id="y">Y</span>',
+		);
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.message).toContain('aria-labelledby');
+		expect(violations[0]?.message).toContain('content');
+	});
+
+	test('aria-label + alt (img)', async () => {
+		const { violations } = await mlRuleTest(rule, '<img alt="Photo" aria-label="X">');
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.message).toContain('aria-label');
+		expect(violations[0]?.message).toContain('alt');
+	});
+
+	test('aria-labelledby + alt (img)', async () => {
+		const { violations } = await mlRuleTest(rule, '<img alt="Photo" aria-labelledby="y"><span id="y">Y</span>');
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.message).toContain('aria-labelledby');
+		expect(violations[0]?.message).toContain('alt');
+	});
+
+	test('aria-labelledby + aria-label', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<input type="text" aria-labelledby="y" aria-label="X"><span id="y">Y</span>',
+		);
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.message).toContain('aria-labelledby');
+		expect(violations[0]?.message).toContain('aria-label');
+	});
+
+	test('aria-labelledby + aria-label + content (3 sources)', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<button aria-labelledby="y" aria-label="X">Click</button><span id="y">Y</span>',
+		);
+		expect(violations.length).toBe(2);
+	});
+
+	test('aria-label + legend (fieldset)', async () => {
+		const { violations } = await mlRuleTest(rule, '<fieldset aria-label="X"><legend>Group</legend></fieldset>');
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.message).toContain('aria-label');
+		expect(violations[0]?.message).toContain('legend');
+	});
+
+	test('aria-label + caption (table)', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<table aria-label="X"><caption>Title</caption><tr><td>Data</td></tr></table>',
+		);
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.message).toContain('aria-label');
+		expect(violations[0]?.message).toContain('caption');
+	});
+
+	test('aria-label + value (input[type=submit])', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="submit" value="Go" aria-label="X">');
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.message).toContain('aria-label');
+		expect(violations[0]?.message).toContain('value');
+	});
+
+	test('aria-labelledby self-reference + content (heading)', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<h2 id="h" aria-labelledby="h foo">Meeting</h2><span id="foo">Notes</span>',
+		);
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.message).toContain('aria-labelledby');
+		expect(violations[0]?.message).toContain('content');
+	});
+
+	test('aria-labelledby referencing label ID + extra context', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<label for="x" id="lbl">Name</label><input id="x" aria-labelledby="lbl extra"><span id="extra">(required)</span>',
+		);
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.message).toContain('aria-labelledby');
+		expect(violations[0]?.message).toContain('label');
+	});
+
+	test('summary + aria-label', async () => {
+		const { violations } = await mlRuleTest(rule, '<details><summary aria-label="X">Details</summary></details>');
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.message).toContain('aria-label');
+		expect(violations[0]?.message).toContain('content');
+	});
+});
+
+describe('Options: checkTitleFallback / checkPlaceholderFallback', () => {
+	test('title + label, option false (default) — no violation', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<input id="x" type="text" title="Hint"><label for="x">L</label>',
+		);
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('title + label, option true — violation', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<input id="x" type="text" title="Hint"><label for="x">L</label>',
+			{
+				rule: { options: { checkTitleFallback: true } },
+			},
+		);
+		expect(violations.length).toBe(1);
+	});
+
+	test('placeholder + label, option false (default) — no violation', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<input id="x" type="text" placeholder="Hint"><label for="x">L</label>',
+		);
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('placeholder + label, option true — violation', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<input id="x" type="text" placeholder="Hint"><label for="x">L</label>',
+			{
+				rule: { options: { checkPlaceholderFallback: true } },
+			},
+		);
+		expect(violations.length).toBe(1);
+	});
+});
+
+describe('Edge cases', () => {
+	test('empty aria-label="" does not count as a source', async () => {
+		const { violations } = await mlRuleTest(rule, '<button aria-label="">Click</button>');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('empty aria-labelledby="" does not count as a source', async () => {
+		const { violations } = await mlRuleTest(rule, '<button aria-labelledby="">Click</button>');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('aria-labelledby referencing non-existent ID does not count', async () => {
+		const { violations } = await mlRuleTest(rule, '<button aria-labelledby="nonexistent">Click</button>');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('mutable attribute (JSX) is skipped', async () => {
+		const { violations } = await mlRuleTest(rule, '<button aria-label={label}>Click</button>', {
+			parser: { '.*': '@markuplint/jsx-parser' },
+		});
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('mutable attribute (Vue) is skipped', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<template><button :aria-label="label">Click</button></template>',
+			{
+				parser: { '.*': '@markuplint/vue-parser' },
+			},
+		);
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('mutable attribute (Svelte) is skipped', async () => {
+		const { violations } = await mlRuleTest(rule, '<button aria-label={label}>Click</button>', {
+			parser: { '.*': '@markuplint/svelte-parser' },
+		});
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('nameFrom prohibited role (generic) is skipped', async () => {
+		const { violations } = await mlRuleTest(rule, '<div role="generic" aria-label="X">Text</div>');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('nameFrom prohibited role (presentation) is skipped', async () => {
+		const { violations } = await mlRuleTest(rule, '<div role="presentation" aria-label="X">Text</div>');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('nameFrom prohibited role (none) is skipped', async () => {
+		const { violations } = await mlRuleTest(rule, '<div role="none" aria-label="X">Text</div>');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('nested fieldset — legend belongs to inner fieldset, not outer', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<fieldset aria-label="X"><fieldset><legend>Inner</legend></fieldset></fieldset>',
+		);
+		// Only aria-label on outer fieldset, no legend as direct child → 0 violations
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('nested table — caption belongs to inner table, not outer', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<table aria-label="X"><tr><td><table><caption>Inner</caption><tr><td>D</td></tr></table></td></tr></table>',
+		);
+		// Only aria-label on outer table, no caption as direct child → 0 violations
+		expect(violations).toStrictEqual([]);
+	});
+});

--- a/packages/@markuplint/rules/src/redundant-accessible-name/index.ts
+++ b/packages/@markuplint/rules/src/redundant-accessible-name/index.ts
@@ -1,0 +1,156 @@
+import type { PlainData } from '@markuplint/ml-config';
+import type { Element, RuleConfigValue, Document } from '@markuplint/ml-core';
+import type { ComputedRole } from '@markuplint/ml-spec';
+
+import { createRule, getComputedRole } from '@markuplint/ml-core';
+import { ARIA_RECOMMENDED_VERSION, isExposed } from '@markuplint/ml-spec';
+
+import { accnameMayBeMutable, getOwnedLabel } from '../helpers.js';
+
+import meta from './meta.js';
+
+type NamingSource = {
+	readonly label: string;
+};
+
+/**
+ * Rule that detects elements with multiple accessible name sources
+ * where a higher-priority source overrides a lower-priority one.
+ */
+export default createRule({
+	meta,
+	defaultSeverity: 'warning',
+	defaultOptions: {
+		checkTitleFallback: false,
+		checkPlaceholderFallback: false,
+	},
+	async verify({ document, report, t }) {
+		await document.walkOn('Element', el => {
+			const ariaVersion = ARIA_RECOMMENDED_VERSION;
+
+			// Skip mutable elements (template expressions etc.)
+			if (accnameMayBeMutable(el, document)) {
+				return;
+			}
+
+			// Skip hidden elements
+			if (!isExposed(el, document.specs, ariaVersion)) {
+				return;
+			}
+
+			// Skip nameFrom: "prohibited" roles (generic, none, presentation)
+			const computed = getComputedRole(document.specs, el, ariaVersion);
+			if (computed.role?.accessibleNameProhibited) {
+				return;
+			}
+
+			const sources = collectNamingSources(el, document, el.rule.options, computed);
+
+			if (sources.length >= 2) {
+				const winner = sources[0]!;
+				const overridden = sources.slice(1);
+				for (const loser of overridden) {
+					report({
+						scope: el,
+						message: t('The accessible name from "{0*}" overrides "{1*}"', winner.label, loser.label),
+					});
+				}
+			}
+		});
+	},
+});
+
+function collectNamingSources<V extends RuleConfigValue, O extends PlainData>(
+	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+	el: Element<V, O>,
+	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+	document: Document<V, O>,
+	options: {
+		readonly checkTitleFallback: boolean;
+		readonly checkPlaceholderFallback: boolean;
+	},
+	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+	computed: ComputedRole,
+): readonly NamingSource[] {
+	const sources: NamingSource[] = [];
+
+	// 1. aria-labelledby
+	const ariaLabelledby = el.getAttribute('aria-labelledby');
+	if (ariaLabelledby && ariaLabelledby.trim()) {
+		const ids = ariaLabelledby.trim().split(/\s+/);
+		const hasResolvableId = ids.some(id => document.querySelector(`[id="${id}"]`));
+		if (hasResolvableId) {
+			sources.push({ label: 'aria-labelledby' });
+		}
+	}
+
+	// 2. aria-label
+	const ariaLabel = el.getAttribute('aria-label');
+	if (ariaLabel && ariaLabel.trim()) {
+		sources.push({ label: 'aria-label' });
+	}
+
+	// 3. label (explicit or implicit) — only for labelable elements
+	const ownedLabel = getOwnedLabel(el, document);
+	if (ownedLabel) {
+		sources.push({ label: 'label' });
+	}
+
+	// 4. alt — img, area, input[type=image]
+	if (el.matches('img, area, input[type=image]')) {
+		const alt = el.getAttribute('alt');
+		if (alt != null && alt.trim()) {
+			sources.push({ label: 'alt' });
+		}
+	}
+
+	// 5. content — role allows nameFromContent
+	if (computed.role?.accessibleNameFromContent) {
+		const text = el.textContent.trim();
+		if (text) {
+			sources.push({ label: 'content' });
+		}
+	}
+
+	// 6. value — input[type=button/submit/reset]
+	if (el.matches('input[type=button], input[type=submit], input[type=reset]')) {
+		const value = el.getAttribute('value');
+		if (value != null && value.trim()) {
+			sources.push({ label: 'value' });
+		}
+	}
+
+	// 7. legend — fieldset (direct child only)
+	if (el.matches('fieldset')) {
+		const legend = el.querySelector(':scope > legend');
+		if (legend && legend.textContent.trim()) {
+			sources.push({ label: 'legend' });
+		}
+	}
+
+	// 8. caption — table (direct child only)
+	if (el.matches('table')) {
+		const caption = el.querySelector(':scope > caption');
+		if (caption && caption.textContent.trim()) {
+			sources.push({ label: 'caption' });
+		}
+	}
+
+	// 9. title (optional)
+	if (options.checkTitleFallback) {
+		const title = el.getAttribute('title');
+		if (title != null && title.trim()) {
+			sources.push({ label: 'title' });
+		}
+	}
+
+	// 10. placeholder (optional)
+	if (options.checkPlaceholderFallback) {
+		const placeholder = el.getAttribute('placeholder');
+		if (placeholder != null && placeholder.trim()) {
+			sources.push({ label: 'placeholder' });
+		}
+	}
+
+	return sources;
+}

--- a/packages/@markuplint/rules/src/redundant-accessible-name/meta.ts
+++ b/packages/@markuplint/rules/src/redundant-accessible-name/meta.ts
@@ -1,0 +1,4 @@
+/** Rule metadata for the `redundant-accessible-name` rule, categorized as accessibility. */
+export default {
+	category: 'a11y',
+} as const;

--- a/packages/@markuplint/rules/src/redundant-accessible-name/schema.json
+++ b/packages/@markuplint/rules/src/redundant-accessible-name/schema.json
@@ -1,0 +1,47 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"value": {
+			"type": "boolean"
+		},
+		"options": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"checkTitleFallback": {
+					"type": "boolean",
+					"default": false,
+					"description": "Report title attribute as a redundant accessible name source.",
+					"description:ja": "title属性を冗長なアクセシブル名ソースとして報告します。"
+				},
+				"checkPlaceholderFallback": {
+					"type": "boolean",
+					"default": false,
+					"description": "Report placeholder attribute as a redundant accessible name source.",
+					"description:ja": "placeholder属性を冗長なアクセシブル名ソースとして報告します。"
+				}
+			}
+		}
+	},
+	"oneOf": [
+		{
+			"$ref": "#/definitions/value"
+		},
+		{
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"value": { "$ref": "#/definitions/value" },
+				"options": { "$ref": "#/definitions/options" },
+				"option": { "$ref": "#/definitions/options", "deprecated": true },
+				"severity": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/ml-config/schema.json#/definitions/severity",
+					"default": "warning"
+				},
+				"reason": {
+					"type": "string"
+				}
+			}
+		}
+	]
+}

--- a/packages/markuplint/src/cli/init/get-default-rules.spec.ts
+++ b/packages/markuplint/src/cli/init/get-default-rules.spec.ts
@@ -129,6 +129,10 @@ test('default-rules', () => {
 			category: 'validation',
 			defaultValue: true,
 		},
+		'redundant-accessible-name': {
+			category: 'a11y',
+			defaultValue: false,
+		},
 		'require-accessible-name': {
 			category: 'a11y',
 			defaultValue: true,


### PR DESCRIPTION
## Summary

Closes #1478

- Add `redundant-accessible-name` rule that detects elements with multiple accessible name sources where a higher-priority source overrides a lower-priority one per the [AccName 1.2](https://www.w3.org/TR/accname-1.2/) algorithm
- Add the rule to the `a11y` preset in `@markuplint/config-presets`
- Priority-ordered detection: `aria-labelledby` > `aria-label` > `label` > `alt` > content > `value` > `legend` > `caption` (+ optional `title`/`placeholder`)
- Skip mutable attributes (JSX/Vue/Svelte), hidden elements, and `nameFrom: prohibited` roles
- Restrict `<legend>`/`<caption>` to direct children only (`:scope >`) to prevent false positives with nested `<fieldset>`/`<table>`
- 39 tests covering violations, edge cases, options, and framework parsers
- Documentation with AccName step links, WCAG 2.5.3 guidance, intentional override examples, and known limitations

## Test plan

- [x] `npx vitest run packages/@markuplint/rules/src/redundant-accessible-name/` — 39 tests pass
- [x] `yarn build` — 38 projects build successfully
- [x] `yarn lint` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)