### PR TITLE
feat(rules): add require-dialog-autofocus rule

### DIFF
--- a/packages/@markuplint/config-presets/README.md
+++ b/packages/@markuplint/config-presets/README.md
@@ -34,6 +34,7 @@ No consecutive `<br>`| |✅|✅|✅|✅|✅|✅|❌|❌|❌|❌|❌|❌|
 No refer to no existent **ID**| |✅|✅|✅|✅|✅|✅|❌|❌|✅|❌|❌|❌|
 No redundant **accessible name** sources| |✅|✅|✅|✅|✅|✅|❌|❌|❌|❌|❌|❌|
 Require **accessible name**| |✅|✅|✅|✅|✅|✅|❌|❌|❌|❌|❌|❌|
+Require **autofocus** in modal dialogs| |✅|✅|✅|✅|✅|✅|❌|❌|❌|❌|❌|❌|
 Require `<h1>`| |✅|✅|✅|✅|✅|✅|❌|❌|❌|❌|❌|❌|
 Align row and column| |✅|✅|✅|✅|✅|✅|❌|❌|❌|❌|❌|❌|
 Use `<ul>`| |✅|✅|✅|✅|✅|✅|❌|❌|❌|❌|❌|❌|

--- a/packages/@markuplint/config-presets/src/preset.a11y.jsonc
+++ b/packages/@markuplint/config-presets/src/preset.a11y.jsonc
@@ -69,6 +69,11 @@
 		"require-accessible-name": true,
 
 		/**
+		 * Require **autofocus** in modal dialogs
+		 */
+		"require-dialog-autofocus": true,
+
+		/**
 		 * Require `<h1>`
 		 *
 		 */

--- a/packages/@markuplint/rules/schema.json
+++ b/packages/@markuplint/rules/schema.json
@@ -108,6 +108,9 @@
 				"require-datetime": {
 					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/require-datetime/schema.json"
 				},
+				"require-dialog-autofocus": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/require-dialog-autofocus/schema.json"
+				},
 				"required-attr": {
 					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/required-attr/schema.json"
 				},

--- a/packages/@markuplint/rules/src/index.ts
+++ b/packages/@markuplint/rules/src/index.ts
@@ -43,6 +43,7 @@ import PlaceholderLabelOption from './placeholder-label-option/index.js';
 import RedundantAccessibleName from './redundant-accessible-name/index.js';
 import RequireAccessibleName from './require-accessible-name/index.js';
 import RequireDatetime from './require-datetime/index.js';
+import RequireDialogAutofocus from './require-dialog-autofocus/index.js';
 import RequiredAttr from './required-attr/index.js';
 import RequiredElement from './required-element/index.js';
 import RequiredH1 from './required-h1/index.js';
@@ -89,6 +90,7 @@ const rules = {
 	'redundant-accessible-name': RedundantAccessibleName,
 	'require-accessible-name': RequireAccessibleName,
 	'require-datetime': RequireDatetime,
+	'require-dialog-autofocus': RequireDialogAutofocus,
 	'required-attr': RequiredAttr,
 	'required-element': RequiredElement,
 	'required-h1': RequiredH1,

--- a/packages/@markuplint/rules/src/require-dialog-autofocus/README.ja.md
+++ b/packages/@markuplint/rules/src/require-dialog-autofocus/README.ja.md
@@ -1,0 +1,60 @@
+---
+description: show-modal コマンドで表示される dialog 要素に autofocus 属性を持つ要素が必要です
+---
+
+# `require-dialog-autofocus`
+
+<!-- textlint-disable ja-technical-writing/ja-no-mixed-period -->
+
+`show-modal` コマンドで表示される `<dialog>` 要素に、`autofocus` 属性を持つ子孫要素（または自身）が必要です。
+
+[`showModal()`](https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-dialog-showmodal) でモーダルダイアログが表示される際、ブラウザは `autofocus` を持つ最初の子孫要素にフォーカスを移します。`autofocus` がない場合、`<dialog>` 要素自体にフォーカスが当たりますが、これはアクセシビリティ上望ましくありません。スクリーンリーダーのユーザーがダイアログの内容を見落とす可能性があり、キーボードユーザーはインタラクティブな要素に到達するために余分なタブ操作が必要になります。
+
+このルールは [Invoker Commands API](https://open-ui.org/components/invokers.explainer/) を使用してモーダルダイアログを静的に検出します。`command="show-modal"` と `commandfor` で `<dialog>` 要素を参照する `<button>` がある場合、そのダイアログがモーダルとして表示されることを示します。
+
+> [!WARNING]
+> デフォルトの重大度は `warning` です。
+
+## ルール詳細
+
+### :x: 不正
+
+```html
+<button command="show-modal" commandfor="my-dialog">開く</button>
+<dialog id="my-dialog">
+  <p>このダイアログには autofocus 要素がありません。</p>
+  <button command="close" commandfor="my-dialog">閉じる</button>
+</dialog>
+```
+
+### :o: 正しい
+
+```html
+<button command="show-modal" commandfor="my-dialog">開く</button>
+<dialog id="my-dialog">
+  <input type="text" autofocus />
+  <button command="close" commandfor="my-dialog">閉じる</button>
+</dialog>
+```
+
+```html
+<button command="show-modal" commandfor="my-dialog">開く</button>
+<dialog id="my-dialog">
+  <button autofocus command="close" commandfor="my-dialog">閉じる</button>
+</dialog>
+```
+
+## スコープ
+
+このルールは `command="show-modal"` を持つ `<button>` から参照される `<dialog>` 要素のみをチェックします。JavaScript で `showModal()` を呼び出してプログラム的に開かれるダイアログや、宣言的なトリガーのないダイアログはチェックされません。
+
+`commandfor` で参照される非 dialog 要素もスキップされます。`command` 値の比較は HTML 仕様に従い大文字小文字を区別しません。
+
+## 関連
+
+- [Issue #689](https://github.com/markuplint/markuplint/issues/689)
+- [HTML Living Standard: dialog 要素](https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element)
+- [Invoker Commands API Explainer](https://open-ui.org/components/invokers.explainer/)
+- [MDN: autofocus](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autofocus)
+
+<!-- textlint-enable ja-technical-writing/ja-no-mixed-period -->

--- a/packages/@markuplint/rules/src/require-dialog-autofocus/README.ja.md
+++ b/packages/@markuplint/rules/src/require-dialog-autofocus/README.ja.md
@@ -8,12 +8,19 @@ description: show-modal コマンドで表示される dialog 要素に autofocu
 
 `show-modal` コマンドで表示される `<dialog>` 要素に、`autofocus` 属性を持つ子孫要素（または自身）が必要です。
 
-[`showModal()`](https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-dialog-showmodal) でモーダルダイアログが表示される際、ブラウザは `autofocus` を持つ最初の子孫要素にフォーカスを移します。`autofocus` がない場合、`<dialog>` 要素自体にフォーカスが当たりますが、これはアクセシビリティ上望ましくありません。スクリーンリーダーのユーザーがダイアログの内容を見落とす可能性があり、キーボードユーザーはインタラクティブな要素に到達するために余分なタブ操作が必要になります。
+[`showModal()`](https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-dialog-showmodal) でモーダルダイアログが表示される際、ブラウザは[ダイアログフォーカスステップ](https://html.spec.whatwg.org/multipage/interactive-elements.html#dialog-focusing-steps)を実行します。`autofocus` がない場合、`<dialog>` 要素自体にフォーカスがフォールバックします。動作上は問題ありませんが、アクセシビリティ上望ましくありません。スクリーンリーダーのユーザーがダイアログの内容を見落とす可能性があり、キーボードユーザーはインタラクティブな要素に到達するために余分なタブ操作が必要になります。
+
+> 著者は、ダイアログが開いた後にユーザーがすぐに操作することが期待される子孫要素に、autofocus属性を使用すべきである。
+
+[HTML Living Standard: dialog要素](https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element)より引用
 
 このルールは [Invoker Commands API](https://open-ui.org/components/invokers.explainer/) を使用してモーダルダイアログを静的に検出します。`command="show-modal"` と `commandfor` で `<dialog>` 要素を参照する `<button>` がある場合、そのダイアログがモーダルとして表示されることを示します。
 
 > [!WARNING]
-> デフォルトの重大度は `warning` です。
+> デフォルトの重大度は `warning` です。HTML仕様では `autofocus` の使用は「推奨（should）」であり「必須（must）」ではないためです。`autofocus` がなくても、ダイアログフォーカスステップのフォールバックによりダイアログ要素またはその最初のフォーカス可能な子孫にフォーカスが移動します。
+
+> [!NOTE]
+> このルールは [Invoker Commands API](https://developer.mozilla.org/en-US/docs/Web/API/Invoker_Commands_API)（`command`/`commandfor` 属性）に依存しています。この API を使用していない場合（例: JavaScript で `dialog.showModal()` を呼び出してダイアログを開く場合）、このルールは違反を検出しません。Invoker Commands API は2026年初頭に [Baseline サポート](https://developer.mozilla.org/en-US/docs/Web/API/Invoker_Commands_API)を達成しました。
 
 ## ルール詳細
 
@@ -30,6 +37,7 @@ description: show-modal コマンドで表示される dialog 要素に autofocu
 ### :o: 正しい
 
 ```html
+<!-- 子孫の input に autofocus -->
 <button command="show-modal" commandfor="my-dialog">開く</button>
 <dialog id="my-dialog">
   <input type="text" autofocus />
@@ -38,15 +46,26 @@ description: show-modal コマンドで表示される dialog 要素に autofocu
 ```
 
 ```html
+<!-- 子孫の button に autofocus -->
 <button command="show-modal" commandfor="my-dialog">開く</button>
 <dialog id="my-dialog">
   <button autofocus command="close" commandfor="my-dialog">閉じる</button>
 </dialog>
 ```
 
+```html
+<!-- dialog 自身に autofocus -->
+<button command="show-modal" commandfor="my-dialog">開く</button>
+<dialog id="my-dialog" autofocus>
+  <p>インタラクティブ要素のないコンテンツ。</p>
+</dialog>
+```
+
 ## スコープ
 
-このルールは `command="show-modal"` を持つ `<button>` から参照される `<dialog>` 要素のみをチェックします。JavaScript で `showModal()` を呼び出してプログラム的に開かれるダイアログや、宣言的なトリガーのないダイアログはチェックされません。
+このルールは `command="show-modal"` を持つ `<button>` から参照される `<dialog>` 要素のみをチェックします。他の `command` 値（`close`、`toggle-popover` など）は対象外です。
+
+JavaScript で `showModal()` を呼び出してプログラム的に開かれるダイアログや、宣言的なトリガーのないダイアログはチェックされません。**Invoker Commands API を使用していないプロジェクトでは、このルールは違反を報告しません。**
 
 `commandfor` で参照される非 dialog 要素もスキップされます。`command` 値の比較は HTML 仕様に従い大文字小文字を区別しません。
 
@@ -54,6 +73,8 @@ description: show-modal コマンドで表示される dialog 要素に autofocu
 
 - [Issue #689](https://github.com/markuplint/markuplint/issues/689)
 - [HTML Living Standard: dialog 要素](https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element)
+- [HTML Living Standard: ダイアログフォーカスステップ](https://html.spec.whatwg.org/multipage/interactive-elements.html#dialog-focusing-steps)
+- [WAI-ARIA APG: モーダルダイアログパターン](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/)
 - [Invoker Commands API Explainer](https://open-ui.org/components/invokers.explainer/)
 - [MDN: autofocus](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autofocus)
 

--- a/packages/@markuplint/rules/src/require-dialog-autofocus/README.ja.md
+++ b/packages/@markuplint/rules/src/require-dialog-autofocus/README.ja.md
@@ -69,6 +69,12 @@ JavaScript で `showModal()` を呼び出してプログラム的に開かれる
 
 `commandfor` で参照される非 dialog 要素もスキップされます。`command` 値の比較は HTML 仕様に従い大文字小文字を区別しません。
 
+## 既知の制限事項
+
+- **JavaScript で開かれるダイアログ**: Invoker Commands API を使用せず JavaScript の `dialog.showModal()` で開かれるダイアログは、静的解析では検出できません。
+- **動的な `autofocus`**: JavaScript で動的に `autofocus` を追加するケース（例: `element.setAttribute('autofocus', '')`）は検出できません。
+- **フォーカス配置の適切性**: このルールは `autofocus` が「存在するか」のみをチェックし、「最も適切な要素に配置されているか」はチェックしません。初期フォーカスの配置ガイダンスについては [WAI-ARIA APG: モーダルダイアログパターン](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/)を参照してください。
+
 ## 関連
 
 - [Issue #689](https://github.com/markuplint/markuplint/issues/689)

--- a/packages/@markuplint/rules/src/require-dialog-autofocus/README.md
+++ b/packages/@markuplint/rules/src/require-dialog-autofocus/README.md
@@ -68,6 +68,12 @@ Dialogs that are opened programmatically (via `showModal()` in JavaScript) or di
 
 Non-dialog elements referenced by `commandfor` are also skipped. The `command` value comparison is case-insensitive per the HTML spec.
 
+## Known Limitations
+
+- **JavaScript-triggered dialogs**: Dialogs opened via `dialog.showModal()` in JavaScript without the Invoker Commands API cannot be detected by static analysis.
+- **Dynamic `autofocus`**: If `autofocus` is added dynamically via JavaScript (e.g., `element.setAttribute('autofocus', '')`), this rule cannot detect it.
+- **Focus placement quality**: This rule checks only whether `autofocus` _exists_, not whether it is placed on the most appropriate element. For guidance on where to place initial focus, see the [WAI-ARIA APG: Modal Dialog Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/).
+
 ## See Also
 
 - [Issue #689](https://github.com/markuplint/markuplint/issues/689)

--- a/packages/@markuplint/rules/src/require-dialog-autofocus/README.md
+++ b/packages/@markuplint/rules/src/require-dialog-autofocus/README.md
@@ -1,0 +1,57 @@
+---
+id: require-dialog-autofocus
+description: Requires a dialog shown via the show-modal command to contain an element with the autofocus attribute
+---
+
+# `require-dialog-autofocus`
+
+Requires a `<dialog>` element shown via the `show-modal` command to contain a descendant (or itself) with the `autofocus` attribute.
+
+When a modal dialog is shown via [`showModal()`](https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-dialog-showmodal), the browser moves focus to the first descendant with `autofocus`. Without `autofocus`, focus goes to the `<dialog>` element itself, which is not ideal for accessibility — screen reader users may miss the dialog content, and keyboard users may need extra tab presses to reach interactive elements.
+
+This rule uses the [Invoker Commands API](https://open-ui.org/components/invokers.explainer/) to statically detect modal dialogs: a `<button>` with `command="show-modal"` and `commandfor` pointing to a `<dialog>` element indicates that the dialog will be shown as a modal.
+
+> [!WARNING]
+> Default severity is `warning`.
+
+## Rule Details
+
+### :x: Incorrect
+
+```html
+<button command="show-modal" commandfor="my-dialog">Open</button>
+<dialog id="my-dialog">
+  <p>This dialog has no autofocus element.</p>
+  <button command="close" commandfor="my-dialog">Close</button>
+</dialog>
+```
+
+### :o: Correct
+
+```html
+<button command="show-modal" commandfor="my-dialog">Open</button>
+<dialog id="my-dialog">
+  <input type="text" autofocus />
+  <button command="close" commandfor="my-dialog">Close</button>
+</dialog>
+```
+
+```html
+<button command="show-modal" commandfor="my-dialog">Open</button>
+<dialog id="my-dialog">
+  <button autofocus command="close" commandfor="my-dialog">Close</button>
+</dialog>
+```
+
+## Scope
+
+This rule only checks `<dialog>` elements that are referenced by a `<button>` with `command="show-modal"`. Dialogs that are opened programmatically (via `showModal()` in JavaScript) or dialogs without a declarative trigger are not checked.
+
+Non-dialog elements referenced by `commandfor` are also skipped. The `command` value comparison is case-insensitive per the HTML spec.
+
+## See Also
+
+- [Issue #689](https://github.com/markuplint/markuplint/issues/689)
+- [HTML Living Standard: The dialog element](https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element)
+- [Invoker Commands API Explainer](https://open-ui.org/components/invokers.explainer/)
+- [MDN: autofocus](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autofocus)

--- a/packages/@markuplint/rules/src/require-dialog-autofocus/README.md
+++ b/packages/@markuplint/rules/src/require-dialog-autofocus/README.md
@@ -7,12 +7,19 @@ description: Requires a dialog shown via the show-modal command to contain an el
 
 Requires a `<dialog>` element shown via the `show-modal` command to contain a descendant (or itself) with the `autofocus` attribute.
 
-When a modal dialog is shown via [`showModal()`](https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-dialog-showmodal), the browser moves focus to the first descendant with `autofocus`. Without `autofocus`, focus goes to the `<dialog>` element itself, which is not ideal for accessibility — screen reader users may miss the dialog content, and keyboard users may need extra tab presses to reach interactive elements.
+When a modal dialog is shown via [`showModal()`](https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-dialog-showmodal), the browser executes the [dialog focusing steps](https://html.spec.whatwg.org/multipage/interactive-elements.html#dialog-focusing-steps). Without `autofocus`, focus falls back to the `<dialog>` element itself. While functional, this is not ideal for accessibility — screen reader users may miss the dialog content, and keyboard users may need extra tab presses to reach interactive elements.
+
+> Authors should use the autofocus attribute on the descendant element of the dialog that the user is expected to immediately interact with after the dialog opens.
+
+Cite: [HTML Living Standard: The dialog element](https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element)
 
 This rule uses the [Invoker Commands API](https://open-ui.org/components/invokers.explainer/) to statically detect modal dialogs: a `<button>` with `command="show-modal"` and `commandfor` pointing to a `<dialog>` element indicates that the dialog will be shown as a modal.
 
 > [!WARNING]
-> Default severity is `warning`.
+> Default severity is `warning` because the HTML spec recommends (`should`) but does not require (`must`) the use of `autofocus`. Without `autofocus`, the dialog focusing steps still provide a fallback that moves focus to the dialog element or its first focusable descendant.
+
+> [!NOTE]
+> This rule relies on the [Invoker Commands API](https://developer.mozilla.org/en-US/docs/Web/API/Invoker_Commands_API) (`command`/`commandfor` attributes). If your project does not use this API (e.g., you open dialogs via `dialog.showModal()` in JavaScript), this rule will not detect any violations. The Invoker Commands API reached [Baseline support](https://developer.mozilla.org/en-US/docs/Web/API/Invoker_Commands_API) in early 2026.
 
 ## Rule Details
 
@@ -29,6 +36,7 @@ This rule uses the [Invoker Commands API](https://open-ui.org/components/invoker
 ### :o: Correct
 
 ```html
+<!-- autofocus on an input descendant -->
 <button command="show-modal" commandfor="my-dialog">Open</button>
 <dialog id="my-dialog">
   <input type="text" autofocus />
@@ -37,15 +45,26 @@ This rule uses the [Invoker Commands API](https://open-ui.org/components/invoker
 ```
 
 ```html
+<!-- autofocus on a button descendant -->
 <button command="show-modal" commandfor="my-dialog">Open</button>
 <dialog id="my-dialog">
   <button autofocus command="close" commandfor="my-dialog">Close</button>
 </dialog>
 ```
 
+```html
+<!-- autofocus on the dialog itself -->
+<button command="show-modal" commandfor="my-dialog">Open</button>
+<dialog id="my-dialog" autofocus>
+  <p>Content without interactive elements.</p>
+</dialog>
+```
+
 ## Scope
 
-This rule only checks `<dialog>` elements that are referenced by a `<button>` with `command="show-modal"`. Dialogs that are opened programmatically (via `showModal()` in JavaScript) or dialogs without a declarative trigger are not checked.
+This rule only checks `<dialog>` elements that are referenced by a `<button>` with `command="show-modal"`. Other `command` values (e.g., `close`, `toggle-popover`) are not in scope.
+
+Dialogs that are opened programmatically (via `showModal()` in JavaScript) or dialogs without a declarative trigger are not checked. **If your project does not use the Invoker Commands API, this rule will not report any violations.**
 
 Non-dialog elements referenced by `commandfor` are also skipped. The `command` value comparison is case-insensitive per the HTML spec.
 
@@ -53,5 +72,7 @@ Non-dialog elements referenced by `commandfor` are also skipped. The `command` v
 
 - [Issue #689](https://github.com/markuplint/markuplint/issues/689)
 - [HTML Living Standard: The dialog element](https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element)
+- [HTML Living Standard: Dialog focusing steps](https://html.spec.whatwg.org/multipage/interactive-elements.html#dialog-focusing-steps)
+- [WAI-ARIA APG: Modal Dialog Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/)
 - [Invoker Commands API Explainer](https://open-ui.org/components/invokers.explainer/)
 - [MDN: autofocus](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autofocus)

--- a/packages/@markuplint/rules/src/require-dialog-autofocus/index.spec.ts
+++ b/packages/@markuplint/rules/src/require-dialog-autofocus/index.spec.ts
@@ -1,0 +1,134 @@
+import { mlRuleTest } from 'markuplint';
+import { describe, expect, test } from 'vitest';
+
+import rule from './index.js';
+
+describe('Violations', () => {
+	test('dialog without autofocus descendant', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					'<button command="show-modal" commandfor="d">Open</button><dialog id="d"><p>Content</p></dialog>',
+				)
+			).violations,
+		).toStrictEqual([
+			{
+				severity: 'warning',
+				line: 1,
+				col: 58,
+				message:
+					'The "dialog" element referenced by a "show-modal" command requires an element with the "autofocus" attribute',
+				raw: '<dialog id="d">',
+			},
+		]);
+	});
+
+	test('case-insensitive: SHOW-MODAL', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					'<button command="SHOW-MODAL" commandfor="d">Open</button><dialog id="d"><p>Content</p></dialog>',
+				)
+			).violations.length,
+		).toBe(1);
+	});
+
+	test('multiple dialogs: one with autofocus, one without', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			`
+<button command="show-modal" commandfor="d1">Open 1</button>
+<button command="show-modal" commandfor="d2">Open 2</button>
+<dialog id="d1"><input autofocus /></dialog>
+<dialog id="d2"><p>No autofocus</p></dialog>
+`,
+		);
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.raw).toBe('<dialog id="d2">');
+	});
+});
+
+describe('No violations', () => {
+	test('dialog descendant has autofocus', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					'<button command="show-modal" commandfor="d">Open</button><dialog id="d"><input autofocus /></dialog>',
+				)
+			).violations.length,
+		).toBe(0);
+	});
+
+	test('dialog itself has autofocus', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					'<button command="show-modal" commandfor="d">Open</button><dialog id="d" autofocus><p>Content</p></dialog>',
+				)
+			).violations.length,
+		).toBe(0);
+	});
+
+	test('dialog not referenced by show-modal', async () => {
+		expect((await mlRuleTest(rule, '<dialog id="d"><p>Content</p></dialog>')).violations.length).toBe(0);
+	});
+
+	test('command is close (not show-modal)', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					'<button command="close" commandfor="d">Close</button><dialog id="d"><p>Content</p></dialog>',
+				)
+			).violations.length,
+		).toBe(0);
+	});
+
+	test('command is toggle-popover (not show-modal)', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					'<button command="toggle-popover" commandfor="d">Toggle</button><div id="d" popover>Popover</div>',
+				)
+			).violations.length,
+		).toBe(0);
+	});
+
+	test('commandfor references non-dialog element', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					'<button command="show-modal" commandfor="d">Open</button><div id="d"><p>Content</p></div>',
+				)
+			).violations.length,
+		).toBe(0);
+	});
+
+	test('commandfor references non-existent id', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					'<button command="show-modal" commandfor="missing">Open</button><dialog id="d"><p>Content</p></dialog>',
+				)
+			).violations.length,
+		).toBe(0);
+	});
+
+	test('deeply nested autofocus descendant', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					'<button command="show-modal" commandfor="d">Open</button><dialog id="d"><div><div><input autofocus /></div></div></dialog>',
+				)
+			).violations.length,
+		).toBe(0);
+	});
+});

--- a/packages/@markuplint/rules/src/require-dialog-autofocus/index.spec.ts
+++ b/packages/@markuplint/rules/src/require-dialog-autofocus/index.spec.ts
@@ -48,6 +48,28 @@ describe('Violations', () => {
 		expect(violations.length).toBe(1);
 		expect(violations[0]?.raw).toBe('<dialog id="d2">');
 	});
+
+	test('case-insensitive: Show-Modal (mixed case)', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					'<button command="Show-Modal" commandfor="d">Open</button><dialog id="d"><p>Content</p></dialog>',
+				)
+			).violations.length,
+		).toBe(1);
+	});
+
+	test('empty dialog without any children', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					'<button command="show-modal" commandfor="d">Open</button><dialog id="d"></dialog>',
+				)
+			).violations.length,
+		).toBe(1);
+	});
 });
 
 describe('No violations', () => {
@@ -129,6 +151,54 @@ describe('No violations', () => {
 					'<button command="show-modal" commandfor="d">Open</button><dialog id="d"><div><div><input autofocus /></div></div></dialog>',
 				)
 			).violations.length,
+		).toBe(0);
+	});
+
+	test('autofocus with empty string value (boolean attribute)', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					'<button command="show-modal" commandfor="d">Open</button><dialog id="d"><input autofocus="" /></dialog>',
+				)
+			).violations.length,
+		).toBe(0);
+	});
+
+	test('autofocus with redundant value', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					'<button command="show-modal" commandfor="d">Open</button><dialog id="d"><input autofocus="autofocus" /></dialog>',
+				)
+			).violations.length,
+		).toBe(0);
+	});
+
+	test('duplicate triggers for same dialog report only once', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			`
+<button command="show-modal" commandfor="d">Open 1</button>
+<button command="show-modal" commandfor="d">Open 2</button>
+<dialog id="d"><p>Content</p></dialog>
+`,
+		);
+		expect(violations.length).toBe(1);
+	});
+
+	test('command without commandfor is ignored', async () => {
+		expect(
+			(await mlRuleTest(rule, '<button command="show-modal">Open</button><dialog id="d"><p>Content</p></dialog>'))
+				.violations.length,
+		).toBe(0);
+	});
+
+	test('commandfor without command is ignored', async () => {
+		expect(
+			(await mlRuleTest(rule, '<button commandfor="d">Open</button><dialog id="d"><p>Content</p></dialog>'))
+				.violations.length,
 		).toBe(0);
 	});
 });

--- a/packages/@markuplint/rules/src/require-dialog-autofocus/index.ts
+++ b/packages/@markuplint/rules/src/require-dialog-autofocus/index.ts
@@ -14,6 +14,7 @@ export default createRule({
 	meta: meta,
 	verify({ document, report, t }) {
 		const triggers = document.querySelectorAll('button[command][commandfor]');
+		const reportedDialogIds = new Set<string>();
 
 		for (const trigger of triggers) {
 			const command = trigger.getAttribute('command');
@@ -23,6 +24,10 @@ export default createRule({
 
 			const targetId = trigger.getAttribute('commandfor');
 			if (!targetId) {
+				continue;
+			}
+
+			if (reportedDialogIds.has(targetId)) {
 				continue;
 			}
 
@@ -44,6 +49,7 @@ export default createRule({
 				continue;
 			}
 
+			reportedDialogIds.add(targetId);
 			report({
 				scope: target,
 				message: t(

--- a/packages/@markuplint/rules/src/require-dialog-autofocus/index.ts
+++ b/packages/@markuplint/rules/src/require-dialog-autofocus/index.ts
@@ -1,0 +1,58 @@
+import { createRule } from '@markuplint/ml-core';
+
+import meta from './meta.js';
+
+/**
+ * Rule that requires a dialog element referenced by a `show-modal` command
+ * to contain a descendant (or itself) with the `autofocus` attribute.
+ *
+ * Without `autofocus`, the dialog element itself receives focus when shown
+ * as a modal, which is not ideal for accessibility.
+ */
+export default createRule({
+	defaultSeverity: 'warning',
+	meta: meta,
+	verify({ document, report, t }) {
+		const triggers = document.querySelectorAll('button[command][commandfor]');
+
+		for (const trigger of triggers) {
+			const command = trigger.getAttribute('command');
+			if (!command || command.toLowerCase() !== 'show-modal') {
+				continue;
+			}
+
+			const targetId = trigger.getAttribute('commandfor');
+			if (!targetId) {
+				continue;
+			}
+
+			const target = document.getElementById(targetId);
+			if (!target) {
+				continue;
+			}
+
+			if (target.localName !== 'dialog') {
+				continue;
+			}
+
+			if (target.hasAttribute('autofocus')) {
+				continue;
+			}
+
+			const autofocusDescendants = target.querySelectorAll('[autofocus]');
+			if (autofocusDescendants.length > 0) {
+				continue;
+			}
+
+			report({
+				scope: target,
+				message: t(
+					'The "{0*}" element referenced by a "{1*}" command requires an element with the "{2*}" attribute',
+					'dialog',
+					'show-modal',
+					'autofocus',
+				),
+			});
+		}
+	},
+});

--- a/packages/@markuplint/rules/src/require-dialog-autofocus/index.ts
+++ b/packages/@markuplint/rules/src/require-dialog-autofocus/index.ts
@@ -3,11 +3,24 @@ import { createRule } from '@markuplint/ml-core';
 import meta from './meta.js';
 
 /**
- * Rule that requires a dialog element referenced by a `show-modal` command
+ * Rule that requires a `<dialog>` element referenced by a `show-modal` command
  * to contain a descendant (or itself) with the `autofocus` attribute.
  *
- * Without `autofocus`, the dialog element itself receives focus when shown
- * as a modal, which is not ideal for accessibility.
+ * Without `autofocus`, the browser's dialog focusing steps fall back to the
+ * `<dialog>` element itself, which is not ideal for accessibility — screen
+ * reader users may miss the dialog content, and keyboard users may need
+ * extra tab presses to reach interactive elements.
+ *
+ * Detection algorithm:
+ * 1. Find all `<button>` elements with both `command` and `commandfor` attributes
+ * 2. Filter to triggers whose `command` value is `show-modal` (case-insensitive)
+ * 3. Resolve the referenced `<dialog>` via `document.getElementById(commandfor)`
+ * 4. Skip non-dialog targets and already-reported dialogs (deduplication)
+ * 5. Report if neither the dialog nor any descendant has the `autofocus` attribute
+ *
+ * @see https://html.spec.whatwg.org/multipage/interactive-elements.html#dialog-focusing-steps
+ * @see https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element
+ * @see https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/
  */
 export default createRule({
 	defaultSeverity: 'warning',

--- a/packages/@markuplint/rules/src/require-dialog-autofocus/meta.ts
+++ b/packages/@markuplint/rules/src/require-dialog-autofocus/meta.ts
@@ -1,0 +1,4 @@
+/** Rule metadata for the `require-dialog-autofocus` rule, categorized as accessibility. */
+export default {
+	category: 'a11y',
+} as const;

--- a/packages/@markuplint/rules/src/require-dialog-autofocus/schema.json
+++ b/packages/@markuplint/rules/src/require-dialog-autofocus/schema.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"value": {
+			"type": "boolean"
+		}
+	},
+	"oneOf": [
+		{
+			"$ref": "#/definitions/value"
+		},
+		{
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"value": { "$ref": "#/definitions/value" },
+				"severity": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/ml-config/schema.json#/definitions/severity",
+					"default": "warning"
+				},
+				"reason": {
+					"type": "string"
+				}
+			}
+		}
+	]
+}

--- a/packages/markuplint/src/cli/init/get-default-rules.spec.ts
+++ b/packages/markuplint/src/cli/init/get-default-rules.spec.ts
@@ -141,6 +141,10 @@ test('default-rules', () => {
 			category: 'validation',
 			defaultValue: true,
 		},
+		'require-dialog-autofocus': {
+			category: 'a11y',
+			defaultValue: false,
+		},
 		'required-attr': {
 			category: 'validation',
 			defaultValue: [],


### PR DESCRIPTION
## Summary

- Add new `require-dialog-autofocus` rule that detects `<dialog>` elements referenced by `<button command="show-modal">` lacking an `autofocus` attribute on any descendant (or itself)
- Uses the [Invoker Commands API](https://open-ui.org/components/invokers.explainer/) (`command`/`commandfor` attributes) for static modal dialog detection
- Default severity is `warning` (HTML spec says "should", not "must")
- Added to `a11y` preset

## Changes

- **New rule**: `packages/@markuplint/rules/src/require-dialog-autofocus/` (index.ts, meta.ts, schema.json, index.spec.ts, README.md, README.ja.md)
- **Rule registry**: Updated `src/index.ts` and `schema.json` in `@markuplint/rules`
- **Preset**: Added to `preset.a11y.jsonc`
- **Snapshot**: Updated `get-default-rules.spec.ts`

## Detection Algorithm

1. Find all `<button>` elements with both `command` and `commandfor` attributes
2. Filter to triggers whose `command` value is `show-modal` (case-insensitive)
3. Resolve the referenced `<dialog>` via `document.getElementById(commandfor)`
4. Skip non-dialog targets and already-reported dialogs (deduplication)
5. Report if neither the dialog nor any descendant has the `autofocus` attribute

## Test plan

- [x] 18 test cases (5 violation + 13 no-violation) covering case-insensitive matching, empty dialog, deeply nested autofocus, boolean attribute variants, duplicate trigger deduplication, non-dialog targets, missing IDs, close/toggle-popover commands
- [x] `get-default-rules.spec.ts` snapshot updated
- [x] `yarn lint-check` passes (0 errors, 0 warnings)
- [x] `yarn build` passes (38 projects)
- [x] `yarn test` passes (152 files, 1844 tests)

Closes #689

🤖 Generated with [Claude Code](https://claude.com/claude-code)