### PR TITLE
test(rules): add regression tests for ARIA issues #816, #673, #272

### DIFF
--- a/packages/@markuplint/rules/src/wai-aria/README.ja.md
+++ b/packages/@markuplint/rules/src/wai-aria/README.ja.md
@@ -15,6 +15,7 @@ description: WAI-ARIAおよびARIA in HTMLの仕様のとおりrole属性また�
   - プロパティ/ステートに無効な値を指定した場合
   - ARIA in HTMLの仕様における要素に許可されていないロールを指定した場合
   - 必須のプロパティ/ステートを指定していない場合
+  - ロールが必要とする子ロールを持たない場合（例: `table`は`row`を必要とする）
 - 推奨されない使い方
   - 非推奨（廃止予定）のロールを指定した場合
   - 非推奨（廃止予定）のプロパティ/ステートを指定した場合
@@ -22,6 +23,9 @@ description: WAI-ARIAおよびARIA in HTMLの仕様のとおりrole属性また�
   - ARIA in HTMLの仕様において、HTMLの属性と同等の意味を持つプロパティ/ステートを指定した場合
 - プリファレンス
   - プロパティ/ステートのデフォルト値を明示的に指定した場合
+- オプションチェック（デフォルトで無効）
+  - childrenPresentationalを持つロールの子孫要素にARIA属性を指定した場合
+  - `aria-hidden`で非表示にされたフォーカス可能なインタラクティブ要素を使用した場合
 
 <!-- textlint-disable ja-technical-writing/ja-no-mixed-period -->
 

--- a/packages/@markuplint/rules/src/wai-aria/README.md
+++ b/packages/@markuplint/rules/src/wai-aria/README.md
@@ -13,9 +13,10 @@ Warn if:
   - Use the role that doesn't exist in the spec.
   - Use the abstract role.
   - Use the property/state that doesn't belong to a set role (or an implicit role).
-  - Use an invalid value of the property/state .
+  - Use an invalid value of the property/state.
   - Use the not permitted role according to ARIA in HTML.
   - Don't set the required property/state.
+  - The role doesn't have the required child roles (e.g., `table` requires `row`).
 - Unrecommended.
   - Set the deprecated role.
   - Set the deprecated property/state.
@@ -23,6 +24,9 @@ Warn if:
   - Set the property/state explicitly when its element has semantic HTML attribute equivalent to it according to ARIA in HTML.
 - Preference
   - Set the default value of the property/state explicitly.
+- Optional checks (disabled by default)
+  - Set ARIA attributes on descendants of roles whose children are presentational.
+  - Use focusable interactive elements hidden via `aria-hidden`.
 
 ❌ Examples of **incorrect** code for this rule
 

--- a/packages/@markuplint/rules/src/wai-aria/index.spec.ts
+++ b/packages/@markuplint/rules/src/wai-aria/index.spec.ts
@@ -1642,6 +1642,275 @@ describe('ARIA 1.3 — image/img synonym in permitted roles', () => {
 	});
 });
 
+// #816: gridcell context role — should only be valid in grid/treegrid, not table
+// The ARIA spec says gridcell's requiredContextRole is ["row"], so any row is accepted.
+// However, <td role="gridcell"> in a <table> is caught by the permittedAriaRoles check
+// (ARIA in HTML spec forbids overwriting td to gridcell in a table context).
+// Verdict: Detected via permittedAriaRoles, not requiredContextRole. Issue is addressed.
+describe('Issue #816 — gridcell context role validation', () => {
+	const v1_2 = { rule: { options: { version: '1.2' as const } } };
+	const v1_3 = { rule: { options: { version: '1.3' as const } } };
+
+	test('grid > row > gridcell is valid (1.2)', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<div role="grid"><div role="row"><div role="gridcell">Cell</div></div></div>',
+			v1_2,
+		);
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('grid > row > gridcell is valid (1.3)', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<div role="grid"><div role="row"><div role="gridcell">Cell</div></div></div>',
+			v1_3,
+		);
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('treegrid > row > gridcell is valid (1.2)', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<div role="treegrid"><div role="row"><div role="gridcell">Cell</div></div></div>',
+			v1_2,
+		);
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('treegrid > row > gridcell is valid (1.3)', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<div role="treegrid"><div role="row"><div role="gridcell">Cell</div></div></div>',
+			v1_3,
+		);
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('table > rowgroup > row > td[gridcell] is detected by permittedAriaRoles (1.2)', async () => {
+		// The permittedAriaRoles check catches td being overwritten to gridcell in a table
+		const { violations } = await mlRuleTest(
+			rule,
+			'<table><tbody><tr><td role="gridcell">Cell</td></tr></tbody></table>',
+			v1_2,
+		);
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 29,
+				message:
+					'Cannot overwrite the "gridcell" role to the "td" element according to ARIA in HTML specification',
+				raw: 'gridcell',
+			},
+		]);
+	});
+
+	test('table > rowgroup > row > td[gridcell] is detected by permittedAriaRoles (1.3)', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<table><tbody><tr><td role="gridcell">Cell</td></tr></tbody></table>',
+			v1_3,
+		);
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 29,
+				message:
+					'Cannot overwrite the "gridcell" role to the "td" element according to ARIA in HTML specification',
+				raw: 'gridcell',
+			},
+		]);
+	});
+
+	test('table > row > cell is valid (1.2)', async () => {
+		const { violations } = await mlRuleTest(rule, '<table><tbody><tr><td>Cell</td></tr></tbody></table>', v1_2);
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('table > row > cell is valid (1.3)', async () => {
+		const { violations } = await mlRuleTest(rule, '<table><tbody><tr><td>Cell</td></tr></tbody></table>', v1_3);
+		expect(violations).toStrictEqual([]);
+	});
+});
+
+// #673: presentation/none wrapper transparency for required owned elements
+// In 1.2, radiogroup.requiredOwnedElements = ["radio"], presentation/none should be transparent.
+// In 1.3, radiogroup.requiredOwnedElements = [] — the check doesn't fire at all.
+// Verdict: presentation transparency works in both versions. Issue is resolved.
+describe('Issue #673 — presentation wrapper transparency', () => {
+	const v1_2 = { rule: { options: { version: '1.2' as const } } };
+	const v1_3 = { rule: { options: { version: '1.3' as const } } };
+
+	test('radiogroup > radio (direct child) is valid (1.2)', async () => {
+		// radio role requires aria-checked
+		const { violations } = await mlRuleTest(
+			rule,
+			'<div role="radiogroup"><div role="radio" aria-checked="false">Option 1</div></div>',
+			v1_2,
+		);
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('radiogroup > radio (direct child) is valid (1.3)', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<div role="radiogroup"><div role="radio" aria-checked="false">Option 1</div></div>',
+			v1_3,
+		);
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('radiogroup > li[presentation] > button[radio] — no requiredOwnedElements violation (1.2)', async () => {
+		// The only violation should be about aria-checked on the radio, NOT about
+		// radiogroup missing its required owned radio element (presentation is transparent)
+		const { violations } = await mlRuleTest(
+			rule,
+			'<div role="radiogroup"><li role="presentation"><button role="radio">Option 1</button></li></div>',
+			v1_2,
+		);
+		const ownedElementViolations = violations.filter(v => v.message.includes('radio" role'));
+		// Should only have "Require aria-checked", not "requires the radio role"
+		expect(ownedElementViolations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 48,
+				message: 'Require the "aria-checked" ARIA state on the "radio" role',
+				raw: '<button role="radio">',
+			},
+		]);
+	});
+
+	test('radiogroup > li[presentation] > button[radio] with aria-checked is valid (1.2)', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<div role="radiogroup"><li role="presentation"><button role="radio" aria-checked="false">Option 1</button></li></div>',
+			v1_2,
+		);
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('radiogroup > li[presentation] > button[radio] with aria-checked is valid (1.3)', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<div role="radiogroup"><li role="presentation"><button role="radio" aria-checked="false">Option 1</button></li></div>',
+			v1_3,
+		);
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('radiogroup > li[none] > button[radio] with aria-checked is valid (1.2)', async () => {
+		// "none" is a synonym for "presentation" — should also be transparent
+		const { violations } = await mlRuleTest(
+			rule,
+			'<div role="radiogroup"><li role="none"><button role="radio" aria-checked="false">Option 1</button></li></div>',
+			v1_2,
+		);
+		expect(violations).toStrictEqual([]);
+	});
+});
+
+// #272: Allowed descendants of ARIA roles (requiredOwnedElements)
+// Tests that requiredOwnedElements checks work correctly in both ARIA versions.
+// In 1.3, the "table" role expects "caption", "row", "rowgroup > row" (1.2 has no caption).
+// In 1.3, generic (div) wrappers are transparent for owned element checks.
+// Verdict: checkingRequiredOwnedElements works correctly in both versions.
+describe('Issue #272 — Allowed descendants of ARIA roles', () => {
+	const v1_2 = { rule: { options: { version: '1.2' as const } } };
+	const v1_3 = { rule: { options: { version: '1.3' as const } } };
+
+	test('table without row is a violation (1.2)', async () => {
+		const { violations } = await mlRuleTest(rule, '<div role="table"><div>content</div></div>', v1_2);
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 1,
+				message: 'The "table" role expects the roles: "row", "rowgroup > row"',
+				raw: '<div role="table">',
+			},
+		]);
+	});
+
+	test('table without row is a violation (1.3)', async () => {
+		const { violations } = await mlRuleTest(rule, '<div role="table"><div>content</div></div>', v1_3);
+		// 1.3 adds "caption" to the expected roles
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 1,
+				message: 'The "table" role expects the roles: "caption", "row", "rowgroup > row"',
+				raw: '<div role="table">',
+			},
+		]);
+	});
+
+	test('list without listitem is a violation (1.2)', async () => {
+		const { violations } = await mlRuleTest(rule, '<div role="list"><div>content</div></div>', v1_2);
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 1,
+				message: 'The "list" role expects the "listitem" role',
+				raw: '<div role="list">',
+			},
+		]);
+	});
+
+	test('list without listitem is a violation (1.3)', async () => {
+		const { violations } = await mlRuleTest(rule, '<div role="list"><div>content</div></div>', v1_3);
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 1,
+				message: 'The "list" role expects the "listitem" role',
+				raw: '<div role="list">',
+			},
+		]);
+	});
+
+	test('list > listitem is valid (1.2)', async () => {
+		const { violations } = await mlRuleTest(rule, '<div role="list"><div role="listitem">Item</div></div>', v1_2);
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('list > listitem is valid (1.3)', async () => {
+		const { violations } = await mlRuleTest(rule, '<div role="list"><div role="listitem">Item</div></div>', v1_3);
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('list > div > listitem (1.2) — generic is NOT transparent', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<div role="list"><div><div role="listitem">Item</div></div></div>',
+			v1_2,
+		);
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 1,
+				message: 'The "list" role expects the "listitem" role',
+				raw: '<div role="list">',
+			},
+		]);
+	});
+
+	test('list > div > listitem (1.3) — generic IS transparent', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<div role="list"><div><div role="listitem">Item</div></div></div>',
+			v1_3,
+		);
+		expect(violations).toStrictEqual([]);
+	});
+});
+
 describe('Issue #2465 — aria-valuenow restrictions and missing alt fields', () => {
 	test('input[type=range] with value and aria-valuenow', async () => {
 		const { violations } = await mlRuleTest(rule, '<input type="range" value="50" aria-valuenow="50">');


### PR DESCRIPTION
## Summary

- Add 22 regression tests for three ARIA-related issues: #816, #673, #272
- All tests verify behavior in both ARIA 1.2 and 1.3
- **#816**: gridcell context role — detected via permittedAriaRoles for HTML elements; ARIA formal model limitation for pure div-based roles
- **#673**: presentation/none wrapper transparency — fixed in Feb 2026 during ARIA 1.3 generic transparency work
- **#272**: requiredOwnedElements check — implemented since June–October 2022, enhanced for ARIA 1.3

## Test plan

- [x] 120 tests pass in `wai-aria/index.spec.ts`
- [x] `yarn lint` passes (0 errors, 0 warnings, 0 CSpell issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)