### PR TITLE
feat: add Markdown and MDX parsers

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -99,6 +99,7 @@
 		"Masato",
 		"masuP9",
 		"mdast",
+		"mdxjs",
 		"miita",
 		"mikimhk",
 		"Miruka",

--- a/packages/@markuplint/markdown-parser/ARCHITECTURE.md
+++ b/packages/@markuplint/markdown-parser/ARCHITECTURE.md
@@ -1,0 +1,190 @@
+# @markuplint/markdown-parser
+
+## Overview
+
+`@markuplint/markdown-parser` parses Markdown (`.md`) files for markuplint. It converts both Markdown-native syntax and embedded HTML into markuplint's AST. Markdown constructs (headings, links, images, lists, emphasis, tables, etc.) are mapped to their equivalent HTML elements, enabling lint rules like `heading-levels`, `required-attr`, and `wai-aria` to work on Markdown content. Raw HTML regions are delegated to `HtmlParser`.
+
+## Design Decisions
+
+### Why `remark-parse` (unified ecosystem)?
+
+| Approach                     | Pros                                                                    | Cons                                                              | Verdict    |
+| ---------------------------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------- | ---------- |
+| **`remark-parse`** (unified) | De facto standard; mdast AST with position info; extensible via plugins | Adds unified ecosystem as dependency                              | **Chosen** |
+| **`@mdx-js/mdx`**            | Official MDX package                                                    | Wraps `remark-parse` internally; adds 24 unnecessary dependencies | Rejected   |
+| **`micromark`** (direct)     | Maximum control; lowest level                                           | Must build mdast conversion manually; no practical benefit        | Rejected   |
+
+### Why extend `Parser` via `MarkdownAwareParser` (not `HtmlParser`)?
+
+Earlier designs extended `HtmlParser` and treated Markdown as opaque psblock nodes. The current design extends `Parser<MdastNode>` through `MarkdownAwareParser` because:
+
+1. **Markdown elements are now lintable** -- headings, links, images, etc. are converted to their HTML equivalents, enabling rule coverage
+2. **Synthetic attributes** -- Markdown's `![alt](src)` produces `<img src="..." alt="...">` with synthesized attributes
+3. **Shared base class** -- `MarkdownAwareParser` provides common Markdown-to-HTML conversion logic reused by `@markuplint/mdx-parser`
+
+Raw HTML regions (CommonMark HTML blocks and inline HTML) are still parsed via a cached `HtmlParser` instance for full HTML support.
+
+### Markdown elements as HTML equivalents
+
+| Markdown Syntax     | HTML Element               | Attributes                       |
+| ------------------- | -------------------------- | -------------------------------- |
+| `# Heading`         | `h1`-`h6`                  | --                               |
+| `[text](url)`       | `a`                        | `href`, optionally `title`       |
+| `![alt](url)`       | `img`                      | `src`, `alt`, optionally `title` |
+| `*text*` / `_text_` | `em`                       | --                               |
+| `**text**`          | `strong`                   | --                               |
+| `- item`            | `ul` > `li`                | --                               |
+| `1. item`           | `ol` > `li`                | `start` when != 1                |
+| `> quote`           | `blockquote`               | --                               |
+| `` `code` ``        | `code`                     | --                               |
+| ` ```lang ... ``` ` | `pre` > `code`             | `class="language-{lang}"`        |
+| `---`               | `hr`                       | --                               |
+| GFM `\| table \|`   | `table` > `tr` > `th`/`td` | --                               |
+| GFM `~~text~~`      | `del`                      | --                               |
+| `[text][ref]`       | `a`                        | resolved from definitions        |
+| `![alt][ref]`       | `img`                      | resolved from definitions        |
+
+### Synthetic attribute positions
+
+Markdown syntax does not have discrete source positions for attributes. Synthesized attributes (e.g., `href` from `[text](url)`) point to the element's own token range. This is an intentional trade-off: markuplint can check attribute existence and values, but attribute-level source positions are approximate.
+
+### blockquote and cite
+
+The HTML `<blockquote>` element supports a `cite` attribute for source URLs, but Markdown's `> quote` syntax has no equivalent. The parser does not synthesize a `cite` attribute.
+
+## How It Works
+
+```
+.md source file
+    |
+    v
+[remark-parse + remark-gfm + remark-frontmatter]
+    |                       Parse Markdown into mdast AST
+    v
+[collectDefinitions()]     Extract [id]: url definitions
+    |
+    v
+[nodeize() per mdast node]
+    |
+    +-- heading         -->  h1-h6 element with text children
+    +-- paragraph       -->  p element with inline children
+    +-- emphasis/strong -->  em/strong elements
+    +-- link            -->  a element with href, title attrs
+    +-- image           -->  img element with src, alt, title attrs
+    +-- list/listItem   -->  ul/ol > li elements
+    +-- blockquote      -->  blockquote element
+    +-- inlineCode      -->  code element with text child
+    +-- code (fenced)   -->  pre > code elements
+    +-- table/row/cell  -->  table > tr > th/td elements
+    +-- delete (GFM)    -->  del element
+    +-- linkReference   -->  a element (resolved) or psblock
+    +-- imageReference  -->  img element (resolved) or psblock
+    +-- html            -->  HtmlParser.parse() with offset mapping
+    +-- text            -->  MLASTText
+    +-- yaml            -->  psblock (#ps:yaml)
+    +-- definition      -->  psblock
+    v
+MLASTDocument             Positions reference the original .md file
+```
+
+### Class Hierarchy
+
+```
+Parser<MdastNode>               (from @markuplint/parser-utils)
+  |
+  MarkdownAwareParser           (shared Markdown-to-HTML conversion)
+    |                            - createSyntheticAttr()
+    |                            - visitMarkdownElement()
+    |                            - visitLinkElement() / visitImageElement()
+    |                            - visitListElement() / visitCodeBlock()
+    |                            - visitTableElement()
+    |                            - nodeizeMarkdownNode()
+    |                            - collectDefinitions()
+    |
+    MarkdownParser              (this package)
+      |                          - tokenize(): remark-parse + remark-gfm
+      |                          - nodeize(): delegates then handles html/text/yaml
+      |                          - #htmlParser: cached HtmlParser for HTML regions
+```
+
+### GFM Table Header Detection
+
+GFM tables use the first row as the header row. The parser tracks this via:
+
+1. `visitTableElement()` records the first row's source offset in `#headerRowOffsets`
+2. `nodeizeMarkdownNode()` for `tableRow` checks the offset set to decide `th` vs `td`
+3. The set is consumed (deleted) after use, so subsequent rows produce `td` cells
+
+### Link/Image Reference Resolution
+
+1. `tokenize()` calls `collectDefinitions()` to build a `Map<identifier, Definition>`
+2. `nodeizeMarkdownNode()` dispatches `linkReference`/`imageReference` to resolution methods
+3. Resolved references produce `<a>` or `<img>` elements; unresolved ones become psblock nodes
+4. Note: remark-parse resolves references at parse time when definitions exist, so unresolved references typically appear as plain text rather than `linkReference` nodes
+
+## Architecture Diagram
+
+```mermaid
+flowchart TD
+    subgraph upstream ["Upstream"]
+        parserUtils["@markuplint/parser-utils\n(Parser base class)"]
+        htmlParser["@markuplint/html-parser\n(HtmlParser for HTML regions)"]
+        remark["remark-parse\n(Markdown -> mdast)"]
+        remarkGfm["remark-gfm\n(GFM tables, strikethrough)"]
+        remarkFm["remark-frontmatter\n(Front matter support)"]
+    end
+
+    subgraph pkg ["@markuplint/markdown-parser"]
+        aware["MarkdownAwareParser\nextends Parser<MdastNode>"]
+        mdParser["MarkdownParser\nextends MarkdownAwareParser"]
+    end
+
+    subgraph downstream ["Downstream"]
+        mdxParser["@markuplint/mdx-parser\n(reuses MarkdownAwareParser)"]
+        mlCore["@markuplint/ml-core\n(MLASTDocument -> MLDOM)"]
+    end
+
+    parserUtils -->|"base class"| aware
+    remark -->|"mdast AST"| mdParser
+    remarkGfm -->|"GFM extensions"| mdParser
+    remarkFm -->|"front matter"| mdParser
+    htmlParser -->|"HTML region parsing"| mdParser
+    aware -->|"extends"| mdParser
+    aware -->|"shared base"| mdxParser
+    mdParser -->|"MLASTDocument"| mlCore
+```
+
+## External Dependencies
+
+| Dependency                 | Purpose                                |
+| -------------------------- | -------------------------------------- |
+| `@markuplint/html-parser`  | Parses raw HTML regions in Markdown    |
+| `@markuplint/ml-ast`       | AST type definitions                   |
+| `@markuplint/parser-utils` | Parser base class, token utilities     |
+| `unified`                  | Processor pipeline for remark          |
+| `remark-parse`             | Markdown -> mdast parser               |
+| `remark-gfm`               | GFM extensions (tables, strikethrough) |
+| `remark-frontmatter`       | Front matter (YAML) support in mdast   |
+
+## Directory Structure
+
+```
+src/
++-- index.ts                 -- Re-exports parser instance and MarkdownAwareParser
++-- parser.ts                -- MarkdownParser class
++-- markdown-aware-parser.ts -- MarkdownAwareParser shared base class
++-- index.spec.ts            -- Unit and integration tests
+```
+
+## Relationship to @markuplint/mdx-parser
+
+Both parsers share `MarkdownAwareParser` as a common base class. The key differences:
+
+| Aspect          | markdown-parser (.md)      | mdx-parser (.mdx)                  |
+| --------------- | -------------------------- | ---------------------------------- |
+| Base class      | MarkdownAwareParser        | MarkdownAwareParser                |
+| HTML regions    | HtmlParser re-parse        | parseCodeFragment (XML-style)      |
+| JSX support     | No                         | Yes (components, expressions, ESM) |
+| Attribute style | HTML (`class`, `for`)      | JSX (`className`, `htmlFor`)       |
+| Tag closing     | HTML rules (void elements) | XML rules (self-closing required)  |
+| Spec package    | None needed                | `@markuplint/react-spec`           |

--- a/packages/@markuplint/markdown-parser/README.ja.md
+++ b/packages/@markuplint/markdown-parser/README.ja.md
@@ -1,0 +1,47 @@
+# @markuplint/markdown-parser
+
+[![npm version](https://badge.fury.io/js/%40markuplint%2Fmarkdown-parser.svg)](https://www.npmjs.com/package/@markuplint/markdown-parser)
+
+**Markdown** ファイルで **markuplint** を使用するためのパーサーです。
+
+Markdown 構文（見出し、リンク、画像、リスト、テーブルなど）を対応する HTML 要素に変換し、markuplint のルールで解析できるようにします。[GFM](https://github.github.com/gfm/)（テーブル、取り消し線、オートリンク）および YAML フロントマターをサポートしています。
+
+## インストール
+
+```shell
+$ npm install -D @markuplint/markdown-parser
+
+$ yarn add -D @markuplint/markdown-parser
+```
+
+## 使い方
+
+[設定ファイル](https://markuplint.dev/configuration/#properties/parser)に `parser` オプションを追加してください。
+
+```json
+{
+  "parser": {
+    ".md$": "@markuplint/markdown-parser"
+  }
+}
+```
+
+## 対応構文
+
+| Markdown                              | HTML                         |
+| ------------------------------------- | ---------------------------- |
+| `# 見出し`                            | `<h1>` – `<h6>`              |
+| `[テキスト](url)` / `[テキスト][ref]` | `<a href="...">`             |
+| `![alt](url)` / `![alt][ref]`         | `<img src="..." alt="...">`  |
+| `- アイテム` / `1. アイテム`          | `<ul>` / `<ol>` と `<li>`    |
+| `` `コード` ``                        | `<code>`                     |
+| フェンスコードブロック                | `<pre><code>`                |
+| `> 引用`                              | `<blockquote>`               |
+| GFM テーブル                          | `<table>` と `<th>` / `<td>` |
+| `~~テキスト~~`                        | `<del>`                      |
+| `---`                                 | `<hr>`                       |
+| 生 HTML                               | HTML としてパース            |
+
+## 既知の制限事項
+
+- **合成された属性位置**: Markdown 構文から導出された属性（例: `[テキスト](url)` の `href`）は、属性値の正確な文字位置ではなく、Markdown 構文全体のソース位置を共有します。

--- a/packages/@markuplint/markdown-parser/README.md
+++ b/packages/@markuplint/markdown-parser/README.md
@@ -1,0 +1,47 @@
+# @markuplint/markdown-parser
+
+[![npm version](https://badge.fury.io/js/%40markuplint%2Fmarkdown-parser.svg)](https://www.npmjs.com/package/@markuplint/markdown-parser)
+
+Use **markuplint** with **Markdown** files.
+
+Converts Markdown constructs (headings, links, images, lists, tables, etc.) to their corresponding HTML elements so that markuplint rules can analyze them. Supports [GFM](https://github.github.com/gfm/) (tables, strikethrough, autolinks) and YAML frontmatter.
+
+## Install
+
+```shell
+$ npm install -D @markuplint/markdown-parser
+
+$ yarn add -D @markuplint/markdown-parser
+```
+
+## Usage
+
+Add `parser` option to your [configuration](https://markuplint.dev/configuration/#properties/parser).
+
+```json
+{
+  "parser": {
+    ".md$": "@markuplint/markdown-parser"
+  }
+}
+```
+
+## Supported Syntax
+
+| Markdown                      | HTML                           |
+| ----------------------------- | ------------------------------ |
+| `# Heading`                   | `<h1>` – `<h6>`                |
+| `[text](url)` / `[text][ref]` | `<a href="...">`               |
+| `![alt](url)` / `![alt][ref]` | `<img src="..." alt="...">`    |
+| `- item` / `1. item`          | `<ul>` / `<ol>` with `<li>`    |
+| `` `code` ``                  | `<code>`                       |
+| Fenced code block             | `<pre><code>`                  |
+| `> quote`                     | `<blockquote>`                 |
+| GFM table                     | `<table>` with `<th>` / `<td>` |
+| `~~text~~`                    | `<del>`                        |
+| `---`                         | `<hr>`                         |
+| Raw HTML                      | Parsed as HTML                 |
+
+## Known Limitations
+
+- **Synthesized attribute positions**: Attributes derived from Markdown syntax (e.g., `href` from `[text](url)`) share the source position of the enclosing Markdown construct rather than pointing to the exact character range of the attribute value.

--- a/packages/@markuplint/markdown-parser/package.json
+++ b/packages/@markuplint/markdown-parser/package.json
@@ -1,0 +1,38 @@
+{
+	"name": "@markuplint/markdown-parser",
+	"version": "4.0.0",
+	"description": "Markdown parser for markuplint",
+	"repository": "git@github.com:markuplint/markuplint.git",
+	"author": "Yusuke Hirao <yusukehirao@me.com>",
+	"license": "MIT",
+	"engines": {
+		"node": ">=22"
+	},
+	"type": "module",
+	"exports": {
+		".": {
+			"import": "./lib/index.js",
+			"types": "./lib/index.d.ts"
+		}
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"scripts": {
+		"build": "tsc --project tsconfig.build.json",
+		"dev": "tsc --watch --project tsconfig.build.json",
+		"clean": "tsc --build --clean tsconfig.build.json"
+	},
+	"dependencies": {
+		"@markuplint/html-parser": "4.6.23",
+		"@markuplint/ml-ast": "4.4.11",
+		"@markuplint/parser-utils": "4.8.11",
+		"remark-frontmatter": "5.0.0",
+		"remark-gfm": "4.0.1",
+		"remark-parse": "11.0.0",
+		"unified": "11.0.5"
+	},
+	"devDependencies": {
+		"@types/mdast": "4.0.4"
+	}
+}

--- a/packages/@markuplint/markdown-parser/src/index.spec.ts
+++ b/packages/@markuplint/markdown-parser/src/index.spec.ts
@@ -1,0 +1,747 @@
+import { describe, test, expect } from 'vitest';
+
+import { nodeListToDebugMaps } from '@markuplint/parser-utils';
+
+import { parser } from './parser.js';
+import { getLineAndColumn } from './markdown-aware-parser.js';
+
+function parse(code: string) {
+	return parser.parse(code);
+}
+
+describe('MarkdownParser', () => {
+	describe('Markdown elements', () => {
+		test('heading', () => {
+			const doc = parse('# Heading');
+			const maps = nodeListToDebugMaps(doc.nodeList);
+			expect(maps).toStrictEqual(['[1:1]>[1:10](0,9)h1: #\u2423Heading', '[1:3]>[1:10](2,9)#text: Heading']);
+		});
+
+		test('heading depth', () => {
+			const doc = parse('### Heading 3');
+			const maps = nodeListToDebugMaps(doc.nodeList);
+			expect(maps).toStrictEqual([
+				'[1:1]>[1:14](0,13)h3: ###\u2423Heading\u24233',
+				'[1:5]>[1:14](4,13)#text: Heading\u24233',
+			]);
+		});
+
+		test('heading h6 (max depth)', () => {
+			const doc = parse('###### Heading 6');
+			const maps = nodeListToDebugMaps(doc.nodeList);
+			expect(maps).toStrictEqual([
+				'[1:1]>[1:17](0,16)h6: ######\u2423Heading\u24236',
+				'[1:8]>[1:17](7,16)#text: Heading\u24236',
+			]);
+		});
+
+		test('paragraph', () => {
+			const doc = parse('Some paragraph text.');
+			const maps = nodeListToDebugMaps(doc.nodeList);
+			expect(maps).toStrictEqual([
+				'[1:1]>[1:21](0,20)p: Some\u2423paragraph\u2423text.',
+				'[1:1]>[1:21](0,20)#text: Some\u2423paragraph\u2423text.',
+			]);
+		});
+
+		test('emphasis', () => {
+			const doc = parse('*emphasized*');
+			const maps = nodeListToDebugMaps(doc.nodeList);
+			expect(maps).toStrictEqual([
+				'[1:1]>[1:13](0,12)p: *emphasized*',
+				'[1:1]>[1:13](0,12)em: *emphasized*',
+				'[1:2]>[1:12](1,11)#text: emphasized',
+			]);
+		});
+
+		test('strong', () => {
+			const doc = parse('**bold**');
+			const maps = nodeListToDebugMaps(doc.nodeList);
+			expect(maps).toStrictEqual([
+				'[1:1]>[1:9](0,8)p: **bold**',
+				'[1:1]>[1:9](0,8)strong: **bold**',
+				'[1:3]>[1:7](2,6)#text: bold',
+			]);
+		});
+
+		test('link', () => {
+			const doc = parse('[link text](https://example.com)');
+			const startTag = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'a');
+			expect(startTag).toBeDefined();
+			const href = startTag!.attributes.find(a => a.type === 'attr' && a.name.raw === 'href');
+			expect(href).toBeDefined();
+			expect(href!.value.raw).toBe('https://example.com');
+		});
+
+		test('link with title', () => {
+			const doc = parse('[link](https://example.com "title text")');
+			const startTag = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'a');
+			expect(startTag).toBeDefined();
+			const title = startTag!.attributes.find(a => a.type === 'attr' && a.name.raw === 'title');
+			expect(title).toBeDefined();
+			expect(title!.value.raw).toBe('title text');
+		});
+
+		test('link without title does NOT have title attribute', () => {
+			const doc = parse('[link](https://example.com)');
+			const startTag = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'a');
+			expect(startTag).toBeDefined();
+			const title = startTag!.attributes.find(a => a.type === 'attr' && a.name.raw === 'title');
+			expect(title).toBeUndefined();
+		});
+
+		test('image', () => {
+			const doc = parse('![alt text](image.png)');
+			const startTag = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'img');
+			expect(startTag).toBeDefined();
+			const src = startTag!.attributes.find(a => a.type === 'attr' && a.name.raw === 'src');
+			expect(src).toBeDefined();
+			expect(src!.value.raw).toBe('image.png');
+			const alt = startTag!.attributes.find(a => a.type === 'attr' && a.name.raw === 'alt');
+			expect(alt).toBeDefined();
+			expect(alt!.value.raw).toBe('alt text');
+		});
+
+		test('image with empty alt', () => {
+			const doc = parse('![](image.png)');
+			const startTag = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'img');
+			expect(startTag).toBeDefined();
+			const alt = startTag!.attributes.find(a => a.type === 'attr' && a.name.raw === 'alt');
+			expect(alt).toBeDefined();
+			expect(alt!.value.raw).toBe('');
+		});
+
+		test('image without title does NOT have title attribute', () => {
+			const doc = parse('![alt](image.png)');
+			const startTag = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'img');
+			expect(startTag).toBeDefined();
+			const title = startTag!.attributes.find(a => a.type === 'attr' && a.name.raw === 'title');
+			expect(title).toBeUndefined();
+			// Verify exactly 2 attributes: src and alt
+			expect(startTag!.attributes.length).toBe(2);
+		});
+
+		test('image with title has title attribute', () => {
+			const doc = parse('![alt](image.png "my title")');
+			const startTag = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'img');
+			expect(startTag).toBeDefined();
+			const title = startTag!.attributes.find(a => a.type === 'attr' && a.name.raw === 'title');
+			expect(title).toBeDefined();
+			expect(title!.value.raw).toBe('my title');
+			// Verify exactly 3 attributes: src, alt, title
+			expect(startTag!.attributes.length).toBe(3);
+		});
+
+		test('unordered list', () => {
+			const doc = parse('- item 1\n- item 2\n');
+			const ul = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'ul');
+			expect(ul).toBeDefined();
+			const lis = doc.nodeList.filter(n => n?.type === 'starttag' && n.nodeName === 'li');
+			expect(lis.length).toBe(2);
+		});
+
+		test('ordered list', () => {
+			const doc = parse('1. item 1\n2. item 2\n');
+			const ol = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'ol');
+			expect(ol).toBeDefined();
+		});
+
+		test('ordered list with custom start', () => {
+			const doc = parse('5. item 5\n6. item 6\n');
+			const ol = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'ol');
+			expect(ol).toBeDefined();
+			const start = ol!.attributes.find(a => a.type === 'attr' && a.name.raw === 'start');
+			expect(start).toBeDefined();
+			expect(start!.value.raw).toBe('5');
+		});
+
+		test('ordered list starting at 1 does NOT have start attribute', () => {
+			const doc = parse('1. first\n2. second\n');
+			const ol = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'ol');
+			expect(ol).toBeDefined();
+			const start = ol!.attributes.find(a => a.type === 'attr' && a.name.raw === 'start');
+			expect(start).toBeUndefined();
+		});
+
+		test('blockquote', () => {
+			const doc = parse('> quoted text');
+			const maps = nodeListToDebugMaps(doc.nodeList);
+			expect(maps).toStrictEqual([
+				'[1:1]>[1:14](0,13)blockquote: >␣quoted␣text',
+				'[1:3]>[1:14](2,13)p: quoted␣text',
+				'[1:3]>[1:14](2,13)#text: quoted␣text',
+			]);
+		});
+
+		test('thematic break', () => {
+			const doc = parse('---\n');
+			const maps = nodeListToDebugMaps(doc.nodeList);
+			expect(maps).toStrictEqual(['[1:1]>[1:4](0,3)hr: ---']);
+		});
+
+		test('inline code', () => {
+			const doc = parse('`code here`');
+			const code = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'code');
+			expect(code).toBeDefined();
+			expect(code!.childNodes.length).toBe(1);
+			expect(code!.childNodes[0].type).toBe('text');
+			expect(code!.childNodes[0].raw).toBe('code here');
+		});
+
+		test('inline code with double backticks', () => {
+			// remark parses `` code `` as inlineCode with value "code"
+			// The remaining " here ``" is a separate text node
+			const doc = parse('`` code `` here ``');
+			const code = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'code');
+			expect(code).toBeDefined();
+			expect(code!.childNodes.length).toBe(1);
+			expect(code!.childNodes[0].raw).toBe('code');
+		});
+
+		test('code block becomes pre>code elements', () => {
+			const doc = parse('```html\n<div>not parsed</div>\n```\n');
+			const pre = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'pre');
+			expect(pre).toBeDefined();
+			const code = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'code');
+			expect(code).toBeDefined();
+			const langAttr = code!.attributes.find(a => a.type === 'attr' && a.name.raw === 'class');
+			expect(langAttr).toBeDefined();
+			expect(langAttr!.value.raw).toBe('language-html');
+		});
+
+		test('code block without language', () => {
+			const doc = parse('```\nsome code\n```\n');
+			const pre = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'pre');
+			expect(pre).toBeDefined();
+			const code = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'code');
+			expect(code).toBeDefined();
+			expect(code!.attributes.length).toBe(0);
+		});
+
+		test('code block text content is preserved', () => {
+			const doc = parse('```js\nconst x = 1;\n```\n');
+			const code = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'code');
+			expect(code).toBeDefined();
+			expect(code!.childNodes.length).toBe(1);
+			expect(code!.childNodes[0].type).toBe('text');
+			expect(code!.childNodes[0].raw).toBe('const x = 1;');
+		});
+
+		test('code block with empty content has no text child', () => {
+			const doc = parse('```\n```\n');
+			const code = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'code');
+			expect(code).toBeDefined();
+			expect(code!.childNodes.length).toBe(0);
+		});
+
+		test('hard line break (two trailing spaces) becomes <br>', () => {
+			const doc = parse('line one  \nline two\n');
+			const br = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'br');
+			expect(br).toBeDefined();
+		});
+
+		test('nested markdown: bold link', () => {
+			const doc = parse('**[bold link](url)**');
+			const strong = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'strong');
+			expect(strong).toBeDefined();
+			const link = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'a');
+			expect(link).toBeDefined();
+			const href = link!.attributes.find(a => a.type === 'attr' && a.name.raw === 'href');
+			expect(href!.value.raw).toBe('url');
+		});
+	});
+
+	describe('Link and image references', () => {
+		test('linkReference resolves to <a> element', () => {
+			const doc = parse('[link text][ref]\n\n[ref]: https://example.com "Example"\n');
+			const a = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'a');
+			expect(a).toBeDefined();
+			const href = a!.attributes.find(attr => attr.type === 'attr' && attr.name.raw === 'href');
+			expect(href).toBeDefined();
+			expect(href!.value.raw).toBe('https://example.com');
+			const title = a!.attributes.find(attr => attr.type === 'attr' && attr.name.raw === 'title');
+			expect(title).toBeDefined();
+			expect(title!.value.raw).toBe('Example');
+		});
+
+		test('imageReference resolves to <img> element', () => {
+			const doc = parse('![alt text][img]\n\n[img]: image.png "Title"\n');
+			const img = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'img');
+			expect(img).toBeDefined();
+			const src = img!.attributes.find(attr => attr.type === 'attr' && attr.name.raw === 'src');
+			expect(src).toBeDefined();
+			expect(src!.value.raw).toBe('image.png');
+			const alt = img!.attributes.find(attr => attr.type === 'attr' && attr.name.raw === 'alt');
+			expect(alt).toBeDefined();
+			expect(alt!.value.raw).toBe('alt text');
+		});
+
+		test('unresolved linkReference is treated as plain text by remark', () => {
+			// remark-parse does not produce linkReference nodes when definition is missing;
+			// it treats the syntax as literal text in a paragraph.
+			const doc = parse('[text][missing]\n');
+			const p = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'p');
+			expect(p).toBeDefined();
+			const text = doc.nodeList.find(n => n?.type === 'text');
+			expect(text).toBeDefined();
+			expect(text!.raw).toContain('[text][missing]');
+		});
+
+		test('unresolved imageReference is treated as plain text by remark', () => {
+			const doc = parse('![alt][missing]\n');
+			const p = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'p');
+			expect(p).toBeDefined();
+			const text = doc.nodeList.find(n => n?.type === 'text');
+			expect(text).toBeDefined();
+			expect(text!.raw).toContain('![alt][missing]');
+		});
+
+		test('shortcut linkReference [ref] resolves using identifier as label', () => {
+			const doc = parse('[example]\n\n[example]: https://example.com\n');
+			const a = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'a');
+			expect(a).toBeDefined();
+			const href = a!.attributes.find(attr => attr.type === 'attr' && attr.name.raw === 'href');
+			expect(href).toBeDefined();
+			expect(href!.value.raw).toBe('https://example.com');
+		});
+
+		test('linkReference title from definition is passed to <a>', () => {
+			const doc = parse('[link text][ref]\n\n[ref]: https://example.com "Example"\n');
+			const a = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'a');
+			expect(a).toBeDefined();
+			expect(a!.attributes.length).toBe(2);
+			const title = a!.attributes.find(attr => attr.type === 'attr' && attr.name.raw === 'title');
+			expect(title).toBeDefined();
+			expect(title!.value.raw).toBe('Example');
+		});
+
+		test('linkReference without title in definition does NOT have title attribute', () => {
+			const doc = parse('[link text][ref]\n\n[ref]: https://example.com\n');
+			const a = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'a');
+			expect(a).toBeDefined();
+			const title = a!.attributes.find(attr => attr.type === 'attr' && attr.name.raw === 'title');
+			expect(title).toBeUndefined();
+			// Only href attribute
+			expect(a!.attributes.length).toBe(1);
+		});
+	});
+
+	describe('GFM extensions', () => {
+		test('GFM table becomes table>tr>th/td elements', () => {
+			const doc = parse('| A | B |\n| - | - |\n| 1 | 2 |\n');
+			const table = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'table');
+			expect(table).toBeDefined();
+			const ths = doc.nodeList.filter(n => n?.type === 'starttag' && n.nodeName === 'th');
+			expect(ths.length).toBe(2);
+			const tds = doc.nodeList.filter(n => n?.type === 'starttag' && n.nodeName === 'td');
+			expect(tds.length).toBe(2);
+		});
+
+		test('GFM table header cells contain correct text', () => {
+			const doc = parse('| Name | Age |\n| - | - |\n| Alice | 30 |\n');
+			const ths = doc.nodeList.filter(n => n?.type === 'starttag' && n.nodeName === 'th');
+			expect(ths.length).toBe(2);
+			// Verify text content of header cells
+			const thTexts = ths.map(th => th.childNodes.find(c => c.type === 'text')?.raw);
+			expect(thTexts).toStrictEqual(['Name', 'Age']);
+		});
+
+		test('GFM table data cells contain correct text', () => {
+			const doc = parse('| A | B |\n| - | - |\n| 1 | 2 |\n| 3 | 4 |\n');
+			const tds = doc.nodeList.filter(n => n?.type === 'starttag' && n.nodeName === 'td');
+			expect(tds.length).toBe(4);
+			const tdTexts = tds.map(td => td.childNodes.find(c => c.type === 'text')?.raw);
+			expect(tdTexts).toStrictEqual(['1', '2', '3', '4']);
+		});
+
+		test('GFM table with only header row has 0 td cells', () => {
+			const doc = parse('| A | B |\n| - | - |\n');
+			const ths = doc.nodeList.filter(n => n?.type === 'starttag' && n.nodeName === 'th');
+			expect(ths.length).toBe(2);
+			const tds = doc.nodeList.filter(n => n?.type === 'starttag' && n.nodeName === 'td');
+			expect(tds.length).toBe(0);
+		});
+
+		test('GFM strikethrough becomes <del> element', () => {
+			const doc = parse('~~deleted~~\n');
+			const del = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'del');
+			expect(del).toBeDefined();
+		});
+
+		test('GFM strikethrough contains correct text content', () => {
+			const doc = parse('~~deleted text~~\n');
+			const del = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'del');
+			expect(del).toBeDefined();
+			const text = del!.childNodes.find(c => c.type === 'text');
+			expect(text).toBeDefined();
+			expect(text!.raw).toBe('deleted text');
+		});
+	});
+
+	describe('HTML blocks', () => {
+		test('simple div (remark html node)', () => {
+			const doc = parse('<div>hello</div>');
+			const maps = nodeListToDebugMaps(doc.nodeList);
+			expect(maps).toStrictEqual([
+				'[1:1]>[1:6](0,5)div: <div>',
+				'[1:6]>[1:11](5,10)#text: hello',
+				'[1:11]>[1:17](10,16)div: </div>',
+			]);
+		});
+
+		test('HTML block in markdown', () => {
+			const doc = parse('# Heading\n\n<div class="note">\n  <p>content</p>\n</div>\n');
+			// Heading is now an h1 element
+			const h1 = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'h1');
+			expect(h1).toBeDefined();
+			// HTML block div is still present
+			const div = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'div');
+			expect(div).toBeDefined();
+		});
+
+		test('HTML comment (block-level)', () => {
+			const doc = parse('<!-- comment -->\n');
+			const maps = nodeListToDebugMaps(doc.nodeList);
+			expect(maps).toStrictEqual(['[1:1]>[1:17](0,16)#comment: <!--\u2423comment\u2423-->']);
+		});
+
+		test('inline HTML in paragraph', () => {
+			const doc = parse('This is <em>emphasized</em> text');
+			const p = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'p');
+			expect(p).toBeDefined();
+			const em = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'em');
+			expect(em).toBeDefined();
+		});
+
+		test('self-closing void element', () => {
+			const doc = parse('<hr>');
+			const maps = nodeListToDebugMaps(doc.nodeList);
+			expect(maps).toStrictEqual(['[1:1]>[1:5](0,4)hr: <hr>']);
+		});
+	});
+
+	describe('Front matter', () => {
+		test('YAML front matter becomes psblock', () => {
+			const doc = parse('---\ntitle: Test\n---\n\n<div>content</div>\n');
+			const yaml = doc.nodeList.find(n => n?.type === 'psblock' && n.nodeName === '#ps:yaml');
+			expect(yaml).toBeDefined();
+			const div = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'div');
+			expect(div).toBeDefined();
+		});
+	});
+
+	describe('Adjacent HTML blocks', () => {
+		test('remark splits adjacent HTML blocks separated by blank lines', () => {
+			const doc = parse('<div class="wrapper">\n\n<p>paragraph inside div</p>\n\n</div>\n');
+			const div = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'div');
+			expect(div).toBeDefined();
+			const p = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'p');
+			expect(p).toBeDefined();
+		});
+	});
+
+	describe('Multiple HTML comments', () => {
+		test('consecutive comments are parsed', () => {
+			const doc = parse('<!-- TODO: fix this -->\n<!-- NOTE: this is a note -->\n');
+			const comments = doc.nodeList.filter(n => n?.type === 'comment');
+			expect(comments.length).toBe(2);
+		});
+	});
+
+	describe('HTML with entities', () => {
+		test('HTML entities in HTML blocks are preserved', () => {
+			const doc = parse('<p>&amp; &lt; &gt;</p>\n');
+			const p = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'p');
+			expect(p).toBeDefined();
+			const text = doc.nodeList.find(n => n?.type === 'text' && n.raw.includes('&amp;'));
+			expect(text).toBeDefined();
+		});
+	});
+
+	describe('Multiple void elements', () => {
+		test('consecutive void elements with newlines between them', () => {
+			const doc = parse('<br>\n<hr>\n<img src="test.png" alt="test">\n');
+			const br = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'br');
+			const hr = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'hr');
+			const img = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'img');
+			expect(br).toBeDefined();
+			expect(hr).toBeDefined();
+			expect(img).toBeDefined();
+		});
+	});
+
+	describe('State isolation between parse() calls', () => {
+		test('definitions do not leak across parse() calls', () => {
+			// First parse: define [ref]
+			const doc1 = parse('[link][ref]\n\n[ref]: https://example.com\n');
+			const a = doc1.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'a');
+			expect(a).toBeDefined();
+
+			// Second parse: [ref] without definition — should NOT resolve
+			const doc2 = parse('[link][ref]\n');
+			const a2 = doc2.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'a');
+			expect(a2).toBeUndefined();
+			const text = doc2.nodeList.find(n => n?.type === 'text');
+			expect(text).toBeDefined();
+			expect(text!.raw).toContain('[link][ref]');
+		});
+
+		test('table header state does not leak across parse() calls', () => {
+			// First parse: table with header
+			const doc1 = parse('| A |\n| - |\n| 1 |\n');
+			const ths1 = doc1.nodeList.filter(n => n?.type === 'starttag' && n.nodeName === 'th');
+			expect(ths1.length).toBe(1);
+
+			// Second parse: different table
+			const doc2 = parse('| B |\n| - |\n| 2 |\n');
+			const ths2 = doc2.nodeList.filter(n => n?.type === 'starttag' && n.nodeName === 'th');
+			expect(ths2.length).toBe(1);
+			const tds2 = doc2.nodeList.filter(n => n?.type === 'starttag' && n.nodeName === 'td');
+			expect(tds2.length).toBe(1);
+		});
+	});
+
+	describe('Multiple tables in one document', () => {
+		test('two GFM tables both have correct th/td', () => {
+			const doc = parse('| A | B |\n| - | - |\n| 1 | 2 |\n\n| C | D |\n| - | - |\n| 3 | 4 |\n');
+			const tables = doc.nodeList.filter(n => n?.type === 'starttag' && n.nodeName === 'table');
+			expect(tables.length).toBe(2);
+			const ths = doc.nodeList.filter(n => n?.type === 'starttag' && n.nodeName === 'th');
+			expect(ths.length).toBe(4);
+			const tds = doc.nodeList.filter(n => n?.type === 'starttag' && n.nodeName === 'td');
+			expect(tds.length).toBe(4);
+		});
+	});
+
+	describe('collectDefinitions duplicate identifier', () => {
+		test('first definition wins for duplicate identifiers (CommonMark spec)', () => {
+			const doc = parse('[link][ref]\n\n[ref]: https://first.com\n[ref]: https://second.com\n');
+			const a = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'a');
+			expect(a).toBeDefined();
+			const href = a!.attributes.find(attr => attr.type === 'attr' && attr.name.raw === 'href');
+			expect(href).toBeDefined();
+			expect(href!.value.raw).toBe('https://first.com');
+		});
+	});
+
+	describe('Empty link', () => {
+		test('empty link text [](url) produces <a> element', () => {
+			const doc = parse('[](https://example.com)\n');
+			const a = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'a');
+			expect(a).toBeDefined();
+			const href = a!.attributes.find(attr => attr.type === 'attr' && attr.name.raw === 'href');
+			expect(href).toBeDefined();
+			expect(href!.value.raw).toBe('https://example.com');
+		});
+	});
+
+	describe('Footnotes', () => {
+		test('footnoteReference becomes psblock with correct raw', () => {
+			const doc = parse('Text with a note[^1]\n\n[^1]: Footnote content\n');
+			const fnRef = doc.nodeList.find(n => n?.type === 'psblock' && n.nodeName === '#ps:footnoteReference');
+			expect(fnRef).toBeDefined();
+			expect(fnRef!.nodeName).toBe('#ps:footnoteReference');
+			expect(fnRef!.raw).toBe('[^1]');
+		});
+
+		test('footnoteDefinition becomes psblock with correct raw', () => {
+			const doc = parse('Text with a note[^1]\n\n[^1]: Footnote content\n');
+			const fnDef = doc.nodeList.find(n => n?.type === 'psblock' && n.nodeName === '#ps:footnoteDefinition');
+			expect(fnDef).toBeDefined();
+			expect(fnDef!.nodeName).toBe('#ps:footnoteDefinition');
+			expect(fnDef!.raw).toContain('Footnote content');
+		});
+	});
+
+	describe('GFM table alignment', () => {
+		test('table with alignment syntax produces correct th/td', () => {
+			// TODO: GFM align attribute is not yet mapped to HTML align attribute
+			const doc = parse('| Left | Center | Right |\n| :--- | :---: | ---: |\n| a | b | c |\n');
+			const table = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'table');
+			expect(table).toBeDefined();
+			const ths = doc.nodeList.filter(n => n?.type === 'starttag' && n.nodeName === 'th');
+			expect(ths.length).toBe(3);
+			const tds = doc.nodeList.filter(n => n?.type === 'starttag' && n.nodeName === 'td');
+			expect(tds.length).toBe(3);
+			const thTexts = ths.map(th => th.childNodes.find(c => c.type === 'text')?.raw);
+			expect(thTexts).toStrictEqual(['Left', 'Center', 'Right']);
+		});
+	});
+
+	describe('Deep nesting', () => {
+		test('blockquote > list > emphasis > link', () => {
+			const doc = parse('> - *[link text](https://example.com)*\n');
+			const blockquote = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'blockquote');
+			expect(blockquote).toBeDefined();
+			const ul = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'ul');
+			expect(ul).toBeDefined();
+			const em = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'em');
+			expect(em).toBeDefined();
+			const a = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'a');
+			expect(a).toBeDefined();
+			const href = a!.attributes.find(attr => attr.type === 'attr' && attr.name.raw === 'href');
+			expect(href!.value.raw).toBe('https://example.com');
+		});
+	});
+
+	describe('Edge cases', () => {
+		test('empty input produces empty nodeList', () => {
+			const doc = parse('');
+			expect(doc.nodeList).toStrictEqual([]);
+		});
+
+		test('whitespace-only input produces empty nodeList', () => {
+			const doc = parse('   \n');
+			expect(doc.nodeList).toStrictEqual([]);
+		});
+	});
+
+	describe('Error handling', () => {
+		test('invalid HTML in HTML block does not throw', () => {
+			// Markdown parser should gracefully handle invalid HTML
+			expect(() => parse('<div><span>unclosed tags')).not.toThrow();
+		});
+	});
+
+	describe('Attributes with special characters', () => {
+		test('attributes containing spaces are preserved in HTML blocks', () => {
+			const doc = parse('<div data-value="hello world" class="foo bar">content</div>\n');
+			const div = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'div');
+			expect(div).toBeDefined();
+			const dataValue = div!.attributes.find(a => a.type === 'attr' && a.name.raw === 'data-value');
+			expect(dataValue).toBeDefined();
+			expect(dataValue!.value.raw).toBe('hello world');
+		});
+	});
+
+	describe('Nested HTML elements', () => {
+		test('deeply nested HTML elements are fully parsed', () => {
+			const doc = parse('<div>\n  <span>\n    <strong>deep</strong>\n  </span>\n</div>\n');
+			const div = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'div');
+			expect(div).toBeDefined();
+			const span = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'span');
+			expect(span).toBeDefined();
+			const strong = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'strong');
+			expect(strong).toBeDefined();
+		});
+	});
+
+	describe('Multiple separate HTML blocks in markdown', () => {
+		test('HTML blocks separated by markdown content', () => {
+			const doc = parse('# Heading 1\n\n<div>block 1</div>\n\nSome text.\n\n<div>block 2</div>\n');
+			const h1 = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'h1');
+			expect(h1).toBeDefined();
+			const p = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'p');
+			expect(p).toBeDefined();
+			const divs = doc.nodeList.filter(n => n?.type === 'starttag' && n.nodeName === 'div');
+			expect(divs.length).toBe(2);
+		});
+	});
+
+	describe('HTML immediately after front matter', () => {
+		test('HTML on the line immediately after front matter closing fence', () => {
+			const doc = parse('---\ntitle: Test\n---\n<div>immediately after</div>\n');
+			const yaml = doc.nodeList.find(n => n?.type === 'psblock' && n.nodeName === '#ps:yaml');
+			expect(yaml).toBeDefined();
+			const div = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'div');
+			expect(div).toBeDefined();
+		});
+	});
+
+	describe('Mixed inline HTML tags', () => {
+		test('inline HTML tags within paragraph', () => {
+			const doc = parse('This has <em>emphasis</em> and <strong>strong</strong> text\n');
+			const p = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'p');
+			expect(p).toBeDefined();
+			const em = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'em');
+			expect(em).toBeDefined();
+			const strong = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'strong');
+			expect(strong).toBeDefined();
+		});
+	});
+
+	describe('Document metadata', () => {
+		test('isFragment is true', () => {
+			const doc = parse('<div>hello</div>');
+			expect(doc.isFragment).toBe(true);
+		});
+
+		test('raw preserves original source', () => {
+			const source = '# Hello\n\n<div>world</div>\n';
+			const doc = parse(source);
+			expect(doc.raw).toBe(source);
+		});
+	});
+
+	describe('imageReference edge cases', () => {
+		test('imageReference without title in definition does NOT have title attribute', () => {
+			const doc = parse('![alt text][img]\n\n[img]: image.png\n');
+			const img = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'img');
+			expect(img).toBeDefined();
+			const title = img!.attributes.find(attr => attr.type === 'attr' && attr.name.raw === 'title');
+			expect(title).toBeUndefined();
+			// Only src and alt attributes
+			expect(img!.attributes.length).toBe(2);
+		});
+
+		test('imageReference with empty alt ![][ref]', () => {
+			const doc = parse('![][img]\n\n[img]: image.png\n');
+			const img = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'img');
+			expect(img).toBeDefined();
+			const alt = img!.attributes.find(attr => attr.type === 'attr' && attr.name.raw === 'alt');
+			expect(alt).toBeDefined();
+			expect(alt!.value.raw).toBe('');
+			const src = img!.attributes.find(attr => attr.type === 'attr' && attr.name.raw === 'src');
+			expect(src).toBeDefined();
+			expect(src!.value.raw).toBe('image.png');
+		});
+
+		test('same definition used by multiple imageReferences', () => {
+			const doc = parse('![first][img]\n\n![second][img]\n\n[img]: photo.png\n');
+			const imgs = doc.nodeList.filter(n => n?.type === 'starttag' && n.nodeName === 'img');
+			expect(imgs.length).toBe(2);
+			const alts = imgs.map(
+				img => img.attributes.find(a => a.type === 'attr' && a.name.raw === 'alt')?.value.raw,
+			);
+			expect(alts).toStrictEqual(['first', 'second']);
+			const srcValues = imgs.map(
+				img => img.attributes.find(a => a.type === 'attr' && a.name.raw === 'src')?.value.raw,
+			);
+			expect(srcValues).toStrictEqual(['photo.png', 'photo.png']);
+		});
+	});
+
+	describe('State isolation: empty-nonEmpty-empty cycle', () => {
+		test('empty parse after non-empty parse returns empty nodeList', () => {
+			const doc1 = parse('# Heading\n\n[link][ref]\n\n[ref]: url\n');
+			expect(doc1.nodeList.length).toBeGreaterThan(0);
+
+			const doc2 = parse('');
+			expect(doc2.nodeList).toStrictEqual([]);
+
+			const doc3 = parse('# Another heading');
+			const h1 = doc3.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'h1');
+			expect(h1).toBeDefined();
+		});
+	});
+});
+
+describe('getLineAndColumn', () => {
+	test('returns line 1, col 1 for offset 0', () => {
+		expect(getLineAndColumn('hello', 0)).toStrictEqual({ line: 1, col: 1 });
+	});
+
+	test('correctly counts lines across newlines', () => {
+		expect(getLineAndColumn('aaa\nbbb\nccc', 4)).toStrictEqual({ line: 2, col: 1 });
+		expect(getLineAndColumn('aaa\nbbb\nccc', 5)).toStrictEqual({ line: 2, col: 2 });
+		expect(getLineAndColumn('aaa\nbbb\nccc', 8)).toStrictEqual({ line: 3, col: 1 });
+	});
+
+	test('handles empty string at offset 0', () => {
+		expect(getLineAndColumn('', 0)).toStrictEqual({ line: 1, col: 1 });
+	});
+
+	test('offset at end of line (before newline)', () => {
+		expect(getLineAndColumn('abc\n', 3)).toStrictEqual({ line: 1, col: 4 });
+	});
+});

--- a/packages/@markuplint/markdown-parser/src/index.ts
+++ b/packages/@markuplint/markdown-parser/src/index.ts
@@ -1,0 +1,7 @@
+/**
+ * @module @markuplint/markdown-parser
+ */
+
+/** @internal Exported for subclass use by mdx-parser; not part of the public API. */
+export { MarkdownAwareParser } from './markdown-aware-parser.js';
+export { parser } from './parser.js';

--- a/packages/@markuplint/markdown-parser/src/markdown-aware-parser.ts
+++ b/packages/@markuplint/markdown-parser/src/markdown-aware-parser.ts
@@ -1,0 +1,656 @@
+import type {
+	MLASTAttr,
+	MLASTElement,
+	MLASTHTMLAttr,
+	MLASTNodeTreeItem,
+	MLASTParentNode,
+	MLASTText,
+} from '@markuplint/ml-ast';
+import type { ParserOptions, Token } from '@markuplint/parser-utils';
+import type {
+	Code,
+	Definition,
+	Image,
+	ImageReference,
+	InlineCode,
+	Link,
+	LinkReference,
+	List,
+	RootContent,
+	Table,
+} from 'mdast';
+
+import { Parser, getNamespace } from '@markuplint/parser-utils';
+
+type MdastNode = RootContent;
+
+/**
+ * Abstract base class for parsers that handle Markdown content.
+ *
+ * Provides shared logic for converting mdast nodes (headings, links, images,
+ * lists, code, tables, etc.) into markuplint's AST. Both MarkdownParser and
+ * MDXParser extend this class to avoid code duplication.
+ */
+
+export abstract class MarkdownAwareParser extends Parser<MdastNode> {
+	/**
+	 * Stores link/image reference definitions (`[id]: url "title"`)
+	 * extracted during tokenization for resolving linkReference/imageReference nodes.
+	 */
+	protected definitions = new Map<string, Definition>();
+
+	/**
+	 * Offsets of table rows that are header rows (first row of each table).
+	 * Set by visitTableElement, read by nodeizeMarkdownNode for tableRow dispatch.
+	 */
+	readonly #headerRowOffsets = new Set<number>();
+
+	/**
+	 * Current cell element name ('th' or 'td').
+	 * Set by tableRow processing, read by tableCell processing.
+	 * Reset to 'td' after each row.
+	 */
+	#currentCellName: 'th' | 'td' = 'td';
+
+	constructor(options?: ParserOptions) {
+		super(options);
+	}
+
+	/**
+	 * Resets mutable state accumulated during a previous `parse()` call.
+	 *
+	 * Must be called at the beginning of every `tokenize()` invocation to
+	 * prevent definitions, header-row offsets, and cell-name state from
+	 * leaking across successive `parse()` calls on the same parser instance.
+	 */
+	protected resetMarkdownState() {
+		this.definitions.clear();
+		this.#headerRowOffsets.clear();
+		this.#currentCellName = 'td';
+	}
+
+	/**
+	 * Adjusts the flattened node list for Markdown output.
+	 *
+	 * Disables whitespace and invalid-node exposure because Markdown
+	 * generates only synthetic elements with no real HTML whitespace tokens.
+	 *
+	 * @param nodeList - The flattened node tree produced by the base class.
+	 * @returns The adjusted node list.
+	 */
+	afterFlattenNodes(nodeList: readonly MLASTNodeTreeItem[]) {
+		return super.afterFlattenNodes(nodeList, {
+			exposeWhiteSpace: false,
+			exposeInvalidNode: false,
+		});
+	}
+
+	/**
+	 * Creates a synthetic HTML attribute token for Markdown-derived elements.
+	 *
+	 * The attribute positions point to the element's own token range because
+	 * Markdown syntax does not have discrete attribute source positions.
+	 *
+	 * @param name - The attribute name (e.g., `"href"`, `"alt"`).
+	 * @param value - The attribute value extracted from Markdown syntax.
+	 * @param token - The source token whose position is reused for the attribute.
+	 * @returns A fully-formed HTML attribute node.
+	 */
+	protected createSyntheticAttr(name: string, value: string, token: Token): MLASTHTMLAttr {
+		const emptyToken = this.createToken('', token.offset, token.line, token.col);
+		const nameToken = this.createToken(name, token.offset, token.line, token.col);
+		const valueToken = this.createToken(value, token.offset, token.line, token.col);
+		const attrToken = this.createToken(`${name}="${value}"`, token.offset, token.line, token.col);
+
+		return {
+			...attrToken,
+			type: 'attr',
+			nodeName: name,
+			spacesBeforeName: emptyToken,
+			name: nameToken,
+			spacesBeforeEqual: emptyToken,
+			equal: this.createToken('=', token.offset, token.line, token.col),
+			spacesAfterEqual: emptyToken,
+			startQuote: this.createToken('"', token.offset, token.line, token.col),
+			value: valueToken,
+			endQuote: this.createToken('"', token.offset, token.line, token.col),
+			isDuplicatable: false,
+		};
+	}
+
+	/**
+	 * Builds a generic HTML element node from a Markdown construct.
+	 *
+	 * @param token - The source token covering the entire construct.
+	 * @param nodeName - The HTML element name (e.g., `"p"`, `"h1"`, `"li"`).
+	 * @param childNodes - The mdast children to recurse into.
+	 * @param depth - Current nesting depth in the AST.
+	 * @param parentNode - Parent AST node, or `null` for top-level nodes.
+	 * @param attributes - Optional pre-built attributes to attach.
+	 * @returns The element node followed by its descendants.
+	 */
+	protected visitMarkdownElement(
+		token: Token,
+		nodeName: string,
+		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+		childNodes: readonly MdastNode[],
+		depth: number,
+		parentNode: MLASTParentNode | null,
+		attributes: readonly MLASTAttr[] = [],
+	): readonly MLASTNodeTreeItem[] {
+		const startTag: MLASTElement = {
+			...token,
+			...this.createToken(token),
+			attributes: [...attributes],
+			type: 'starttag',
+			elementType: this.detectElementType(nodeName),
+			namespace: getNamespace(nodeName, parentNode),
+			childNodes: [],
+			blockBehavior: null,
+			depth,
+			parentNode,
+			pairNode: null,
+			tagOpenChar: '',
+			tagCloseChar: '',
+			isGhost: false,
+			isFragment: false,
+			nodeName,
+		};
+
+		// Safe cast: childNodes are always subtypes of RootContent (= MdastNode)
+		const siblings = this.visitChildren([...childNodes] as MdastNode[], startTag);
+
+		return [startTag, ...siblings];
+	}
+
+	/**
+	 * Builds an `<a>` element with `href` (and optionally `title`) attributes.
+	 *
+	 * @param originNode - The mdast `link` node.
+	 * @param token - The source token covering the link.
+	 * @param depth - Current nesting depth.
+	 * @param parentNode - Parent AST node, or `null` for top-level.
+	 * @returns The `<a>` element node and its descendants.
+	 */
+	protected visitLinkElement(
+		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+		originNode: Link,
+		token: Token,
+		depth: number,
+		parentNode: MLASTParentNode | null,
+	): readonly MLASTNodeTreeItem[] {
+		const attrs: MLASTHTMLAttr[] = [this.createSyntheticAttr('href', originNode.url, token)];
+
+		if (originNode.title != null) {
+			attrs.push(this.createSyntheticAttr('title', originNode.title, token));
+		}
+
+		return this.visitMarkdownElement(token, 'a', originNode.children, depth, parentNode, attrs);
+	}
+
+	/**
+	 * Builds an `<img>` element with `src`, `alt`, and optionally `title` attributes.
+	 *
+	 * @param originNode - The mdast `image` node.
+	 * @param token - The source token covering the image.
+	 * @param depth - Current nesting depth.
+	 * @param parentNode - Parent AST node, or `null` for top-level.
+	 * @returns The `<img>` element node.
+	 */
+	protected visitImageElement(
+		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+		originNode: Image,
+		token: Token,
+		depth: number,
+		parentNode: MLASTParentNode | null,
+	): readonly MLASTNodeTreeItem[] {
+		const attrs: MLASTHTMLAttr[] = [
+			this.createSyntheticAttr('src', originNode.url, token),
+			this.createSyntheticAttr('alt', originNode.alt ?? '', token),
+		];
+
+		if (originNode.title != null) {
+			attrs.push(this.createSyntheticAttr('title', originNode.title, token));
+		}
+
+		return this.visitMarkdownElement(token, 'img', [], depth, parentNode, attrs);
+	}
+
+	/**
+	 * Builds a `<ul>` or `<ol>` element. Adds a `start` attribute when the
+	 * ordered list begins at a number other than 1.
+	 *
+	 * @param originNode - The mdast `list` node.
+	 * @param token - The source token covering the list.
+	 * @param depth - Current nesting depth.
+	 * @param parentNode - Parent AST node, or `null` for top-level.
+	 * @returns The list element node and its descendants.
+	 */
+	protected visitListElement(
+		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+		originNode: List,
+		token: Token,
+		depth: number,
+		parentNode: MLASTParentNode | null,
+	): readonly MLASTNodeTreeItem[] {
+		const nodeName = originNode.ordered ? 'ol' : 'ul';
+		const attrs: MLASTHTMLAttr[] = [];
+
+		if (originNode.ordered && originNode.start != null && originNode.start !== 1) {
+			attrs.push(this.createSyntheticAttr('start', String(originNode.start), token));
+		}
+
+		return this.visitMarkdownElement(token, nodeName, originNode.children, depth, parentNode, attrs);
+	}
+
+	/**
+	 * Builds a `<code>` element for inline code spans (backtick-delimited).
+	 *
+	 * @param originNode - The mdast `inlineCode` node.
+	 * @param token - The source token covering the code span.
+	 * @param offset - Start offset in the original source.
+	 * @param endOffset - End offset in the original source.
+	 * @param depth - Current nesting depth.
+	 * @param parentNode - Parent AST node, or `null` for top-level.
+	 * @returns The `<code>` element node (with a text child when content is found).
+	 */
+	protected visitInlineCode(
+		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+		originNode: InlineCode,
+		token: Token,
+		offset: number,
+		endOffset: number,
+		depth: number,
+		parentNode: MLASTParentNode | null,
+	): readonly MLASTNodeTreeItem[] {
+		const startTag: MLASTElement = {
+			...token,
+			...this.createToken(token),
+			attributes: [],
+			type: 'starttag',
+			elementType: this.detectElementType('code'),
+			namespace: getNamespace('code', parentNode),
+			childNodes: [],
+			blockBehavior: null,
+			depth,
+			parentNode,
+			pairNode: null,
+			tagOpenChar: '',
+			tagCloseChar: '',
+			isGhost: false,
+			isFragment: false,
+			nodeName: 'code',
+		};
+
+		const raw = this.rawCode.slice(offset, endOffset);
+		const valueStart = raw.indexOf(originNode.value);
+		// Defensive guard: if value cannot be found in raw source (e.g., whitespace-only code spans) or is empty
+		if (valueStart === -1 || originNode.value.length === 0) {
+			return [startTag];
+		}
+
+		const valueOffset = offset + valueStart;
+		const valueEndOffset = valueOffset + originNode.value.length;
+		const textToken = this.sliceFragment(valueOffset, valueEndOffset);
+
+		const textNode: MLASTText = {
+			...textToken,
+			...this.createToken(textToken),
+			type: 'text',
+			depth: depth + 1,
+			nodeName: '#text',
+			parentNode: startTag,
+		};
+
+		this.appendChild(startTag, textNode);
+
+		return [startTag];
+	}
+
+	/**
+	 * Builds a `<pre><code>` structure for fenced code blocks.
+	 * When a language is specified, adds `class="language-{lang}"` to the `<code>` element.
+	 *
+	 * @param originNode - The mdast `code` node.
+	 * @param token - The source token covering the fenced block.
+	 * @param depth - Current nesting depth.
+	 * @param parentNode - Parent AST node, or `null` for top-level.
+	 * @returns The `<pre>` and `<code>` element nodes.
+	 */
+	protected visitCodeBlock(
+		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+		originNode: Code,
+		token: Token,
+		depth: number,
+		parentNode: MLASTParentNode | null,
+	): readonly MLASTNodeTreeItem[] {
+		// Build <pre> element
+		const preTag: MLASTElement = {
+			...token,
+			...this.createToken(token),
+			attributes: [],
+			type: 'starttag',
+			elementType: this.detectElementType('pre'),
+			namespace: getNamespace('pre', parentNode),
+			childNodes: [],
+			blockBehavior: null,
+			depth,
+			parentNode,
+			pairNode: null,
+			tagOpenChar: '',
+			tagCloseChar: '',
+			isGhost: false,
+			isFragment: false,
+			nodeName: 'pre',
+		};
+
+		// Build <code> element as child of <pre>
+		const codeAttrs: MLASTHTMLAttr[] = [];
+		if (originNode.lang) {
+			codeAttrs.push(this.createSyntheticAttr('class', `language-${originNode.lang}`, token));
+		}
+
+		const codeTag: MLASTElement = {
+			...token,
+			...this.createToken(token),
+			attributes: codeAttrs,
+			type: 'starttag',
+			elementType: this.detectElementType('code'),
+			namespace: getNamespace('code', preTag),
+			childNodes: [],
+			blockBehavior: null,
+			depth: depth + 1,
+			parentNode: preTag,
+			pairNode: null,
+			tagOpenChar: '',
+			tagCloseChar: '',
+			isGhost: false,
+			isFragment: false,
+			nodeName: 'code',
+		};
+
+		// Add code content as text node if present
+		if (originNode.value.length > 0) {
+			const position = originNode.position;
+			if (position) {
+				const rawContent = this.rawCode.slice(position.start.offset ?? 0, position.end.offset ?? 0);
+				const valueStart = rawContent.indexOf(originNode.value);
+				if (valueStart !== -1) {
+					const valueOffset = (position.start.offset ?? 0) + valueStart;
+					const valueEndOffset = valueOffset + originNode.value.length;
+					const textToken = this.sliceFragment(valueOffset, valueEndOffset);
+
+					const textNode: MLASTText = {
+						...textToken,
+						...this.createToken(textToken),
+						type: 'text',
+						depth: depth + 2,
+						nodeName: '#text',
+						parentNode: codeTag,
+					};
+
+					this.appendChild(codeTag, textNode);
+				}
+			}
+		}
+
+		this.appendChild(preTag, codeTag);
+
+		return [preTag, codeTag];
+	}
+
+	/**
+	 * Builds a `<table>` element from a GFM table node.
+	 * Marks the first row's offset as a header row so that its cells become `<th>`.
+	 *
+	 * @param originNode - The mdast `table` node (GFM extension).
+	 * @param token - The source token covering the table.
+	 * @param depth - Current nesting depth.
+	 * @param parentNode - Parent AST node, or `null` for top-level.
+	 * @returns The `<table>` element node and its descendants.
+	 */
+	protected visitTableElement(
+		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+		originNode: Table,
+		token: Token,
+		depth: number,
+		parentNode: MLASTParentNode | null,
+	): readonly MLASTNodeTreeItem[] {
+		const firstRow = originNode.children[0];
+		if (firstRow?.position?.start.offset != null) {
+			this.#headerRowOffsets.add(firstRow.position.start.offset);
+		}
+
+		return this.visitMarkdownElement(token, 'table', originNode.children as MdastNode[], depth, parentNode);
+	}
+
+	/**
+	 * Dispatches a single mdast node to the appropriate visit method.
+	 *
+	 * @param originNode - The mdast node to convert.
+	 * @param token - The source token covering the node's range.
+	 * @param offset - Start offset in the original source.
+	 * @param endOffset - End offset in the original source.
+	 * @param depth - Current nesting depth.
+	 * @param parentNode - Parent AST node, or `null` for top-level nodes.
+	 * @returns An array of AST nodes for recognized Markdown constructs,
+	 *   or `null` when the node type is not handled here (the caller is
+	 *   responsible for handling it — typically `text`, `html`, or
+	 *   parser-specific node types).
+	 */
+	protected nodeizeMarkdownNode(
+		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+		originNode: MdastNode,
+		token: Token,
+		offset: number,
+		endOffset: number,
+		depth: number,
+		parentNode: MLASTParentNode | null,
+	): readonly MLASTNodeTreeItem[] | null {
+		switch (originNode.type) {
+			case 'heading': {
+				const nodeName = `h${originNode.depth}`;
+				return this.visitMarkdownElement(token, nodeName, originNode.children, depth, parentNode);
+			}
+			case 'paragraph': {
+				return this.visitMarkdownElement(token, 'p', originNode.children, depth, parentNode);
+			}
+			case 'emphasis': {
+				return this.visitMarkdownElement(token, 'em', originNode.children, depth, parentNode);
+			}
+			case 'strong': {
+				return this.visitMarkdownElement(token, 'strong', originNode.children, depth, parentNode);
+			}
+			case 'link': {
+				return this.visitLinkElement(originNode, token, depth, parentNode);
+			}
+			case 'image': {
+				return this.visitImageElement(originNode, token, depth, parentNode);
+			}
+			case 'list': {
+				return this.visitListElement(originNode, token, depth, parentNode);
+			}
+			case 'listItem': {
+				return this.visitMarkdownElement(token, 'li', originNode.children, depth, parentNode);
+			}
+			case 'blockquote': {
+				return this.visitMarkdownElement(token, 'blockquote', originNode.children, depth, parentNode);
+			}
+			case 'thematicBreak': {
+				return this.visitMarkdownElement(token, 'hr', [], depth, parentNode);
+			}
+			case 'break': {
+				return this.visitMarkdownElement(token, 'br', [], depth, parentNode);
+			}
+			case 'inlineCode': {
+				return this.visitInlineCode(originNode, token, offset, endOffset, depth, parentNode);
+			}
+			case 'code': {
+				return this.visitCodeBlock(originNode, token, depth, parentNode);
+			}
+			case 'linkReference': {
+				return this.visitLinkReference(originNode, token, depth, parentNode);
+			}
+			case 'imageReference': {
+				return this.visitImageReference(originNode, token, depth, parentNode);
+			}
+			case 'table': {
+				return this.visitTableElement(originNode, token, depth, parentNode);
+			}
+			case 'tableRow': {
+				const isHeader = this.#headerRowOffsets.delete(offset);
+				if (isHeader) {
+					this.#currentCellName = 'th';
+				}
+				// tableRow.children is TableCell[] — safely widens to MdastNode[]
+				const result = this.visitMarkdownElement(
+					token,
+					'tr',
+					originNode.children as MdastNode[],
+					depth,
+					parentNode,
+				);
+				this.#currentCellName = 'td';
+				return result;
+			}
+			case 'tableCell': {
+				return this.visitMarkdownElement(
+					token,
+					this.#currentCellName,
+					originNode.children as MdastNode[],
+					depth,
+					parentNode,
+				);
+			}
+			case 'delete': {
+				return this.visitMarkdownElement(token, 'del', originNode.children as MdastNode[], depth, parentNode);
+			}
+			case 'yaml':
+			case 'definition':
+			case 'footnoteReference':
+			case 'footnoteDefinition': {
+				return this.visitPsBlock({
+					...token,
+					depth,
+					parentNode,
+					nodeName: originNode.type,
+					isFragment: false,
+				});
+			}
+			case 'text': {
+				// Caller handles text nodes directly
+				return null;
+			}
+			default: {
+				// null = the caller is responsible for handling this node type
+				return null;
+			}
+		}
+	}
+
+	/**
+	 * Resolves a linkReference using collected definitions, producing an `<a>` element.
+	 * Falls back to a psblock when the definition is not found.
+	 */
+	private visitLinkReference(
+		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+		originNode: LinkReference,
+		token: Token,
+		depth: number,
+		parentNode: MLASTParentNode | null,
+	): readonly MLASTNodeTreeItem[] {
+		const def = this.definitions.get(originNode.identifier);
+		if (!def) {
+			return this.visitPsBlock({
+				...token,
+				depth,
+				parentNode,
+				nodeName: 'linkReference',
+				isFragment: false,
+			});
+		}
+
+		const attrs: MLASTHTMLAttr[] = [this.createSyntheticAttr('href', def.url, token)];
+		if (def.title != null) {
+			attrs.push(this.createSyntheticAttr('title', def.title, token));
+		}
+
+		return this.visitMarkdownElement(token, 'a', originNode.children as MdastNode[], depth, parentNode, attrs);
+	}
+
+	/**
+	 * Resolves an imageReference using collected definitions, producing an `<img>` element.
+	 * Falls back to a psblock when the definition is not found.
+	 */
+	private visitImageReference(
+		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+		originNode: ImageReference,
+		token: Token,
+		depth: number,
+		parentNode: MLASTParentNode | null,
+	): readonly MLASTNodeTreeItem[] {
+		const def = this.definitions.get(originNode.identifier);
+		if (!def) {
+			return this.visitPsBlock({
+				...token,
+				depth,
+				parentNode,
+				nodeName: 'imageReference',
+				isFragment: false,
+			});
+		}
+
+		const attrs: MLASTHTMLAttr[] = [
+			this.createSyntheticAttr('src', def.url, token),
+			this.createSyntheticAttr('alt', originNode.alt ?? '', token),
+		];
+		if (def.title != null) {
+			attrs.push(this.createSyntheticAttr('title', def.title, token));
+		}
+
+		return this.visitMarkdownElement(token, 'img', [], depth, parentNode, attrs);
+	}
+
+	/**
+	 * Extracts definition nodes from mdast children and populates `this.definitions`.
+	 *
+	 * Per CommonMark spec, the first definition for a given identifier takes
+	 * precedence. remark-parse emits all definition nodes in source order, so
+	 * we skip duplicates via `Map.has` to honour the first-wins rule.
+	 *
+	 * @param children - The root-level mdast children to scan for `definition` nodes.
+	 */
+	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+	protected collectDefinitions(children: readonly RootContent[]) {
+		for (const child of children) {
+			if (child.type === 'definition' && !this.definitions.has(child.identifier)) {
+				this.definitions.set(child.identifier, child);
+			}
+		}
+	}
+}
+
+/**
+ * Computes the 1-based line number and 1-based column for a given offset.
+ *
+ * Equivalent to `getPosition()` in `@markuplint/parser-utils`, but that
+ * function is not exported from the package. Kept as a standalone utility
+ * to avoid coupling to parser-utils internals.
+ *
+ * @param source - The full source string.
+ * @param offset - The 0-based character offset to resolve.
+ * @returns An object with 1-based `line` and `col` values.
+ */
+export function getLineAndColumn(source: string, offset: number): { line: number; col: number } {
+	let line = 1;
+	let col = 1;
+	for (let i = 0; i < offset; i++) {
+		if (source[i] === '\n') {
+			line++;
+			col = 1;
+		} else {
+			col++;
+		}
+	}
+	return { line, col };
+}

--- a/packages/@markuplint/markdown-parser/src/parser.ts
+++ b/packages/@markuplint/markdown-parser/src/parser.ts
@@ -1,0 +1,109 @@
+import type { MLASTNodeTreeItem, MLASTParentNode } from '@markuplint/ml-ast';
+import type { RootContent } from 'mdast';
+
+import { HtmlParser } from '@markuplint/html-parser';
+import remarkFrontmatter from 'remark-frontmatter';
+import remarkGfm from 'remark-gfm';
+import remarkParse from 'remark-parse';
+import { unified } from 'unified';
+
+import { MarkdownAwareParser, getLineAndColumn } from './markdown-aware-parser.js';
+
+type MdastNode = RootContent;
+
+/**
+ * Parser for Markdown files that converts Markdown syntax to HTML AST elements.
+ *
+ * Uses remark-parse to produce an mdast, then maps Markdown constructs
+ * (headings, paragraphs, lists, links, etc.) to their corresponding HTML
+ * element AST nodes. Raw HTML regions are parsed via HtmlParser.
+ */
+class MarkdownParser extends MarkdownAwareParser {
+	readonly #htmlParser = new HtmlParser();
+
+	/**
+	 * Tokenizes the raw Markdown source into an mdast tree.
+	 *
+	 * Resets parser state, parses via remark (with GFM and frontmatter plugins),
+	 * and collects link/image reference definitions for later resolution.
+	 *
+	 * @returns The mdast children and fragment flag.
+	 */
+	tokenize() {
+		this.resetMarkdownState();
+
+		const processor = unified().use(remarkParse).use(remarkGfm).use(remarkFrontmatter, ['yaml']);
+
+		const mdast = processor.parse(this.rawCode);
+
+		this.collectDefinitions(mdast.children);
+
+		return {
+			ast: mdast.children,
+			isFragment: true,
+		};
+	}
+
+	/**
+	 * Converts a single mdast node into markuplint AST nodes.
+	 *
+	 * Delegates to the shared `nodeizeMarkdownNode()` for common Markdown
+	 * constructs. Handles `html` regions via HtmlParser and `text` nodes directly.
+	 *
+	 * @param originNode - The mdast node to convert.
+	 * @param parentNode - Parent AST node, or `null` for top-level.
+	 * @param depth - Current nesting depth.
+	 * @returns An array of markuplint AST nodes.
+	 */
+	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+	nodeize(originNode: MdastNode, parentNode: MLASTParentNode | null, depth: number) {
+		const position = originNode.position;
+		if (!position) {
+			return [];
+		}
+
+		const offset = position.start.offset ?? 0;
+		const endOffset = position.end.offset ?? offset;
+		const token = this.sliceFragment(offset, endOffset);
+
+		// Try common Markdown node handling first
+		const result = this.nodeizeMarkdownNode(originNode, token, offset, endOffset, depth, parentNode);
+		if (result !== null) {
+			return result;
+		}
+
+		switch (originNode.type) {
+			case 'html': {
+				return this.#parseHtmlRegion(originNode, offset);
+			}
+			case 'text': {
+				return this.visitText({
+					...token,
+					depth,
+					parentNode,
+				});
+			}
+			default: {
+				return this.visitPsBlock({
+					...token,
+					depth,
+					parentNode,
+					nodeName: originNode.type,
+					isFragment: false,
+				});
+			}
+		}
+	}
+
+	#parseHtmlRegion(originNode: { readonly value: string }, offset: number): readonly MLASTNodeTreeItem[] {
+		const { line, col } = getLineAndColumn(this.rawCode, offset);
+		const doc = this.#htmlParser.parse(originNode.value, {
+			offsetOffset: offset,
+			offsetLine: line,
+			offsetColumn: col,
+		});
+		return [...doc.nodeList];
+	}
+}
+
+export const parser = new MarkdownParser();

--- a/packages/@markuplint/markdown-parser/tsconfig.build.json
+++ b/packages/@markuplint/markdown-parser/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "./lib",
+		"rootDir": "./src"
+	},
+	"include": ["./src/**/*"],
+	"exclude": ["node_modules", "lib", "./src/**/*.spec.ts"]
+}

--- a/packages/@markuplint/markdown-parser/tsconfig.json
+++ b/packages/@markuplint/markdown-parser/tsconfig.json
@@ -1,0 +1,17 @@
+{
+	"extends": "../../../tsconfig.json",
+	"compilerOptions": {
+		"composite": true
+	},
+	"references": [
+		{
+			"path": "../html-parser"
+		},
+		{
+			"path": "../parser-utils"
+		},
+		{
+			"path": "../ml-ast"
+		}
+	]
+}

--- a/packages/@markuplint/mdx-parser/ARCHITECTURE.md
+++ b/packages/@markuplint/mdx-parser/ARCHITECTURE.md
@@ -1,0 +1,212 @@
+# @markuplint/mdx-parser
+
+## Overview
+
+`@markuplint/mdx-parser` parses MDX (`.mdx`) files for markuplint. MDX combines Markdown with JSX, allowing React components, JavaScript expressions, and ES module imports/exports alongside Markdown content. This parser converts both JSX elements and Markdown constructs into markuplint's AST, enabling lint rules to work on MDX documents.
+
+## Design Decisions
+
+### Why extend `MarkdownAwareParser`?
+
+Both plain Markdown and MDX share the same Markdown constructs (headings, links, images, lists, emphasis, etc.). The `MarkdownAwareParser` base class (from `@markuplint/markdown-parser`) provides shared conversion logic for these constructs. The MDX parser adds:
+
+1. **JSX element handling** -- `mdxJsxFlowElement`/`mdxJsxTextElement` mapped to `MLASTElement`
+2. **Expression handling** -- `{expr}` mapped to psblock nodes
+3. **ESM handling** -- `import`/`export` mapped to psblock nodes
+4. **JSX-specific options** -- XML-style end tags, booleanish attributes, case-sensitive tag names
+
+### MDX JSX vs HTML
+
+| Aspect            | Markdown HTML             | MDX JSX                             |
+| ----------------- | ------------------------- | ----------------------------------- |
+| Self-closing tags | Optional (`<br>`)         | Required (`<br />`)                 |
+| Comments          | `<!-- comment -->`        | `{/* comment */}`                   |
+| Attribute names   | HTML (`class`, `for`)     | JSX (`className`, `htmlFor`)        |
+| Attribute values  | Strings only (`data="x"`) | Strings or expressions (`data={x}`) |
+| Components        | Not supported             | `<MyComponent />`                   |
+
+### Why `remark-parse` + `remark-mdx` (not `@mdx-js/mdx`)?
+
+`@mdx-js/mdx` internally wraps `remark-parse` + `remark-mdx` and adds ~24 unnecessary dependencies for JS compilation that markuplint doesn't need. The parse-stage mdast is identical either way.
+
+### MDX v2/v3 only (not v1)
+
+MDX v1 uses a fundamentally different parser architecture with no shared code. Since v1 is deprecated and the ecosystem has migrated, we target v2/v3 only.
+
+### No `@markuplint/mdx-spec` package needed
+
+MDX uses React JSX syntax. The existing `@markuplint/react-spec` provides JSX attribute mappings:
+
+```json
+{
+  "parser": { "\\.mdx$": "@markuplint/mdx-parser" },
+  "specs": { "\\.mdx$": "@markuplint/react-spec" }
+}
+```
+
+## How It Works
+
+```
+.mdx source file
+    |
+    v
+[remark-parse + remark-gfm + remark-mdx + remark-frontmatter]
+    |
+    v
+[collectDefinitions()]       Extract [id]: url definitions
+    |
+    v
+[flattenMdastChildren()]     Unwrap JSX elements from paragraph wrappers
+    |
+    v
+[nodeize() per mdast node]
+    |
+    +-- mdxJsxFlowElement   -->  MLASTElement via parseCodeFragment
+    +-- mdxJsxTextElement   -->  MLASTElement via parseCodeFragment
+    +-- mdxFlowExpression   -->  psblock
+    +-- mdxTextExpression   -->  psblock
+    +-- mdxjsEsm            -->  psblock (import/export)
+    +-- heading             -->  h1-h6 element (via MarkdownAwareParser)
+    +-- paragraph           -->  p element
+    +-- emphasis/strong     -->  em/strong elements
+    +-- link/image          -->  a/img elements with attributes
+    +-- list/listItem       -->  ul/ol > li elements
+    +-- blockquote          -->  blockquote element
+    +-- inlineCode/code     -->  code / pre>code elements
+    +-- table/row/cell      -->  table > tr > th/td elements
+    +-- delete (GFM)        -->  del element
+    +-- linkReference       -->  a element (resolved) or psblock
+    +-- imageReference      -->  img element (resolved) or psblock
+    +-- text                -->  MLASTText
+    +-- yaml                -->  psblock (#ps:yaml)
+    +-- html (rare in MDX)  -->  parseCodeFragment
+    v
+MLASTDocument
+```
+
+### Class Hierarchy
+
+```
+Parser<MdastNode>               (from @markuplint/parser-utils)
+  |
+  MarkdownAwareParser           (from @markuplint/markdown-parser)
+    |                            - Shared Markdown-to-HTML conversion
+    |
+    MDXParser                   (this package)
+      |                          - tokenize(): remark-parse + remark-gfm + remark-mdx
+      |                          - nodeize(): MDX types first, then Markdown delegation
+      |                          - #visitJsxElement(): JSX -> MLASTElement
+      |                          - visitAttr(): JSX attribute handling (quoteSet, IDL mapping)
+      |                          - detectElementType(): uppercase/dot = authored
+```
+
+### Paragraph Flattening
+
+MDX's remark-mdx wraps inline JSX elements in `paragraph` nodes:
+
+```mdx
+Text with <Badge>inline</Badge> component.
+```
+
+produces a `paragraph` containing `text`, `mdxJsxTextElement`, `text`. The `flattenMdastChildren()` function detects paragraphs containing JSX and unwraps their children to the top level, ensuring JSX elements are directly accessible.
+
+Pure Markdown paragraphs (no JSX) are kept as-is and converted to `<p>` elements.
+
+### JSX Element Handling
+
+JSX elements are parsed via `parseCodeFragment()` with `namelessFragment: true`:
+
+1. **Self-closing** (`<Component prop="val" />`): entire token is the start tag
+2. **With children** (`<Card>...</Card>`): split into start tag token + children + end tag token
+3. **Fragments** (`<>...</>`): produce `#jsx-fragment` nodes
+
+The start tag is parsed by `parseCodeFragment` to extract attributes, then `visitElement()` wires up children.
+
+### JSX Attribute Handling
+
+| Attribute Form     | Example                    | Mapping                  |
+| ------------------ | -------------------------- | ------------------------ |
+| String value       | `name="email"`             | Standard attribute       |
+| Expression value   | `data={value}`             | `isDynamicValue: true`   |
+| Object expression  | `style={{ color: "red" }}` | `isDynamicValue: true`   |
+| Boolean (no value) | `disabled`                 | Empty value (booleanish) |
+| Spread             | `{...props}`               | `type: 'spread'`         |
+
+IDL attribute mapping (`className` -> `class`, `htmlFor` -> `for`) via `searchIDLAttribute()`.
+
+### Component Detection
+
+| Tag               | `detectElementType()` | Example                     |
+| ----------------- | --------------------- | --------------------------- |
+| `<div>`           | `html`                | Native HTML element         |
+| `<MyComponent>`   | `authored`            | React component             |
+| `<Layout.Header>` | `authored`            | Member expression component |
+| `<x-widget>`      | `web-component`       | Custom element              |
+
+## Architecture Diagram
+
+```mermaid
+flowchart TD
+    subgraph upstream ["Upstream"]
+        parserUtils["@markuplint/parser-utils\n(Parser, searchIDLAttribute)"]
+        mdParser["@markuplint/markdown-parser\n(MarkdownAwareParser)"]
+        remark["remark-parse + remark-gfm\n(Markdown + GFM)"]
+        remarkMdx["remark-mdx\n(MDX syntax extensions)"]
+        remarkFm["remark-frontmatter\n(Front matter support)"]
+    end
+
+    subgraph pkg ["@markuplint/mdx-parser"]
+        mdxParser["MDXParser\nextends MarkdownAwareParser"]
+        flatten["flattenMdastChildren()\nparagraph unwrapping"]
+        jsxVisit["#visitJsxElement()\nJSX -> MLASTElement"]
+    end
+
+    subgraph downstream ["Downstream"]
+        mlCore["@markuplint/ml-core\n(MLASTDocument -> MLDOM)"]
+        reactSpec["@markuplint/react-spec\n(JSX attribute specs)"]
+    end
+
+    parserUtils -->|"base utilities"| mdParser
+    mdParser -->|"MarkdownAwareParser"| mdxParser
+    remark -->|"mdast AST"| mdxParser
+    remarkMdx -->|"MDX node types"| mdxParser
+    remarkFm -->|"front matter"| mdxParser
+    mdxParser --> flatten --> jsxVisit
+    mdxParser -->|"MLASTDocument"| mlCore
+    reactSpec -->|"JSX attribute mapping"| mlCore
+```
+
+## External Dependencies
+
+| Dependency                    | Purpose                                       |
+| ----------------------------- | --------------------------------------------- |
+| `@markuplint/markdown-parser` | MarkdownAwareParser base class                |
+| `@markuplint/ml-ast`          | AST type definitions                          |
+| `@markuplint/parser-utils`    | Parser utilities, `searchIDLAttribute`        |
+| `unified`                     | Processor pipeline for remark                 |
+| `remark-parse`                | Markdown -> mdast parser                      |
+| `remark-gfm`                  | GFM extensions (tables, strikethrough)        |
+| `remark-mdx`                  | MDX syntax extensions (JSX, expressions, ESM) |
+| `remark-frontmatter`          | Front matter (YAML) support                   |
+
+## Directory Structure
+
+```
+src/
++-- index.ts              -- Re-exports parser instance
++-- parser.ts             -- MDXParser class, flattenMdastChildren helper
++-- index.spec.ts         -- Unit and integration tests
+```
+
+## Relationship to @markuplint/markdown-parser
+
+Both parsers share `MarkdownAwareParser` as a common base class:
+
+| Aspect          | markdown-parser (.md)      | mdx-parser (.mdx)                  |
+| --------------- | -------------------------- | ---------------------------------- |
+| Base class      | MarkdownAwareParser        | MarkdownAwareParser                |
+| HTML regions    | HtmlParser re-parse        | parseCodeFragment (XML-style)      |
+| JSX support     | No                         | Yes (components, expressions, ESM) |
+| Attribute style | HTML (`class`, `for`)      | JSX (`className`, `htmlFor`)       |
+| Tag closing     | HTML rules (void elements) | XML rules (self-closing required)  |
+| Spec package    | None needed                | `@markuplint/react-spec`           |

--- a/packages/@markuplint/mdx-parser/README.ja.md
+++ b/packages/@markuplint/mdx-parser/README.ja.md
@@ -1,0 +1,43 @@
+# @markuplint/mdx-parser
+
+[![npm version](https://badge.fury.io/js/%40markuplint%2Fmdx-parser.svg)](https://www.npmjs.com/package/@markuplint/mdx-parser)
+
+[**MDX**](https://mdxjs.com/) ファイルで **markuplint** を使用するためのパーサーです。
+
+JSX 要素、式、import/export を標準的な Markdown コンテンツと併せてパースします。Markdown 構文は対応する HTML 要素に変換され、markuplint のルールで解析できるようになります。[GFM](https://github.github.com/gfm/)（テーブル、取り消し線、オートリンク）および YAML フロントマターをサポートしています。
+
+## インストール
+
+```shell
+$ npm install -D @markuplint/mdx-parser
+
+$ yarn add -D @markuplint/mdx-parser
+```
+
+## 使い方
+
+[設定ファイル](https://markuplint.dev/configuration/#properties/parser)に `parser` と `specs` オプションを追加してください。
+
+```json
+{
+  "parser": {
+    ".mdx$": "@markuplint/mdx-parser"
+  },
+  "specs": {
+    ".mdx$": "@markuplint/react-spec"
+  }
+}
+```
+
+## 機能
+
+- **JSX 要素**: 自己閉じ（`<Badge />`）とコンテナ（`<Card>...</Card>`）の両方のコンポーネントに対応
+- **IDL 属性変換**: React スタイルの属性（例: `className`、`htmlFor`）を対応する HTML 属性に変換
+- **式**: `{variable}` や `{condition ? a : b}` を動的な値として扱う
+- **ESM import/export**: `import` 文と `export` 文をブロックとして認識
+- **JSX 内の Markdown**: JSX コンテナ内の Markdown コンテンツを再帰的にパース
+
+## 既知の制限事項
+
+- **MDX v2/v3 のみ**: MDX v1 構文はサポートされていません。
+- **合成された属性位置**: Markdown 構文から導出された属性（例: `[テキスト](url)` の `href`）は、属性値の正確な文字位置ではなく、Markdown 構文全体のソース位置を共有します。

--- a/packages/@markuplint/mdx-parser/README.md
+++ b/packages/@markuplint/mdx-parser/README.md
@@ -1,0 +1,43 @@
+# @markuplint/mdx-parser
+
+[![npm version](https://badge.fury.io/js/%40markuplint%2Fmdx-parser.svg)](https://www.npmjs.com/package/@markuplint/mdx-parser)
+
+Use **markuplint** with [**MDX**](https://mdxjs.com/) files.
+
+Parses JSX elements, expressions, and imports alongside standard Markdown content. Markdown constructs are converted to their corresponding HTML elements so that markuplint rules can analyze them. Supports [GFM](https://github.github.com/gfm/) (tables, strikethrough, autolinks) and YAML frontmatter.
+
+## Install
+
+```shell
+$ npm install -D @markuplint/mdx-parser
+
+$ yarn add -D @markuplint/mdx-parser
+```
+
+## Usage
+
+Add `parser` and `specs` options to your [configuration](https://markuplint.dev/configuration/#properties/parser).
+
+```json
+{
+  "parser": {
+    ".mdx$": "@markuplint/mdx-parser"
+  },
+  "specs": {
+    ".mdx$": "@markuplint/react-spec"
+  }
+}
+```
+
+## Features
+
+- **JSX elements**: Both self-closing (`<Badge />`) and container (`<Card>...</Card>`) components
+- **IDL attribute conversion**: React-style attributes (e.g., `className`, `htmlFor`) are mapped to their HTML equivalents
+- **Expressions**: `{variable}` and `{condition ? a : b}` are treated as dynamic values
+- **ESM imports/exports**: `import` and `export` statements are recognized as blocks
+- **Markdown inside JSX**: Markdown content within JSX containers is recursively parsed
+
+## Known Limitations
+
+- **MDX v2/v3 only**: MDX v1 syntax is not supported.
+- **Synthesized attribute positions**: Attributes derived from Markdown syntax (e.g., `href` from `[text](url)`) share the source position of the enclosing Markdown construct rather than pointing to the exact character range of the attribute value.

--- a/packages/@markuplint/mdx-parser/package.json
+++ b/packages/@markuplint/mdx-parser/package.json
@@ -1,0 +1,39 @@
+{
+	"name": "@markuplint/mdx-parser",
+	"version": "4.0.0",
+	"description": "MDX parser for markuplint",
+	"repository": "git@github.com:markuplint/markuplint.git",
+	"author": "Yusuke Hirao <yusukehirao@me.com>",
+	"license": "MIT",
+	"engines": {
+		"node": ">=22"
+	},
+	"type": "module",
+	"exports": {
+		".": {
+			"import": "./lib/index.js",
+			"types": "./lib/index.d.ts"
+		}
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"scripts": {
+		"build": "tsc --project tsconfig.build.json",
+		"dev": "tsc --watch --project tsconfig.build.json",
+		"clean": "tsc --build --clean tsconfig.build.json"
+	},
+	"dependencies": {
+		"@markuplint/markdown-parser": "4.0.0",
+		"@markuplint/ml-ast": "4.4.11",
+		"@markuplint/parser-utils": "4.8.11",
+		"remark-frontmatter": "5.0.0",
+		"remark-gfm": "4.0.1",
+		"remark-mdx": "3.1.1",
+		"remark-parse": "11.0.0",
+		"unified": "11.0.5"
+	},
+	"devDependencies": {
+		"@types/mdast": "4.0.4"
+	}
+}

--- a/packages/@markuplint/mdx-parser/src/index.spec.ts
+++ b/packages/@markuplint/mdx-parser/src/index.spec.ts
@@ -1,0 +1,922 @@
+import { describe, test, expect } from 'vitest';
+
+import { nodeListToDebugMaps } from '@markuplint/parser-utils';
+
+import { parser } from './parser.js';
+
+function parse(code: string) {
+	return parser.parse(code);
+}
+
+describe('MDXParser', () => {
+	describe('JSX elements', () => {
+		test('self-closing component', () => {
+			const doc = parse('<MyComponent prop="value" />');
+			const maps = nodeListToDebugMaps(doc.nodeList);
+			expect(maps).toStrictEqual(['[1:1]>[1:29](0,28)MyComponent: <MyComponent␣prop="value"␣/>']);
+		});
+
+		test('HTML element with children', () => {
+			const doc = parse('<div>hello</div>');
+			const maps = nodeListToDebugMaps(doc.nodeList);
+			expect(maps).toStrictEqual([
+				'[1:1]>[1:6](0,5)div: <div>',
+				'[1:6]>[1:11](5,10)#text: hello',
+				'[1:11]>[1:17](10,16)div: </div>',
+			]);
+		});
+
+		test('block-level JSX element', () => {
+			const doc = parse('<Card>\n  content\n</Card>\n');
+			const maps = nodeListToDebugMaps(doc.nodeList);
+			expect(maps[0]).toBe('[1:1]>[1:7](0,6)Card: <Card>');
+			expect(maps.at(-1)).toBe('[3:1]>[3:8](17,24)Card: </Card>');
+		});
+	});
+
+	describe('Component detection', () => {
+		test('uppercase name is authored element', () => {
+			const doc = parse('<MyComponent />');
+			const startTag = doc.nodeList.find(n => n?.type === 'starttag');
+			expect(startTag?.elementType).toBe('authored');
+		});
+
+		test('lowercase name is HTML element', () => {
+			const doc = parse('<div>x</div>');
+			const startTag = doc.nodeList.find(n => n?.type === 'starttag');
+			expect(startTag?.elementType).toBe('html');
+		});
+	});
+
+	describe('Expressions', () => {
+		test('block expression becomes psblock', () => {
+			const doc = parse('{1 + 1}');
+			const maps = nodeListToDebugMaps(doc.nodeList);
+			expect(maps).toStrictEqual(['[1:1]>[1:8](0,7)#ps:mdxFlowExpression: {1␣+␣1}']);
+		});
+
+		test('import becomes psblock', () => {
+			const doc = parse('import X from "./x"');
+			const maps = nodeListToDebugMaps(doc.nodeList);
+			expect(maps).toStrictEqual(['[1:1]>[1:20](0,19)#ps:mdxjsEsm: import␣X␣from␣"./x"']);
+		});
+
+		test('export becomes psblock', () => {
+			const doc = parse('export const x = 1');
+			const maps = nodeListToDebugMaps(doc.nodeList);
+			expect(maps).toStrictEqual(['[1:1]>[1:19](0,18)#ps:mdxjsEsm: export␣const␣x␣=␣1']);
+		});
+	});
+
+	describe('Markdown content', () => {
+		test('heading becomes h1 element', () => {
+			const doc = parse('# Hello');
+			const h1 = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'h1');
+			expect(h1).toBeDefined();
+			expect(h1!.elementType).toBe('html');
+		});
+
+		test.each([
+			['## H2', 'h2'],
+			['### H3', 'h3'],
+			['#### H4', 'h4'],
+			['##### H5', 'h5'],
+			['###### H6', 'h6'],
+		] as const)('heading %s becomes %s element', (md, tag) => {
+			const doc = parse(md);
+			const el = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === tag);
+			expect(el).toBeDefined();
+			expect(el!.elementType).toBe('html');
+		});
+
+		test('paragraph becomes p element', () => {
+			const doc = parse('Some text here.');
+			const p = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'p');
+			expect(p).toBeDefined();
+		});
+
+		test('emphasis becomes em element', () => {
+			const doc = parse('*emphasized*');
+			const em = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'em');
+			expect(em).toBeDefined();
+			const text = em!.childNodes.find(c => c.type === 'text');
+			expect(text).toBeDefined();
+			expect(text!.raw).toBe('emphasized');
+		});
+
+		test('strong becomes strong element', () => {
+			const doc = parse('**bold**');
+			const strong = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'strong');
+			expect(strong).toBeDefined();
+			const text = strong!.childNodes.find(c => c.type === 'text');
+			expect(text).toBeDefined();
+			expect(text!.raw).toBe('bold');
+		});
+
+		test('link becomes <a> with href', () => {
+			const doc = parse('[link](https://example.com)');
+			const a = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'a');
+			expect(a).toBeDefined();
+			const href = a!.attributes.find(attr => attr.type === 'attr' && attr.name.raw === 'href');
+			expect(href).toBeDefined();
+			expect(href!.value.raw).toBe('https://example.com');
+		});
+
+		test('image becomes <img> with src and alt', () => {
+			const doc = parse('![alt text](image.png)');
+			const img = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'img');
+			expect(img).toBeDefined();
+			const src = img!.attributes.find(attr => attr.type === 'attr' && attr.name.raw === 'src');
+			expect(src!.value.raw).toBe('image.png');
+			const alt = img!.attributes.find(attr => attr.type === 'attr' && attr.name.raw === 'alt');
+			expect(alt!.value.raw).toBe('alt text');
+		});
+	});
+
+	describe('Front matter', () => {
+		test('YAML front matter becomes psblock', () => {
+			const doc = parse('---\ntitle: Test\n---\n\n<div>x</div>\n');
+			const maps = nodeListToDebugMaps(doc.nodeList);
+			expect(maps[0]).toBe('[1:1]>[3:4](0,19)#ps:yaml: ---⏎title:␣Test⏎---');
+		});
+	});
+
+	describe('Error handling', () => {
+		test('unclosed JSX tag throws ParserError', () => {
+			// MDX requires explicit closing tags, unlike HTML.
+			// remark-mdx throws a ParserError when a tag is not closed.
+			expect(() => parse('<div>unclosed tag in MDX\n')).toThrow(/Expected a closing tag for `<div>`/);
+		});
+
+		test('invalid expression throws ParserError', () => {
+			// Malformed JS expressions inside {} are rejected by acorn.
+			expect(() => parse('{1 +}\n')).toThrow(/Could not parse expression with acorn/);
+		});
+
+		test('mismatched closing tag throws ParserError', () => {
+			// MDX enforces matching open/close tag names (XML-style).
+			expect(() => parse('<div>text</span>\n')).toThrow(
+				/Unexpected closing tag `<\/span>`, expected corresponding closing tag for `<div>`/,
+			);
+		});
+
+		test('empty input returns empty nodeList without throwing', () => {
+			const doc = parse('');
+			expect(doc.nodeList).toStrictEqual([]);
+		});
+	});
+
+	describe('Document metadata', () => {
+		test('isFragment is true', () => {
+			const doc = parse('<div>hello</div>');
+			expect(doc.isFragment).toBe(true);
+		});
+
+		test('raw preserves original source', () => {
+			const source = '# Hello\n\n<div>world</div>\n';
+			const doc = parse(source);
+			expect(doc.raw).toBe(source);
+		});
+	});
+
+	describe('JSX Fragments', () => {
+		test('fragment with children produces starttag node', () => {
+			const doc = parse('<>\n  <div>inside fragment</div>\n</>');
+			const maps = nodeListToDebugMaps(doc.nodeList);
+			expect(maps).toStrictEqual(['[1:1]>[1:3](0,2)#jsx-fragment: <>']);
+		});
+
+		test('fragment starttag has nodeName #jsx-fragment', () => {
+			const doc = parse('<>\n  <div>inside fragment</div>\n</>');
+			const startTag = doc.nodeList.find(n => n?.type === 'starttag');
+			expect(startTag?.nodeName).toBe('#jsx-fragment');
+		});
+	});
+
+	describe('Dot notation components', () => {
+		test('dot notation component is parsed as authored element', () => {
+			const doc = parse('<Layout.Header>content</Layout.Header>');
+			const maps = nodeListToDebugMaps(doc.nodeList);
+			expect(maps).toStrictEqual([
+				'[1:1]>[1:16](0,15)Layout.Header: <Layout.Header>',
+				'[1:16]>[1:23](15,22)#text: content',
+				'[1:23]>[1:39](22,38)Layout.Header: </Layout.Header>',
+			]);
+		});
+
+		test('dot notation elementType is authored', () => {
+			const doc = parse('<Layout.Header>content</Layout.Header>');
+			const startTag = doc.nodeList.find(n => n?.type === 'starttag');
+			expect(startTag?.elementType).toBe('authored');
+		});
+	});
+
+	describe('Expression attributes', () => {
+		test('curly-brace attribute values are marked as dynamic', () => {
+			const doc = parse('<Component data={value} style={{ color: "red" }} />');
+			const startTag = doc.nodeList.find(n => n?.type === 'starttag');
+			expect(startTag).toBeDefined();
+			const attrs = startTag!.attributes;
+			expect(attrs).toHaveLength(2);
+
+			const dataAttr = attrs.find(a => a.type === 'attr' && a.name.raw === 'data');
+			expect(dataAttr).toBeDefined();
+			expect(dataAttr!.isDynamicValue).toBe(true);
+			expect(dataAttr!.value.raw).toBe('value');
+
+			const styleAttr = attrs.find(a => a.type === 'attr' && a.name.raw === 'style');
+			expect(styleAttr).toBeDefined();
+			expect(styleAttr!.isDynamicValue).toBe(true);
+			expect(styleAttr!.value.raw).toBe('{ color: "red" }');
+		});
+
+		test('debug map for expression attributes', () => {
+			const doc = parse('<Component data={value} style={{ color: "red" }} />');
+			const maps = nodeListToDebugMaps(doc.nodeList);
+			expect(maps).toStrictEqual([
+				'[1:1]>[1:52](0,51)Component: <Component␣data={value}␣style={{␣color:␣"red"␣}}␣/>',
+			]);
+		});
+	});
+
+	describe('Spread attributes', () => {
+		test('spread attribute is detected as spread type', () => {
+			const doc = parse('<Component {...props} />');
+			const startTag = doc.nodeList.find(n => n?.type === 'starttag');
+			expect(startTag).toBeDefined();
+			const attrs = startTag!.attributes;
+			expect(attrs).toHaveLength(1);
+			expect(attrs[0].type).toBe('spread');
+			expect(attrs[0].raw).toBe('{...props}');
+		});
+
+		test('debug map for spread attribute element', () => {
+			const doc = parse('<Component {...props} />');
+			const maps = nodeListToDebugMaps(doc.nodeList);
+			expect(maps).toStrictEqual(['[1:1]>[1:25](0,24)Component: <Component␣{...props}␣/>']);
+		});
+	});
+
+	describe('Nested JSX elements', () => {
+		test('outer element wraps inner as child', () => {
+			const doc = parse('<Outer>\n  <Inner>content</Inner>\n</Outer>');
+			const maps = nodeListToDebugMaps(doc.nodeList);
+			expect(maps[0]).toBe('[1:1]>[1:8](0,7)Outer: <Outer>');
+			expect(maps.at(-1)).toBe('[3:1]>[3:9](33,41)Outer: </Outer>');
+		});
+
+		test('inner JSX element appears in nodeList', () => {
+			const doc = parse('<Outer>\n  <Inner>content</Inner>\n</Outer>');
+			const maps = nodeListToDebugMaps(doc.nodeList);
+			// remark-mdx wraps inline children in a paragraph; now parsed as p element
+			expect(maps[1]).toBe('[2:3]>[2:10](10,17)Inner: <Inner>');
+		});
+
+		test('outer element types are authored', () => {
+			const doc = parse('<Outer>\n  <Inner>content</Inner>\n</Outer>');
+			const outerStart = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'Outer');
+			expect(outerStart?.elementType).toBe('authored');
+		});
+	});
+
+	describe('Mixed content in paragraphs (inline JSX)', () => {
+		test('paragraph with inline JSX is unwrapped into individual nodes', () => {
+			const doc = parse('Text with <Badge color="blue">inline</Badge> component.');
+			const maps = nodeListToDebugMaps(doc.nodeList);
+			expect(maps).toStrictEqual([
+				'[1:1]>[1:11](0,10)#text: Text␣with␣',
+				'[1:11]>[1:31](10,30)Badge: <Badge␣color="blue">',
+				'[1:31]>[1:37](30,36)#text: inline',
+				'[1:37]>[1:45](36,44)Badge: </Badge>',
+				'[1:45]>[1:56](44,55)#text: ␣component.',
+			]);
+		});
+
+		test('inline JSX component is authored element', () => {
+			const doc = parse('Text with <Badge color="blue">inline</Badge> component.');
+			const badge = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'Badge');
+			expect(badge?.elementType).toBe('authored');
+		});
+	});
+
+	describe('JSX comments', () => {
+		test('JSX comment becomes mdxFlowExpression psblock', () => {
+			const doc = parse('{/* This is a comment */}');
+			const maps = nodeListToDebugMaps(doc.nodeList);
+			expect(maps).toStrictEqual(['[1:1]>[1:26](0,25)#ps:mdxFlowExpression: {/*␣This␣is␣a␣comment␣*/}']);
+		});
+	});
+
+	describe('Multiple imports with component usage', () => {
+		test('imports are combined into single ESM psblock', () => {
+			const doc = parse(
+				'import { Alert } from "./Alert"\nimport { Badge } from "./Badge"\n\n<Alert type="warning">\n  <Badge>NEW</Badge>\n</Alert>',
+			);
+			const maps = nodeListToDebugMaps(doc.nodeList);
+
+			// Both imports become a single mdxjsEsm psblock
+			expect(maps[0]).toBe(
+				'[1:1]>[2:32](0,63)#ps:mdxjsEsm: import␣{␣Alert␣}␣from␣"./Alert"⏎import␣{␣Badge␣}␣from␣"./Badge"',
+			);
+
+			// Alert element start tag
+			expect(maps[1]).toBe('[4:1]>[4:23](65,87)Alert: <Alert␣type="warning">');
+
+			// Alert element end tag
+			expect(maps.at(-1)).toBe('[6:1]>[6:9](109,117)Alert: </Alert>');
+		});
+
+		test('Alert component is authored', () => {
+			const doc = parse(
+				'import { Alert } from "./Alert"\nimport { Badge } from "./Badge"\n\n<Alert type="warning">\n  <Badge>NEW</Badge>\n</Alert>',
+			);
+			const alert = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'Alert');
+			expect(alert?.elementType).toBe('authored');
+		});
+	});
+
+	describe('Markdown mixed with JSX', () => {
+		test('realistic MDX document structure', () => {
+			const doc = parse('# Heading\n\nSome paragraph text.\n\n<Card>content</Card>\n\nMore paragraph text.');
+			const maps = nodeListToDebugMaps(doc.nodeList);
+			expect(maps).toStrictEqual([
+				'[1:1]>[1:10](0,9)h1: #␣Heading',
+				'[1:3]>[1:10](2,9)#text: Heading',
+				'[3:1]>[3:21](11,31)p: Some␣paragraph␣text.',
+				'[3:1]>[3:21](11,31)#text: Some␣paragraph␣text.',
+				'[5:1]>[5:7](33,39)Card: <Card>',
+				'[5:7]>[5:14](39,46)#text: content',
+				'[5:14]>[5:21](46,53)Card: </Card>',
+				'[7:1]>[7:21](55,75)p: More␣paragraph␣text.',
+				'[7:1]>[7:21](55,75)#text: More␣paragraph␣text.',
+			]);
+		});
+
+		test('heading is an h1 element', () => {
+			const doc = parse('# Heading\n\nSome paragraph text.\n\n<Card>content</Card>\n\nMore paragraph text.');
+			const heading = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'h1');
+			expect(heading).toBeDefined();
+			expect(heading!.type).toBe('starttag');
+		});
+
+		test('Card element is authored', () => {
+			const doc = parse('# Heading\n\nSome paragraph text.\n\n<Card>content</Card>\n\nMore paragraph text.');
+			const card = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'Card');
+			expect(card?.elementType).toBe('authored');
+		});
+	});
+
+	describe('Boolean attributes in JSX', () => {
+		test('boolean attributes have empty value', () => {
+			const doc = parse('<Input disabled required name="email" />');
+			const startTag = doc.nodeList.find(n => n?.type === 'starttag');
+			expect(startTag).toBeDefined();
+			const attrs = startTag!.attributes;
+			expect(attrs).toHaveLength(3);
+
+			const disabled = attrs.find(a => a.type === 'attr' && a.name.raw === 'disabled');
+			expect(disabled).toBeDefined();
+			expect(disabled!.value.raw).toBe('');
+
+			const required = attrs.find(a => a.type === 'attr' && a.name.raw === 'required');
+			expect(required).toBeDefined();
+			expect(required!.value.raw).toBe('');
+
+			const name = attrs.find(a => a.type === 'attr' && a.name.raw === 'name');
+			expect(name).toBeDefined();
+			expect(name!.value.raw).toBe('email');
+		});
+
+		test('debug map for boolean attributes', () => {
+			const doc = parse('<Input disabled required name="email" />');
+			const maps = nodeListToDebugMaps(doc.nodeList);
+			expect(maps).toStrictEqual(['[1:1]>[1:41](0,40)Input: <Input␣disabled␣required␣name="email"␣/>']);
+		});
+	});
+
+	describe('Self-closing HTML void elements in MDX', () => {
+		test('void elements are parsed as individual nodes', () => {
+			const doc = parse('<br />\n<hr />\n<img src="test.png" alt="test" />');
+			const maps = nodeListToDebugMaps(doc.nodeList);
+			expect(maps).toStrictEqual([
+				'[1:1]>[1:7](0,6)br: <br␣/>',
+				'[2:1]>[2:7](7,13)hr: <hr␣/>',
+				'[3:1]>[3:34](14,47)img: <img␣src="test.png"␣alt="test"␣/>',
+			]);
+		});
+
+		test('void elements are html type', () => {
+			const doc = parse('<br />\n<hr />\n<img src="test.png" alt="test" />');
+			const br = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'br');
+			const hr = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'hr');
+			const img = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'img');
+			expect(br?.elementType).toBe('html');
+			expect(hr?.elementType).toBe('html');
+			expect(img?.elementType).toBe('html');
+		});
+
+		test('img element has attributes', () => {
+			const doc = parse('<br />\n<hr />\n<img src="test.png" alt="test" />');
+			const img = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'img');
+			expect(img).toBeDefined();
+			expect(img!.attributes).toHaveLength(2);
+
+			const src = img!.attributes.find(a => a.type === 'attr' && a.name.raw === 'src');
+			expect(src).toBeDefined();
+			expect(src!.value.raw).toBe('test.png');
+
+			const alt = img!.attributes.find(a => a.type === 'attr' && a.name.raw === 'alt');
+			expect(alt).toBeDefined();
+			expect(alt!.value.raw).toBe('test');
+		});
+	});
+
+	describe('Empty component (no children, no attributes)', () => {
+		test('empty self-closing component is parsed correctly', () => {
+			const doc = parse('<Spacer />');
+			const maps = nodeListToDebugMaps(doc.nodeList);
+			expect(maps).toStrictEqual(['[1:1]>[1:11](0,10)Spacer: <Spacer␣/>']);
+		});
+
+		test('empty component is authored element', () => {
+			const doc = parse('<Spacer />');
+			const startTag = doc.nodeList.find(n => n?.type === 'starttag');
+			expect(startTag?.elementType).toBe('authored');
+			expect(startTag?.nodeName).toBe('Spacer');
+		});
+
+		test('empty component has no attributes', () => {
+			const doc = parse('<Spacer />');
+			const startTag = doc.nodeList.find(n => n?.type === 'starttag');
+			expect(startTag).toBeDefined();
+			expect(startTag!.attributes).toHaveLength(0);
+		});
+	});
+
+	describe('Link and image references', () => {
+		test('linkReference resolves to <a> element', () => {
+			const doc = parse('[link text][ref]\n\n[ref]: https://example.com "Example"\n');
+			const a = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'a');
+			expect(a).toBeDefined();
+			const href = a!.attributes.find(attr => attr.type === 'attr' && attr.name.raw === 'href');
+			expect(href).toBeDefined();
+			expect(href!.value.raw).toBe('https://example.com');
+			const title = a!.attributes.find(attr => attr.type === 'attr' && attr.name.raw === 'title');
+			expect(title).toBeDefined();
+			expect(title!.value.raw).toBe('Example');
+		});
+
+		test('linkReference without title does NOT have title attribute', () => {
+			const doc = parse('[link text][ref]\n\n[ref]: https://example.com\n');
+			const a = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'a');
+			expect(a).toBeDefined();
+			const title = a!.attributes.find(attr => attr.type === 'attr' && attr.name.raw === 'title');
+			expect(title).toBeUndefined();
+			expect(a!.attributes.length).toBe(1);
+		});
+
+		test('imageReference resolves to <img> element with alt', () => {
+			const doc = parse('![alt text][img]\n\n[img]: image.png\n');
+			const img = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'img');
+			expect(img).toBeDefined();
+			const src = img!.attributes.find(attr => attr.type === 'attr' && attr.name.raw === 'src');
+			expect(src).toBeDefined();
+			expect(src!.value.raw).toBe('image.png');
+			const alt = img!.attributes.find(attr => attr.type === 'attr' && attr.name.raw === 'alt');
+			expect(alt).toBeDefined();
+			expect(alt!.value.raw).toBe('alt text');
+		});
+
+		test('unresolved linkReference is treated as plain text', () => {
+			const doc = parse('[text][missing]\n');
+			const a = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'a');
+			expect(a).toBeUndefined();
+			const text = doc.nodeList.find(n => n?.type === 'text');
+			expect(text).toBeDefined();
+			expect(text!.raw).toContain('[text][missing]');
+		});
+
+		test('unresolved imageReference is treated as plain text', () => {
+			const doc = parse('![alt][missing]\n');
+			const img = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'img');
+			expect(img).toBeUndefined();
+			const text = doc.nodeList.find(n => n?.type === 'text');
+			expect(text).toBeDefined();
+			expect(text!.raw).toContain('![alt][missing]');
+		});
+	});
+
+	describe('Blockquote with JSX', () => {
+		test('JSX inside blockquote is parsed correctly', () => {
+			const doc = parse('> <Badge>test</Badge>\n');
+			const blockquote = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'blockquote');
+			expect(blockquote).toBeDefined();
+			const badge = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'Badge');
+			expect(badge).toBeDefined();
+			expect(badge!.elementType).toBe('authored');
+			const text = badge!.childNodes.find(c => c.type === 'text');
+			expect(text).toBeDefined();
+			expect(text!.raw).toBe('test');
+		});
+	});
+
+	describe('HTML nodes in MDX', () => {
+		test('HTML comment syntax is invalid in MDX v2 (use JSX comment instead)', () => {
+			// MDX v2 does not support HTML comments; it requires {/* */} syntax
+			expect(() => parse('<!-- comment -->\n')).toThrow(/Unexpected character `!`/);
+		});
+
+		test('JSX comment is valid alternative to HTML comment', () => {
+			const doc = parse('{/* comment */}\n');
+			const psblock = doc.nodeList.find(n => n?.type === 'psblock');
+			expect(psblock).toBeDefined();
+			expect(psblock!.raw).toContain('/* comment */');
+		});
+	});
+
+	describe('Footnotes', () => {
+		test('footnoteReference becomes psblock with correct raw', () => {
+			const doc = parse('Text with a note[^1]\n\n[^1]: Footnote content\n');
+			const fnRef = doc.nodeList.find(n => n?.type === 'psblock' && n.nodeName === '#ps:footnoteReference');
+			expect(fnRef).toBeDefined();
+			expect(fnRef!.nodeName).toBe('#ps:footnoteReference');
+			expect(fnRef!.raw).toBe('[^1]');
+		});
+
+		test('footnoteDefinition becomes psblock with correct raw', () => {
+			const doc = parse('Text with a note[^1]\n\n[^1]: Footnote content\n');
+			const fnDef = doc.nodeList.find(n => n?.type === 'psblock' && n.nodeName === '#ps:footnoteDefinition');
+			expect(fnDef).toBeDefined();
+			expect(fnDef!.nodeName).toBe('#ps:footnoteDefinition');
+			expect(fnDef!.raw).toContain('Footnote content');
+		});
+	});
+
+	describe('State isolation between parse() calls', () => {
+		test('definitions do not leak across MDX parse() calls', () => {
+			// First parse: define [ref]
+			const doc1 = parse('[link][ref]\n\n[ref]: https://example.com\n');
+			const a1 = doc1.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'a');
+			expect(a1).toBeDefined();
+
+			// Second parse: [ref] without definition — should NOT resolve
+			const doc2 = parse('[link][ref]\n');
+			const a2 = doc2.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'a');
+			expect(a2).toBeUndefined();
+			const text = doc2.nodeList.find(n => n?.type === 'text');
+			expect(text).toBeDefined();
+			expect(text!.raw).toContain('[link][ref]');
+		});
+
+		test('table header state does not leak across MDX parse() calls', () => {
+			const doc1 = parse('| A |\n| - |\n| 1 |\n');
+			const ths1 = doc1.nodeList.filter(n => n?.type === 'starttag' && n.nodeName === 'th');
+			expect(ths1.length).toBe(1);
+
+			const doc2 = parse('| B |\n| - |\n| 2 |\n');
+			const ths2 = doc2.nodeList.filter(n => n?.type === 'starttag' && n.nodeName === 'th');
+			expect(ths2.length).toBe(1);
+			const tds2 = doc2.nodeList.filter(n => n?.type === 'starttag' && n.nodeName === 'td');
+			expect(tds2.length).toBe(1);
+		});
+	});
+
+	describe('Inline expression in paragraph (flattenMdastChildren)', () => {
+		test('paragraph with inline expression is unwrapped', () => {
+			const doc = parse('Text {variable} more text');
+			const expr = doc.nodeList.find(n => n?.type === 'psblock' && n.nodeName === '#ps:mdxTextExpression');
+			expect(expr).toBeDefined();
+			expect(expr!.raw).toBe('{variable}');
+		});
+
+		test('paragraph without JSX or expressions is preserved as <p>', () => {
+			const doc = parse('Just plain paragraph text.');
+			const p = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'p');
+			expect(p).toBeDefined();
+			// No unwrapping happened — text is inside <p>
+			const text = p!.childNodes.find(c => c.type === 'text');
+			expect(text).toBeDefined();
+			expect(text!.raw).toBe('Just plain paragraph text.');
+		});
+	});
+
+	describe('MDX inline code and code blocks', () => {
+		test('inline code in MDX produces <code> element', () => {
+			const doc = parse('Use `const x = 1` here');
+			const code = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'code');
+			expect(code).toBeDefined();
+			expect(code!.childNodes.length).toBe(1);
+			expect(code!.childNodes[0].raw).toBe('const x = 1');
+		});
+
+		test('fenced code block in MDX produces pre>code elements', () => {
+			const doc = parse('```typescript\nconst x: number = 1;\n```\n');
+			const pre = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'pre');
+			expect(pre).toBeDefined();
+			const code = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'code');
+			expect(code).toBeDefined();
+			const langAttr = code!.attributes.find(a => a.type === 'attr' && a.name.raw === 'class');
+			expect(langAttr).toBeDefined();
+			expect(langAttr!.value.raw).toBe('language-typescript');
+			expect(code!.childNodes.length).toBe(1);
+			expect(code!.childNodes[0].raw).toBe('const x: number = 1;');
+		});
+	});
+
+	describe('Export default', () => {
+		test('export default function becomes mdxjsEsm psblock', () => {
+			const doc = parse('export default function Layout() {}\n');
+			const esm = doc.nodeList.find(n => n?.type === 'psblock' && n.nodeName === '#ps:mdxjsEsm');
+			expect(esm).toBeDefined();
+			expect(esm!.raw).toContain('export default function Layout');
+		});
+
+		test('export default object expression', () => {
+			const doc = parse("export default { title: 'My Page' }\n");
+			const esm = doc.nodeList.find(n => n?.type === 'psblock' && n.nodeName === '#ps:mdxjsEsm');
+			expect(esm).toBeDefined();
+			expect(esm!.raw).toContain('export default');
+		});
+	});
+
+	describe('Multiple named exports', () => {
+		test('multiple export const statements become mdxjsEsm psblock', () => {
+			const doc = parse('export const a = 1\nexport const b = 2\n');
+			const esmBlocks = doc.nodeList.filter(n => n?.type === 'psblock' && n.nodeName === '#ps:mdxjsEsm');
+			// remark-mdx combines adjacent exports into one ESM block
+			expect(esmBlocks.length).toBeGreaterThanOrEqual(1);
+			const raw = esmBlocks.map(e => e.raw).join('');
+			expect(raw).toContain('export const a');
+			expect(raw).toContain('export const b');
+		});
+	});
+
+	describe('Multi-line JSX attributes', () => {
+		test('attributes spanning multiple lines are parsed correctly', () => {
+			const doc = parse('<Component\n  name="test"\n  value={42}\n  disabled\n/>\n');
+			const startTag = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'Component');
+			expect(startTag).toBeDefined();
+			expect(startTag!.attributes.length).toBe(3);
+			const name = startTag!.attributes.find(a => a.type === 'attr' && a.name.raw === 'name');
+			expect(name).toBeDefined();
+			expect(name!.value.raw).toBe('test');
+			const value = startTag!.attributes.find(a => a.type === 'attr' && a.name.raw === 'value');
+			expect(value).toBeDefined();
+			expect(value!.isDynamicValue).toBe(true);
+			expect(value!.value.raw).toBe('42');
+			const disabled = startTag!.attributes.find(a => a.type === 'attr' && a.name.raw === 'disabled');
+			expect(disabled).toBeDefined();
+			expect(disabled!.value.raw).toBe('');
+		});
+	});
+
+	describe('JSX children templates', () => {
+		test('nested component structure (Card > CardHeader + CardBody)', () => {
+			const doc = parse('<Card>\n  <CardHeader>Title</CardHeader>\n  <CardBody>Content</CardBody>\n</Card>\n');
+			const card = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'Card');
+			expect(card).toBeDefined();
+			expect(card!.elementType).toBe('authored');
+			const header = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'CardHeader');
+			expect(header).toBeDefined();
+			expect(header!.elementType).toBe('authored');
+			const body = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'CardBody');
+			expect(body).toBeDefined();
+			expect(body!.elementType).toBe('authored');
+		});
+	});
+
+	describe('Markdown inside JSX', () => {
+		test('Markdown heading inside JSX component', () => {
+			const doc = parse('<Callout>\n\n## Warning\n\nBe careful\n\n</Callout>\n');
+			const callout = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'Callout');
+			expect(callout).toBeDefined();
+			const h2 = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'h2');
+			expect(h2).toBeDefined();
+			const p = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'p');
+			expect(p).toBeDefined();
+		});
+	});
+
+	describe('Multiple inline JSX in paragraph', () => {
+		test('multiple JSX elements in same paragraph', () => {
+			const doc = parse('<Badge>A</Badge> and <Badge>B</Badge>\n');
+			const badges = doc.nodeList.filter(n => n?.type === 'starttag' && n.nodeName === 'Badge');
+			expect(badges.length).toBe(2);
+			const texts = badges.map(b => b.childNodes.find(c => c.type === 'text')?.raw);
+			expect(texts).toStrictEqual(['A', 'B']);
+		});
+	});
+
+	describe('Empty open/close tags (no children)', () => {
+		test('element with explicit closing tag but no children', () => {
+			const doc = parse('<div></div>\n');
+			const div = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'div');
+			expect(div).toBeDefined();
+			expect(div!.elementType).toBe('html');
+		});
+
+		test('authored component with explicit closing tag but no children', () => {
+			const doc = parse('<Container></Container>\n');
+			const el = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'Container');
+			expect(el).toBeDefined();
+			expect(el!.elementType).toBe('authored');
+		});
+	});
+
+	describe('Expression attribute with complex value', () => {
+		test('ternary expression in attribute value', () => {
+			const doc = parse('<Component value={isActive ? "yes" : "no"} />\n');
+			const startTag = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'Component');
+			expect(startTag).toBeDefined();
+			const attr = startTag!.attributes.find(a => a.type === 'attr' && a.name.raw === 'value');
+			expect(attr).toBeDefined();
+			expect(attr!.isDynamicValue).toBe(true);
+			expect(attr!.value.raw).toBe('isActive ? "yes" : "no"');
+		});
+
+		test('array expression in attribute value', () => {
+			const doc = parse('<Component items={[1, 2, 3]} />\n');
+			const startTag = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'Component');
+			expect(startTag).toBeDefined();
+			const attr = startTag!.attributes.find(a => a.type === 'attr' && a.name.raw === 'items');
+			expect(attr).toBeDefined();
+			expect(attr!.isDynamicValue).toBe(true);
+			expect(attr!.value.raw).toBe('[1, 2, 3]');
+		});
+	});
+
+	describe('IDL attribute name conversion', () => {
+		test('className is mapped to class as potentialName', () => {
+			const doc = parse('<div className="test">text</div>\n');
+			const div = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'div');
+			expect(div).toBeDefined();
+			const attr = div!.attributes.find(a => a.type === 'attr' && a.name.raw === 'className');
+			expect(attr).toBeDefined();
+			expect(attr!.potentialName).toBe('class');
+			// candidate is not set because rawName === idlPropName ("className")
+		});
+
+		test('htmlFor is mapped to for as potentialName', () => {
+			const doc = parse('<label htmlFor="input-id">Label</label>\n');
+			const label = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'label');
+			expect(label).toBeDefined();
+			const attr = label!.attributes.find(a => a.type === 'attr' && a.name.raw === 'htmlFor');
+			expect(attr).toBeDefined();
+			expect(attr!.potentialName).toBe('for');
+			// candidate is not set because rawName === idlPropName ("htmlFor")
+		});
+
+		test('class in JSX gets candidate set to className (rawName differs from IDL name)', () => {
+			const doc = parse('<div class="test">text</div>\n');
+			const div = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'div');
+			expect(div).toBeDefined();
+			const attr = div!.attributes.find(a => a.type === 'attr' && a.name.raw === 'class');
+			expect(attr).toBeDefined();
+			expect(attr!.candidate).toBe('className');
+		});
+	});
+
+	describe('MDX Markdown elements', () => {
+		test('unordered list in MDX', () => {
+			const doc = parse('- item 1\n- item 2\n');
+			const ul = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'ul');
+			expect(ul).toBeDefined();
+			const lis = doc.nodeList.filter(n => n?.type === 'starttag' && n.nodeName === 'li');
+			expect(lis.length).toBe(2);
+		});
+
+		test('thematicBreak in MDX (with content around it to avoid frontmatter)', () => {
+			const doc = parse('Text above\n\n---\n\nText below\n');
+			const hr = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'hr');
+			expect(hr).toBeDefined();
+		});
+
+		test('hard line break in MDX (two trailing spaces)', () => {
+			const doc = parse('line one  \nline two\n');
+			const br = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'br');
+			expect(br).toBeDefined();
+		});
+	});
+
+	describe('List with JSX content', () => {
+		test('list items containing JSX components', () => {
+			const doc = parse('- <Badge>item 1</Badge>\n- <Badge>item 2</Badge>\n');
+			const ul = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'ul');
+			expect(ul).toBeDefined();
+			const badges = doc.nodeList.filter(n => n?.type === 'starttag' && n.nodeName === 'Badge');
+			expect(badges.length).toBe(2);
+		});
+	});
+
+	describe('Heading with JSX', () => {
+		test('heading containing inline JSX component', () => {
+			const doc = parse('# Hello <Badge>New</Badge>\n');
+			const h1 = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'h1');
+			expect(h1).toBeDefined();
+			const badge = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'Badge');
+			expect(badge).toBeDefined();
+			expect(badge!.elementType).toBe('authored');
+		});
+	});
+
+	describe('Deep nesting JSX', () => {
+		test('three levels of nested JSX components', () => {
+			const doc = parse('<Level1>\n  <Level2>\n    <Level3>deep</Level3>\n  </Level2>\n</Level1>\n');
+			const l1 = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'Level1');
+			const l2 = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'Level2');
+			const l3 = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'Level3');
+			expect(l1).toBeDefined();
+			expect(l2).toBeDefined();
+			expect(l3).toBeDefined();
+			expect(l1!.elementType).toBe('authored');
+			expect(l2!.elementType).toBe('authored');
+			expect(l3!.elementType).toBe('authored');
+		});
+	});
+
+	describe('Consecutive expressions', () => {
+		test('multiple flow expressions in sequence', () => {
+			const doc = parse('{a}\n\n{b}\n\n{c}\n');
+			const exprs = doc.nodeList.filter(n => n?.type === 'psblock' && n.raw.startsWith('{'));
+			expect(exprs.length).toBe(3);
+			expect(exprs[0].raw).toBe('{a}');
+			expect(exprs[1].raw).toBe('{b}');
+			expect(exprs[2].raw).toBe('{c}');
+		});
+	});
+
+	describe('Empty expression', () => {
+		test('expression with only a comment', () => {
+			const doc = parse('{/* empty */}\n');
+			const expr = doc.nodeList.find(n => n?.type === 'psblock');
+			expect(expr).toBeDefined();
+			expect(expr!.raw).toBe('{/* empty */}');
+		});
+	});
+
+	describe('GFM autolink with JSX', () => {
+		test('autolink URL and JSX component in same paragraph', () => {
+			const doc = parse('Visit https://example.com and <Badge>click</Badge>\n');
+			const badge = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'Badge');
+			expect(badge).toBeDefined();
+			const a = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'a');
+			expect(a).toBeDefined();
+			const href = a!.attributes.find(attr => attr.type === 'attr' && attr.name.raw === 'href');
+			expect(href).toBeDefined();
+			expect(href!.value.raw).toBe('https://example.com');
+		});
+	});
+
+	describe('flattenMdastChildren: expression-only paragraph', () => {
+		test('paragraph containing only an expression is unwrapped (no <p>)', () => {
+			const doc = parse('{variable}\n');
+			const expr = doc.nodeList.find(n => n?.type === 'psblock');
+			expect(expr).toBeDefined();
+			const p = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'p');
+			expect(p).toBeUndefined();
+		});
+	});
+
+	describe('GFM extensions', () => {
+		test('GFM table produces table>tr>th/td elements', () => {
+			const doc = parse('| A | B |\n| - | - |\n| 1 | 2 |\n');
+			const table = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'table');
+			expect(table).toBeDefined();
+			const ths = doc.nodeList.filter(n => n?.type === 'starttag' && n.nodeName === 'th');
+			expect(ths.length).toBe(2);
+			const tds = doc.nodeList.filter(n => n?.type === 'starttag' && n.nodeName === 'td');
+			expect(tds.length).toBe(2);
+		});
+
+		test('GFM table header cells contain correct text', () => {
+			const doc = parse('| Name | Age |\n| - | - |\n| Alice | 30 |\n');
+			const ths = doc.nodeList.filter(n => n?.type === 'starttag' && n.nodeName === 'th');
+			expect(ths.length).toBe(2);
+			const thTexts = ths.map(th => th.childNodes.find(c => c.type === 'text')?.raw);
+			expect(thTexts).toStrictEqual(['Name', 'Age']);
+		});
+
+		test('GFM table with only header row has 0 td cells', () => {
+			const doc = parse('| A | B |\n| - | - |\n');
+			const ths = doc.nodeList.filter(n => n?.type === 'starttag' && n.nodeName === 'th');
+			expect(ths.length).toBe(2);
+			const tds = doc.nodeList.filter(n => n?.type === 'starttag' && n.nodeName === 'td');
+			expect(tds.length).toBe(0);
+		});
+
+		test('GFM strikethrough becomes <del> element', () => {
+			const doc = parse('~~deleted~~\n');
+			const del = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'del');
+			expect(del).toBeDefined();
+		});
+
+		test('GFM strikethrough contains correct text content', () => {
+			const doc = parse('~~deleted text~~\n');
+			const del = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'del');
+			expect(del).toBeDefined();
+			const text = del!.childNodes.find(c => c.type === 'text');
+			expect(text).toBeDefined();
+			expect(text!.raw).toBe('deleted text');
+		});
+	});
+});

--- a/packages/@markuplint/mdx-parser/src/index.ts
+++ b/packages/@markuplint/mdx-parser/src/index.ts
@@ -1,0 +1,4 @@
+/**
+ * @module @markuplint/mdx-parser
+ */
+export { parser } from './parser.js';

--- a/packages/@markuplint/mdx-parser/src/parser.ts
+++ b/packages/@markuplint/mdx-parser/src/parser.ts
@@ -1,0 +1,324 @@
+import type { MLASTNodeTreeItem, MLASTParentNode } from '@markuplint/ml-ast';
+import type { Token } from '@markuplint/parser-utils';
+import type { RootContent } from 'mdast';
+import type { MdxJsxFlowElement, MdxJsxTextElement } from 'mdast-util-mdx-jsx';
+
+import { MarkdownAwareParser } from '@markuplint/markdown-parser';
+import { searchIDLAttribute } from '@markuplint/parser-utils';
+import remarkFrontmatter from 'remark-frontmatter';
+import remarkGfm from 'remark-gfm';
+import remarkMdx from 'remark-mdx';
+import remarkParse from 'remark-parse';
+import { unified } from 'unified';
+
+type MdastNode = RootContent;
+
+/**
+ * Parser for MDX files that maps JSX elements to markuplint's AST.
+ *
+ * Uses remark-parse + remark-mdx to produce an MDX-extended mdast,
+ * then converts JSX elements to MLASTElement nodes and delegates
+ * Markdown content to the shared MarkdownAwareParser base class.
+ */
+class MDXParser extends MarkdownAwareParser {
+	constructor() {
+		super({
+			endTagType: 'xml',
+			booleanish: true,
+			tagNameCaseSensitive: true,
+		});
+	}
+
+	/**
+	 * Tokenizes the raw MDX source into an mdast tree.
+	 *
+	 * Resets parser state, parses via remark (with GFM, MDX, and frontmatter
+	 * plugins), collects link/image reference definitions, and flattens
+	 * JSX elements out of paragraph wrappers.
+	 *
+	 * @returns The flattened mdast children and fragment flag.
+	 */
+	tokenize() {
+		this.resetMarkdownState();
+
+		const processor = unified().use(remarkParse).use(remarkGfm).use(remarkMdx).use(remarkFrontmatter, ['yaml']);
+
+		const mdast = processor.parse(this.rawCode);
+
+		this.collectDefinitions(mdast.children);
+
+		return {
+			ast: flattenMdastChildren(mdast.children),
+			isFragment: true,
+		};
+	}
+
+	/**
+	 * Converts a single mdast node into markuplint AST nodes.
+	 *
+	 * Handles MDX-specific nodes (JSX elements, expressions, ESM imports/exports)
+	 * first, then delegates to the shared `nodeizeMarkdownNode()` for common
+	 * Markdown constructs.
+	 *
+	 * @param originNode - The mdast node to convert.
+	 * @param parentNode - Parent AST node, or `null` for top-level.
+	 * @param depth - Current nesting depth.
+	 * @returns An array of markuplint AST nodes.
+	 */
+	nodeize(
+		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+		originNode: MdastNode,
+		parentNode: MLASTParentNode | null,
+		depth: number,
+	) {
+		const position = originNode.position;
+		if (!position) {
+			return [];
+		}
+
+		const offset = position.start.offset ?? 0;
+		const endOffset = position.end.offset ?? offset;
+		const token = this.sliceFragment(offset, endOffset);
+
+		// MDX-specific node types first
+		switch (originNode.type) {
+			case 'mdxJsxFlowElement':
+			case 'mdxJsxTextElement': {
+				return this.#visitJsxElement(originNode, token, depth, parentNode);
+			}
+			case 'mdxFlowExpression':
+			case 'mdxTextExpression': {
+				return this.visitPsBlock({
+					...token,
+					depth,
+					parentNode,
+					nodeName: originNode.type,
+					isFragment: false,
+				});
+			}
+			case 'mdxjsEsm': {
+				return this.visitPsBlock({
+					...token,
+					depth,
+					parentNode,
+					nodeName: 'mdxjsEsm',
+					isFragment: false,
+				});
+			}
+		}
+
+		// Try common Markdown node handling
+		const result = this.nodeizeMarkdownNode(originNode, token, offset, endOffset, depth, parentNode);
+		if (result !== null) {
+			return result;
+		}
+
+		switch (originNode.type) {
+			case 'text': {
+				return this.visitText({
+					...token,
+					depth,
+					parentNode,
+				});
+			}
+			case 'html': {
+				return this.parseCodeFragment({
+					...token,
+					depth,
+					parentNode,
+				});
+			}
+			default: {
+				// Unhandled node types fallback to psblock
+				return this.visitPsBlock({
+					...token,
+					depth,
+					parentNode,
+					nodeName: originNode.type,
+					isFragment: false,
+				});
+			}
+		}
+	}
+
+	/**
+	 * Processes a JSX attribute token with IDL name conversion and dynamic value detection.
+	 *
+	 * Converts React-style IDL property names (e.g., `className`) to their
+	 * HTML content attribute equivalents (e.g., `class`) via `searchIDLAttribute`.
+	 * Marks `{...}` quoted values as dynamic.
+	 *
+	 * @param token - The raw attribute token from the source.
+	 * @returns The processed attribute node.
+	 */
+	visitAttr(token: Token) {
+		const attr = super.visitAttr(token, {
+			quoteSet: [
+				{ start: '"', end: '"', type: 'string' },
+				{ start: "'", end: "'", type: 'string' },
+				{ start: '{', end: '}', type: 'script' },
+			],
+		});
+
+		if (attr.type === 'spread') {
+			return attr;
+		}
+
+		const rawName = attr.name.raw;
+		const { idlPropName, contentAttrName } = searchIDLAttribute(rawName);
+
+		this.updateAttr(attr, {
+			potentialName: contentAttrName,
+		});
+
+		if (rawName !== idlPropName) {
+			this.updateAttr(attr, {
+				candidate: idlPropName,
+			});
+		}
+
+		if (attr.startQuote.raw === '{' && attr.endQuote.raw === '}') {
+			this.updateAttr(attr, {
+				isDynamicValue: true,
+			});
+		}
+
+		return attr;
+	}
+
+	/**
+	 * MDX components use uppercase or dot notation following React's convention.
+	 *
+	 * @param nodeName - The element name to classify.
+	 * @returns The element type (`'html'` or `'authored'`).
+	 */
+	detectElementType(nodeName: string) {
+		return super.detectElementType(nodeName, /^[A-Z]|\./);
+	}
+
+	/**
+	 * Visits a JSX element from the mdast, computing start tag and end tag
+	 * positions from the element's children and delegating to visitElement.
+	 */
+	#visitJsxElement(
+		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+		originNode: MdxJsxFlowElement | MdxJsxTextElement,
+		token: Token,
+		depth: number,
+		parentNode: MLASTParentNode | null,
+	): readonly MLASTNodeTreeItem[] {
+		const children = originNode.children;
+		const isSelfClosing = token.raw.trimEnd().endsWith('/>');
+
+		if (isSelfClosing || children.length === 0) {
+			// Self-closing or empty element: the whole token is the start tag
+			const parsedNodes = this.parseCodeFragment(
+				{
+					...token,
+					depth,
+					parentNode,
+				},
+				{ namelessFragment: true },
+			);
+
+			const startTag = parsedNodes.at(0);
+			if (!startTag || startTag.type !== 'starttag') {
+				return this.visitPsBlock({
+					...token,
+					depth,
+					parentNode,
+					nodeName: originNode.type,
+					isFragment: false,
+				});
+			}
+
+			return super.visitElement(startTag, [], {
+				namelessFragment: true,
+				createEndTagToken: () => null,
+			});
+		}
+
+		// Element with children: split into start tag + children + end tag
+		const firstChild = children[0];
+		const lastChild = children.at(-1);
+		const firstChildOffset = firstChild?.position?.start.offset ?? token.offset + token.raw.length;
+		const lastChildEndOffset = lastChild?.position?.end.offset ?? firstChildOffset;
+		const elementEndOffset = originNode.position?.end.offset ?? 0;
+
+		const startTagToken = this.sliceFragment(token.offset, firstChildOffset);
+
+		const parsedNodes = this.parseCodeFragment(
+			{
+				...startTagToken,
+				depth,
+				parentNode,
+			},
+			{ namelessFragment: true },
+		);
+
+		const startTag = parsedNodes.at(0);
+		if (!startTag || startTag.type !== 'starttag') {
+			return this.visitPsBlock({
+				...token,
+				depth,
+				parentNode,
+				nodeName: originNode.type,
+				isFragment: false,
+			});
+		}
+
+		return super.visitElement(startTag, [...children] as MdastNode[], {
+			namelessFragment: true,
+			createEndTagToken: () => {
+				if (lastChildEndOffset >= elementEndOffset) {
+					return null;
+				}
+				const endTagToken = this.sliceFragment(lastChildEndOffset, elementEndOffset);
+				if (!endTagToken.raw.trim()) {
+					return null;
+				}
+				return {
+					...endTagToken,
+					depth,
+					parentNode,
+				};
+			},
+		});
+	}
+}
+
+/**
+ * Flattens top-level mdast children by extracting JSX elements
+ * from paragraph wrappers so they appear at the top level.
+ *
+ * Only inspects direct children of root; does not recurse into nested nodes.
+ * Position information of unwrapped children is preserved from the original mdast.
+ *
+ * @param children - The root-level mdast children to process.
+ * @returns A new array with JSX-containing paragraphs unwrapped.
+ */
+// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+function flattenMdastChildren(children: MdastNode[]): MdastNode[] {
+	const result: MdastNode[] = [];
+
+	for (const child of children) {
+		if (child.type === 'paragraph' && 'children' in child) {
+			const pgChildren = (child as { children: MdastNode[] }).children;
+			const hasJsx = pgChildren.some(c => c.type === 'mdxJsxTextElement' || c.type === 'mdxTextExpression');
+
+			if (hasJsx) {
+				// JSX in paragraph: unwrap all children to top level
+				result.push(...pgChildren);
+			} else {
+				// Pure markdown paragraph: keep as-is
+				result.push(child);
+			}
+		} else {
+			result.push(child);
+		}
+	}
+
+	return result;
+}
+
+export const parser = new MDXParser();

--- a/packages/@markuplint/mdx-parser/tsconfig.build.json
+++ b/packages/@markuplint/mdx-parser/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "./lib",
+		"rootDir": "./src"
+	},
+	"include": ["./src/**/*"],
+	"exclude": ["node_modules", "lib", "./src/**/*.spec.ts"]
+}

--- a/packages/@markuplint/mdx-parser/tsconfig.json
+++ b/packages/@markuplint/mdx-parser/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"extends": "../../../tsconfig.json",
+	"compilerOptions": {
+		"composite": true
+	},
+	"references": [
+		{
+			"path": "../parser-utils"
+		},
+		{
+			"path": "../ml-ast"
+		}
+	]
+}

--- a/packages/@markuplint/rules/src/heading-levels/index.spec.ts
+++ b/packages/@markuplint/rules/src/heading-levels/index.spec.ts
@@ -1,5 +1,5 @@
 import { mlRuleTest } from 'markuplint';
-import { test, expect } from 'vitest';
+import { describe, test, expect } from 'vitest';
 
 import rule from './index.js';
 
@@ -58,4 +58,141 @@ test('Skipped', async () => {
 			raw: '<h5>',
 		},
 	]);
+});
+
+describe('Markdown parser', () => {
+	test('HTML headings in Markdown: h1 then h3 skips h2', async () => {
+		const { violations } = await mlRuleTest(rule, '<h1>Heading 1</h1>\n\n<h3>Heading 3</h3>\n', {
+			parser: {
+				'.*': '@markuplint/markdown-parser',
+			},
+		});
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 3,
+				col: 1,
+				message: 'Heading levels must not be skipped',
+				raw: '<h3>',
+			},
+		]);
+	});
+
+	test('HTML headings in Markdown: no skip', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<h1>Heading 1</h1>\n\n<h2>Heading 2</h2>\n\n<h3>Heading 3</h3>\n',
+			{
+				parser: {
+					'.*': '@markuplint/markdown-parser',
+				},
+			},
+		);
+		expect(violations.length).toBe(0);
+	});
+
+	test('Markdown syntax headings: h1 then h3 skips h2', async () => {
+		// Markdown headings are now converted to HTML heading elements.
+		// Therefore heading-levels rule detects h1 → h3 skip.
+		const { violations } = await mlRuleTest(rule, '# Heading 1\n\n### Heading 3\n', {
+			parser: {
+				'.*': '@markuplint/markdown-parser',
+			},
+		});
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 3,
+				col: 1,
+				message: 'Heading levels must not be skipped',
+				raw: '### Heading 3',
+			},
+		]);
+	});
+
+	test('Mixed Markdown + HTML headings: h1 Markdown then h3 HTML skips h2', async () => {
+		const { violations } = await mlRuleTest(rule, '# Heading 1\n\n<h3>Heading 3</h3>\n', {
+			parser: {
+				'.*': '@markuplint/markdown-parser',
+			},
+		});
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 3,
+				col: 1,
+				message: 'Heading levels must not be skipped',
+				raw: '<h3>',
+			},
+		]);
+	});
+});
+
+describe('Markdown parser - multiple heading skip', () => {
+	test('h1 then h2 then h4 skips h3', async () => {
+		const { violations } = await mlRuleTest(rule, '# Heading 1\n\n## Heading 2\n\n#### Heading 4\n', {
+			parser: {
+				'.*': '@markuplint/markdown-parser',
+			},
+		});
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 5,
+				col: 1,
+				message: 'Heading levels must not be skipped',
+				raw: '#### Heading 4',
+			},
+		]);
+	});
+});
+
+describe('MDX parser', () => {
+	test('HTML headings in MDX: h1 then h3 skips h2', async () => {
+		const { violations } = await mlRuleTest(rule, '<h1>Heading 1</h1>\n\n<h3>Heading 3</h3>\n', {
+			parser: {
+				'.*': '@markuplint/mdx-parser',
+			},
+		});
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 3,
+				col: 1,
+				message: 'Heading levels must not be skipped',
+				raw: '<h3>',
+			},
+		]);
+	});
+
+	test('HTML headings in MDX: no skip', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<h1>Heading 1</h1>\n\n<h2>Heading 2</h2>\n\n<h3>Heading 3</h3>\n',
+			{
+				parser: {
+					'.*': '@markuplint/mdx-parser',
+				},
+			},
+		);
+		expect(violations.length).toBe(0);
+	});
+
+	test('Markdown syntax headings in MDX: h1 then h3 skips h2', async () => {
+		// Markdown headings are now converted to HTML heading elements in MDX too.
+		const { violations } = await mlRuleTest(rule, '# Heading 1\n\n### Heading 3\n', {
+			parser: {
+				'.*': '@markuplint/mdx-parser',
+			},
+		});
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 3,
+				col: 1,
+				message: 'Heading levels must not be skipped',
+				raw: '### Heading 3',
+			},
+		]);
+	});
 });

--- a/packages/@markuplint/rules/src/required-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/required-attr/index.spec.ts
@@ -524,3 +524,101 @@ describe('Issues', () => {
 		]);
 	});
 });
+
+describe('MDX parser', () => {
+	test('MDX img element requires alt attribute', async () => {
+		const { violations } = await mlRuleTest(rule, '<img src="photo.png" />\n', {
+			parser: {
+				'.*': '@markuplint/mdx-parser',
+			},
+			nodeRule: [
+				{
+					selector: 'img',
+					rule: {
+						severity: 'error',
+						value: 'alt',
+					},
+				},
+			],
+		});
+		expect(violations.length).toBe(1);
+		expect(violations[0].message).toContain('alt');
+	});
+
+	test('MDX img with alt passes required-attr', async () => {
+		const { violations } = await mlRuleTest(rule, '<img src="photo.png" alt="A photo" />\n', {
+			parser: {
+				'.*': '@markuplint/mdx-parser',
+			},
+			nodeRule: [
+				{
+					selector: 'img',
+					rule: {
+						severity: 'error',
+						value: 'alt',
+					},
+				},
+			],
+		});
+		expect(violations.length).toBe(0);
+	});
+});
+
+describe('Markdown parser', () => {
+	test('Markdown image with alt text passes required-attr for alt', async () => {
+		const { violations } = await mlRuleTest(rule, '![alt text](img.png)\n', {
+			parser: {
+				'.*': '@markuplint/markdown-parser',
+			},
+			nodeRule: [
+				{
+					selector: 'img',
+					rule: {
+						severity: 'error',
+						value: 'alt',
+					},
+				},
+			],
+		});
+		expect(violations.length).toBe(0);
+	});
+
+	test('Markdown image with empty alt passes required-attr (attribute exists)', async () => {
+		const { violations } = await mlRuleTest(rule, '![](img.png)\n', {
+			parser: {
+				'.*': '@markuplint/markdown-parser',
+			},
+			nodeRule: [
+				{
+					selector: 'img',
+					rule: {
+						severity: 'error',
+						value: 'alt',
+					},
+				},
+			],
+		});
+		expect(violations.length).toBe(0);
+	});
+
+	test('Markdown image missing required src reports correct position', async () => {
+		const { violations } = await mlRuleTest(rule, 'Text\n\n![alt](img.png)\n', {
+			parser: {
+				'.*': '@markuplint/markdown-parser',
+			},
+			nodeRule: [
+				{
+					selector: 'img',
+					rule: {
+						severity: 'error',
+						value: ['src', 'alt', 'width'],
+					},
+				},
+			],
+		});
+		expect(violations.length).toBe(1);
+		expect(violations[0].line).toBe(3);
+		expect(violations[0].col).toBe(1);
+		expect(violations[0].raw).toBe('![alt](img.png)');
+	});
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2415,6 +2415,37 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@markuplint/markdown-parser@npm:4.0.0, @markuplint/markdown-parser@workspace:packages/@markuplint/markdown-parser":
+  version: 0.0.0-use.local
+  resolution: "@markuplint/markdown-parser@workspace:packages/@markuplint/markdown-parser"
+  dependencies:
+    "@markuplint/html-parser": "npm:4.6.23"
+    "@markuplint/ml-ast": "npm:4.4.11"
+    "@markuplint/parser-utils": "npm:4.8.11"
+    "@types/mdast": "npm:4.0.4"
+    remark-frontmatter: "npm:5.0.0"
+    remark-gfm: "npm:4.0.1"
+    remark-parse: "npm:11.0.0"
+    unified: "npm:11.0.5"
+  languageName: unknown
+  linkType: soft
+
+"@markuplint/mdx-parser@workspace:packages/@markuplint/mdx-parser":
+  version: 0.0.0-use.local
+  resolution: "@markuplint/mdx-parser@workspace:packages/@markuplint/mdx-parser"
+  dependencies:
+    "@markuplint/markdown-parser": "npm:4.0.0"
+    "@markuplint/ml-ast": "npm:4.4.11"
+    "@markuplint/parser-utils": "npm:4.8.11"
+    "@types/mdast": "npm:4.0.4"
+    remark-frontmatter: "npm:5.0.0"
+    remark-gfm: "npm:4.0.1"
+    remark-mdx: "npm:3.1.1"
+    remark-parse: "npm:11.0.0"
+    unified: "npm:11.0.5"
+  languageName: unknown
+  linkType: soft
+
 "@markuplint/ml-ast@npm:4.4.11, @markuplint/ml-ast@workspace:packages/@markuplint/ml-ast":
   version: 0.0.0-use.local
   resolution: "@markuplint/ml-ast@workspace:packages/@markuplint/ml-ast"
@@ -4224,7 +4255,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/debug@npm:4.1.12":
+"@types/debug@npm:4.1.12, @types/debug@npm:^4.0.0":
   version: 4.1.12
   resolution: "@types/debug@npm:4.1.12"
   dependencies:
@@ -4247,7 +4278,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:1.0.8, @types/estree@npm:^1.0.0, @types/estree@npm:^1.0.5, @types/estree@npm:^1.0.6, @types/estree@npm:^1.0.8":
+"@types/estree-jsx@npm:^1.0.0":
+  version: 1.0.5
+  resolution: "@types/estree-jsx@npm:1.0.5"
+  dependencies:
+    "@types/estree": "npm:*"
+  checksum: 10c0/07b354331516428b27a3ab99ee397547d47eb223c34053b48f84872fafb841770834b90cc1a0068398e7c7ccb15ec51ab00ec64b31dc5e3dbefd624638a35c6d
+  languageName: node
+  linkType: hard
+
+"@types/estree@npm:*, @types/estree@npm:1.0.8, @types/estree@npm:^1.0.0, @types/estree@npm:^1.0.5, @types/estree@npm:^1.0.6, @types/estree@npm:^1.0.8":
   version: 1.0.8
   resolution: "@types/estree@npm:1.0.8"
   checksum: 10c0/39d34d1afaa338ab9763f37ad6066e3f349444f9052b9676a7cc0252ef9485a41c6d81c9c4e0d26e9077993354edf25efc853f3224dd4b447175ef62bdcc86a5
@@ -4273,7 +4313,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/hast@npm:^3.0.4":
+"@types/hast@npm:^3.0.0, @types/hast@npm:^3.0.4":
   version: 3.0.4
   resolution: "@types/hast@npm:3.0.4"
   dependencies:
@@ -4313,6 +4353,15 @@ __metadata:
   version: 4.17.23
   resolution: "@types/lodash@npm:4.17.23"
   checksum: 10c0/9d9cbfb684e064a2b78aab9e220d398c9c2a7d36bc51a07b184ff382fa043a99b3d00c16c7f109b4eb8614118f4869678dbae7d5c6700ed16fb9340e26cc0bf6
+  languageName: node
+  linkType: hard
+
+"@types/mdast@npm:4.0.4, @types/mdast@npm:^4.0.0":
+  version: 4.0.4
+  resolution: "@types/mdast@npm:4.0.4"
+  dependencies:
+    "@types/unist": "npm:*"
+  checksum: 10c0/84f403dbe582ee508fd9c7643ac781ad8597fcbfc9ccb8d4715a2c92e4545e5772cbd0dbdf18eda65789386d81b009967fdef01b24faf6640f817287f54d9c82
   languageName: node
   linkType: hard
 
@@ -4422,7 +4471,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/unist@npm:*":
+"@types/unist@npm:*, @types/unist@npm:^3.0.0":
   version: 3.0.3
   resolution: "@types/unist@npm:3.0.3"
   checksum: 10c0/2b1e4adcab78388e088fcc3c0ae8700f76619dbcb4741d7d201f87e2cb346bfc29a89003cfea2d76c996e1061452e14fcd737e8b25aacf949c1f2d6b2bc3dd60
@@ -5074,7 +5123,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn-jsx@npm:^5.3.2":
+"acorn-jsx@npm:^5.0.0, acorn-jsx@npm:^5.3.2":
   version: 5.3.2
   resolution: "acorn-jsx@npm:5.3.2"
   peerDependencies:
@@ -5101,7 +5150,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.11.0, acorn@npm:^8.12.1, acorn@npm:^8.15.0, acorn@npm:^8.4.1":
+"acorn@npm:^8.0.0, acorn@npm:^8.11.0, acorn@npm:^8.12.1, acorn@npm:^8.15.0, acorn@npm:^8.4.1":
   version: 8.15.0
   resolution: "acorn@npm:8.15.0"
   bin:
@@ -6008,6 +6057,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ccount@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "ccount@npm:2.0.1"
+  checksum: 10c0/3939b1664390174484322bc3f45b798462e6c07ee6384cb3d645e0aa2f318502d174845198c1561930e1d431087f74cf1fe291ae9a4722821a9f4ba67e574350
+  languageName: node
+  linkType: hard
+
 "chai@npm:^6.2.1":
   version: 6.2.2
   resolution: "chai@npm:6.2.2"
@@ -6069,6 +6125,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"character-entities-html4@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "character-entities-html4@npm:2.1.0"
+  checksum: 10c0/fe61b553f083400c20c0b0fd65095df30a0b445d960f3bbf271536ae6c3ba676f39cb7af0b4bf2755812f08ab9b88f2feed68f9aebb73bb153f7a115fe5c6e40
+  languageName: node
+  linkType: hard
+
 "character-entities-legacy@npm:^1.0.0":
   version: 1.1.4
   resolution: "character-entities-legacy@npm:1.1.4"
@@ -6076,10 +6139,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"character-entities-legacy@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "character-entities-legacy@npm:3.0.0"
+  checksum: 10c0/ec4b430af873661aa754a896a2b55af089b4e938d3d010fad5219299a6b6d32ab175142699ee250640678cd64bdecd6db3c9af0b8759ab7b155d970d84c4c7d1
+  languageName: node
+  linkType: hard
+
 "character-entities@npm:^1.0.0":
   version: 1.2.4
   resolution: "character-entities@npm:1.2.4"
   checksum: 10c0/ad015c3d7163563b8a0ee1f587fb0ef305ef344e9fd937f79ca51cccc233786a01d591d989d5bf7b2e66b528ac9efba47f3b1897358324e69932f6d4b25adfe1
+  languageName: node
+  linkType: hard
+
+"character-entities@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "character-entities@npm:2.0.2"
+  checksum: 10c0/b0c645a45bcc90ff24f0e0140f4875a8436b8ef13b6bcd31ec02cfb2ca502b680362aa95386f7815bdc04b6464d48cf191210b3840d7c04241a149ede591a308
   languageName: node
   linkType: hard
 
@@ -6096,6 +6173,13 @@ __metadata:
   version: 1.1.4
   resolution: "character-reference-invalid@npm:1.1.4"
   checksum: 10c0/29f05081c5817bd1e975b0bf61e77b60a40f62ad371d0f0ce0fdb48ab922278bc744d1fbe33771dced751887a8403f265ff634542675c8d7375f6ff4811efd0e
+  languageName: node
+  linkType: hard
+
+"character-reference-invalid@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "character-reference-invalid@npm:2.0.1"
+  checksum: 10c0/2ae0dec770cd8659d7e8b0ce24392d83b4c2f0eb4a3395c955dce5528edd4cc030a794cfa06600fcdd700b3f2de2f9b8e40e309c0011c4180e3be64a0b42e6a1
   languageName: node
   linkType: hard
 
@@ -7156,6 +7240,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"decode-named-character-reference@npm:^1.0.0":
+  version: 1.3.0
+  resolution: "decode-named-character-reference@npm:1.3.0"
+  dependencies:
+    character-entities: "npm:^2.0.0"
+  checksum: 10c0/787f4c87f3b82ea342aa7c2d7b1882b6fb9511bb77f72ae44dcaabea0470bacd1e9c6a0080ab886545019fa0cb3a7109573fad6b61a362844c3a0ac52b36e4bb
+  languageName: node
+  linkType: hard
+
 "decompress-response@npm:^6.0.0":
   version: 6.0.0
   resolution: "decompress-response@npm:6.0.0"
@@ -7291,6 +7384,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dequal@npm:^2.0.0":
+  version: 2.0.3
+  resolution: "dequal@npm:2.0.3"
+  checksum: 10c0/f98860cdf58b64991ae10205137c0e97d384c3a4edc7f807603887b7c4b850af1224a33d88012009f150861cbee4fa2d322c4cc04b9313bee312e47f6ecaa888
+  languageName: node
+  linkType: hard
+
 "detect-file@npm:^1.0.0":
   version: 1.0.0
   resolution: "detect-file@npm:1.0.0"
@@ -7332,6 +7432,15 @@ __metadata:
   version: 5.6.2
   resolution: "devalue@npm:5.6.2"
   checksum: 10c0/654f257ec525a2d3f35c941bfbb361148bc65ced060710969fbaa1c45abf1c9d7c4fcb77310bf8d2fb73c34cf60bad10710e7bf5b15643bbc082518ea04cb00b
+  languageName: node
+  linkType: hard
+
+"devlop@npm:^1.0.0, devlop@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "devlop@npm:1.1.0"
+  dependencies:
+    dequal: "npm:^2.0.0"
+  checksum: 10c0/e0928ab8f94c59417a2b8389c45c55ce0a02d9ac7fd74ef62d01ba48060129e1d594501b77de01f3eeafc7cb00773819b0df74d96251cf20b31c5b3071f45c0e
   languageName: node
   linkType: hard
 
@@ -7946,6 +8055,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"escape-string-regexp@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "escape-string-regexp@npm:5.0.0"
+  checksum: 10c0/6366f474c6f37a802800a435232395e04e9885919873e382b157ab7e8f0feb8fed71497f84a6f6a81a49aab41815522f5839112bd38026d203aea0c91622df95
+  languageName: node
+  linkType: hard
+
 "eslint-compat-utils@npm:^0.5.1":
   version: 0.5.1
   resolution: "eslint-compat-utils@npm:0.5.1"
@@ -8334,6 +8450,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"estree-util-is-identifier-name@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "estree-util-is-identifier-name@npm:3.0.0"
+  checksum: 10c0/d1881c6ed14bd588ebd508fc90bf2a541811dbb9ca04dec2f39d27dcaa635f85b5ed9bbbe7fc6fb1ddfca68744a5f7c70456b4b7108b6c4c52780631cc787c5b
+  languageName: node
+  linkType: hard
+
+"estree-util-visit@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "estree-util-visit@npm:2.0.0"
+  dependencies:
+    "@types/estree-jsx": "npm:^1.0.0"
+    "@types/unist": "npm:^3.0.0"
+  checksum: 10c0/acda8b03cc8f890d79c7c7361f6c95331ba84b7ccc0c32b49f447fc30206b20002b37ffdfc97b6ad16e6fe065c63ecbae1622492e2b6b4775c15966606217f39
+  languageName: node
+  linkType: hard
+
 "estree-walker@npm:^3.0.3":
   version: 3.0.3
   resolution: "estree-walker@npm:3.0.3"
@@ -8640,6 +8773,15 @@ __metadata:
   dependencies:
     format: "npm:^0.2.0"
   checksum: 10c0/c86c11500c1b676787296f31ade8473adcc6784f118f07c1a9429730b6288d0412f96e069ce010aa57e4f65a9cccb5abee8868bbe3c5f10de63b20482c9baebd
+  languageName: node
+  linkType: hard
+
+"fault@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "fault@npm:2.0.1"
+  dependencies:
+    format: "npm:^0.2.0"
+  checksum: 10c0/b80fbf1019b9ce8b08ee09ce86e02b028563e13a32ac3be34e42bfac00a97b96d8dee6d31e26578ffc16224eb6729e01ff1f97ddfeee00494f4f56c0aeed4bdd
   languageName: node
   linkType: hard
 
@@ -10394,6 +10536,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-hexadecimal@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "is-hexadecimal@npm:2.0.1"
+  checksum: 10c0/3eb60fe2f1e2bbc760b927dcad4d51eaa0c60138cf7fc671803f66353ad90c301605b502c7ea4c6bb0548e1c7e79dfd37b73b632652e3b76030bba603a7e9626
+  languageName: node
+  linkType: hard
+
 "is-inside-container@npm:^1.0.0":
   version: 1.0.0
   resolution: "is-inside-container@npm:1.0.0"
@@ -11744,6 +11893,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"longest-streak@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "longest-streak@npm:3.1.0"
+  checksum: 10c0/7c2f02d0454b52834d1bcedef79c557bd295ee71fdabb02d041ff3aa9da48a90b5df7c0409156dedbc4df9b65da18742652aaea4759d6ece01f08971af6a7eaa
+  languageName: node
+  linkType: hard
+
 "longest@npm:^2.0.1":
   version: 2.0.1
   resolution: "longest@npm:2.0.1"
@@ -11931,6 +12087,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"markdown-table@npm:^3.0.0":
+  version: 3.0.4
+  resolution: "markdown-table@npm:3.0.4"
+  checksum: 10c0/1257b31827629a54c24a5030a3dac952256c559174c95ce3ef89bebd6bff0cb1444b1fd667b1a1bb53307f83278111505b3e26f0c4e7b731e0060d435d2d930b
+  languageName: node
+  linkType: hard
+
 "markuplint-packages@workspace:.":
   version: 0.0.0-use.local
   resolution: "markuplint-packages@workspace:."
@@ -12029,6 +12192,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mdast-util-find-and-replace@npm:^3.0.0":
+  version: 3.0.2
+  resolution: "mdast-util-find-and-replace@npm:3.0.2"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    escape-string-regexp: "npm:^5.0.0"
+    unist-util-is: "npm:^6.0.0"
+    unist-util-visit-parents: "npm:^6.0.0"
+  checksum: 10c0/c8417a35605d567772ff5c1aa08363ff3010b0d60c8ea68c53cba09bf25492e3dd261560425c1756535f3b7107f62e7ff3857cdd8fb1e62d1b2cc2ea6e074ca2
+  languageName: node
+  linkType: hard
+
 "mdast-util-footnote@npm:^0.1.0":
   version: 0.1.7
   resolution: "mdast-util-footnote@npm:0.1.7"
@@ -12052,12 +12227,46 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mdast-util-from-markdown@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "mdast-util-from-markdown@npm:2.0.2"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    "@types/unist": "npm:^3.0.0"
+    decode-named-character-reference: "npm:^1.0.0"
+    devlop: "npm:^1.0.0"
+    mdast-util-to-string: "npm:^4.0.0"
+    micromark: "npm:^4.0.0"
+    micromark-util-decode-numeric-character-reference: "npm:^2.0.0"
+    micromark-util-decode-string: "npm:^2.0.0"
+    micromark-util-normalize-identifier: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+    unist-util-stringify-position: "npm:^4.0.0"
+  checksum: 10c0/76eb2bd2c6f7a0318087c73376b8af6d7561c1e16654e7667e640f391341096c56142618fd0ff62f6d39e5ab4895898b9789c84cd7cec2874359a437a0e1ff15
+  languageName: node
+  linkType: hard
+
 "mdast-util-frontmatter@npm:^0.2.0":
   version: 0.2.0
   resolution: "mdast-util-frontmatter@npm:0.2.0"
   dependencies:
     micromark-extension-frontmatter: "npm:^0.2.0"
   checksum: 10c0/fd7630e24d668c1a1890b268736567a6f0a547438f68b800f59168292d1c05cf9105724b3a33de4de5f573ea7e8e6f54c39bdca5ea5224435abfe77980579acc
+  languageName: node
+  linkType: hard
+
+"mdast-util-frontmatter@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "mdast-util-frontmatter@npm:2.0.1"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    devlop: "npm:^1.0.0"
+    escape-string-regexp: "npm:^5.0.0"
+    mdast-util-from-markdown: "npm:^2.0.0"
+    mdast-util-to-markdown: "npm:^2.0.0"
+    micromark-extension-frontmatter: "npm:^2.0.0"
+  checksum: 10c0/d9b0b70dd9c574cc0220d4e05dd8e9d86ac972a6a5af9e0c49c839b31cb750d4313445cfbbdf9264a7fbe3f8c8d920b45358b8500f4286e6b9dc830095b25b9a
   languageName: node
   linkType: hard
 
@@ -12072,12 +12281,49 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mdast-util-gfm-autolink-literal@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "mdast-util-gfm-autolink-literal@npm:2.0.1"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    ccount: "npm:^2.0.0"
+    devlop: "npm:^1.0.0"
+    mdast-util-find-and-replace: "npm:^3.0.0"
+    micromark-util-character: "npm:^2.0.0"
+  checksum: 10c0/963cd22bd42aebdec7bdd0a527c9494d024d1ad0739c43dc040fee35bdfb5e29c22564330a7418a72b5eab51d47a6eff32bc0255ef3ccb5cebfe8970e91b81b6
+  languageName: node
+  linkType: hard
+
+"mdast-util-gfm-footnote@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "mdast-util-gfm-footnote@npm:2.1.0"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    devlop: "npm:^1.1.0"
+    mdast-util-from-markdown: "npm:^2.0.0"
+    mdast-util-to-markdown: "npm:^2.0.0"
+    micromark-util-normalize-identifier: "npm:^2.0.0"
+  checksum: 10c0/8ab965ee6be3670d76ec0e95b2ba3101fc7444eec47564943ab483d96ac17d29da2a4e6146a2a288be30c21b48c4f3938a1e54b9a46fbdd321d49a5bc0077ed0
+  languageName: node
+  linkType: hard
+
 "mdast-util-gfm-strikethrough@npm:^0.2.0":
   version: 0.2.3
   resolution: "mdast-util-gfm-strikethrough@npm:0.2.3"
   dependencies:
     mdast-util-to-markdown: "npm:^0.6.0"
   checksum: 10c0/1de00913769c252add1f48fea547121d971ef7a8bfe6a89b775dea38aa319e6b10b6f514b492586aa7e660f8880b5c2390e411302a0b2386ed793f914b9eca71
+  languageName: node
+  linkType: hard
+
+"mdast-util-gfm-strikethrough@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "mdast-util-gfm-strikethrough@npm:2.0.0"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    mdast-util-from-markdown: "npm:^2.0.0"
+    mdast-util-to-markdown: "npm:^2.0.0"
+  checksum: 10c0/b053e93d62c7545019bd914271ea9e5667ad3b3b57d16dbf68e56fea39a7e19b4a345e781312714eb3d43fdd069ff7ee22a3ca7f6149dfa774554f19ce3ac056
   languageName: node
   linkType: hard
 
@@ -12091,12 +12337,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mdast-util-gfm-table@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "mdast-util-gfm-table@npm:2.0.0"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    devlop: "npm:^1.0.0"
+    markdown-table: "npm:^3.0.0"
+    mdast-util-from-markdown: "npm:^2.0.0"
+    mdast-util-to-markdown: "npm:^2.0.0"
+  checksum: 10c0/128af47c503a53bd1c79f20642561e54a510ad5e2db1e418d28fefaf1294ab839e6c838e341aef5d7e404f9170b9ca3d1d89605f234efafde93ee51174a6e31e
+  languageName: node
+  linkType: hard
+
 "mdast-util-gfm-task-list-item@npm:^0.1.0":
   version: 0.1.6
   resolution: "mdast-util-gfm-task-list-item@npm:0.1.6"
   dependencies:
     mdast-util-to-markdown: "npm:~0.6.0"
   checksum: 10c0/6b5b5239f031b630cd433cfd0bb30b7258dfac7d49c86a2c937127bc00fda186f798cf2a671507bcfad00f075d2d8779be9c109549052d98f1b4927e6e12d8be
+  languageName: node
+  linkType: hard
+
+"mdast-util-gfm-task-list-item@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "mdast-util-gfm-task-list-item@npm:2.0.0"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    devlop: "npm:^1.0.0"
+    mdast-util-from-markdown: "npm:^2.0.0"
+    mdast-util-to-markdown: "npm:^2.0.0"
+  checksum: 10c0/258d725288482b636c0a376c296431390c14b4f29588675297cb6580a8598ed311fc73ebc312acfca12cc8546f07a3a285a53a3b082712e2cbf5c190d677d834
   languageName: node
   linkType: hard
 
@@ -12110,6 +12381,92 @@ __metadata:
     mdast-util-gfm-task-list-item: "npm:^0.1.0"
     mdast-util-to-markdown: "npm:^0.6.1"
   checksum: 10c0/109c5f3e3340c25ecec5fb0b9b1a4137fb0948ffbc38ed4b85d477f3da471c2a475a84f2cb2569663768d6967aedf0f3a18b936ea907d0e34374f4eeaed18c5a
+  languageName: node
+  linkType: hard
+
+"mdast-util-gfm@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "mdast-util-gfm@npm:3.1.0"
+  dependencies:
+    mdast-util-from-markdown: "npm:^2.0.0"
+    mdast-util-gfm-autolink-literal: "npm:^2.0.0"
+    mdast-util-gfm-footnote: "npm:^2.0.0"
+    mdast-util-gfm-strikethrough: "npm:^2.0.0"
+    mdast-util-gfm-table: "npm:^2.0.0"
+    mdast-util-gfm-task-list-item: "npm:^2.0.0"
+    mdast-util-to-markdown: "npm:^2.0.0"
+  checksum: 10c0/4bedcfb6a20e39901c8772f0d2bb2d7a64ae87a54c13cbd92eec062cf470fbb68c2ad754e149af5b30794e2de61c978ab1de1ace03c0c40f443ca9b9b8044f81
+  languageName: node
+  linkType: hard
+
+"mdast-util-mdx-expression@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "mdast-util-mdx-expression@npm:2.0.1"
+  dependencies:
+    "@types/estree-jsx": "npm:^1.0.0"
+    "@types/hast": "npm:^3.0.0"
+    "@types/mdast": "npm:^4.0.0"
+    devlop: "npm:^1.0.0"
+    mdast-util-from-markdown: "npm:^2.0.0"
+    mdast-util-to-markdown: "npm:^2.0.0"
+  checksum: 10c0/9a1e57940f66431f10312fa239096efa7627f375e7933b5d3162c0b5c1712a72ac87447aff2b6838d2bbd5c1311b188718cc90b33b67dc67a88550e0a6ef6183
+  languageName: node
+  linkType: hard
+
+"mdast-util-mdx-jsx@npm:^3.0.0":
+  version: 3.2.0
+  resolution: "mdast-util-mdx-jsx@npm:3.2.0"
+  dependencies:
+    "@types/estree-jsx": "npm:^1.0.0"
+    "@types/hast": "npm:^3.0.0"
+    "@types/mdast": "npm:^4.0.0"
+    "@types/unist": "npm:^3.0.0"
+    ccount: "npm:^2.0.0"
+    devlop: "npm:^1.1.0"
+    mdast-util-from-markdown: "npm:^2.0.0"
+    mdast-util-to-markdown: "npm:^2.0.0"
+    parse-entities: "npm:^4.0.0"
+    stringify-entities: "npm:^4.0.0"
+    unist-util-stringify-position: "npm:^4.0.0"
+    vfile-message: "npm:^4.0.0"
+  checksum: 10c0/3acadaf3b962254f7ad2990fed4729961dc0217ca31fde9917986e880843f3ecf3392b1f22d569235cacd180d50894ad266db7af598aedca69d330d33c7ac613
+  languageName: node
+  linkType: hard
+
+"mdast-util-mdx@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "mdast-util-mdx@npm:3.0.0"
+  dependencies:
+    mdast-util-from-markdown: "npm:^2.0.0"
+    mdast-util-mdx-expression: "npm:^2.0.0"
+    mdast-util-mdx-jsx: "npm:^3.0.0"
+    mdast-util-mdxjs-esm: "npm:^2.0.0"
+    mdast-util-to-markdown: "npm:^2.0.0"
+  checksum: 10c0/4faea13f77d6bc9aa64ee41a5e4779110b73444a17fda363df6ebe880ecfa58b321155b71f8801c3faa6d70d6222a32a00cbd6dbf5fad8db417f4688bc9c74e1
+  languageName: node
+  linkType: hard
+
+"mdast-util-mdxjs-esm@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "mdast-util-mdxjs-esm@npm:2.0.1"
+  dependencies:
+    "@types/estree-jsx": "npm:^1.0.0"
+    "@types/hast": "npm:^3.0.0"
+    "@types/mdast": "npm:^4.0.0"
+    devlop: "npm:^1.0.0"
+    mdast-util-from-markdown: "npm:^2.0.0"
+    mdast-util-to-markdown: "npm:^2.0.0"
+  checksum: 10c0/5bda92fc154141705af2b804a534d891f28dac6273186edf1a4c5e3f045d5b01dbcac7400d27aaf91b7e76e8dce007c7b2fdf136c11ea78206ad00bdf9db46bc
+  languageName: node
+  linkType: hard
+
+"mdast-util-phrasing@npm:^4.0.0":
+  version: 4.1.0
+  resolution: "mdast-util-phrasing@npm:4.1.0"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    unist-util-is: "npm:^6.0.0"
+  checksum: 10c0/bf6c31d51349aa3d74603d5e5a312f59f3f65662ed16c58017169a5fb0f84ca98578f626c5ee9e4aa3e0a81c996db8717096705521bddb4a0185f98c12c9b42f
   languageName: node
   linkType: hard
 
@@ -12127,10 +12484,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mdast-util-to-markdown@npm:^2.0.0":
+  version: 2.1.2
+  resolution: "mdast-util-to-markdown@npm:2.1.2"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    "@types/unist": "npm:^3.0.0"
+    longest-streak: "npm:^3.0.0"
+    mdast-util-phrasing: "npm:^4.0.0"
+    mdast-util-to-string: "npm:^4.0.0"
+    micromark-util-classify-character: "npm:^2.0.0"
+    micromark-util-decode-string: "npm:^2.0.0"
+    unist-util-visit: "npm:^5.0.0"
+    zwitch: "npm:^2.0.0"
+  checksum: 10c0/4649722a6099f12e797bd8d6469b2b43b44e526b5182862d9c7766a3431caad2c0112929c538a972f214e63c015395e5d3f54bd81d9ac1b16e6d8baaf582f749
+  languageName: node
+  linkType: hard
+
 "mdast-util-to-string@npm:^2.0.0":
   version: 2.0.0
   resolution: "mdast-util-to-string@npm:2.0.0"
   checksum: 10c0/a4231085133cdfec24644b694c13661e5a01d26716be0105b6792889faa04b8030e4abbf72d4be3363098b2b38b2b98f1f1f1f0858eb6580dc04e2aca1436a37
+  languageName: node
+  linkType: hard
+
+"mdast-util-to-string@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "mdast-util-to-string@npm:4.0.0"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+  checksum: 10c0/2d3c1af29bf3fe9c20f552ee9685af308002488f3b04b12fa66652c9718f66f41a32f8362aa2d770c3ff464c034860b41715902ada2306bb0a055146cef064d7
   languageName: node
   linkType: hard
 
@@ -12230,6 +12613,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"micromark-core-commonmark@npm:^2.0.0":
+  version: 2.0.3
+  resolution: "micromark-core-commonmark@npm:2.0.3"
+  dependencies:
+    decode-named-character-reference: "npm:^1.0.0"
+    devlop: "npm:^1.0.0"
+    micromark-factory-destination: "npm:^2.0.0"
+    micromark-factory-label: "npm:^2.0.0"
+    micromark-factory-space: "npm:^2.0.0"
+    micromark-factory-title: "npm:^2.0.0"
+    micromark-factory-whitespace: "npm:^2.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-chunked: "npm:^2.0.0"
+    micromark-util-classify-character: "npm:^2.0.0"
+    micromark-util-html-tag-name: "npm:^2.0.0"
+    micromark-util-normalize-identifier: "npm:^2.0.0"
+    micromark-util-resolve-all: "npm:^2.0.0"
+    micromark-util-subtokenize: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/bd4a794fdc9e88dbdf59eaf1c507ddf26e5f7ddf4e52566c72239c0f1b66adbcd219ba2cd42350debbe24471434d5f5e50099d2b3f4e5762ca222ba8e5b549ee
+  languageName: node
+  linkType: hard
+
 "micromark-extension-footnote@npm:^0.3.0":
   version: 0.3.2
   resolution: "micromark-extension-footnote@npm:0.3.2"
@@ -12248,12 +12655,66 @@ __metadata:
   languageName: node
   linkType: hard
 
+"micromark-extension-frontmatter@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "micromark-extension-frontmatter@npm:2.0.0"
+  dependencies:
+    fault: "npm:^2.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/7d0d876e598917a67146d29f536d6fbbf9d1b2401a77e2f64a3f80f934a63ff26fa94b01759c9185c24b2a91e4e6abf908fa7aa246f00a7778a6b37a17464300
+  languageName: node
+  linkType: hard
+
+"micromark-extension-gfm-autolink-literal@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "micromark-extension-gfm-autolink-literal@npm:2.1.0"
+  dependencies:
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-sanitize-uri: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/84e6fbb84ea7c161dfa179665dc90d51116de4c28f3e958260c0423e5a745372b7dcbc87d3cde98213b532e6812f847eef5ae561c9397d7f7da1e59872ef3efe
+  languageName: node
+  linkType: hard
+
 "micromark-extension-gfm-autolink-literal@npm:~0.5.0":
   version: 0.5.7
   resolution: "micromark-extension-gfm-autolink-literal@npm:0.5.7"
   dependencies:
     micromark: "npm:~2.11.3"
   checksum: 10c0/4e56021641200cd88a9e05be531405bba007db9187554e06d0dfb5d8c49df67991322f2f952d6a25bbe3972ef0543a08d7ea00dff7b8577f8f3ca196c6544114
+  languageName: node
+  linkType: hard
+
+"micromark-extension-gfm-footnote@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "micromark-extension-gfm-footnote@npm:2.1.0"
+  dependencies:
+    devlop: "npm:^1.0.0"
+    micromark-core-commonmark: "npm:^2.0.0"
+    micromark-factory-space: "npm:^2.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-normalize-identifier: "npm:^2.0.0"
+    micromark-util-sanitize-uri: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/d172e4218968b7371b9321af5cde8c77423f73b233b2b0fcf3ff6fd6f61d2e0d52c49123a9b7910612478bf1f0d5e88c75a3990dd68f70f3933fe812b9f77edc
+  languageName: node
+  linkType: hard
+
+"micromark-extension-gfm-strikethrough@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "micromark-extension-gfm-strikethrough@npm:2.1.0"
+  dependencies:
+    devlop: "npm:^1.0.0"
+    micromark-util-chunked: "npm:^2.0.0"
+    micromark-util-classify-character: "npm:^2.0.0"
+    micromark-util-resolve-all: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/ef4f248b865bdda71303b494671b7487808a340b25552b11ca6814dff3fcfaab9be8d294643060bbdb50f79313e4a686ab18b99cbe4d3ee8a4170fcd134234fb
   languageName: node
   linkType: hard
 
@@ -12266,6 +12727,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"micromark-extension-gfm-table@npm:^2.0.0":
+  version: 2.1.1
+  resolution: "micromark-extension-gfm-table@npm:2.1.1"
+  dependencies:
+    devlop: "npm:^1.0.0"
+    micromark-factory-space: "npm:^2.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/04bc00e19b435fa0add62cd029d8b7eb6137522f77832186b1d5ef34544a9bd030c9cf85e92ddfcc5c31f6f0a58a43d4b96dba4fc21316037c734630ee12c912
+  languageName: node
+  linkType: hard
+
 "micromark-extension-gfm-table@npm:~0.4.0":
   version: 0.4.3
   resolution: "micromark-extension-gfm-table@npm:0.4.3"
@@ -12275,10 +12749,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"micromark-extension-gfm-tagfilter@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "micromark-extension-gfm-tagfilter@npm:2.0.0"
+  dependencies:
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/995558843fff137ae4e46aecb878d8a4691cdf23527dcf1e2f0157d66786be9f7bea0109c52a8ef70e68e3f930af811828ba912239438e31a9cfb9981f44d34d
+  languageName: node
+  linkType: hard
+
 "micromark-extension-gfm-tagfilter@npm:~0.3.0":
   version: 0.3.0
   resolution: "micromark-extension-gfm-tagfilter@npm:0.3.0"
   checksum: 10c0/5a81cffbcad7f314ddb3b761c5e2db5a5286e231e68559861da821ee748838cc9323fd22af5cbbe68569e826fa8159f2f2b0d53dc8aecc458ef48b2503a071fb
+  languageName: node
+  linkType: hard
+
+"micromark-extension-gfm-task-list-item@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "micromark-extension-gfm-task-list-item@npm:2.1.0"
+  dependencies:
+    devlop: "npm:^1.0.0"
+    micromark-factory-space: "npm:^2.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/78aa537d929e9309f076ba41e5edc99f78d6decd754b6734519ccbbfca8abd52e1c62df68d41a6ae64d2a3fc1646cea955893c79680b0b4385ced4c52296181f
   languageName: node
   linkType: hard
 
@@ -12305,6 +12801,317 @@ __metadata:
   languageName: node
   linkType: hard
 
+"micromark-extension-gfm@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "micromark-extension-gfm@npm:3.0.0"
+  dependencies:
+    micromark-extension-gfm-autolink-literal: "npm:^2.0.0"
+    micromark-extension-gfm-footnote: "npm:^2.0.0"
+    micromark-extension-gfm-strikethrough: "npm:^2.0.0"
+    micromark-extension-gfm-table: "npm:^2.0.0"
+    micromark-extension-gfm-tagfilter: "npm:^2.0.0"
+    micromark-extension-gfm-task-list-item: "npm:^2.0.0"
+    micromark-util-combine-extensions: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/970e28df6ebdd7c7249f52a0dda56e0566fbfa9ae56c8eeeb2445d77b6b89d44096880cd57a1c01e7821b1f4e31009109fbaca4e89731bff7b83b8519690e5d9
+  languageName: node
+  linkType: hard
+
+"micromark-extension-mdx-expression@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "micromark-extension-mdx-expression@npm:3.0.1"
+  dependencies:
+    "@types/estree": "npm:^1.0.0"
+    devlop: "npm:^1.0.0"
+    micromark-factory-mdx-expression: "npm:^2.0.0"
+    micromark-factory-space: "npm:^2.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-events-to-acorn: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/4d8cc5353b083b06bd51c98389de9c198261a5b2b440b75e85000a18d10511f21ba77538d6dfde0e0589df9de3fba9a1d14c2448d30c92d6b461c26d86e397f4
+  languageName: node
+  linkType: hard
+
+"micromark-extension-mdx-jsx@npm:^3.0.0":
+  version: 3.0.2
+  resolution: "micromark-extension-mdx-jsx@npm:3.0.2"
+  dependencies:
+    "@types/estree": "npm:^1.0.0"
+    devlop: "npm:^1.0.0"
+    estree-util-is-identifier-name: "npm:^3.0.0"
+    micromark-factory-mdx-expression: "npm:^2.0.0"
+    micromark-factory-space: "npm:^2.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-events-to-acorn: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+    vfile-message: "npm:^4.0.0"
+  checksum: 10c0/5693b2e51934ac29a6aab521eaa2151f891d1fe092550bbd4ce24e4dd7567c1421a54f5e585a57dfa1769a79570f6df57ddd7a98bf0889dd11d495847a266dd7
+  languageName: node
+  linkType: hard
+
+"micromark-extension-mdx-md@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "micromark-extension-mdx-md@npm:2.0.0"
+  dependencies:
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/bae91c61273de0e5ba80a980c03470e6cd9d7924aa936f46fbda15d780704d9386e945b99eda200e087b96254fbb4271a9545d5ce02676cd6ae67886a8bf82df
+  languageName: node
+  linkType: hard
+
+"micromark-extension-mdxjs-esm@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "micromark-extension-mdxjs-esm@npm:3.0.0"
+  dependencies:
+    "@types/estree": "npm:^1.0.0"
+    devlop: "npm:^1.0.0"
+    micromark-core-commonmark: "npm:^2.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-events-to-acorn: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+    unist-util-position-from-estree: "npm:^2.0.0"
+    vfile-message: "npm:^4.0.0"
+  checksum: 10c0/13e3f726495a960650cdedcba39198ace5bdc953ccb12c14d71fc9ed9bb88e40cc3ba9231e973f6984da3b3573e7ddb23ce409f7c16f52a8d57b608bf46c748d
+  languageName: node
+  linkType: hard
+
+"micromark-extension-mdxjs@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "micromark-extension-mdxjs@npm:3.0.0"
+  dependencies:
+    acorn: "npm:^8.0.0"
+    acorn-jsx: "npm:^5.0.0"
+    micromark-extension-mdx-expression: "npm:^3.0.0"
+    micromark-extension-mdx-jsx: "npm:^3.0.0"
+    micromark-extension-mdx-md: "npm:^2.0.0"
+    micromark-extension-mdxjs-esm: "npm:^3.0.0"
+    micromark-util-combine-extensions: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/fd84f036ddad0aabbc12e7f1b3e9dcfe31573bbc413c5ae903779ef0366d7a4c08193547e7ba75718c9f45654e45f52e575cfc2f23a5f89205a8a70d9a506aea
+  languageName: node
+  linkType: hard
+
+"micromark-factory-destination@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-factory-destination@npm:2.0.1"
+  dependencies:
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/bbafcf869cee5bf511161354cb87d61c142592fbecea051000ff116068dc85216e6d48519d147890b9ea5d7e2864a6341c0c09d9948c203bff624a80a476023c
+  languageName: node
+  linkType: hard
+
+"micromark-factory-label@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-factory-label@npm:2.0.1"
+  dependencies:
+    devlop: "npm:^1.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/0137716b4ecb428114165505e94a2f18855c8bbea21b07a8b5ce514b32a595ed789d2b967125718fc44c4197ceaa48f6609d58807a68e778138d2e6b91b824e8
+  languageName: node
+  linkType: hard
+
+"micromark-factory-mdx-expression@npm:^2.0.0":
+  version: 2.0.3
+  resolution: "micromark-factory-mdx-expression@npm:2.0.3"
+  dependencies:
+    "@types/estree": "npm:^1.0.0"
+    devlop: "npm:^1.0.0"
+    micromark-factory-space: "npm:^2.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-events-to-acorn: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+    unist-util-position-from-estree: "npm:^2.0.0"
+    vfile-message: "npm:^4.0.0"
+  checksum: 10c0/a6004ef6272dd01a5d718f2affd7bfb5e08f0849340f5fd96ac823fbc5e9d3b3343acedda50805873ccda5e3b8af4d5fbb302abc874544044ac90c217345cf97
+  languageName: node
+  linkType: hard
+
+"micromark-factory-space@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-factory-space@npm:2.0.1"
+  dependencies:
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/f9ed43f1c0652d8d898de0ac2be3f77f776fffe7dd96bdbba1e02d7ce33d3853c6ff5daa52568fc4fa32cdf3a62d86b85ead9b9189f7211e1d69ff2163c450fb
+  languageName: node
+  linkType: hard
+
+"micromark-factory-title@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-factory-title@npm:2.0.1"
+  dependencies:
+    micromark-factory-space: "npm:^2.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/e72fad8d6e88823514916890099a5af20b6a9178ccf78e7e5e05f4de99bb8797acb756257d7a3a57a53854cb0086bf8aab15b1a9e9db8982500dd2c9ff5948b6
+  languageName: node
+  linkType: hard
+
+"micromark-factory-whitespace@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-factory-whitespace@npm:2.0.1"
+  dependencies:
+    micromark-factory-space: "npm:^2.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/20a1ec58698f24b766510a309b23a10175034fcf1551eaa9da3adcbed3e00cd53d1ebe5f030cf873f76a1cec3c34eb8c50cc227be3344caa9ed25d56cf611224
+  languageName: node
+  linkType: hard
+
+"micromark-util-character@npm:^2.0.0":
+  version: 2.1.1
+  resolution: "micromark-util-character@npm:2.1.1"
+  dependencies:
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/d3fe7a5e2c4060fc2a076f9ce699c82a2e87190a3946e1e5eea77f563869b504961f5668d9c9c014724db28ac32fa909070ea8b30c3a39bd0483cc6c04cc76a1
+  languageName: node
+  linkType: hard
+
+"micromark-util-chunked@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-util-chunked@npm:2.0.1"
+  dependencies:
+    micromark-util-symbol: "npm:^2.0.0"
+  checksum: 10c0/b68c0c16fe8106949537bdcfe1be9cf36c0ccd3bc54c4007003cb0984c3750b6cdd0fd77d03f269a3382b85b0de58bde4f6eedbe7ecdf7244759112289b1ab56
+  languageName: node
+  linkType: hard
+
+"micromark-util-classify-character@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-util-classify-character@npm:2.0.1"
+  dependencies:
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/8a02e59304005c475c332f581697e92e8c585bcd45d5d225a66c1c1b14ab5a8062705188c2ccec33cc998d33502514121478b2091feddbc751887fc9c290ed08
+  languageName: node
+  linkType: hard
+
+"micromark-util-combine-extensions@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-util-combine-extensions@npm:2.0.1"
+  dependencies:
+    micromark-util-chunked: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/f15e282af24c8372cbb10b9b0b3e2c0aa681fea0ca323a44d6bc537dc1d9382c819c3689f14eaa000118f5a163245358ce6276b2cda9a84439cdb221f5d86ae7
+  languageName: node
+  linkType: hard
+
+"micromark-util-decode-numeric-character-reference@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "micromark-util-decode-numeric-character-reference@npm:2.0.2"
+  dependencies:
+    micromark-util-symbol: "npm:^2.0.0"
+  checksum: 10c0/9c8a9f2c790e5593ffe513901c3a110e9ec8882a08f466da014112a25e5059b51551ca0aeb7ff494657d86eceb2f02ee556c6558b8d66aadc61eae4a240da0df
+  languageName: node
+  linkType: hard
+
+"micromark-util-decode-string@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-util-decode-string@npm:2.0.1"
+  dependencies:
+    decode-named-character-reference: "npm:^1.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-decode-numeric-character-reference: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+  checksum: 10c0/f24d75b2e5310be6e7b6dee532e0d17d3bf46996841d6295f2a9c87a2046fff4ab603c52ab9d7a7a6430a8b787b1574ae895849c603d262d1b22eef71736b5cb
+  languageName: node
+  linkType: hard
+
+"micromark-util-encode@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-util-encode@npm:2.0.1"
+  checksum: 10c0/b2b29f901093845da8a1bf997ea8b7f5e061ffdba85070dfe14b0197c48fda64ffcf82bfe53c90cf9dc185e69eef8c5d41cae3ba918b96bc279326921b59008a
+  languageName: node
+  linkType: hard
+
+"micromark-util-events-to-acorn@npm:^2.0.0":
+  version: 2.0.3
+  resolution: "micromark-util-events-to-acorn@npm:2.0.3"
+  dependencies:
+    "@types/estree": "npm:^1.0.0"
+    "@types/unist": "npm:^3.0.0"
+    devlop: "npm:^1.0.0"
+    estree-util-visit: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+    vfile-message: "npm:^4.0.0"
+  checksum: 10c0/a4e0716e943ffdd16a918edf51d4f8291ec2692f5c4d04693dbef3358716fba891f288197afd102c14f4d98dac09d52351046ab7aad1d50b74677bdd5fa683c0
+  languageName: node
+  linkType: hard
+
+"micromark-util-html-tag-name@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-util-html-tag-name@npm:2.0.1"
+  checksum: 10c0/ae80444db786fde908e9295f19a27a4aa304171852c77414516418650097b8afb401961c9edb09d677b06e97e8370cfa65638dde8438ebd41d60c0a8678b85b9
+  languageName: node
+  linkType: hard
+
+"micromark-util-normalize-identifier@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-util-normalize-identifier@npm:2.0.1"
+  dependencies:
+    micromark-util-symbol: "npm:^2.0.0"
+  checksum: 10c0/5299265fa360769fc499a89f40142f10a9d4a5c3dd8e6eac8a8ef3c2e4a6570e4c009cf75ea46dce5ee31c01f25587bde2f4a5cc0a935584ae86dd857f2babbd
+  languageName: node
+  linkType: hard
+
+"micromark-util-resolve-all@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-util-resolve-all@npm:2.0.1"
+  dependencies:
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/bb6ca28764696bb479dc44a2d5b5fe003e7177aeae1d6b0d43f24cc223bab90234092d9c3ce4a4d2b8df095ccfd820537b10eb96bb7044d635f385d65a4c984a
+  languageName: node
+  linkType: hard
+
+"micromark-util-sanitize-uri@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-util-sanitize-uri@npm:2.0.1"
+  dependencies:
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-encode: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+  checksum: 10c0/60e92166e1870fd4f1961468c2651013ff760617342918e0e0c3c4e872433aa2e60c1e5a672bfe5d89dc98f742d6b33897585cf86ae002cda23e905a3c02527c
+  languageName: node
+  linkType: hard
+
+"micromark-util-subtokenize@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "micromark-util-subtokenize@npm:2.1.0"
+  dependencies:
+    devlop: "npm:^1.0.0"
+    micromark-util-chunked: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/bee69eece4393308e657c293ba80d92ebcb637e5f55e21dcf9c3fa732b91a8eda8ac248d76ff375e675175bfadeae4712e5158ef97eef1111789da1ce7ab5067
+  languageName: node
+  linkType: hard
+
+"micromark-util-symbol@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-util-symbol@npm:2.0.1"
+  checksum: 10c0/f2d1b207771e573232436618e78c5e46cd4b5c560dd4a6d63863d58018abbf49cb96ec69f7007471e51434c60de3c9268ef2bf46852f26ff4aacd10f9da16fe9
+  languageName: node
+  linkType: hard
+
+"micromark-util-types@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "micromark-util-types@npm:2.0.2"
+  checksum: 10c0/c8c15b96c858db781c4393f55feec10004bf7df95487636c9a9f7209e51002a5cca6a047c5d2a5dc669ff92da20e57aaa881e81a268d9ccadb647f9dce305298
+  languageName: node
+  linkType: hard
+
 "micromark@npm:^2.11.3, micromark@npm:~2.11.0, micromark@npm:~2.11.3":
   version: 2.11.4
   resolution: "micromark@npm:2.11.4"
@@ -12312,6 +13119,31 @@ __metadata:
     debug: "npm:^4.0.0"
     parse-entities: "npm:^2.0.0"
   checksum: 10c0/67307cbacae621ab1eb23e333a5addc7600cf97d3b40cad22fc1c2d03d734d6d9cbc3f5a7e5d655a8c0862a949abe590ab7cfa96be366bfe09e239a94e6eea55
+  languageName: node
+  linkType: hard
+
+"micromark@npm:^4.0.0":
+  version: 4.0.2
+  resolution: "micromark@npm:4.0.2"
+  dependencies:
+    "@types/debug": "npm:^4.0.0"
+    debug: "npm:^4.0.0"
+    decode-named-character-reference: "npm:^1.0.0"
+    devlop: "npm:^1.0.0"
+    micromark-core-commonmark: "npm:^2.0.0"
+    micromark-factory-space: "npm:^2.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-chunked: "npm:^2.0.0"
+    micromark-util-combine-extensions: "npm:^2.0.0"
+    micromark-util-decode-numeric-character-reference: "npm:^2.0.0"
+    micromark-util-encode: "npm:^2.0.0"
+    micromark-util-normalize-identifier: "npm:^2.0.0"
+    micromark-util-resolve-all: "npm:^2.0.0"
+    micromark-util-sanitize-uri: "npm:^2.0.0"
+    micromark-util-subtokenize: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/07462287254219d6eda6eac8a3cebaff2994e0575499e7088027b825105e096e4f51e466b14b2a81b71933a3b6c48ee069049d87bc2c2127eee50d9cc69e8af6
   languageName: node
   linkType: hard
 
@@ -13690,6 +14522,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"parse-entities@npm:^4.0.0":
+  version: 4.0.2
+  resolution: "parse-entities@npm:4.0.2"
+  dependencies:
+    "@types/unist": "npm:^2.0.0"
+    character-entities-legacy: "npm:^3.0.0"
+    character-reference-invalid: "npm:^2.0.0"
+    decode-named-character-reference: "npm:^1.0.0"
+    is-alphanumerical: "npm:^2.0.0"
+    is-decimal: "npm:^2.0.0"
+    is-hexadecimal: "npm:^2.0.0"
+  checksum: 10c0/a13906b1151750b78ed83d386294066daf5fb559e08c5af9591b2d98cc209123103016a01df776f65f8219ad26652d6d6b210d0974d452049cddfc53a8916c34
+  languageName: node
+  linkType: hard
+
 "parse-imports-exports@npm:^0.2.4":
   version: 0.2.4
   resolution: "parse-imports-exports@npm:0.2.4"
@@ -14697,6 +15544,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"remark-frontmatter@npm:5.0.0":
+  version: 5.0.0
+  resolution: "remark-frontmatter@npm:5.0.0"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    mdast-util-frontmatter: "npm:^2.0.0"
+    micromark-extension-frontmatter: "npm:^2.0.0"
+    unified: "npm:^11.0.0"
+  checksum: 10c0/102325d5edbcf30eaf74de8a0a6e03096cc2370dfef19080fd2dd208f368fbb2323388751ac9931a1aa38a4f2828fa4bad6c52dc5249dcadcd34861693b52bf9
+  languageName: node
+  linkType: hard
+
 "remark-frontmatter@npm:^3.0.0":
   version: 3.0.0
   resolution: "remark-frontmatter@npm:3.0.0"
@@ -14704,6 +15563,20 @@ __metadata:
     mdast-util-frontmatter: "npm:^0.2.0"
     micromark-extension-frontmatter: "npm:^0.2.0"
   checksum: 10c0/19aabb28b5dbc84fea764238324821315147ce5612283932e11a69e65b98f79ea87d88de16d7b20196281846e324b54331507ba6021a1ce32ff8a43a28dcc44b
+  languageName: node
+  linkType: hard
+
+"remark-gfm@npm:4.0.1":
+  version: 4.0.1
+  resolution: "remark-gfm@npm:4.0.1"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    mdast-util-gfm: "npm:^3.0.0"
+    micromark-extension-gfm: "npm:^3.0.0"
+    remark-parse: "npm:^11.0.0"
+    remark-stringify: "npm:^11.0.0"
+    unified: "npm:^11.0.0"
+  checksum: 10c0/427ecc6af3e76222662061a5f670a3e4e33ec5fffe2cabf04034da6a3f9a1bda1fc023e838a636385ba314e66e2bebbf017ca61ebea357eb0f5200fe0625a4b7
   languageName: node
   linkType: hard
 
@@ -14717,12 +15590,45 @@ __metadata:
   languageName: node
   linkType: hard
 
+"remark-mdx@npm:3.1.1":
+  version: 3.1.1
+  resolution: "remark-mdx@npm:3.1.1"
+  dependencies:
+    mdast-util-mdx: "npm:^3.0.0"
+    micromark-extension-mdxjs: "npm:^3.0.0"
+  checksum: 10c0/3e5585d4c2448d8ac7548b1d148f04b89251ff47fbfc80be1428cecec2fc2530abe30a5da53bb031283f8a78933259df6120c1cd4cc7cc1d43978d508798ba88
+  languageName: node
+  linkType: hard
+
+"remark-parse@npm:11.0.0, remark-parse@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "remark-parse@npm:11.0.0"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    mdast-util-from-markdown: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+    unified: "npm:^11.0.0"
+  checksum: 10c0/6eed15ddb8680eca93e04fcb2d1b8db65a743dcc0023f5007265dda558b09db595a087f622062ccad2630953cd5cddc1055ce491d25a81f3317c858348a8dd38
+  languageName: node
+  linkType: hard
+
 "remark-parse@npm:^9.0.0":
   version: 9.0.0
   resolution: "remark-parse@npm:9.0.0"
   dependencies:
     mdast-util-from-markdown: "npm:^0.8.0"
   checksum: 10c0/7523b2a2e3c7a80f7530b4d5615e8862890abe321cdc4f6f7b103c70ceb4b3eca14cc71127149f05d5e29ed521b0c7505af9f11b1293921cf7cdf6d794104a21
+  languageName: node
+  linkType: hard
+
+"remark-stringify@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "remark-stringify@npm:11.0.0"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    mdast-util-to-markdown: "npm:^2.0.0"
+    unified: "npm:^11.0.0"
+  checksum: 10c0/0cdb37ce1217578f6f847c7ec9f50cbab35df5b9e3903d543e74b405404e67c07defcb23cd260a567b41b769400f6de03c2c3d9cd6ae7a6707d5c8d89ead489f
   languageName: node
   linkType: hard
 
@@ -15867,6 +16773,16 @@ __metadata:
   dependencies:
     safe-buffer: "npm:~5.1.0"
   checksum: 10c0/b4f89f3a92fd101b5653ca3c99550e07bdf9e13b35037e9e2a1c7b47cec4e55e06ff3fc468e314a0b5e80bfbaf65c1ca5a84978764884ae9413bec1fc6ca924e
+  languageName: node
+  linkType: hard
+
+"stringify-entities@npm:^4.0.0":
+  version: 4.0.4
+  resolution: "stringify-entities@npm:4.0.4"
+  dependencies:
+    character-entities-html4: "npm:^2.0.0"
+    character-entities-legacy: "npm:^3.0.0"
+  checksum: 10c0/537c7e656354192406bdd08157d759cd615724e9d0873602d2c9b2f6a5c0a8d0b1d73a0a08677848105c5eebac6db037b57c0b3a4ec86331117fa7319ed50448
   languageName: node
   linkType: hard
 
@@ -17308,6 +18224,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"unified@npm:11.0.5, unified@npm:^11.0.0":
+  version: 11.0.5
+  resolution: "unified@npm:11.0.5"
+  dependencies:
+    "@types/unist": "npm:^3.0.0"
+    bail: "npm:^2.0.0"
+    devlop: "npm:^1.0.0"
+    extend: "npm:^3.0.0"
+    is-plain-obj: "npm:^4.0.0"
+    trough: "npm:^2.0.0"
+    vfile: "npm:^6.0.0"
+  checksum: 10c0/53c8e685f56d11d9d458a43e0e74328a4d6386af51c8ac37a3dcabec74ce5026da21250590d4aff6733ccd7dc203116aae2b0769abc18cdf9639a54ae528dfc9
+  languageName: node
+  linkType: hard
+
 "unified@npm:^10.0.0, unified@npm:^10.1.2":
   version: 10.1.2
   resolution: "unified@npm:10.1.2"
@@ -17375,6 +18306,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"unist-util-is@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "unist-util-is@npm:6.0.1"
+  dependencies:
+    "@types/unist": "npm:^3.0.0"
+  checksum: 10c0/5a487d390193811d37a68264e204dbc7c15c40b8fc29b5515a535d921d071134f571d7b5cbd59bcd58d5ce1c0ab08f20fc4a1f0df2287a249c979267fc32ce06
+  languageName: node
+  linkType: hard
+
+"unist-util-position-from-estree@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "unist-util-position-from-estree@npm:2.0.0"
+  dependencies:
+    "@types/unist": "npm:^3.0.0"
+  checksum: 10c0/39127bf5f0594e0a76d9241dec4f7aa26323517120ce1edd5ed91c8c1b9df7d6fb18af556e4b6250f1c7368825720ed892e2b6923be5cdc08a9bb16536dc37b3
+  languageName: node
+  linkType: hard
+
 "unist-util-stringify-position@npm:^2.0.0":
   version: 2.0.3
   resolution: "unist-util-stringify-position@npm:2.0.3"
@@ -17393,6 +18342,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"unist-util-stringify-position@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "unist-util-stringify-position@npm:4.0.0"
+  dependencies:
+    "@types/unist": "npm:^3.0.0"
+  checksum: 10c0/dfe1dbe79ba31f589108cb35e523f14029b6675d741a79dea7e5f3d098785045d556d5650ec6a8338af11e9e78d2a30df12b1ee86529cded1098da3f17ee999e
+  languageName: node
+  linkType: hard
+
 "unist-util-visit-parents@npm:^3.0.0":
   version: 3.1.1
   resolution: "unist-util-visit-parents@npm:3.1.1"
@@ -17400,6 +18358,16 @@ __metadata:
     "@types/unist": "npm:^2.0.0"
     unist-util-is: "npm:^4.0.0"
   checksum: 10c0/231c80c5ba8e79263956fcaa25ed2a11ad7fe77ac5ba0d322e9d51bbc4238501e3bb52f405e518bcdc5471e27b33eff520db0aa4a3b1feb9fb6e2de6ae385d49
+  languageName: node
+  linkType: hard
+
+"unist-util-visit-parents@npm:^6.0.0":
+  version: 6.0.2
+  resolution: "unist-util-visit-parents@npm:6.0.2"
+  dependencies:
+    "@types/unist": "npm:^3.0.0"
+    unist-util-is: "npm:^6.0.0"
+  checksum: 10c0/f1e4019dbd930301825895e3737b1ee0cd682f7622ddd915062135cbb39f8c090aaece3a3b5eae1f2ea52ec33f0931abb8f8a8b5c48a511a4203e3d360a8cd49
   languageName: node
   linkType: hard
 
@@ -17411,6 +18379,17 @@ __metadata:
     unist-util-is: "npm:^4.0.0"
     unist-util-visit-parents: "npm:^3.0.0"
   checksum: 10c0/7b11303d82271ca53a2ced2d56c87a689dd518596c99ff4a11cdff750f5cc5c0e4b64b146bd2363557cb29443c98713bfd1e8dc6d1c3f9d474b9eb1f23a60888
+  languageName: node
+  linkType: hard
+
+"unist-util-visit@npm:^5.0.0":
+  version: 5.1.0
+  resolution: "unist-util-visit@npm:5.1.0"
+  dependencies:
+    "@types/unist": "npm:^3.0.0"
+    unist-util-is: "npm:^6.0.0"
+    unist-util-visit-parents: "npm:^6.0.0"
+  checksum: 10c0/a56e1bbbf63fcb55abe379e660b9a3367787e8be1e2473bdb7e86cfa6f32b6c1fa0092432d7040b8a30b2fc674bbbe024ffe6d03c3d6bf4839b064f584463a4e
   languageName: node
   linkType: hard
 
@@ -17666,6 +18645,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vfile-message@npm:^4.0.0":
+  version: 4.0.3
+  resolution: "vfile-message@npm:4.0.3"
+  dependencies:
+    "@types/unist": "npm:^3.0.0"
+    unist-util-stringify-position: "npm:^4.0.0"
+  checksum: 10c0/33d9f219610d27987689bb14fa5573d2daa146941d1a05416dd7702c4215b23f44ed81d059e70d0e4e24f9a57d5f4dc9f18d35a993f04cf9446a7abe6d72d0c0
+  languageName: node
+  linkType: hard
+
 "vfile@npm:^4.0.0":
   version: 4.2.1
   resolution: "vfile@npm:4.2.1"
@@ -17687,6 +18676,16 @@ __metadata:
     unist-util-stringify-position: "npm:^3.0.0"
     vfile-message: "npm:^3.0.0"
   checksum: 10c0/c36bd4c3f16ec0c6cbad0711ca99200316bbf849d6b07aa4cb5d9062cc18ae89249fe62af9521926e9659c0e6bc5c2c1da0fe26b41fb71e757438297e1a41da4
+  languageName: node
+  linkType: hard
+
+"vfile@npm:^6.0.0":
+  version: 6.0.3
+  resolution: "vfile@npm:6.0.3"
+  dependencies:
+    "@types/unist": "npm:^3.0.0"
+    vfile-message: "npm:^4.0.0"
+  checksum: 10c0/e5d9eb4810623f23758cfc2205323e33552fb5972e5c2e6587babe08fe4d24859866277404fb9e2a20afb71013860d96ec806cb257536ae463c87d70022ab9ef
   languageName: node
   linkType: hard
 
@@ -18496,5 +19495,12 @@ __metadata:
   version: 1.0.5
   resolution: "zwitch@npm:1.0.5"
   checksum: 10c0/26dc7d32e5596824b565db1da9650d00d32659c1211195bef50c25c60820f9c942aa7abefe678fc1ed0b97c1755036ac1bde5f97881d7d0e73e04e02aca56957
+  languageName: node
+  linkType: hard
+
+"zwitch@npm:^2.0.0":
+  version: 2.0.4
+  resolution: "zwitch@npm:2.0.4"
+  checksum: 10c0/3c7830cdd3378667e058ffdb4cf2bb78ac5711214e2725900873accb23f3dfe5f9e7e5a06dcdc5f29605da976fc45c26d9a13ca334d6eea2245a15e77b8fc06e
   languageName: node
   linkType: hard


### PR DESCRIPTION
## Summary

Closes #799

- Add `@markuplint/markdown-parser` that converts Markdown syntax (headings, links, images, lists, tables, code blocks, etc.) to HTML AST elements for markuplint analysis
- Add `@markuplint/mdx-parser` that handles JSX elements, expressions, and ESM alongside Markdown content via shared `MarkdownAwareParser` base class
- Add integration tests for `heading-levels` and `required-attr` rules with the new parsers

### Key design decisions

- **`MarkdownAwareParser` base class**: Shared abstract class in `markdown-parser` that maps mdast nodes to HTML elements, extended by both parsers to avoid code duplication
- **remark ecosystem**: `remark-parse` + `remark-gfm` + `remark-frontmatter` (+ `remark-mdx` for MDX) for robust Markdown/MDX tokenization
- **IDL attribute conversion** (MDX): React-style props (`className`, `htmlFor`) mapped to HTML content attributes via `searchIDLAttribute`
- **Reference resolution**: Link/image references resolved against collected definitions with first-wins semantics per CommonMark spec

### Test coverage

- `markdown-parser`: 77 tests
- `mdx-parser`: 98 tests
- `rules` integration: 34 tests (heading-levels + required-attr)

## Test plan

- [x] `yarn lint-check` passes (0 errors, 0 warnings)
- [x] `yarn build` succeeds (40 projects)
- [x] `yarn test` passes (2014 tests, 153 test files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)