### PR TITLE
docs(website): add Markdown and MDX parsers to documentation

### DIFF
--- a/website/docs/guides/besides-html.md
+++ b/website/docs/guides/besides-html.md
@@ -38,6 +38,8 @@ npm install -D @markuplint/vue-parser @markuplint/vue-spec
 | [**Alpine.js**](https://alpinejs.dev)                                                      | `@markuplint/alpine-parser`                  | `@markuplint/alpine-parser/spec` |
 | [**HTMX**](https://htmx.org)                                                               | `@markuplint/htmx-parser`                    | `@markuplint/htmx-parser/spec`   |
 | [**Tagged template literals**](https://lit.dev/) (lit-html etc.)                           | `@markuplint/tagged-template-literal-parser` | -                                |
+| [**Markdown**](https://commonmark.org/)                                                    | `@markuplint/markdown-parser`                | -                                |
+| [**MDX**](https://mdxjs.com/)                                                              | `@markuplint/mdx-parser`                     | `@markuplint/react-spec`         |
 | [**Pug**](https://pugjs.org/)                                                              | `@markuplint/pug-parser`                     | -                                |
 | [**PHP**](https://www.php.net/)                                                            | `@markuplint/php-parser`                     | -                                |
 | [**Smarty**](https://www.smarty.net/)                                                      | `@markuplint/smarty-parser`                  | -                                |
@@ -126,6 +128,25 @@ Set a regular expression that can identify the target file name to the `parser` 
 {
   "parser": {
     "\\.ts$": "@markuplint/tagged-template-literal-parser"
+  }
+}
+```
+
+```json class=config title="Use Markdown"
+{
+  "parser": {
+    "\\.md$": "@markuplint/markdown-parser"
+  }
+}
+```
+
+```json class=config title="Use MDX"
+{
+  "parser": {
+    "\\.mdx$": "@markuplint/mdx-parser"
+  },
+  "specs": {
+    "\\.mdx$": "@markuplint/react-spec"
   }
 }
 ```

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/besides-html.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/besides-html.md
@@ -38,6 +38,8 @@ npm install -D @markuplint/vue-parser @markuplint/vue-spec
 | [**Alpine.js**](https://alpinejs.dev)                                                      | `@markuplint/alpine-parser`                  | `@markuplint/alpine-parser/spec` |
 | [**HTMX**](https://htmx.org)                                                               | `@markuplint/htmx-parser`                    | `@markuplint/htmx-parser/spec`   |
 | [**タグ付きテンプレートリテラル**](https://lit.dev/)（lit-html等）                         | `@markuplint/tagged-template-literal-parser` | -                                |
+| [**Markdown**](https://commonmark.org/)                                                    | `@markuplint/markdown-parser`                | -                                |
+| [**MDX**](https://mdxjs.com/)                                                              | `@markuplint/mdx-parser`                     | `@markuplint/react-spec`         |
 | [**Pug**](https://pugjs.org/)                                                              | `@markuplint/pug-parser`                     | -                                |
 | [**PHP**](https://www.php.net/)                                                            | `@markuplint/php-parser`                     | -                                |
 | [**Smarty**](https://www.smarty.net/)                                                      | `@markuplint/smarty-parser`                  | -                                |
@@ -125,6 +127,25 @@ npm install -D @markuplint/vue-parser @markuplint/vue-spec
 {
   "parser": {
     "\\.ts$": "@markuplint/tagged-template-literal-parser"
+  }
+}
+```
+
+```json class=config title="Markdownでつかう"
+{
+  "parser": {
+    "\\.md$": "@markuplint/markdown-parser"
+  }
+}
+```
+
+```json class=config title="MDXでつかう"
+{
+  "parser": {
+    "\\.mdx$": "@markuplint/mdx-parser"
+  },
+  "specs": {
+    "\\.mdx$": "@markuplint/react-spec"
   }
 }
 ```

--- a/website/i18n/ja/docusaurus-plugin-content-pages/index.tsx
+++ b/website/i18n/ja/docusaurus-plugin-content-pages/index.tsx
@@ -63,8 +63,8 @@ export default function Home(): JSX.Element {
               description: (
                 <>
                   Markuplintは、プラグインを通じてHTML以外の構文やテンプレートエンジンについても評価することができます。Pug,
-                  JSX(React), Vue, Svelte, Astro, Alpine.js, HTMX, タグ付きテンプレートリテラル(lit-html), PHP, Smarty,
-                  eRuby, EJS, Mustache/Handlebars, Nunjucks,
+                  JSX(React), Vue, Svelte, Astro, Alpine.js, HTMX, タグ付きテンプレートリテラル(lit-html), Markdown, MDX,
+                  PHP, Smarty, eRuby, EJS, Mustache/Handlebars, Nunjucks,
                   Liquid用のプラグインが用意されています。また、欲しい構文に対応したプラグインを作成するAPIも提供します。
                 </>
               ),

--- a/website/scripts/prebuild/rule-content.mts
+++ b/website/scripts/prebuild/rule-content.mts
@@ -33,8 +33,10 @@ export function rewriteRuleContent(
     ].join('\n'),
   );
 
-  // Replace relative paths
+  // Replace relative paths and strip README filenames for Docusaurus compatibility
   content = content.replaceAll('](../', '](./');
+  content = content.replaceAll('/README.md)', ')');
+  content = content.replaceAll('/README.ja.md)', ')');
 
   return content;
 }

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -65,7 +65,7 @@ export default function Home(): JSX.Element {
                 <>
                   Markuplint can evaluate it for syntaxes and template engines besides HTML through plugins. There are
                   plugins for Pug, JSX(React), Vue, Svelte, Astro, Alpine.js, HTMX, Tagged Template Literals (lit-html),
-                  PHP, Smarty, eRuby, EJS, Mustache/Handlebars, Nunjucks, and Liquid. And it also provides the API that
+                  Markdown, MDX, PHP, Smarty, eRuby, EJS, Mustache/Handlebars, Nunjucks, and Liquid. And it also provides the API that
                   creates the plugin for the syntax you want.
                 </>
               ),


### PR DESCRIPTION
## Summary

- Add Markdown and MDX entries to the supported syntaxes table in the "Using to besides HTML" guide (en/ja)
- Add configuration examples for Markdown and MDX parsers (en/ja)
- Add Markdown and MDX to the top page feature description (en/ja)

## Test plan

- [x] `yarn lint-check` passes (0 errors, 0 warnings)
- [x] `yarn build` succeeds (40 projects)
- [x] `yarn test` passes (2054 tests, 154 test files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)