### PR TITLE
fix(types): accept BCP 47 private-use tags like x-default

### DIFF
--- a/packages/@markuplint/types/docs/validators.ja.md
+++ b/packages/@markuplint/types/docs/validators.ja.md
@@ -295,19 +295,19 @@ WHATWGが定義する各種名前フォーマットに対する、シンプル�
 
 [BCP 47](https://tools.ietf.org/rfc/bcp/bcp47.html)（RFC 5646 + RFC 4647）に準拠した言語タグの検証を行います。
 
-npmパッケージ `bcp-47` を組み込んでパースし、有効な `language` サブタグが含まれているかを確認します。
+npmパッケージ `bcp-47` を組み込んでパースし、有効な `language` サブタグまたは `privateuse` サブタグ（例: `x-default`）が含まれているかを確認します。
 
 ```typescript
 // src/rfc/is-bcp-47.ts
 export const isBCP47: FormattedPrimitiveTypeCreator = () => {
   return value => {
-    const { language } = parse(value);
-    return !!language;
+    const { language, privateuse } = parse(value);
+    return !!language || (privateuse != null && privateuse.length > 0);
   };
 };
 ```
 
-`defs.ts` では `BCP47` 型として登録されており、HTML要素の `lang` 属性の検証に使用されます。
+`defs.ts` では `BCP47` 型として登録されており、HTML要素の `lang` 属性や `hreflang` 属性の検証に使用されます。
 
 ---
 

--- a/packages/@markuplint/types/docs/validators.md
+++ b/packages/@markuplint/types/docs/validators.md
@@ -295,19 +295,19 @@ All of these are `FormattedPrimitiveTypeCreator` factories -- they return `() =>
 
 Validates language tags according to [BCP 47](https://tools.ietf.org/rfc/bcp/bcp47.html) (RFC 5646 + RFC 4647).
 
-The validator integrates the `bcp-47` npm package. It parses the value and checks that a valid `language` subtag is present:
+The validator integrates the `bcp-47` npm package. It parses the value and checks that either a valid `language` subtag or a `privateuse` subtag (e.g., `x-default`) is present:
 
 ```typescript
 // src/rfc/is-bcp-47.ts
 export const isBCP47: FormattedPrimitiveTypeCreator = () => {
   return value => {
-    const { language } = parse(value);
-    return !!language;
+    const { language, privateuse } = parse(value);
+    return !!language || (privateuse != null && privateuse.length > 0);
   };
 };
 ```
 
-This is registered in `defs.ts` as the `BCP47` type, used for the `lang` attribute on HTML elements.
+This is registered in `defs.ts` as the `BCP47` type, used for the `lang` and `hreflang` attributes on HTML elements.
 
 ---
 

--- a/packages/@markuplint/types/src/rfc/is-bcp-47.spec.ts
+++ b/packages/@markuplint/types/src/rfc/is-bcp-47.spec.ts
@@ -23,3 +23,11 @@ test('Invalid', () => {
 test('Surrounded by spaces', () => {
 	expect(is(' en ')).toBe(false);
 });
+
+test('x-default (private use)', () => {
+	expect(is('x-default')).toBe(true);
+});
+
+test('x-custom (private use)', () => {
+	expect(is('x-custom')).toBe(true);
+});

--- a/packages/@markuplint/types/src/rfc/is-bcp-47.ts
+++ b/packages/@markuplint/types/src/rfc/is-bcp-47.ts
@@ -9,7 +9,7 @@ import { parse } from 'bcp-47';
  */
 export const isBCP47: FormattedPrimitiveTypeCreator = () => {
 	return value => {
-		const { language } = parse(value);
-		return !!language;
+		const { language, privateuse } = parse(value);
+		return !!language || (privateuse != null && privateuse.length > 0);
 	};
 };


### PR DESCRIPTION
## Summary

Closes #718

- Fix BCP 47 validator to accept private-use tags (`x-default`, `x-custom`, etc.) per RFC 5646 Section 2.1
- The validator previously only checked the `language` field, rejecting valid private-use subtags
- Add `privateuse` field check so tags like `hreflang="x-default"` are correctly accepted
- Update validator documentation (EN/JA) to reflect the change

## Test plan

- [x] `npx vitest run packages/@markuplint/types/src/rfc/is-bcp-47.spec.ts` — 7 tests pass (2 new)
- [x] `yarn build` — all 40 packages build successfully
- [x] `yarn lint` — 0 errors, 0 warnings
- [x] `yarn test` — 2097 tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)