### PR TITLE
feat(rules)!: simplify invalid-attr options (#807)

### DIFF
--- a/docs/migration/v4-v5/rules/invalid-attr.ja.md
+++ b/docs/migration/v4-v5/rules/invalid-attr.ja.md
@@ -1,0 +1,128 @@
+# `invalid-attr` 破壊的変更: v4 から v5 への移行ガイド
+
+## 対象読者
+
+- `invalid-attr` オプション（`allowAttrs`、`disallowAttrs`、`attrs`）をカスタマイズしていた**設定ファイル作成者**
+
+## 変更一覧
+
+| 変更内容 | 影響範囲 |
+|---------|---------|
+| `{ type: X }` ラッパーの廃止 | `{ "value": { "type": "Int" } }` 等を使用していた設定 |
+| `attrs` オプションの削除 | 非推奨の `attrs` オプション（v3.7.0 から非推奨）を使用していた設定 |
+| オブジェクト形式の非推奨化 | `allowAttrs` / `disallowAttrs` でオブジェクト形式を使用していた設定 |
+
+## `{ type: X }` ラッパーの廃止
+
+v4 では、`allowAttrs` や `disallowAttrs` の属性値を `{ type: X }` というラッパーオブジェクトで指定できました。v5 ではこのラッパーが廃止され、型文字列を直接指定するようになりました。
+
+### v4
+
+```json
+{
+  "invalid-attr": {
+    "options": {
+      "allowAttrs": [
+        {
+          "name": "x-count",
+          "value": { "type": "Int" }
+        }
+      ]
+    }
+  }
+}
+```
+
+### v5
+
+```json
+{
+  "invalid-attr": {
+    "options": {
+      "allowAttrs": [
+        {
+          "name": "x-count",
+          "value": "Int"
+        }
+      ]
+    }
+  }
+}
+```
+
+`{ enum: [...] }` と `{ pattern: "..." }` は従来通り動作します。
+
+## `attrs` オプションの削除
+
+v3.7.0 から非推奨だった `attrs` オプションが削除されました。代わりに `allowAttrs` と `disallowAttrs` を使用してください。
+
+### v4
+
+```json
+{
+  "invalid-attr": {
+    "options": {
+      "attrs": {
+        "x-data": { "type": "Any" },
+        "x-count": { "type": "Int" },
+        "x-color": { "enum": ["red", "blue"] },
+        "x-id": { "pattern": "/^[a-z]+$/" },
+        "x-banned": { "disallowed": true }
+      }
+    }
+  }
+}
+```
+
+### v5
+
+```json
+{
+  "invalid-attr": {
+    "options": {
+      "allowAttrs": [
+        "x-data",
+        { "name": "x-count", "value": "Int" },
+        { "name": "x-color", "value": { "enum": ["red", "blue"] } },
+        { "name": "x-id", "value": { "pattern": "/^[a-z]+$/" } }
+      ],
+      "disallowAttrs": ["x-banned"]
+    }
+  }
+}
+```
+
+## オブジェクト形式の非推奨化
+
+`allowAttrs` と `disallowAttrs` のオブジェクト形式は非推奨になりました。オブジェクト形式は v5 でもまだ動作しますが、将来のバージョンで削除される予定です。配列形式を使用してください。
+
+### v4
+
+```json
+{
+  "invalid-attr": {
+    "options": {
+      "allowAttrs": {
+        "x-attr": "Int"
+      }
+    }
+  }
+}
+```
+
+### v5
+
+```json
+{
+  "invalid-attr": {
+    "options": {
+      "allowAttrs": [
+        {
+          "name": "x-attr",
+          "value": "Int"
+        }
+      ]
+    }
+  }
+}
+```

--- a/docs/migration/v4-v5/rules/invalid-attr.md
+++ b/docs/migration/v4-v5/rules/invalid-attr.md
@@ -1,0 +1,128 @@
+# `invalid-attr` Breaking Changes: v4 to v5 Migration Guide
+
+## Who This Guide Is For
+
+- **Config authors** who customized `invalid-attr` options with `allowAttrs`, `disallowAttrs`, or `attrs`
+
+## Summary of Changes
+
+| Change | Impact |
+|--------|--------|
+| `{ type: X }` wrapper removed | Configs using `{ "value": { "type": "Int" } }` etc. |
+| `attrs` option deleted | Configs using the deprecated `attrs` option (deprecated since v3.7.0) |
+| Object format deprecated | Configs using the object format for `allowAttrs` / `disallowAttrs` |
+
+## `{ type: X }` Wrapper Removed
+
+In v4, attribute values in `allowAttrs` and `disallowAttrs` could be specified with a `{ type: X }` wrapper object. In v5, this wrapper has been removed. Specify the type string directly.
+
+### v4
+
+```json
+{
+  "invalid-attr": {
+    "options": {
+      "allowAttrs": [
+        {
+          "name": "x-count",
+          "value": { "type": "Int" }
+        }
+      ]
+    }
+  }
+}
+```
+
+### v5
+
+```json
+{
+  "invalid-attr": {
+    "options": {
+      "allowAttrs": [
+        {
+          "name": "x-count",
+          "value": "Int"
+        }
+      ]
+    }
+  }
+}
+```
+
+`{ enum: [...] }` and `{ pattern: "..." }` continue to work as before.
+
+## `attrs` Option Deleted
+
+The `attrs` option, deprecated since v3.7.0, has been removed. Use `allowAttrs` and `disallowAttrs` instead.
+
+### v4
+
+```json
+{
+  "invalid-attr": {
+    "options": {
+      "attrs": {
+        "x-data": { "type": "Any" },
+        "x-count": { "type": "Int" },
+        "x-color": { "enum": ["red", "blue"] },
+        "x-id": { "pattern": "/^[a-z]+$/" },
+        "x-banned": { "disallowed": true }
+      }
+    }
+  }
+}
+```
+
+### v5
+
+```json
+{
+  "invalid-attr": {
+    "options": {
+      "allowAttrs": [
+        "x-data",
+        { "name": "x-count", "value": "Int" },
+        { "name": "x-color", "value": { "enum": ["red", "blue"] } },
+        { "name": "x-id", "value": { "pattern": "/^[a-z]+$/" } }
+      ],
+      "disallowAttrs": ["x-banned"]
+    }
+  }
+}
+```
+
+## Object Format Deprecated
+
+The object format for `allowAttrs` and `disallowAttrs` is deprecated. The object format still works in v5 but will be removed in a future version. Use the array format instead.
+
+### v4
+
+```json
+{
+  "invalid-attr": {
+    "options": {
+      "allowAttrs": {
+        "x-attr": "Int"
+      }
+    }
+  }
+}
+```
+
+### v5
+
+```json
+{
+  "invalid-attr": {
+    "options": {
+      "allowAttrs": [
+        {
+          "name": "x-attr",
+          "value": "Int"
+        }
+      ]
+    }
+  }
+}
+```

--- a/packages/@markuplint/config-presets/src/preset.html-standard.jsonc
+++ b/packages/@markuplint/config-presets/src/preset.html-standard.jsonc
@@ -171,11 +171,14 @@
 			"rules": {
 				"invalid-attr": {
 					"options": {
-						"disallowAttrs": {
-							"name": {
-								"pattern": "{{ value }}"
+						"disallowAttrs": [
+							{
+								"name": "name",
+								"value": {
+									"pattern": "{{ value }}"
+								}
 							}
-						}
+						]
 					},
 					"reason": "A document must not contain a details element that is a descendant of another details element in the same details name group."
 				}

--- a/packages/@markuplint/config-presets/src/preset.rdfa.jsonc
+++ b/packages/@markuplint/config-presets/src/preset.rdfa.jsonc
@@ -13,15 +13,11 @@
 						"allowAttrs": [
 							{
 								"name": "property",
-								"value": {
-									"type": "NoEmptyAny"
-								}
+								"value": "NoEmptyAny"
 							},
 							{
 								"name": "content",
-								"value": {
-									"type": "NoEmptyAny"
-								}
+								"value": "NoEmptyAny"
 							}
 						]
 					}

--- a/packages/@markuplint/rules/src/invalid-attr/README.ja.md
+++ b/packages/@markuplint/rules/src/invalid-attr/README.ja.md
@@ -54,10 +54,6 @@ const Component = (props) => {
 HTML仕様が特定の要素で禁止している属性を意図せず許可しないよう注意してください。
 :::
 
-**配列**もしくは**オブジェクト**を受け取ります。
-
-#### 配列形式 {#allow-attrs-array-format}
-
 配列は**文字列**と**オブジェクト**の要素を含むことができます。
 
 文字列の場合、許可される属性名を指定でき、属性値は制限がありません。オブジェクトの場合、`name`と`value`の両方のプロパティを持つ必要があり、属性値に対してより詳細な制約を指定することができます。
@@ -92,58 +88,9 @@ HTML仕様が特定の要素で禁止している属性を意図せず許可し�
 
 `value`プロパティには[タイプAPI](/docs/api/types)で定義されているものを利用できます。また、`enum`プロパティを指定して許可される値を制限したり、`pattern`プロパティを指定して正規表現で値のパターンを定義することもできます。
 
-[タイプAPI](/docs/api/types)の指定は、`type`プロパティを持つオブジェクトでも指定できます。これは同じ意味を伝えるための代替構文です。
-
-```json
-[
-  {
-    "name": "x-attr",
-    "value": "<'color-profile'>"
-  },
-  // 上記と下記は同じ意味です
-  {
-    "name": "x-attr",
-    "value": {
-      "type": "<'color-profile'>"
-    }
-  }
-]
-```
-
 :::caution
 配列内で同じ属性名がある場合は後から指定されたものが優先されます。
 :::
-
-#### オブジェクト形式
-
-オブジェクト形式は、[非推奨となった旧`attrs`プロパティ](#setting-attrs-option)と同じ構造を持ちます。属性名に対応するプロパティ名を持つオブジェクトを受け取り、`type`、`enum`、`pattern`プロパティを持つオブジェクトを受け付けます。これらのプロパティは前述の[配列形式](#allow-attrs-array-format)で説明したものと同じ意味を持ちます。
-
-:::note
-`disallow`プロパティを持つオブジェクトは受け取りません。代わりに、後述する新しく導入された[`disallowAttrs`](#setting-disallow-attrs-option)オプションを使用してください。
-:::
-
-```json
-{
-  "invalid-attr": {
-    "options": {
-      "allowAttrs": {
-        "x-attr": {
-          "type": "Any"
-        },
-        "x-attr2": {
-          "type": "Int"
-        },
-        "x-attr3": {
-          "enum": ["apple", "orange"]
-        },
-        "x-attr4": {
-          "pattern": "/^[a-z]+$/"
-        }
-      }
-    }
-  }
-}
-```
 
 ### `disallowAttrs`オプションの設定 {#setting-disallow-attrs-option}
 
@@ -186,95 +133,6 @@ HTML仕様が特定の要素で禁止している属性を意図せず許可し�
   }
 }
 ```
-
-### `attrs`オプションの設定 {#setting-attrs-option}
-
-このオプションは`v3.7.0`から非推奨になりました。
-
-<details>
-<summary>オプションの詳細</summary>
-
-#### `enum`
-
-列挙した文字列にマッチする値のみ許可します。
-
-型: `string[]`
-
-```json
-{
-  "invalid-attr": {
-    "options": {
-      "attrs": {
-        "x-attr": {
-          "enum": ["value1", "value2", "value3"]
-        }
-      }
-    }
-  }
-}
-```
-
-#### `pattern`
-
-パターンにマッチする値のみ許可します。 `/` で囲むことで **正規表現** として機能します。
-
-型: `string`
-
-```json
-{
-  "invalid-attr": {
-    "options": {
-      "attrs": {
-        "x-attr": {
-          "pattern": "/[a-z]+/"
-        }
-      }
-    }
-  }
-}
-```
-
-#### `type`
-
-指定した[型](https://markuplint.dev/docs/api/types)にマッチする値のみ許可します。
-
-型: `string`
-
-```json
-{
-  "invalid-attr": {
-    "options": {
-      "attrs": {
-        "x-attr": {
-          "type": "Boolean"
-        }
-      }
-    }
-  }
-}
-```
-
-#### `disallowed`
-
-指定した属性を禁止します。
-
-型: `boolean`
-
-```json
-{
-  "invalid-attr": {
-    "options": {
-      "attrs": {
-        "x-attr": {
-          "disallowed": true
-        }
-      }
-    }
-  }
-}
-```
-
-</details>
 
 ### `ignoreAttrNamePrefix`オプションの設定
 

--- a/packages/@markuplint/rules/src/invalid-attr/README.md
+++ b/packages/@markuplint/rules/src/invalid-attr/README.md
@@ -54,10 +54,6 @@ scope `allowAttrs` so it does not unintentionally allow attributes
 that the HTML specification disallows on specific elements.
 :::
 
-It accepts an **array** or an **object**.
-
-#### Array format {#allow-attrs-array-format}
-
 The array can contain elements of both **string** and **object** types.
 
 For strings, you can specify allowed attribute names, with attribute values being unrestricted. In the case of Objects, they should have both `name` and `value` properties, allowing you to specify more precise constraints for the attribute values.
@@ -92,58 +88,9 @@ For strings, you can specify allowed attribute names, with attribute values bein
 
 You can use the types defined in [The types API](/docs/api/types) for the `value` property. Additionally, you can specify an `enum` property to limit the allowed values or use the `pattern` property to define a pattern for the values using regular expressions.
 
-You can also specify [The types API](/docs/api/types) using an Object type with a `type` property. This is just an alias with a different syntax but conveys the same meaning.
-
-```json
-[
-  {
-    "name": "x-attr",
-    "value": "<'color-profile'>"
-  },
-  // The above and below are equivalent
-  {
-    "name": "x-attr",
-    "value": {
-      "type": "<'color-profile'>"
-    }
-  }
-]
-```
-
 :::caution
 In case of duplicate attribute names within the array, the one specified later will take precedence.
 :::
-
-#### Object format
-
-The Object format follows the same structure as [the deprecated `attrs` property](#setting-attrs-option). It accepts objects with property names corresponding to **attribute names** and with object includes `type`, `enum`, and `pattern` properties. These properties have the same meaning as described earlier in [the Array format](#allow-attrs-array-format).
-
-:::note
-Note that objects with the `disallow` property are not accepted. Instead, please use the newly introduced [`disallowAttrs`](#setting-disallow-attrs-option) option, which will be discussed in the following section.
-:::
-
-```json
-{
-  "invalid-attr": {
-    "options": {
-      "allowAttrs": {
-        "x-attr": {
-          "type": "Any"
-        },
-        "x-attr2": {
-          "type": "Int"
-        },
-        "x-attr3": {
-          "enum": ["apple", "orange"]
-        },
-        "x-attr4": {
-          "pattern": "/^[a-z]+$/"
-        }
-      }
-    }
-  }
-}
-```
 
 ### Setting `disallowAttrs` option {#setting-disallow-attrs-option}
 
@@ -186,95 +133,6 @@ The format for specifying disallowed attributes is the same as for [`allowAttrs`
   }
 }
 ```
-
-### Setting `attrs` option {#setting-attrs-option}
-
-This option is deprecated since `v3.7.0`.
-
-<details>
-<summary>Details of this option</summary>
-
-#### `enum`
-
-Only values ​​that match the enumerated strings are allowed.
-
-Type: `string[]`
-
-```json
-{
-  "invalid-attr": {
-    "options": {
-      "attrs": {
-        "x-attr": {
-          "enum": ["value1", "value2", "value3"]
-        }
-      }
-    }
-  }
-}
-```
-
-#### `pattern`
-
-Only allow values ​​that match the pattern. It works as a **regular expression** by enclosing it in `/`.
-
-Type: `string`
-
-```json
-{
-  "invalid-attr": {
-    "options": {
-      "attrs": {
-        "x-attr": {
-          "pattern": "/[a-z]+/"
-        }
-      }
-    }
-  }
-}
-```
-
-#### `type`
-
-Only values that match the specified [type](https://markuplint.dev/docs/api/types) are allowed.
-
-Type: `string`
-
-```json
-{
-  "invalid-attr": {
-    "options": {
-      "attrs": {
-        "x-attr": {
-          "type": "Boolean"
-        }
-      }
-    }
-  }
-}
-```
-
-#### `disallowed`
-
-Disallow the attribute.
-
-Type: `boolean`
-
-```json
-{
-  "invalid-attr": {
-    "options": {
-      "attrs": {
-        "x-attr": {
-          "disallowed": true
-        }
-      }
-    }
-  }
-}
-```
-
-</details>
 
 ### Setting `ignoreAttrNamePrefix` option
 

--- a/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
@@ -372,9 +372,7 @@ test('custom rule: type', async () => {
 		rule: {
 			options: {
 				allowAttrs: {
-					'x-attr': {
-						type: 'Int',
-					},
+					'x-attr': 'Int',
 				},
 			},
 		},
@@ -405,9 +403,7 @@ test('custom element and custom rule', async () => {
 				rule: {
 					options: {
 						allowAttrs: {
-							'any-attr': {
-								type: 'Int',
-							},
+							'any-attr': 'Int',
 						},
 					},
 				},
@@ -1345,240 +1341,17 @@ test('Multiple Type', async () => {
 	]);
 });
 
-describe('Deprecated options', () => {
-	test('custom rule', async () => {
-		const { violations } = await mlRuleTest(rule, '<x-el x-attr="123"></x-el><x-el x-attr="abc"></x-el>', {
-			rule: {
-				options: {
-					attrs: {
-						'x-attr': {
-							pattern: '/[a-z]+/',
-						},
-					},
-				},
-			},
-		});
-
-		expect(violations).toStrictEqual([
-			{
-				severity: 'error',
-				line: 1,
-				col: 15,
-				message: 'The "x-attr" attribute is unmatched with the below patterns: /[a-z]+/',
-				raw: '123',
-			},
-		]);
-	});
-
-	test('custom rule: type', async () => {
-		const { violations } = await mlRuleTest(rule, '<x-el x-attr="123"></x-el><x-el x-attr="abc"></x-el>', {
-			rule: {
-				options: {
-					attrs: {
-						'x-attr': {
-							type: 'Int',
-						},
-					},
-				},
-			},
-		});
-
-		expect(violations).toStrictEqual([
-			{
-				severity: 'error',
-				line: 1,
-				col: 41,
-				message: 'It includes unexpected characters. the "x-attr" attribute expects integer',
-				raw: 'abc',
-			},
-		]);
-	});
-
-	test('custom element and custom rule', async () => {
-		const { violations } = await mlRuleTest(rule, '<custom-element any-attr="any-string"></custom-element>', {
-			nodeRule: [
-				{
-					selector: 'custom-element',
-					rule: {
-						options: {
-							attrs: {
-								'any-attr': {
-									type: 'Int',
-								},
-							},
-						},
-					},
-				},
-			],
-		});
-
-		expect(violations.length).toBe(1);
-	});
-
-	test('Overwrite type', async () => {
-		const { violations } = await mlRuleTest(
-			rule,
-			'<time datetime="overwrite-type"></time><time datetime="2000-01-01"></time>',
-			{
-				rule: {
-					options: {
-						attrs: {
-							datetime: {
-								enum: ['overwrite-type'],
-							},
-						},
-					},
-				},
-			},
-		);
-		const { violations: violations2 } = await mlRuleTest(
-			rule,
-			'<time datetime="overwrite-type"></time><time datetime="2000-01-01"></time>',
-		);
-
-		expect(violations).toStrictEqual([
-			{
-				severity: 'error',
-				line: 1,
-				col: 56,
-				message: 'The "datetime" attribute expects overwrite-type',
-				raw: '2000-01-01',
-			},
-		]);
-		expect(violations2).toStrictEqual([
-			{
-				severity: 'error',
-				line: 1,
-				col: 17,
-				message:
-					'The year part includes unexpected characters (https://html.spec.whatwg.org/multipage/text-level-semantics.html#datetime-value)',
-				raw: 'overwrite',
-			},
-		]);
-	});
-
-	test('custom rule: disallowed', async () => {
-		const { violations } = await mlRuleTest(rule, '<a onclick="fn()"></>', {
-			rule: {
-				options: {
-					attrs: {
-						onclick: {
-							disallowed: true,
-						},
-					},
-				},
-			},
-		});
-
-		expect(violations).toStrictEqual([
-			{
-				severity: 'error',
-				line: 1,
-				col: 4,
-				message: 'The "onclick" attribute is disallowed',
-				raw: 'onclick',
-			},
-		]);
-	});
-
-	test('React: a custom rule and a mutable attribute', async () => {
-		const { violations } = await mlRuleTest(rule, '<a href={href} target={target} invalidAttr={invalidAttr} />', {
-			parser: {
-				'.*': '@markuplint/jsx-parser',
-			},
-			nodeRule: [
-				{
-					selector: 'a',
-					rule: {
-						options: {
-							attrs: {
-								href: {
-									enum: ['https://markuplint.dev'],
-								},
-							},
-						},
-					},
-				},
-			],
-		});
-
-		expect(violations).toStrictEqual([
-			{
-				severity: 'error',
-				line: 1,
-				col: 32,
-				message: 'The "invalidAttr" attribute is disallowed',
-				raw: 'invalidAttr',
-			},
-		]);
-	});
-
-	test('regexSelector', async () => {
-		const { violations } = await mlRuleTest(
-			rule,
-			`<picture>
-	<source srcset="logo-3x.png 3x">
-	<source srcset="logo@3x.png 3x">
-	<source srcset="logo-2x.png 2x">
-	<source srcset="logo@2x.png 2x">
-	<img src="logo.png" alt="logo">
-</picture>
-`,
-			{
-				nodeRule: [
-					{
-						regexSelector: {
-							nodeName: 'img',
-							attrName: 'src',
-							attrValue: '/^(?<FileName>.+)\\.(?<Exp>png|jpg|webp|gif)$/',
-							combination: {
-								combinator: ':has(~)',
-								nodeName: 'source',
-							},
-						},
-						rule: {
-							options: {
-								attrs: {
-									srcset: {
-										enum: ['{{FileName}}@2x.{{Exp}} 2x', '{{FileName}}@3x.{{Exp}} 3x'],
-									},
-								},
-							},
-						},
-					},
-				],
-			},
-		);
-		expect(violations).toStrictEqual([
-			{
-				severity: 'error',
-				line: 2,
-				col: 18,
-				message: 'The "srcset" attribute expects either "logo@2x.png 2x", "logo@3x.png 3x"',
-				raw: 'logo-3x.png 3x',
-			},
-			{
-				severity: 'error',
-				line: 4,
-				col: 18,
-				message: 'The "srcset" attribute expects either "logo@2x.png 2x", "logo@3x.png 3x"',
-				raw: 'logo-2x.png 2x',
-			},
-		]);
-	});
-
-	test('The `as` attribute', async () => {
-		expect((await mlRuleTest(rule, '<a as="span"></a>')).violations).toStrictEqual([
-			{
-				severity: 'error',
-				line: 1,
-				col: 4,
-				message: 'The "as" attribute is disallowed. Did you mean "is"?',
-				raw: 'as',
-			},
-		]);
-		expect((await mlRuleTest(rule, '<x-link as="a" foo></x-link>')).violations).toStrictEqual([]);
-	});
+test('The `as` attribute', async () => {
+	expect((await mlRuleTest(rule, '<a as="span"></a>')).violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 4,
+			message: 'The "as" attribute is disallowed. Did you mean "is"?',
+			raw: 'as',
+		},
+	]);
+	expect((await mlRuleTest(rule, '<x-link as="a" foo></x-link>')).violations).toStrictEqual([]);
 });
 
 test('CSS Functions', async () => {

--- a/packages/@markuplint/rules/src/invalid-attr/index.ts
+++ b/packages/@markuplint/rules/src/invalid-attr/index.ts
@@ -1,6 +1,7 @@
 import type { AttributeType } from '@markuplint/ml-spec';
 
 import { createRule, getAttrSpecs, getSpec } from '@markuplint/ml-core';
+import { isEnum } from '@markuplint/types';
 
 import { attrCheck } from '../attr-check.js';
 import { log as ruleLog } from '../debug.js';
@@ -20,36 +21,20 @@ type Option = {
 	 *
 	 * @since 3.7.0
 	 */
-	allowAttrs?: (string | Attr)[] | Record<string, ValueRule>;
+	allowAttrs?: (string | Attr)[] | Record<string, AttributeType | PatternRule>;
 
 	/**
 	 * Attributes to disallow in addition to spec restrictions.
 	 *
 	 * @since 3.7.0
 	 */
-	disallowAttrs?: (string | Attr)[] | Record<string, ValueRule>;
+	disallowAttrs?: (string | Attr)[] | Record<string, AttributeType | PatternRule>;
 
 	/** Attribute name prefix(es) to ignore during validation. */
 	ignoreAttrNamePrefix?: string | string[];
 
 	/** Whether to allow additional properties for pretender elements (defaults to `true`). */
 	allowToAddPropertiesForPretender?: boolean;
-
-	/**
-	 * @deprecated Since version 3.7.0. Use `allowAttrs` or `disallowAttrs` instead.
-	 * This option (`attr`) is now considered ambiguous and may lead to confusion.
-	 * Please use the more explicit `allowAttrs` or `disallowAttrs` option
-	 * to specify allowed attributes for the `invalid-attr` rule.
-	 * @see {@link Option.allowAttrs}
-	 * @see {@link Option.disallowAttrs}
-	 */
-	attrs?: Record<
-		string,
-		| ValueRule
-		| {
-				disallowed: true;
-		  }
-	>;
 };
 
 /**
@@ -59,23 +44,15 @@ type Attr = {
 	/** The attribute name. */
 	name: string;
 	/** The expected attribute value type or validation rule. */
-	value: AttributeType | ValueRule;
+	value: AttributeType | PatternRule;
 };
 
 /**
- * A validation constraint for an attribute value, defined as either an
- * enumerated list, a regex pattern, or a spec-based type.
+ * A validation constraint for an attribute value using a regex pattern.
  */
-type ValueRule =
-	| {
-			enum: [string, ...string[]];
-	  }
-	| {
-			pattern: string;
-	  }
-	| {
-			type: AttributeType;
-	  };
+type PatternRule = {
+	pattern: string;
+};
 
 /**
  * Rule that validates attributes against the HTML spec, allowed lists,
@@ -83,9 +60,9 @@ type ValueRule =
  *
  * Checks each attribute for: existence in the spec, correct value type,
  * allowed/disallowed overrides from configuration, and typo suggestions
- * via candidate matching. Supports `allowAttrs`, `disallowAttrs`, and
- * the deprecated `attrs` option. Non-existent attributes on elements that
- * allow additional properties (pretenders) can be optionally permitted.
+ * via candidate matching. Supports `allowAttrs` and `disallowAttrs`.
+ * Non-existent attributes on elements that allow additional properties
+ * (pretenders) can be optionally permitted.
  */
 export default createRule<boolean, Option>({
 	meta: meta,
@@ -132,25 +109,21 @@ export default createRule<boolean, Option>({
 			}
 
 			let invalid: ReturnType<typeof attrCheck> = false;
-			const allowAttrs: Record<string, ValueRule> = {};
-			const disallowAttrs: Record<string, ValueRule> = {};
+			const allowAttrs: Record<string, AttributeType | PatternRule> = {};
+			const disallowAttrs: Record<string, AttributeType | PatternRule> = {};
 
 			if (attr.rule.options.allowAttrs) {
 				if (Array.isArray(attr.rule.options.allowAttrs)) {
 					for (const allowAttr of attr.rule.options.allowAttrs) {
 						if (typeof allowAttr === 'string') {
-							allowAttrs[allowAttr] = { type: 'Any' };
+							allowAttrs[allowAttr] = 'Any';
 							continue;
 						}
-						if (isValueRule(allowAttr.value)) {
-							allowAttrs[allowAttr.name] = allowAttr.value;
-							continue;
-						}
-						allowAttrs[allowAttr.name] = { type: allowAttr.value };
+						allowAttrs[allowAttr.name] = allowAttr.value;
 					}
 				} else {
-					for (const [attrName, valueRule] of Object.entries(attr.rule.options.allowAttrs)) {
-						allowAttrs[attrName] = valueRule;
+					for (const [attrName, attrType] of Object.entries(attr.rule.options.allowAttrs)) {
+						allowAttrs[attrName] = attrType;
 					}
 				}
 			}
@@ -159,28 +132,14 @@ export default createRule<boolean, Option>({
 				if (Array.isArray(attr.rule.options.disallowAttrs)) {
 					for (const disallowAttr of attr.rule.options.disallowAttrs) {
 						if (typeof disallowAttr === 'string') {
-							disallowAttrs[disallowAttr] = { type: 'Any' };
+							disallowAttrs[disallowAttr] = 'Any';
 							continue;
 						}
-						if (isValueRule(disallowAttr.value)) {
-							disallowAttrs[disallowAttr.name] = disallowAttr.value;
-							continue;
-						}
-						disallowAttrs[disallowAttr.name] = { type: disallowAttr.value };
+						disallowAttrs[disallowAttr.name] = disallowAttr.value;
 					}
 				} else {
-					for (const [attrName, valueRule] of Object.entries(attr.rule.options.disallowAttrs)) {
-						disallowAttrs[attrName] = valueRule;
-					}
-				}
-			}
-
-			if (attr.rule.options.attrs) {
-				for (const [attrName, valueRule] of Object.entries(attr.rule.options.attrs)) {
-					if ('disallowed' in valueRule) {
-						disallowAttrs[attrName] = { type: 'Any' };
-					} else {
-						allowAttrs[attrName] = valueRule;
+					for (const [attrName, attrType] of Object.entries(attr.rule.options.disallowAttrs)) {
+						disallowAttrs[attrName] = attrType;
 					}
 				}
 			}
@@ -188,16 +147,8 @@ export default createRule<boolean, Option>({
 			const allowValue = allowAttrs[name] ?? null;
 			const disallowValue = disallowAttrs[name] ?? null;
 
-			if (allowValue) {
-				if ('enum' in allowValue) {
-					invalid = attrCheck(t, name.toLowerCase(), value, true, {
-						name,
-						type: {
-							enum: allowValue.enum,
-						},
-						description: '',
-					});
-				} else if ('pattern' in allowValue) {
+			if (allowValue !== null) {
+				if (isPatternRule(allowValue)) {
 					if (!match(value, allowValue.pattern)) {
 						invalid = {
 							invalidType: 'invalid-value',
@@ -208,29 +159,11 @@ export default createRule<boolean, Option>({
 							),
 						};
 					}
-				} else if ('type' in allowValue) {
-					invalid = attrCheck(t, name, value, true, { name, type: allowValue.type, description: '' });
+				} else {
+					invalid = attrCheck(t, name, value, true, { name, type: allowValue, description: '' });
 				}
-			} else if (disallowValue) {
-				if ('enum' in disallowValue) {
-					const checkResult = attrCheck(t, name.toLowerCase(), value, true, {
-						name,
-						type: {
-							enum: disallowValue.enum,
-						},
-						description: '',
-					});
-					if (checkResult === false) {
-						invalid = {
-							invalidType: 'invalid-value',
-							message: t(
-								'{0} is disallowed to accept the following values: {1}',
-								t('the "{0*}" {1}', name, 'attribute'),
-								t(disallowValue.enum),
-							),
-						};
-					}
-				} else if ('pattern' in disallowValue) {
+			} else if (disallowValue !== null) {
+				if (isPatternRule(disallowValue)) {
 					if (match(value, disallowValue.pattern)) {
 						invalid = {
 							invalidType: 'invalid-value',
@@ -241,27 +174,22 @@ export default createRule<boolean, Option>({
 							),
 						};
 					}
-				} else if ('type' in disallowValue) {
-					if (disallowValue.type === 'Any') {
+				} else if (disallowValue === 'Any') {
+					invalid = {
+						invalidType: 'non-existent',
+						message: t('{0} is disallowed', t('the "{0*}" {1}', name, 'attribute')),
+					};
+				} else {
+					const checkResult = attrCheck(t, name, value, true, {
+						name,
+						type: disallowValue,
+						description: '',
+					});
+					if (checkResult === false) {
 						invalid = {
-							invalidType: 'non-existent',
-							message: t('{0} is disallowed', t('the "{0*}" {1}', name, 'attribute')),
+							invalidType: 'invalid-value',
+							message: createDisallowMessage(t, name, disallowValue),
 						};
-					} else {
-						const checkResult = attrCheck(t, name, value, true, {
-							name,
-							type: disallowValue.type,
-							description: '',
-						});
-						if (checkResult === false) {
-							invalid = {
-								invalidType: 'invalid-value',
-								message: t(
-									'{0} is disallowed',
-									t('{0} of {1}', t('the {0}', 'type'), t('the "{0*}" {1}', name, 'attribute')),
-								),
-							};
-						}
 					}
 				}
 			} else if (attr.ownerElement.elementType === 'html' && attrSpecs) {
@@ -326,36 +254,39 @@ export default createRule<boolean, Option>({
 });
 
 /**
- * Determines whether the given value is a {@link ValueRule} (enum, pattern,
- * or simple type constraint) as opposed to a raw {@link AttributeType}.
+ * Determines whether the given value is a {@link PatternRule}
+ * as opposed to a raw {@link AttributeType}.
  *
  * @param value - The value to inspect.
- * @returns `true` if the value is a {@link ValueRule}, `false` otherwise.
+ * @returns `true` if the value is a {@link PatternRule}, `false` otherwise.
  */
-function isValueRule(
+function isPatternRule(
 	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-	value: AttributeType | ValueRule,
-): value is ValueRule {
-	if (typeof value === 'string') {
-		return false;
+	value: AttributeType | PatternRule,
+): value is PatternRule {
+	return typeof value !== 'string' && 'pattern' in value;
+}
+
+/**
+ * Creates an appropriate disallow message based on the type structure.
+ *
+ * @param t - The i18n translator
+ * @param name - The attribute name
+ * @param type - The attribute type
+ * @returns A localized message string
+ */
+function createDisallowMessage(
+	t: Parameters<typeof attrCheck>[0],
+	name: string,
+	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+	type: AttributeType,
+): string {
+	if (typeof type !== 'string' && isEnum(type)) {
+		return t(
+			'{0} is disallowed to accept the following values: {1}',
+			t('the "{0*}" {1}', name, 'attribute'),
+			t(type.enum),
+		);
 	}
-	if ('enum' in value) {
-		if (Object.keys(value).length > 1) {
-			return false;
-		}
-		return true;
-	}
-	if ('token' in value) {
-		return false;
-	}
-	if ('pattern' in value) {
-		return true;
-	}
-	if (value.type === 'integer' || value.type === 'float') {
-		return false;
-	}
-	if (Object.keys(value).length > 1) {
-		return false;
-	}
-	return true;
+	return t('{0} is disallowed', t('{0} of {1}', t('the {0}', 'type'), t('the "{0*}" {1}', name, 'attribute')));
 }

--- a/packages/@markuplint/rules/src/invalid-attr/schema.json
+++ b/packages/@markuplint/rules/src/invalid-attr/schema.json
@@ -7,8 +7,8 @@
 		"options": {
 			"type": "object",
 			"additionalProperties": false,
-			"description": "```ts\ntype Attr = {\n  name: string;\n  value: AttributeType | ValueRule;\n}\n\ntype ValueRule =\n  | { enum: [string, ...string[]]; }\n  | { pattern: string; }\n  | { type: AttributeType; };\n```\n\n`AttributeType` is [The type API](/docs/api/types).",
-			"description:ja": "```ts\ntype Attr = {\n  name: string;\n  value: AttributeType | ValueRule;\n}\n\ntype ValueRule =\n  | { enum: [string, ...string[]]; }\n  | { pattern: string; }\n  | { type: AttributeType; };\n```\n\n`AttributeType`は[タイプAPI](/docs/api/types)を参照してください。",
+			"description": "```ts\ntype Attr = {\n  name: string;\n  value: AttributeType | PatternRule;\n}\n\ntype PatternRule = { pattern: string; };\n```\n\n`AttributeType` is [The type API](/docs/api/types).",
+			"description:ja": "```ts\ntype Attr = {\n  name: string;\n  value: AttributeType | PatternRule;\n}\n\ntype PatternRule = { pattern: string; };\n```\n\n`AttributeType`は[タイプAPI](/docs/api/types)を参照してください。",
 			"properties": {
 				"allowAttrs": {
 					"oneOf": [
@@ -28,9 +28,7 @@
 											"name": { "type": "string" },
 											"value": {
 												"oneOf": [
-													{ "$ref": "#/definitions/enum" },
 													{ "$ref": "#/definitions/pattern" },
-													{ "$ref": "#/definitions/type" },
 													{
 														"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/types/types.schema.json#/definitions/type"
 													}
@@ -42,14 +40,15 @@
 							}
 						},
 						{
+							"deprecated": true,
 							"type": "object",
-							"_type": "Record<string, ValueRule>",
+							"_type": "Record<string, AttributeType | PatternRule>",
 							"additionalProperties": {
-								"type": "object",
 								"oneOf": [
-									{ "$ref": "#/definitions/enum" },
 									{ "$ref": "#/definitions/pattern" },
-									{ "$ref": "#/definitions/type" }
+									{
+										"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/types/types.schema.json#/definitions/type"
+									}
 								]
 							}
 						}
@@ -75,9 +74,7 @@
 											"name": { "type": "string" },
 											"value": {
 												"oneOf": [
-													{ "$ref": "#/definitions/enum" },
 													{ "$ref": "#/definitions/pattern" },
-													{ "$ref": "#/definitions/type" },
 													{
 														"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/types/types.schema.json#/definitions/type"
 													}
@@ -89,14 +86,15 @@
 							}
 						},
 						{
+							"deprecated": true,
 							"type": "object",
-							"_type": "Record<string, ValueRule>",
+							"_type": "Record<string, AttributeType | PatternRule>",
 							"additionalProperties": {
-								"type": "object",
 								"oneOf": [
-									{ "$ref": "#/definitions/enum" },
 									{ "$ref": "#/definitions/pattern" },
-									{ "$ref": "#/definitions/type" }
+									{
+										"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/types/types.schema.json#/definitions/type"
+									}
 								]
 							}
 						}
@@ -126,45 +124,6 @@
 					"default": "true",
 					"description": "Allow adding properties for a component that pretends to be an HTML native element. The default is `true`. It warns of finding a non-existence attribute if it is set `false` and you use the `pretenders` option.",
 					"description:ja": "HTML要素に偽装しているコンポーネントのプロパティを追加できるようにします。デフォルトは`true`です。`pretenders`オプションを使用している場合に`false`に設定されていると、存在しない属性が見つかると警告します。"
-				},
-				"attrs": {
-					"deprecated": true,
-					"type": "object",
-					"additionalProperties": {
-						"type": "object",
-						"oneOf": [
-							{ "$ref": "#/definitions/enum" },
-							{ "$ref": "#/definitions/pattern" },
-							{ "$ref": "#/definitions/type" },
-							{
-								"type": "object",
-								"additionalProperties": false,
-								"required": ["disallowed"],
-								"properties": {
-									"disallowed": {
-										"type": "boolean"
-									}
-								}
-							}
-						]
-					},
-					"description": "[Deprecated (since v3.7.0): Use `allowAttrs` or `disallowAttrs` instead.] Setting custom rule. Set either `enum`, `pattern`, `type` or `disallowed`.",
-					"description:ja": "[非推奨(v3.7.0より): `allowAttrs`か`disallowAttrs`を利用してください] `enum` `pattern` `type` `disallowed` のいずれかで設定します。"
-				}
-			}
-		},
-		"enum": {
-			"type": "object",
-			"additionalProperties": false,
-			"required": ["enum"],
-			"properties": {
-				"enum": {
-					"type": "array",
-					"uniqueItems": true,
-					"items": {
-						"type": "string",
-						"minimum": 1
-					}
 				}
 			}
 		},
@@ -175,16 +134,6 @@
 			"properties": {
 				"pattern": {
 					"type": "string"
-				}
-			}
-		},
-		"type": {
-			"type": "object",
-			"additionalProperties": false,
-			"required": ["type"],
-			"properties": {
-				"type": {
-					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/types/types.schema.json#/definitions/type"
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

Closes #807

- Remove the deprecated `attrs` option (deprecated since v3.7.0)
- Remove the `{ type: X }` value wrapper — type strings are now specified directly
- Deprecate the object format for `allowAttrs`/`disallowAttrs` (still works, will be removed in a future version)
- Unify value type validation through the types API
- Migrate config-presets to the new format
- Add v4-to-v5 migration guide with comprehensive before/after examples

## BREAKING CHANGE

- `attrs` option has been removed
- `{ type: X }` value wrapper has been removed; use the type string directly (e.g., `"Int"` instead of `{ "type": "Int" }`)

## Test plan

- [x] `yarn lint-check` — 0 errors, 0 warnings
- [x] `yarn build` — all 40 packages built successfully
- [x] `yarn test` — 2088 tests passed (1 skipped)
- [ ] Verify migration guide accuracy against actual config behavior