### PR TITLE
feat: add srcset-sizes-constraint rule and fix Srcset validator (#1051)

### DIFF
--- a/packages/@markuplint/config-presets/README.md
+++ b/packages/@markuplint/config-presets/README.md
@@ -59,6 +59,7 @@ Allow only **permitted contents**| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|
 Need **placeholder label option**| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
 Require the `datetime` attribute if the content of the `time` element is invalid| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
 Specify required attr| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
+[Enforce WHATWG constraints between `srcset`, `sizes`, and `loading` attributes](https://html.spec.whatwg.org/multipage/images.html#srcset-attributes)| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
 [Specify `charset=UTF-8`](https://html.spec.whatwg.org/multipage/semantics.html#charset)| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
 [No use `<small>` as **subheadings**](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-small-element)|Should not use it in `<h1>`, `<h2>`, `<h3>`, `<h4>`, `<h5>`, and `<h6>`.|✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
 [No use `<caption>` within `<figure>`](https://html.spec.whatwg.org/multipage/tables.html#the-caption-element)|When `<table>` is the only content in `<figure>` other than `<figcaption>`, `<caption>` should be omitted in favor of `<figcaption>`.|✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|

--- a/packages/@markuplint/config-presets/src/preset.html-standard.jsonc
+++ b/packages/@markuplint/config-presets/src/preset.html-standard.jsonc
@@ -93,7 +93,14 @@
 		 * Specify required attr
 		 *
 		 */
-		"required-attr": true
+		"required-attr": true,
+
+		/**
+		 * Enforce WHATWG constraints between `srcset`, `sizes`, and `loading` attributes
+		 *
+		 * @see https://html.spec.whatwg.org/multipage/images.html#srcset-attributes
+		 */
+		"srcset-sizes-constraint": true
 	},
 	"nodeRules": [
 		{

--- a/packages/@markuplint/rules/schema.json
+++ b/packages/@markuplint/rules/schema.json
@@ -120,6 +120,9 @@
 				"required-h1": {
 					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/required-h1/schema.json"
 				},
+				"srcset-sizes-constraint": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/srcset-sizes-constraint/schema.json"
+				},
 				"table-row-column-alignment": {
 					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/table-row-column-alignment/schema.json"
 				},

--- a/packages/@markuplint/rules/src/index.ts
+++ b/packages/@markuplint/rules/src/index.ts
@@ -44,6 +44,7 @@ import RedundantAccessibleName from './redundant-accessible-name/index.js';
 import RequireAccessibleName from './require-accessible-name/index.js';
 import RequireDatetime from './require-datetime/index.js';
 import RequireDialogAutofocus from './require-dialog-autofocus/index.js';
+import SrcsetSizesConstraint from './srcset-sizes-constraint/index.js';
 import RequiredAttr from './required-attr/index.js';
 import RequiredElement from './required-element/index.js';
 import RequiredH1 from './required-h1/index.js';
@@ -94,6 +95,7 @@ const rules = {
 	'required-attr': RequiredAttr,
 	'required-element': RequiredElement,
 	'required-h1': RequiredH1,
+	'srcset-sizes-constraint': SrcsetSizesConstraint,
 	'table-row-column-alignment': TableRowColumnAlignment,
 	'use-list': UseList,
 	'wai-aria': WaiAria,

--- a/packages/@markuplint/rules/src/srcset-sizes-constraint/README.ja.md
+++ b/packages/@markuplint/rules/src/srcset-sizes-constraint/README.ja.md
@@ -1,0 +1,82 @@
+---
+id: srcset-sizes-constraint
+description: srcset、sizes、loading属性間のWHATWG仕様制約をチェックします。
+---
+
+# `srcset-sizes-constraint`
+
+`<img>` および `<source>` 要素の `srcset`、`sizes`、`loading` 属性間の WHATWG 仕様制約をチェックします。
+
+[HTML Living Standard](https://html.spec.whatwg.org/multipage/images.html#srcset-attributes) に基づき、以下の制約をチェックします:
+
+| #   | 制約                                                                                      | 対象                       |
+| --- | ----------------------------------------------------------------------------------------- | -------------------------- |
+| 1   | `sizes` がある場合、`srcset` は **幅ディスクリプタ**（`w`）のみ使用する                   | `img`, `source`            |
+| 2   | `srcset` で **幅**（`w`）と **ピクセル密度**（`x`）のディスクリプタを混在させてはならない | `img`, `source`            |
+| 3   | `<img>` の `sizes="auto"` には `loading="lazy"` が必須                                    | `img`                      |
+| 4   | `<source>` の `sizes="auto"` には後続兄弟の `<img>` に `loading="lazy"` が必須            | `source`（`<picture>` 内） |
+| 5   | `srcset` に幅ディスクリプタがある場合、`sizes` が必須                                     | `img`                      |
+
+<!-- textlint-disable ja-technical-writing/ja-no-mixed-period -->
+
+## 動作
+
+- `<img>` と `<picture>` 内の `<source>` 要素のみチェックします。
+- 動的な属性値（Vue の `:srcset`、JSX の `srcset={...}` など）やスプレッド属性を持つ要素はスキップされます。
+- ディスクリプタなしの画像候補（例: `480w` や `2x` のない `image.png`）は暗黙の `1x` 密度ディスクリプタとして扱われます。
+- `sizes="auto"` は、属性値の先頭に `auto` がある場合に認識されます（大文字小文字不区別）。例えば `sizes="auto, 100vw"` は auto として扱われますが、`sizes="100vw, auto"` は auto として認識されません。
+
+## コード例
+
+❌ 間違ったコード例
+
+```html
+<!-- チェック1: sizes + 密度ディスクリプタ -->
+<img srcset="a.png 1x, b.png 2x" sizes="100vw" src="a.png" alt="写真" />
+
+<!-- チェック2: 幅と密度のディスクリプタの混在 -->
+<img srcset="a.png 480w, b.png 2x" src="a.png" alt="写真" />
+
+<!-- チェック3: sizes=autoなのにloading=lazyがない -->
+<img srcset="a.png 480w" sizes="auto" src="a.png" alt="写真" />
+
+<!-- チェック4: sourceのsizes=autoなのに後続imgにloading=lazyがない -->
+<picture>
+  <source srcset="a.webp 480w" sizes="auto" />
+  <img src="a.jpg" alt="写真" />
+</picture>
+
+<!-- チェック5: 幅ディスクリプタがあるのにsizesがない -->
+<img srcset="a.png 480w, b.png 1024w" src="b.png" alt="写真" />
+```
+
+✅ 正しいコード例
+
+```html
+<!-- 幅ディスクリプタとsizes -->
+<img srcset="a.png 480w, b.png 1024w" sizes="(max-width: 600px) 480px, 1024px" src="b.png" alt="写真" />
+
+<!-- sizesなしの密度ディスクリプタ -->
+<img srcset="a.png 1x, b.png 2x" src="a.png" alt="写真" />
+
+<!-- sizes=autoとloading=lazy -->
+<img srcset="a.png 480w" sizes="auto" loading="lazy" src="a.png" alt="写真" />
+
+<!-- sourceのsizes=autoと遅延読み込みimg -->
+<picture>
+  <source srcset="a.webp 480w" sizes="auto" />
+  <img src="a.jpg" loading="lazy" alt="写真" />
+</picture>
+```
+
+<!-- textlint-enable ja-technical-writing/ja-no-mixed-period -->
+
+## `invalid-attr` との重複について
+
+チェック2（ディスクリプタの混在）は、[`invalid-attr`](../invalid-attr/README.ja.md) ルールが使用する `Srcset` 型バリデータと重複します。両方のルールが有効な場合、幅ディスクリプタと密度ディスクリプタの混在が両方のルールから報告される可能性があります。これは意図的な動作です — `invalid-attr` は `srcset` 属性値の構文を検証し、このルールは属性間の制約をチェックします。ディスクリプタ混在の重複報告を避けたい場合は、そのチェックについては `invalid-attr` のみに頼ることができます。
+
+## 参照
+
+- [HTML Living Standard - Srcset attributes](https://html.spec.whatwg.org/multipage/images.html#srcset-attributes)
+- [HTML Living Standard - The img element](https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element)
+- [HTML Living Standard - The source element](https://html.spec.whatwg.org/multipage/embedded-content.html#the-source-element)

--- a/packages/@markuplint/rules/src/srcset-sizes-constraint/README.md
+++ b/packages/@markuplint/rules/src/srcset-sizes-constraint/README.md
@@ -1,0 +1,78 @@
+---
+id: srcset-sizes-constraint
+description: Enforces WHATWG constraints between srcset, sizes, and loading attributes.
+---
+
+# `srcset-sizes-constraint`
+
+Enforces WHATWG constraints between the `srcset`, `sizes`, and `loading` attributes on `<img>` and `<source>` elements.
+
+This rule checks the following constraints based on the [HTML Living Standard](https://html.spec.whatwg.org/multipage/images.html#srcset-attributes):
+
+| #   | Constraint                                                                                   | Target                    |
+| --- | -------------------------------------------------------------------------------------------- | ------------------------- |
+| 1   | When `sizes` is present, `srcset` must use **width descriptors** (`w`) only                  | `img`, `source`           |
+| 2   | `srcset` must not mix **width** (`w`) and **pixel density** (`x`) descriptors                | `img`, `source`           |
+| 3   | `sizes="auto"` on `<img>` requires `loading="lazy"`                                          | `img`                     |
+| 4   | `sizes="auto"` on `<source>` requires the following sibling `<img>` to have `loading="lazy"` | `source` (in `<picture>`) |
+| 5   | When `srcset` uses width descriptors, `sizes` is required                                    | `img`                     |
+
+## How It Works
+
+- Only `<img>` and `<source>` elements inside `<picture>` are checked.
+- Dynamic attribute values (e.g., Vue `:srcset`, JSX `srcset={...}`) and elements with spread attributes are skipped.
+- A descriptor-less image candidate (e.g., `image.png` without `480w` or `2x`) is treated as an implied `1x` density descriptor.
+- `sizes="auto"` is recognized when `auto` appears at the start of the attribute value (case-insensitive). For example, `sizes="auto, 100vw"` is treated as auto, but `sizes="100vw, auto"` is not.
+
+## Examples
+
+❌ Examples of **incorrect** code for this rule
+
+```html
+<!-- Check 1: sizes + density descriptors -->
+<img srcset="a.png 1x, b.png 2x" sizes="100vw" src="a.png" alt="photo" />
+
+<!-- Check 2: mixing width and density descriptors -->
+<img srcset="a.png 480w, b.png 2x" src="a.png" alt="photo" />
+
+<!-- Check 3: sizes=auto without loading=lazy -->
+<img srcset="a.png 480w" sizes="auto" src="a.png" alt="photo" />
+
+<!-- Check 4: source sizes=auto without lazy img -->
+<picture>
+  <source srcset="a.webp 480w" sizes="auto" />
+  <img src="a.jpg" alt="photo" />
+</picture>
+
+<!-- Check 5: width descriptors without sizes -->
+<img srcset="a.png 480w, b.png 1024w" src="b.png" alt="photo" />
+```
+
+✅ Examples of **correct** code for this rule
+
+```html
+<!-- Width descriptors with sizes -->
+<img srcset="a.png 480w, b.png 1024w" sizes="(max-width: 600px) 480px, 1024px" src="b.png" alt="photo" />
+
+<!-- Density descriptors without sizes -->
+<img srcset="a.png 1x, b.png 2x" src="a.png" alt="photo" />
+
+<!-- sizes=auto with loading=lazy -->
+<img srcset="a.png 480w" sizes="auto" loading="lazy" src="a.png" alt="photo" />
+
+<!-- source sizes=auto with lazy img -->
+<picture>
+  <source srcset="a.webp 480w" sizes="auto" />
+  <img src="a.jpg" loading="lazy" alt="photo" />
+</picture>
+```
+
+## Note on overlap with `invalid-attr`
+
+Check 2 (descriptor mixing) overlaps with the `Srcset` type validator used by the [`invalid-attr`](../invalid-attr/README.md) rule. When both rules are enabled, mixing width and density descriptors may be reported by both rules. This is intentional — `invalid-attr` validates the `srcset` attribute value syntax, while this rule checks inter-attribute constraints. If you want to avoid duplicate reports for descriptor mixing, you can rely on `invalid-attr` alone for that check.
+
+## References
+
+- [HTML Living Standard - Srcset attributes](https://html.spec.whatwg.org/multipage/images.html#srcset-attributes)
+- [HTML Living Standard - The img element](https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element)
+- [HTML Living Standard - The source element](https://html.spec.whatwg.org/multipage/embedded-content.html#the-source-element)

--- a/packages/@markuplint/rules/src/srcset-sizes-constraint/index.spec.ts
+++ b/packages/@markuplint/rules/src/srcset-sizes-constraint/index.spec.ts
@@ -1,0 +1,410 @@
+import { mlRuleTest } from 'markuplint';
+import { describe, test, expect } from 'vitest';
+
+import rule from './index.js';
+
+describe('No violations', () => {
+	test('srcset with x descriptors only, no sizes', async () => {
+		expect(
+			(await mlRuleTest(rule, '<img srcset="image-1x.png 1x, image-2x.png 2x" src="image-1x.png" alt="photo">'))
+				.violations,
+		).toStrictEqual([]);
+	});
+
+	test('srcset with w descriptors and sizes', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					'<img srcset="small.png 480w, large.png 1024w" sizes="(max-width: 600px) 480px, 1024px" src="large.png" alt="photo">',
+				)
+			).violations,
+		).toStrictEqual([]);
+	});
+
+	test('sizes=auto with loading=lazy on img', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					'<img srcset="small.png 480w, large.png 1024w" sizes="auto" loading="lazy" src="large.png" alt="photo">',
+				)
+			).violations,
+		).toStrictEqual([]);
+	});
+
+	test('sizes="auto, 100vw" with loading=lazy on img', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					'<img srcset="small.png 480w, large.png 1024w" sizes="auto, 100vw" loading="lazy" src="large.png" alt="photo">',
+				)
+			).violations,
+		).toStrictEqual([]);
+	});
+
+	test('source[sizes=auto] with sibling img[loading=lazy]', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					'<picture><source srcset="s.webp 480w, l.webp 1024w" sizes="auto"><img src="l.jpg" loading="lazy" alt="photo"></picture>',
+				)
+			).violations,
+		).toStrictEqual([]);
+	});
+
+	test('source[sizes=auto] with non-adjacent sibling img[loading=lazy]', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					'<picture><source srcset="a.webp 480w" sizes="auto" type="image/webp"><source srcset="a.jpg 480w" sizes="100vw"><img src="a.jpg" loading="lazy" alt="p"></picture>',
+				)
+			).violations,
+		).toStrictEqual([]);
+	});
+
+	test('single URL srcset without descriptor or sizes', async () => {
+		expect(
+			(await mlRuleTest(rule, '<img srcset="image.png" src="image.png" alt="photo">')).violations,
+		).toStrictEqual([]);
+	});
+
+	test('element without srcset is ignored', async () => {
+		expect((await mlRuleTest(rule, '<img src="image.png" alt="photo">')).violations).toStrictEqual([]);
+	});
+
+	test('source outside picture is ignored', async () => {
+		expect(
+			(await mlRuleTest(rule, '<video><source src="video.mp4" type="video/mp4"></video>')).violations,
+		).toStrictEqual([]);
+	});
+});
+
+describe('Check 1: sizes requires width descriptors in srcset', () => {
+	test('sizes + x descriptors → violation', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<img srcset="image-1x.png 1x, image-2x.png 2x" sizes="100vw" src="image-1x.png" alt="photo">',
+		);
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.raw).toBe('image-1x.png 1x, image-2x.png 2x');
+	});
+
+	test('sizes + no descriptors → violation', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<img srcset="image.png" sizes="100vw" src="image.png" alt="photo">',
+		);
+		expect(violations.length).toBe(1);
+	});
+
+	test('sizes + mixed w and no-descriptor → violation (also Check 2)', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<img srcset="small.png 480w, large.png" sizes="100vw" src="large.png" alt="photo">',
+		);
+		// Check 2 fires for mixing, Check 1 does NOT fire because hasWidth is true
+		expect(violations.length).toBe(1);
+	});
+
+	test('source element: sizes + x descriptors → violation', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<picture><source srcset="p.webp 1x, p2.webp 2x" sizes="100vw"><img src="p.jpg" alt="p"></picture>',
+		);
+		expect(violations.length).toBe(1);
+	});
+});
+
+describe('Check 2: no mixing width and density descriptors', () => {
+	test('w + x mixing → violation (also Check 5: w without sizes)', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<img srcset="small.png 480w, large.png 2x" src="small.png" alt="photo">',
+		);
+		// Check 2 (mixing) + Check 5 (w descriptor without sizes)
+		expect(violations.length).toBe(2);
+		expect(violations[0]?.raw).toBe('small.png 480w, large.png 2x');
+	});
+
+	test('w + no-descriptor mixing → violation (also Check 5: w without sizes)', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<img srcset="small.png 480w, large.png" src="small.png" alt="photo">',
+		);
+		// Check 2 (mixing) + Check 5 (w descriptor without sizes)
+		expect(violations.length).toBe(2);
+	});
+
+	test('all w → no violation', async () => {
+		expect(
+			(await mlRuleTest(rule, '<img srcset="s.png 480w, l.png 1024w" sizes="100vw" src="s.png" alt="p">'))
+				.violations,
+		).toStrictEqual([]);
+	});
+
+	test('all x → no violation', async () => {
+		expect(
+			(await mlRuleTest(rule, '<img srcset="s.png 1x, l.png 2x" src="s.png" alt="p">')).violations,
+		).toStrictEqual([]);
+	});
+
+	test('x + no-descriptor → no violation (both density)', async () => {
+		expect(
+			(await mlRuleTest(rule, '<img srcset="small.png, large.png 2x" src="small.png" alt="p">')).violations,
+		).toStrictEqual([]);
+	});
+
+	test('all no-descriptor → no violation', async () => {
+		expect((await mlRuleTest(rule, '<img srcset="image.png" src="image.png" alt="p">')).violations).toStrictEqual(
+			[],
+		);
+	});
+});
+
+describe('Check 3: sizes=auto on img requires loading=lazy', () => {
+	test('sizes=auto without loading → violation', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<img srcset="s.png 480w, l.png 1024w" sizes="auto" src="l.png" alt="p">',
+		);
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.raw).toBe('auto');
+	});
+
+	test('sizes=auto with loading=eager → violation', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<img srcset="s.png 480w, l.png 1024w" sizes="auto" loading="eager" src="l.png" alt="p">',
+		);
+		expect(violations.length).toBe(1);
+	});
+
+	test('sizes=auto with loading=lazy → no violation', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					'<img srcset="s.png 480w, l.png 1024w" sizes="auto" loading="lazy" src="l.png" alt="p">',
+				)
+			).violations,
+		).toStrictEqual([]);
+	});
+
+	test('sizes="auto, 100vw" without loading → violation', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<img srcset="s.png 480w" sizes="auto, 100vw" src="s.png" alt="p">',
+		);
+		expect(violations.length).toBe(1);
+	});
+
+	test('sizes="100vw, auto" (auto not first) → no Check 3 violation', async () => {
+		expect(
+			(await mlRuleTest(rule, '<img srcset="s.png 480w" sizes="100vw, auto" loading="lazy" src="s.png" alt="p">'))
+				.violations,
+		).toStrictEqual([]);
+	});
+
+	test('sizes=AUTO (uppercase) without loading → violation', async () => {
+		const { violations } = await mlRuleTest(rule, '<img srcset="s.png 480w" sizes="AUTO" src="s.png" alt="p">');
+		expect(violations.length).toBe(1);
+	});
+
+	test('sizes=" auto " (whitespace) with loading=lazy → no violation', async () => {
+		expect(
+			(await mlRuleTest(rule, '<img srcset="s.png 480w" sizes=" auto " loading="lazy" src="s.png" alt="p">'))
+				.violations,
+		).toStrictEqual([]);
+	});
+});
+
+describe('Check 4: sizes=auto on source requires sibling img[loading=lazy]', () => {
+	test('source[sizes=auto] + img without loading → violation', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<picture><source srcset="s.webp 480w" sizes="auto"><img src="s.jpg" alt="p"></picture>',
+		);
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.raw).toBe('auto');
+	});
+
+	test('source[sizes=auto] + img[loading=eager] → violation', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<picture><source srcset="s.webp 480w" sizes="auto"><img src="s.jpg" loading="eager" alt="p"></picture>',
+		);
+		expect(violations.length).toBe(1);
+	});
+
+	test('source[sizes=auto] + img[loading=lazy] → no violation', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					'<picture><source srcset="s.webp 480w" sizes="auto"><img src="s.jpg" loading="lazy" alt="p"></picture>',
+				)
+			).violations,
+		).toStrictEqual([]);
+	});
+
+	test('source[sizes=auto] with no following img → violation', async () => {
+		const { violations } = await mlRuleTest(rule, '<picture><source srcset="s.webp 480w" sizes="auto"></picture>');
+		expect(violations.length).toBe(1);
+	});
+
+	test('source + source + img[loading=lazy] → no violation', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					'<picture><source srcset="a.webp 480w" sizes="auto"><source srcset="b.jpg 480w"><img src="b.jpg" loading="lazy" alt="p"></picture>',
+				)
+			).violations,
+		).toStrictEqual([]);
+	});
+});
+
+describe('Check 5: w descriptors on img require sizes attribute', () => {
+	test('w descriptors without sizes → violation', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<img srcset="small.png 480w, large.png 1024w" src="large.png" alt="photo">',
+		);
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.raw).toBe('<img srcset="small.png 480w, large.png 1024w" src="large.png" alt="photo">');
+	});
+
+	test('w descriptors with sizes → no violation', async () => {
+		expect(
+			(await mlRuleTest(rule, '<img srcset="s.png 480w, l.png 1024w" sizes="100vw" src="l.png" alt="p">'))
+				.violations,
+		).toStrictEqual([]);
+	});
+
+	test('x descriptors without sizes → no violation', async () => {
+		expect(
+			(await mlRuleTest(rule, '<img srcset="s.png 1x, l.png 2x" src="s.png" alt="p">')).violations,
+		).toStrictEqual([]);
+	});
+
+	test('no descriptor without sizes → no violation', async () => {
+		expect((await mlRuleTest(rule, '<img srcset="image.png" src="image.png" alt="p">')).violations).toStrictEqual(
+			[],
+		);
+	});
+
+	test('source with w descriptors without sizes → no Check 5 violation (spec says "may")', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					'<picture><source srcset="s.webp 480w, l.webp 1024w"><img src="l.jpg" alt="p"></picture>',
+				)
+			).violations,
+		).toStrictEqual([]);
+	});
+});
+
+describe('Edge cases', () => {
+	test('empty srcset value → no violation', async () => {
+		expect((await mlRuleTest(rule, '<img srcset="" src="image.png" alt="p">')).violations).toStrictEqual([]);
+	});
+
+	test('whitespace-only srcset → no violation', async () => {
+		expect((await mlRuleTest(rule, '<img srcset="   " src="image.png" alt="p">')).violations).toStrictEqual([]);
+	});
+
+	test('extra whitespace in srcset value → valid', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					'<img srcset="  s.png   480w  ,  l.png   1024w  " sizes="100vw" src="l.png" alt="p">',
+				)
+			).violations,
+		).toStrictEqual([]);
+	});
+
+	test('picture with one valid and one invalid source', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			`<picture>
+  <source srcset="a.webp 480w, b.webp 1024w" sizes="100vw">
+  <source srcset="a.jpg 1x, b.jpg 2x" sizes="100vw">
+  <img src="a.jpg" alt="p">
+</picture>`,
+		);
+		// Second source only: Check 1 violation (sizes + x descriptors)
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.line).toBe(3);
+	});
+
+	test('multiple violations on same element', async () => {
+		// Check 2 (w + x mixing) + Check 3 (sizes=auto without lazy)
+		const { violations } = await mlRuleTest(
+			rule,
+			'<img srcset="s.png 480w, l.png 2x" sizes="auto" src="l.png" alt="p">',
+		);
+		expect(violations.length).toBe(2);
+	});
+
+	test('rule disabled → no violations', async () => {
+		expect(
+			(
+				await mlRuleTest(rule, '<img srcset="s.png 480w, l.png 2x" sizes="auto" src="l.png" alt="p">', {
+					rule: false,
+				})
+			).violations,
+		).toStrictEqual([]);
+	});
+});
+
+describe('Dynamic values', () => {
+	test('Vue dynamic srcset → no violation', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					'<template><img :srcset="computedSrcset" sizes="100vw" src="s.png" alt="p"></template>',
+					{ parser: { '.*': '@markuplint/vue-parser' } },
+				)
+			).violations,
+		).toStrictEqual([]);
+	});
+
+	test('Vue dynamic sizes → no violation', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					'<template><img srcset="s.png 480w" :sizes="computedSizes" src="s.png" alt="p"></template>',
+					{ parser: { '.*': '@markuplint/vue-parser' } },
+				)
+			).violations,
+		).toStrictEqual([]);
+	});
+
+	test('JSX expression srcset → no violation', async () => {
+		expect(
+			(
+				await mlRuleTest(rule, '<img srcset={srcsetValue} sizes="100vw" src="s.png" alt="p" />', {
+					parser: { '.*': '@markuplint/jsx-parser' },
+				})
+			).violations,
+		).toStrictEqual([]);
+	});
+
+	test('JSX spread props → no violation', async () => {
+		expect(
+			(
+				await mlRuleTest(rule, '<img {...props} srcset="s.png 480w" src="s.png" alt="p" />', {
+					parser: { '.*': '@markuplint/jsx-parser' },
+				})
+			).violations,
+		).toStrictEqual([]);
+	});
+});

--- a/packages/@markuplint/rules/src/srcset-sizes-constraint/index.ts
+++ b/packages/@markuplint/rules/src/srcset-sizes-constraint/index.ts
@@ -1,0 +1,127 @@
+import type { Element } from '@markuplint/ml-core';
+
+import { createRule } from '@markuplint/ml-core';
+
+import meta from './meta.js';
+import { hasSizesAuto, parseSrcset } from './parse-srcset.js';
+
+/**
+ * Rule that enforces WHATWG constraints between the `srcset`, `sizes`,
+ * and `loading` attributes on `<img>` and `<source>` elements.
+ */
+export default createRule<boolean>({
+	meta: meta,
+	defaultValue: true,
+	async verify({ document, report }) {
+		await document.walkOn('Element', el => {
+			const localName = el.localName;
+
+			// Only check img and source (inside picture) elements
+			if (localName !== 'img' && localName !== 'source') {
+				return;
+			}
+
+			// source is only relevant inside <picture>
+			if (localName === 'source' && el.parentElement?.localName !== 'picture') {
+				return;
+			}
+
+			// Skip if element has spread attributes (dynamic props)
+			if (el.hasSpreadAttr) {
+				return;
+			}
+
+			const srcsetAttr = el.getAttributeNode('srcset');
+			if (!srcsetAttr) {
+				return;
+			}
+
+			const srcsetIsDynamic = srcsetAttr.isDynamicValue;
+
+			const sizesAttr = el.getAttributeNode('sizes');
+			const sizesValue = sizesAttr?.value ?? null;
+			const sizesIsDynamic = sizesAttr?.isDynamicValue;
+
+			// Parse srcset unless dynamic
+			const parsed = srcsetIsDynamic ? null : parseSrcset(srcsetAttr.value);
+
+			// Check 2: width and density descriptors must not be mixed
+			if (parsed && parsed.hasWidth && (parsed.hasDensity || parsed.hasImplied)) {
+				report({
+					scope: el,
+					line: srcsetAttr.valueNode?.startLine,
+					col: srcsetAttr.valueNode?.startCol,
+					raw: srcsetAttr.valueNode?.raw,
+					message: 'The "srcset" attribute must not mix width and pixel density descriptors',
+				});
+			}
+
+			// Check 1: sizes present → srcset must use width descriptors
+			if (sizesAttr && !sizesIsDynamic && parsed && !parsed.hasWidth) {
+				report({
+					scope: el,
+					line: srcsetAttr.valueNode?.startLine,
+					col: srcsetAttr.valueNode?.startCol,
+					raw: srcsetAttr.valueNode?.raw,
+					message: 'The "srcset" attribute requires width descriptors when the "sizes" attribute is present',
+				});
+			}
+
+			// Check 3: img[sizes=auto] → loading=lazy required
+			if (localName === 'img' && sizesValue != null && !sizesIsDynamic && hasSizesAuto(sizesValue)) {
+				const loading = el.getAttribute('loading');
+				if (loading !== 'lazy') {
+					report({
+						scope: el,
+						line: sizesAttr!.valueNode?.startLine,
+						col: sizesAttr!.valueNode?.startCol,
+						raw: sizesAttr!.valueNode?.raw,
+						message: 'The "sizes" attribute with "auto" requires the "loading" attribute to be "lazy"',
+					});
+				}
+			}
+
+			// Check 4: source[sizes=auto] → following sibling img must have loading=lazy
+			if (localName === 'source' && sizesValue != null && !sizesIsDynamic && hasSizesAuto(sizesValue)) {
+				const img = findFollowingImg(el);
+				if (!img || img.getAttribute('loading') !== 'lazy') {
+					report({
+						scope: el,
+						line: sizesAttr!.valueNode?.startLine,
+						col: sizesAttr!.valueNode?.startCol,
+						raw: sizesAttr!.valueNode?.raw,
+						message:
+							'The "source" element with sizes="auto" requires the following sibling "img" element to have loading="lazy"',
+					});
+				}
+			}
+
+			// Check 5: img with w descriptors → sizes required
+			if (localName === 'img' && parsed && parsed.hasWidth && !sizesAttr) {
+				report({
+					scope: el,
+					message: 'The "sizes" attribute is required when the "srcset" attribute uses width descriptors',
+				});
+			}
+		});
+	},
+});
+
+/**
+ * Find the first following sibling `<img>` element.
+ * Per the spec, the img does not have to be the immediately next sibling.
+ *
+ * @param el - The starting element to search from
+ * @returns The first following sibling `<img>` element, or `null` if none found
+ */
+// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+function findFollowingImg(el: Element<boolean>): Element<boolean> | null {
+	let sibling = el.nextElementSibling;
+	while (sibling != null) {
+		if (sibling.localName === 'img') {
+			return sibling;
+		}
+		sibling = sibling.nextElementSibling;
+	}
+	return null;
+}

--- a/packages/@markuplint/rules/src/srcset-sizes-constraint/meta.ts
+++ b/packages/@markuplint/rules/src/srcset-sizes-constraint/meta.ts
@@ -1,0 +1,4 @@
+/** Rule metadata for `srcset-sizes-constraint`: categorized as a validation rule. */
+export default {
+	category: 'validation',
+} as const;

--- a/packages/@markuplint/rules/src/srcset-sizes-constraint/parse-srcset.ts
+++ b/packages/@markuplint/rules/src/srcset-sizes-constraint/parse-srcset.ts
@@ -1,0 +1,86 @@
+/**
+ * Descriptor type for an image candidate in a srcset attribute.
+ * - `width`: ends with `w` (e.g., `480w`)
+ * - `density`: ends with `x` (e.g., `2x`)
+ * - `none`: no descriptor (implies `1x`)
+ */
+type DescriptorType = 'width' | 'density' | 'none';
+
+type SrcsetCandidate = {
+	readonly url: string;
+	readonly descriptorType: DescriptorType;
+};
+
+type ParseResult = {
+	readonly candidates: readonly SrcsetCandidate[];
+	/** At least one candidate has a width descriptor (`w`). */
+	readonly hasWidth: boolean;
+	/** At least one candidate has a pixel density descriptor (`x`). */
+	readonly hasDensity: boolean;
+	/** At least one candidate has no descriptor (implied `1x`). */
+	readonly hasImplied: boolean;
+};
+
+/**
+ * Parse a `srcset` attribute value into its image candidates.
+ *
+ * @param value - The raw `srcset` attribute value string
+ * @returns Parsed result with candidates and descriptor flags
+ * @see https://html.spec.whatwg.org/multipage/images.html#srcset-attributes
+ */
+
+export function parseSrcset(value: string): ParseResult {
+	const raw = value.trim();
+	if (raw === '') {
+		return { candidates: [], hasWidth: false, hasDensity: false, hasImplied: false };
+	}
+
+	const candidates: SrcsetCandidate[] = [];
+	let hasWidth = false;
+	let hasDensity = false;
+	let hasImplied = false;
+
+	for (const segment of raw.split(',')) {
+		const tokens = segment.trim().split(/\s+/);
+		const url = tokens[0];
+		if (!url) {
+			continue;
+		}
+
+		const descriptor = tokens[1];
+		let descriptorType: DescriptorType = 'none';
+
+		if (descriptor) {
+			if (/^[1-9]\d*w$/.test(descriptor)) {
+				descriptorType = 'width';
+				hasWidth = true;
+			} else if (/^\d+(?:\.\d+)?x$/.test(descriptor)) {
+				descriptorType = 'density';
+				hasDensity = true;
+			}
+			// Invalid descriptors are ignored here; type validation handles them.
+		} else {
+			hasImplied = true;
+		}
+
+		candidates.push({ url, descriptorType });
+	}
+
+	return { candidates, hasWidth, hasDensity, hasImplied };
+}
+
+/**
+ * Check whether a `sizes` attribute value starts with `auto`.
+ *
+ * Per the spec, `auto` is only valid as the first entry in a sizes list.
+ * Examples: `"auto"`, `"auto, 100vw"`, `"AUTO"`.
+ *
+ * @param value - The raw `sizes` attribute value string
+ * @returns `true` if the value starts with `auto` (case-insensitive)
+ * @see https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element
+ */
+
+export function hasSizesAuto(value: string): boolean {
+	const v = value.trim().toLowerCase();
+	return v === 'auto' || /^auto[\s,]/.test(v);
+}

--- a/packages/@markuplint/rules/src/srcset-sizes-constraint/schema.json
+++ b/packages/@markuplint/rules/src/srcset-sizes-constraint/schema.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"value": {
+			"type": "boolean"
+		}
+	},
+	"oneOf": [
+		{
+			"$ref": "#/definitions/value"
+		},
+		{
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"value": { "$ref": "#/definitions/value" },
+				"severity": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/ml-config/schema.json#/definitions/severity",
+					"default": "error"
+				},
+				"reason": {
+					"type": "string"
+				}
+			}
+		}
+	]
+}

--- a/packages/@markuplint/types/src/check.spec.ts
+++ b/packages/@markuplint/types/src/check.spec.ts
@@ -44,11 +44,21 @@ test('BCP47', () => {
 test('Srcset', () => {
 	expect(check('a/bb/ccc/dddd', 'Srcset').matched).toBe(true);
 	expect(check('a/bb/ccc/dddd 200w', 'Srcset').matched).toBe(true);
-	expect(check('a/bb/ccc/dddd 200w, b/cc/ddd/eeee  1.5x ', 'Srcset').matched).toBe(true);
+	// Bug fix: width + density descriptor mixing must be invalid
+	expect(check('a/bb/ccc/dddd 200w, b/cc/ddd/eeee  1.5x ', 'Srcset').matched).toBe(false);
 	expect(check('a/bb/ccc/dddd 200w, b/cc/ddd/eeee  1.5a', 'Srcset').matched).toBe(false);
 	expect(check('a/bb/ccc/dddd 200w, b/cc/ddd/eeee  1.5x  unexpected-string', 'Srcset').matched).toBe(false);
 	// Issue #1171
 	expect(check('/path/to/file 1x, /path/to/file@2x 2x', 'Srcset').matched).toBe(true);
+
+	// Descriptor consistency
+	expect(check('a.jpg 480w, b.jpg 1024w', 'Srcset').matched).toBe(true);
+	expect(check('a.jpg 1x, b.jpg 2x', 'Srcset').matched).toBe(true);
+	expect(check('a.jpg, b.jpg', 'Srcset').matched).toBe(true);
+	expect(check('a.jpg, b.jpg 2x', 'Srcset').matched).toBe(true);
+	expect(check('a.jpg 480w, b.jpg', 'Srcset').matched).toBe(false);
+	expect(check('a.jpg 480w, b.jpg 2x', 'Srcset').matched).toBe(false);
+	expect(check('a.jpg 480w, b.jpg 2x, c.jpg', 'Srcset').matched).toBe(false);
 });
 
 test('IconSize', () => {

--- a/packages/@markuplint/types/src/defs.ts
+++ b/packages/@markuplint/types/src/defs.ts
@@ -463,6 +463,8 @@ export const defs: Defs = {
 		ref: 'https://html.spec.whatwg.org/multipage/images.html#srcset-attributes',
 		is(value) {
 			const images = value.split(',');
+			let hasWidth = false;
+			let hasDensity = false;
 
 			for (const image of images) {
 				// image candidate string
@@ -496,6 +498,7 @@ export const defs: Defs = {
 									],
 								});
 							}
+							hasWidth = true;
 							break;
 						}
 						case 'x': {
@@ -509,6 +512,7 @@ export const defs: Defs = {
 									],
 								});
 							}
+							hasDensity = true;
 							break;
 						}
 						default: {
@@ -526,6 +530,9 @@ export const defs: Defs = {
 							});
 						}
 					}
+				} else {
+					// No descriptor implies 1x (density descriptor)
+					hasDensity = true;
 				}
 
 				if (tail[0]) {
@@ -538,6 +545,17 @@ export const defs: Defs = {
 						],
 					});
 				}
+			}
+
+			if (hasWidth && hasDensity) {
+				return unmatched(value, 'unexpected-token', {
+					expects: [
+						{
+							type: 'format',
+							value: 'consistent descriptors (all width or all density, not mixed)',
+						},
+					],
+				});
 			}
 
 			return matched();

--- a/packages/markuplint/src/cli/init/get-default-rules.spec.ts
+++ b/packages/markuplint/src/cli/init/get-default-rules.spec.ts
@@ -157,6 +157,10 @@ test('default-rules', () => {
 			category: 'a11y',
 			defaultValue: true,
 		},
+		'srcset-sizes-constraint': {
+			category: 'validation',
+			defaultValue: true,
+		},
 		'table-row-column-alignment': {
 			category: 'a11y',
 			defaultValue: false,


### PR DESCRIPTION
## Summary

- Add new `srcset-sizes-constraint` rule that enforces WHATWG constraints between `srcset`, `sizes`, and `loading` attributes on `<img>` and `<source>` elements
- Fix `Srcset` type validator to reject mixed width (`w`) and density (`x`) descriptors

### Checks enforced by the new rule

| # | Constraint | Target |
|---|-----------|--------|
| 1 | `sizes` present → `srcset` must use width descriptors (`w`) only | `img`, `source` |
| 2 | `srcset` must not mix width (`w`) and density (`x`) descriptors | `img`, `source` |
| 3 | `sizes="auto"` on `<img>` requires `loading="lazy"` | `img` |
| 4 | `sizes="auto"` on `<source>` requires following sibling `<img>` to have `loading="lazy"` | `source` (in `<picture>`) |
| 5 | `srcset` with width descriptors on `<img>` requires `sizes` attribute | `img` |

### Changes by package

- **`@markuplint/types`**: Fix `Srcset.is()` to track `hasWidth`/`hasDensity` flags and reject mixed descriptors
- **`@markuplint/rules`**: New `srcset-sizes-constraint` rule (5 checks, 46 tests, EN/JA docs)
- **`@markuplint/config-presets`**: Add rule to `html-standard` preset
- **`markuplint`**: Update default rules snapshot

## Test plan

- [x] 46 rule tests covering all 5 checks, edge cases, and dynamic values (Vue/JSX)
- [x] 7 new Srcset validator tests for descriptor consistency
- [x] Snapshot test updated
- [x] `yarn lint-check` passes
- [x] `yarn build` passes (40 projects)
- [x] `yarn test` passes (2135 tests; 1 pre-existing worktree-specific failure unrelated to this PR)

Closes #1051

🤖 Generated with [Claude Code](https://claude.com/claude-code)