### PR TITLE
feat(html-spec): require href or imagesrcset on link element

### DIFF
--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -52621,7 +52621,8 @@
 					"description": "Provides a hint of the relative priority to use when fetching a resource of a particular type. Allowed values: high Fetch the resource at a high priority relative to other resources of the same type. low Fetch the resource at a low priority relative to other resources of the same type. auto Don't set a preference for the fetch priority. This is the default. It is used if no value or an invalid value is set."
 				},
 				"href": {
-					"description": "This attribute specifies the URL of the linked resource. A URL can be absolute or relative."
+					"description": "This attribute specifies the URL of the linked resource. A URL can be absolute or relative.",
+					"requiredEither": ["imagesrcset"]
 				},
 				"hreflang": {
 					"description": "This attribute indicates the language of the linked resource. It is purely advisory. Values should be valid BCP 47 language tags. Use this attribute only if the href attribute is present."

--- a/packages/@markuplint/html-spec/src/spec.link.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.link.jsonc
@@ -22,8 +22,10 @@
 	},
 	"attributes": {
 		// https://html.spec.whatwg.org/multipage/semantics.html#the-link-element
-		// > A link element must have either a rel attribute or an itemprop attribute, but not both.
-		// > ...must have an href attribute or an imagesrcset attribute (or both).
+		// > One or both of the href or imagesrcset attributes must be present.
+		// Note: requiredEither is NOT added to imagesrcset because it already has
+		// condition/required for imagesizes interaction, and requiredEither would
+		// take precedence (index.ts:88), bypassing that logic.
 		"href": {
 			"requiredEither": ["imagesrcset"]
 		},

--- a/packages/@markuplint/html-spec/src/spec.link.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.link.jsonc
@@ -21,6 +21,12 @@
 		]
 	},
 	"attributes": {
+		// https://html.spec.whatwg.org/multipage/semantics.html#the-link-element
+		// > A link element must have either a rel attribute or an itemprop attribute, but not both.
+		// > ...must have an href attribute or an imagesrcset attribute (or both).
+		"href": {
+			"requiredEither": ["imagesrcset"]
+		},
 		// https://html.spec.whatwg.org/multipage/semantics.html#attr-link-rel
 		"rel": {
 			"type": "LinkTypeForLinkElement",

--- a/packages/@markuplint/rules/src/required-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/required-attr/index.spec.ts
@@ -525,6 +525,31 @@ describe('Issues', () => {
 	});
 });
 
+describe('link element requires href or imagesrcset (#717)', () => {
+	test('violation: link without href or imagesrcset', async () => {
+		expect((await mlRuleTest(rule, '<link rel="stylesheet">')).violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 1,
+				message: 'The "link" element expects the "href" or the "imagesrcset" attribute',
+				raw: '<link rel="stylesheet">',
+			},
+		]);
+	});
+
+	test('no violation: link with href', async () => {
+		expect((await mlRuleTest(rule, '<link rel="stylesheet" href="./style.css">')).violations).toStrictEqual([]);
+	});
+
+	test('no violation: link with imagesrcset (href not required)', async () => {
+		expect(
+			(await mlRuleTest(rule, '<link rel="preload" as="image" imagesrcset="/img.png 1x" imagesizes="100vw">'))
+				.violations,
+		).toStrictEqual([]);
+	});
+});
+
 describe('MDX parser', () => {
 	test('MDX img element requires alt attribute', async () => {
 		const { violations } = await mlRuleTest(rule, '<img src="photo.png" />\n', {

--- a/packages/@markuplint/rules/src/required-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/required-attr/index.spec.ts
@@ -525,6 +525,8 @@ describe('Issues', () => {
 	});
 });
 
+// https://html.spec.whatwg.org/multipage/semantics.html#the-link-element
+// > One or both of the href or imagesrcset attributes must be present.
 describe('link element requires href or imagesrcset (#717)', () => {
 	test('violation: link without href or imagesrcset', async () => {
 		expect((await mlRuleTest(rule, '<link rel="stylesheet">')).violations).toStrictEqual([
@@ -538,14 +540,57 @@ describe('link element requires href or imagesrcset (#717)', () => {
 		]);
 	});
 
+	test('violation: bare link reports both href/imagesrcset and rel/itemprop violations', async () => {
+		const { violations } = await mlRuleTest(rule, '<link>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 1,
+				message: 'The "link" element expects the "href" or the "imagesrcset" attribute',
+				raw: '<link>',
+			},
+			{
+				severity: 'error',
+				line: 1,
+				col: 1,
+				message: 'The "link" element expects the "itemprop" or the "rel" attribute',
+				raw: '<link>',
+			},
+		]);
+	});
+
+	test('violation: itemprop path also requires href or imagesrcset', async () => {
+		expect((await mlRuleTest(rule, '<link itemprop="url">')).violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 1,
+				message: 'The "link" element expects the "href" or the "imagesrcset" attribute',
+				raw: '<link itemprop="url">',
+			},
+		]);
+	});
+
 	test('no violation: link with href', async () => {
 		expect((await mlRuleTest(rule, '<link rel="stylesheet" href="./style.css">')).violations).toStrictEqual([]);
 	});
 
-	test('no violation: link with imagesrcset (href not required)', async () => {
+	test('no violation: link with imagesrcset satisfies "href or imagesrcset" requirement', async () => {
 		expect(
 			(await mlRuleTest(rule, '<link rel="preload" as="image" imagesrcset="/img.png 1x" imagesizes="100vw">'))
 				.violations,
+		).toStrictEqual([]);
+	});
+
+	test('no violation: link with both href and imagesrcset', async () => {
+		expect(
+			(
+				await mlRuleTest(
+					rule,
+					'<link rel="preload" as="image" href="/img.png" imagesrcset="/img.png 1x" imagesizes="100vw">',
+				)
+			).violations,
 		).toStrictEqual([]);
 	});
 });


### PR DESCRIPTION
## Summary

- Add `requiredEither: ["imagesrcset"]` to the `href` attribute of the `link` element spec
- The WHATWG HTML Living Standard requires: *"One or both of the href or imagesrcset attributes must be present."*
- Nu HTML Checker performs the same check

## Changes

- **`@markuplint/html-spec`**: Add `requiredEither` constraint to `href` in `spec.link.jsonc` and `index.json`
- **`@markuplint/rules`**: Add 6 test cases for `required-attr` covering:
  - `<link rel="stylesheet">` → violation (no href or imagesrcset)
  - `<link>` → both href/imagesrcset and rel/itemprop violations
  - `<link itemprop="url">` → violation (itemprop path also requires href)
  - `<link rel="stylesheet" href="...">` → OK
  - `<link rel="preload" as="image" imagesrcset="..." imagesizes="...">` → OK
  - `<link ... href="..." imagesrcset="..." ...>` → OK (both present)

## Design Decision

`requiredEither` is NOT added to the `imagesrcset` side because it already has `condition`/`required` for `imagesizes` interaction. Adding `requiredEither` would take precedence (index.ts L88), bypassing that logic.

## Test plan

- [x] `npx vitest run packages/@markuplint/rules/src/required-attr/index.spec.ts` — 30 tests passed
- [x] `yarn build` — all 40 packages built successfully
- [x] `yarn lint-check` — 0 errors, 0 warnings, 0 spelling issues

Closes #717

🤖 Generated with [Claude Code](https://claude.com/claude-code)