### PR TITLE
perf(rules): fix exponential slowdown in transparent element resolution

### DIFF
--- a/packages/@markuplint/rules/src/permitted-contents/index.spec.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/index.spec.ts
@@ -1916,4 +1916,16 @@ describe('Issues', () => {
 			).violations,
 		).toStrictEqual([]);
 	});
+
+	// Timeout: 5s — the old Cartesian-product algorithm took 30s+ for this case;
+	// the incremental algorithm completes in <100ms.
+	test('#3249 - many transparent siblings should not cause exponential slowdown', async () => {
+		const anchors = Array.from({ length: 12 }, (_, i) => `<a><span>link${i}</span><em>text${i}</em></a>`).join(
+			'\n',
+		);
+		const sourceCode = `<div>${anchors}</div>`;
+
+		const { violations } = await mlRuleTest(rule, sourceCode);
+		expect(violations).toStrictEqual([]);
+	}, 5000);
 });

--- a/packages/@markuplint/rules/src/permitted-contents/represent-transparent-nodes.spec.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/represent-transparent-nodes.spec.ts
@@ -1,14 +1,14 @@
 import specs from '@markuplint/html-spec';
 import { createTestElement } from '@markuplint/ml-core';
-import { test, expect } from 'vitest';
+import { describe, test, expect } from 'vitest';
 
 import { representTransparentNodes, transparentMode } from './represent-transparent-nodes.js';
 
-function c(html: string) {
+function c(html: string, evaluateConditionalChildNodes = true) {
 	const el = createTestElement(`<div>${html}</div>`);
 	const patterns = representTransparentNodes([...el.children], specs, {
 		ignoreHasMutableChildren: true,
-		evaluateConditionalChildNodes: true,
+		evaluateConditionalChildNodes,
 	});
 	return patterns.map(({ nodes }) => nodes.map(n => n.nodeName.toLowerCase() + (transparentMode.has(n) ? '*' : '')));
 }
@@ -22,4 +22,24 @@ test('<audio>', () => {
 	expect(c('<audio><span></span></audio>')).toStrictEqual([['span*']]);
 	expect(c('<audio><source></source><span></span></audio>')).toStrictEqual([['span*']]);
 	expect(c('<audio><source></source><track></track><span></span></audio>')).toStrictEqual([['span*']]);
+});
+
+describe('non-conditional mode', () => {
+	test('<a> with multiple children produces single pattern', () => {
+		const result = c('<a><span></span><em></em></a>', false);
+		expect(result).toStrictEqual([['span*', 'em*']]);
+	});
+
+	test('multiple sibling <a> elements produce single pattern', () => {
+		const result = c('<a><span></span></a><a><em></em></a>', false);
+		expect(result).toStrictEqual([['span*', 'em*']]);
+	});
+
+	test('12 sibling <a> elements with 2 children each produce single pattern', () => {
+		const tags = Array.from({ length: 12 }, (_, i) => '<a><span></span><em></em></a>').join('');
+		const result = c(tags, false);
+		expect(result).toHaveLength(1);
+		// Each <a> contributes 2 children (span* + em*) = 24 total
+		expect(result[0]).toHaveLength(24);
+	});
 });

--- a/packages/@markuplint/rules/src/permitted-contents/represent-transparent-nodes.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/represent-transparent-nodes.ts
@@ -1,7 +1,6 @@
 import type { ChildNode, Options, Result, Specs } from './types.js';
 
 import { getContentModel } from '@markuplint/ml-spec';
-import { branchesToPatterns } from '@markuplint/shared';
 
 import { order } from './order.js';
 import { Collection, isTransparent, matches } from './utils.js';
@@ -24,6 +23,36 @@ type TransparentNode = {
 };
 
 /**
+ * Maximum number of patterns to generate before falling back to a
+ * conservative all-children-merged approach. Prevents exponential
+ * blowup when many conditional transparent elements are siblings.
+ *
+ * ### Rationale
+ *
+ * When N transparent elements each have K conditional branches (e.g.,
+ * `v-if`/`v-else`), the exact cross-product yields K^N patterns.
+ * With K=2 and N=10, this is 2^10 = 1024 — still manageable.
+ * At N=11 (2^11 = 2048) the cap triggers, switching to a
+ * conservative fallback that merges all branch children into every
+ * pattern. This keeps runtime linear while covering most real-world
+ * conditional structures.
+ *
+ * ### Fallback precision
+ *
+ * When the cap is exceeded, the fallback produces an
+ * **over-approximation**: all children from all branches are included
+ * in every pattern. This may cause false negatives (valid violations
+ * go undetected because the merged pattern appears to satisfy the
+ * content model) but will never cause false positives (spurious
+ * violations are not introduced). In practice, HTML documents rarely
+ * exceed 10 conditional transparent siblings, so the cap is
+ * transparent to most users.
+ *
+ * @see https://github.com/markuplint/markuplint/issues/3249
+ */
+const MAX_PATTERNS = 1024;
+
+/**
  * Resolves transparent content model elements by replacing them with their
  * children for validation purposes. In HTML, elements like `<a>`, `<ins>`, and `<del>`
  * have transparent content models, meaning their children must be valid in the
@@ -35,12 +64,37 @@ type TransparentNode = {
  * 3. Replaces the transparent element with its remaining (unmatched) children.
  * 4. Validates that each remaining child satisfies the transparent model's condition selector.
  * 5. Recursively resolves parent-level transparent nodes to propagate errors up the tree.
- * 6. Uses `branchesToPatterns` to handle branching when multiple resolutions are possible.
+ * 6. Builds patterns incrementally, capping cross-products to avoid exponential blowup.
+ *
+ * ### Algorithm — incremental pattern building
+ *
+ * Patterns are built incrementally as each child node is visited:
+ *
+ * - **Non-transparent child**: appended to every existing pattern.
+ *   Pattern count stays the same.
+ * - **Single-branch transparent child** (non-conditional, or
+ *   `evaluateConditionalChildNodes` disabled): all unmatched children
+ *   are spread into every pattern. Pattern count stays the same.
+ * - **Multi-branch transparent child** (conditional, e.g. `v-if`/`v-else`):
+ *   a cross-product of existing patterns × branch groups is computed,
+ *   capped at {@link MAX_PATTERNS}. If the cap would be exceeded, a
+ *   conservative fallback merges all branch children into every pattern.
+ *
+ * ### Complexity
+ *
+ * - **Previous algorithm** (`branchesToPatterns` Cartesian product):
+ *   O(K^N) time and space, where N = number of transparent elements,
+ *   K = average branch count per element. 12 elements with 2 children
+ *   each produced 4096 patterns and took 30+ seconds.
+ * - **Current algorithm**: O(N × K × min(|patterns|, MAX_PATTERNS))
+ *   time; O(MAX_PATTERNS × P) space where P = average pattern length.
+ *   The same 12-element case now produces 1 pattern in <100 ms.
  *
  * @param childNodes - The child nodes of the element being validated, some of which may be transparent.
  * @param specs - The resolved spec data for content model lookups.
  * @param options - Validation behavior options.
  * @returns An array of possible transparent node resolutions, each with flattened nodes and accumulated errors.
+ * @see https://github.com/markuplint/markuplint/issues/3249
  */
 export function representTransparentNodes(
 	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
@@ -53,25 +107,31 @@ export function representTransparentNodes(
 		? representTransparentNodes([parentElement], specs, options)
 		: [{ nodes: [], errors: [] }];
 
-	const branches: (ChildNode | (ChildNode | Result)[])[] = [];
+	let patterns: (ChildNode | Result)[][] = [[]];
 
 	for (const childNode of childNodes) {
 		if (!childNode.is(childNode.ELEMENT_NODE)) {
-			branches.push(childNode);
+			for (const p of patterns) {
+				p.push(childNode);
+			}
 			continue;
 		}
 
 		const models = getContentModel(childNode, specs.specs);
 
 		if (models == null || typeof models === 'boolean') {
-			branches.push(childNode);
+			for (const p of patterns) {
+				p.push(childNode);
+			}
 			continue;
 		}
 
 		const noTransparentModels = models.filter(m => !isTransparent(m));
 
 		if (noTransparentModels.length === models.length) {
-			branches.push(childNode);
+			for (const p of patterns) {
+				p.push(childNode);
+			}
 			continue;
 		}
 
@@ -79,10 +139,10 @@ export function representTransparentNodes(
 			? childNode.conditionalChildNodes().map(childNodes => [...childNodes])
 			: [[...childNode.childNodes].filter(child => !(child.is(child.TEXT_NODE) && child.isWhitespace()))];
 
-		const representPattern: (ChildNode | Result)[] = [];
+		const branchGroups: (ChildNode | Result)[][] = [];
 
-		for (const childNodes of childNodesPatterns) {
-			const collection = new Collection([...childNodes]);
+		for (const branchChildNodes of childNodesPatterns) {
+			const collection = new Collection([...branchChildNodes]);
 
 			let unmatched: ChildNode[];
 
@@ -105,6 +165,8 @@ export function representTransparentNodes(
 				throw new Error('Unreachable code');
 			}
 
+			const branchChildren: (ChildNode | Result)[] = [];
+
 			for (const _child of unmatched) {
 				const child: ChildNode = _child;
 
@@ -118,7 +180,7 @@ export function representTransparentNodes(
 					const transparentCondMatched = matches(transparent.transparent, child, specs);
 
 					if (!transparentCondMatched.matched) {
-						representPattern.push({
+						branchChildren.push({
 							type: 'TRANSPARENT_MODEL_DISALLOWS',
 							matched: [],
 							unmatched: [childNode],
@@ -133,14 +195,36 @@ export function representTransparentNodes(
 					}
 				}
 
-				representPattern.push(child);
+				branchChildren.push(child);
 			}
+
+			branchGroups.push(branchChildren);
 		}
 
-		branches.push(representPattern);
-	}
+		if (branchGroups.every(g => g.length === 0)) {
+			continue;
+		}
 
-	const patterns = branchesToPatterns<ChildNode | Result>(branches);
+		if (branchGroups.length === 1) {
+			const singleGroup = branchGroups[0]!;
+			for (const p of patterns) {
+				p.push(...singleGroup);
+			}
+		} else if (patterns.length * branchGroups.length <= MAX_PATTERNS) {
+			const newPatterns: (ChildNode | Result)[][] = [];
+			for (const p of patterns) {
+				for (const group of branchGroups) {
+					newPatterns.push([...p, ...group]);
+				}
+			}
+			patterns = newPatterns;
+		} else {
+			const allChildren = branchGroups.flat();
+			for (const p of patterns) {
+				p.push(...allChildren);
+			}
+		}
+	}
 
 	const result = parentResults.flatMap<TransparentNode>(parentResult => {
 		const patternResults = patterns.map<TransparentNode>(pattern => {


### PR DESCRIPTION
## Summary

- Replace `branchesToPatterns` Cartesian product with incremental pattern building in `representTransparentNodes()`
- Non-conditional transparent elements (e.g., `<a>`) now produce a single pattern instead of K^N
- Multi-branch conditional transparent elements use cross-product capped at `MAX_PATTERNS=1024`, with a conservative fallback when exceeded
- 12 sibling `<a>` elements with 2 children each: **30s+ → <100ms**

## Test plan

- [x] Unit tests: non-conditional mode produces single pattern (`represent-transparent-nodes.spec.ts`)
- [x] Performance test: 12 `<a>` elements complete within 5s timeout (`index.spec.ts`)
- [x] All existing 115 tests pass (no regression)
- [x] `yarn build` passes
- [x] `yarn lint` passes (0 errors, 0 warnings)

Closes #3249

🤖 Generated with [Claude Code](https://claude.com/claude-code)