### PR TITLE
chore(github): add YusukeHirao as code owner for website docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,10 @@
 
 # Contributors
 website/ @kagankan
+website/docs/ @YusukeHirao
+website/src/pages/index.tsx @YusukeHirao
+website/**/*.md @YusukeHirao
+website/**/*.mdx @YusukeHirao
 
 # Renovate
 package.json


### PR DESCRIPTION
## Summary

- Add `@YusukeHirao` as code owner for `website/docs/`, `website/src/pages/index.tsx`, `website/**/*.md`, and `website/**/*.mdx`
- This allows @YusukeHirao to approve and merge PRs that only touch these paths without requiring @kagankan's approval
- @kagankan remains the code owner for other `website/` files

## Test plan

- [x] No code changes — CODEOWNERS config only
- [x] Verify ownership via GitHub's CODEOWNERS validation after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)