### PR TITLE
feat: detect shortcut keyword in link rel attribute

### DIFF
--- a/packages/@markuplint/config-presets/README.md
+++ b/packages/@markuplint/config-presets/README.md
@@ -66,6 +66,7 @@ Specify required attr| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
 [No use `<caption>` within `<figure>`](https://html.spec.whatwg.org/multipage/tables.html#the-caption-element)|When `<table>` is the only content in `<figure>` other than `<figcaption>`, `<caption>` should be omitted in favor of `<figcaption>`.|✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
 [Require `title` attr in `<input pattern>`](https://html.spec.whatwg.org/multipage/input.html#attr-input-pattern)|When an `<input>` element has a `pattern` attribute specified, authors should include a `title` attribute to give a description of the pattern.|✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
 No nested same `<details>` name group|A document must not contain a details element that is a descendant of another details element in the same details name group.|✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
+[No use `shortcut` keyword in `<link rel>`](https://html.spec.whatwg.org/multipage/links.html#rel-shortcut-icon)|For historical reasons, the icon keyword may be preceded by the keyword "shortcut". However, pages should not use the keyword "shortcut" as it is unnecessary.|✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
 [Require `charset=UTF-8`](https://html.spec.whatwg.org/multipage/semantics.html#charset)| |✅|✅|✅|✅|✅|❌|❌|❌|❌|✅|❌|❌|
 Require `defer` attr|Should load and parse scripts lazily to avoid render-blocking.|✅|✅|✅|✅|✅|❌|❌|❌|❌|✅|❌|❌|
 Require **aspect-ratio**|Require `width` and `height` attr with `<img>` to avoid **Cumulative Layout Shift**|✅|✅|✅|✅|✅|❌|❌|❌|❌|✅|❌|❌|

--- a/packages/@markuplint/config-presets/src/preset.html-standard.jsonc
+++ b/packages/@markuplint/config-presets/src/preset.html-standard.jsonc
@@ -278,6 +278,34 @@
 					"reason": "A document must not contain a details element that is a descendant of another details element in the same details name group."
 				}
 			}
+		},
+		{
+			/**
+			 * No use `shortcut` keyword in `<link rel>`
+			 *
+			 * For historical reasons, the icon keyword may be preceded by the keyword "shortcut".
+			 * However, pages should not use the keyword "shortcut" as it is unnecessary.
+			 *
+			 * @see https://html.spec.whatwg.org/multipage/links.html#rel-shortcut-icon
+			 */
+			"name": "html-standard/no-shortcut-icon",
+			"specConformance": "non-normative",
+			"selector": "link",
+			"rules": {
+				"invalid-attr": {
+					"options": {
+						"disallowAttrs": [
+							{
+								"name": "rel",
+								"value": {
+									"pattern": "/\\bshortcut\\b/i"
+								}
+							}
+						]
+					},
+					"reason": "The \"shortcut\" keyword is unnecessary. Use rel=\"icon\" instead. https://html.spec.whatwg.org/multipage/links.html#rel-shortcut-icon"
+				}
+			}
 		}
 	]
 }

--- a/packages/markuplint/src/named-noderules.spec.ts
+++ b/packages/markuplint/src/named-noderules.spec.ts
@@ -808,6 +808,79 @@ describe('Named nodeRules integration', () => {
 		});
 	});
 
+	describe('html-standard/no-shortcut-icon', () => {
+		it('detects rel="shortcut icon" on link element', async () => {
+			const { violations } = await mlTest(
+				'<!doctype html><html><head><meta charset="UTF-8"><link rel="shortcut icon" href="/favicon.ico"></head><body></body></html>',
+				{
+					extends: ['markuplint:html-standard'],
+				},
+			);
+			const shortcutViolation = violations.find(v => v.name === 'html-standard/no-shortcut-icon');
+			expect(shortcutViolation).toBeDefined();
+			expect(shortcutViolation!.ruleId).toBe('invalid-attr');
+			expect(shortcutViolation!.specConformance).toBe('non-normative');
+		});
+
+		it('detects rel="SHORTCUT ICON" (case-insensitive)', async () => {
+			const { violations } = await mlTest(
+				'<!doctype html><html><head><meta charset="UTF-8"><link rel="SHORTCUT ICON" href="/favicon.ico"></head><body></body></html>',
+				{
+					extends: ['markuplint:html-standard'],
+				},
+			);
+			const shortcutViolation = violations.find(v => v.name === 'html-standard/no-shortcut-icon');
+			expect(shortcutViolation).toBeDefined();
+		});
+
+		it('does not flag rel="icon"', async () => {
+			const { violations } = await mlTest(
+				'<!doctype html><html><head><meta charset="UTF-8"><link rel="icon" href="/favicon.ico"></head><body></body></html>',
+				{
+					extends: ['markuplint:html-standard'],
+				},
+			);
+			const shortcutViolation = violations.find(v => v.name === 'html-standard/no-shortcut-icon');
+			expect(shortcutViolation).toBeUndefined();
+		});
+
+		it('detects rel="shortcut" without icon', async () => {
+			const { violations } = await mlTest(
+				'<!doctype html><html><head><meta charset="UTF-8"><link rel="shortcut" href="/favicon.ico"></head><body></body></html>',
+				{
+					extends: ['markuplint:html-standard'],
+				},
+			);
+			const shortcutViolation = violations.find(v => v.name === 'html-standard/no-shortcut-icon');
+			expect(shortcutViolation).toBeDefined();
+		});
+
+		it('detects rel="icon shortcut" (reversed order)', async () => {
+			const { violations } = await mlTest(
+				'<!doctype html><html><head><meta charset="UTF-8"><link rel="icon shortcut" href="/favicon.ico"></head><body></body></html>',
+				{
+					extends: ['markuplint:html-standard'],
+				},
+			);
+			const shortcutViolation = violations.find(v => v.name === 'html-standard/no-shortcut-icon');
+			expect(shortcutViolation).toBeDefined();
+		});
+
+		it('can be disabled by exact name', async () => {
+			const { violations } = await mlTest(
+				'<!doctype html><html><head><meta charset="UTF-8"><link rel="shortcut icon" href="/favicon.ico"></head><body></body></html>',
+				{
+					extends: ['markuplint:html-standard'],
+					rules: {
+						'html-standard/no-shortcut-icon': false,
+					},
+				},
+			);
+			const shortcutViolation = violations.find(v => v.name === 'html-standard/no-shortcut-icon');
+			expect(shortcutViolation).toBeUndefined();
+		});
+	});
+
 	describe('backwards compatibility', () => {
 		it('conventional config without named rule groups works as before', async () => {
 			const { violations } = await mlTest(

--- a/website/docs/guides/presets.md
+++ b/website/docs/guides/presets.md
@@ -121,6 +121,7 @@ See the [rulesets tables](#rulesets-of-base-presets) below for the full list of 
 | `html-standard/figure-no-caption`           | When `<table>` is the only content in `<figure>` other than `<figcaption>`, `<caption>` should be omitted in favor of `<figcaption>`.           |
 | `html-standard/input-pattern-title`         | When an `<input>` element has a `pattern` attribute specified, authors should include a `title` attribute to give a description of the pattern. |
 | `html-standard/no-nested-details-name`      | A document must not contain a `<details>` element that is a descendant of another `<details>` element in the same name group.                   |
+| `html-standard/no-shortcut-icon`            | The `shortcut` keyword in `<link rel>` is unnecessary. Use `rel="icon"` instead.                                                                |
 
 ### `markuplint:performance` {#preset-performance}
 

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/presets.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/presets.md
@@ -121,6 +121,7 @@
 | `html-standard/figure-no-caption`           | `<figure>`内で`<table>`が`<figcaption>`以外の唯一のコンテンツである場合、`<caption>`を省略して`<figcaption>`を使用すべきです。 |
 | `html-standard/input-pattern-title`         | `<input>`要素に`pattern`属性が指定されている場合、パターンの説明として`title`属性を含めるべきです。                            |
 | `html-standard/no-nested-details-name`      | 同じ名前グループ内の別の`<details>`要素の子孫である`<details>`要素をドキュメント内に含めることはできません。                   |
+| `html-standard/no-shortcut-icon`            | `<link rel>`の`shortcut`キーワードは不要です。代わりに`rel="icon"`を使用してください。                                         |
 
 ### `markuplint:performance` {#preset-performance}
 


### PR DESCRIPTION
## Summary

- Add `html-standard/no-shortcut-icon` nodeRule to the html-standard preset to detect the unnecessary `shortcut` keyword in `<link rel="shortcut icon">`
- The HTML spec allows `shortcut icon` for historical reasons, but pages should use `rel="icon"` instead
- Uses `invalid-attr` with `disallowAttrs` pattern matching (`/\bshortcut\b/i`) for case-insensitive detection

Closes #715

## Changes

- `packages/@markuplint/config-presets/src/preset.html-standard.jsonc`: Add `no-shortcut-icon` nodeRule
- `packages/markuplint/src/named-noderules.spec.ts`: Add 6 integration tests (basic detection, case-insensitive, reversed order, shortcut-only, icon-only, exact-name disable)
- `website/docs/guides/presets.md` + Japanese localization: Add rule to preset table

## Test plan

- [x] `yarn build` — 40/40 packages pass
- [x] `yarn test` — 2356 tests pass (159 files)
- [x] `yarn lint` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)