### PR TITLE
feat(rules): add ignoreAttrs option to required-attr rule

### DIFF
--- a/packages/@markuplint/rules/src/required-attr/README.ja.md
+++ b/packages/@markuplint/rules/src/required-attr/README.ja.md
@@ -96,4 +96,25 @@ const Component = (props) => {
 }
 ```
 
+### `ignoreAttrs`
+
+`ignoreAttrs` オプションを使うと、特定の属性を必須属性チェックから除外できます。ルール全体を無効にせずに、フレームワークが処理する属性や意図的に省略する属性を無視したい場合に便利です。
+
+```json class=config
+{
+  "nodeRules": [
+    {
+      "selector": "img",
+      "rules": {
+        "required-attr": {
+          "options": {
+            "ignoreAttrs": ["src", "srcset"]
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
 <!-- textlint-enable ja-technical-writing/ja-no-mixed-period -->

--- a/packages/@markuplint/rules/src/required-attr/README.md
+++ b/packages/@markuplint/rules/src/required-attr/README.md
@@ -92,3 +92,24 @@ Example configuration that `alt` attribute must be required on `<img>` element:
   ]
 }
 ```
+
+### `ignoreAttrs`
+
+You can use the `ignoreAttrs` option to exclude specific attributes from required-attribute checks. This is useful when you want to keep the rule enabled but ignore certain attributes that are handled by a framework or are intentionally omitted.
+
+```json class=config
+{
+  "nodeRules": [
+    {
+      "selector": "img",
+      "rules": {
+        "required-attr": {
+          "options": {
+            "ignoreAttrs": ["src", "srcset"]
+          }
+        }
+      }
+    }
+  ]
+}
+```

--- a/packages/@markuplint/rules/src/required-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/required-attr/index.spec.ts
@@ -692,3 +692,154 @@ describe('Markdown parser', () => {
 		expect(violations[0].raw).toBe('![alt](img.png)');
 	});
 });
+
+describe('ignoreAttrs option (#690)', () => {
+	test('ignores spec-required attribute when listed in ignoreAttrs', async () => {
+		// <area href="..."> requires "alt" per spec; ignoring it should suppress the violation
+		const { violations } = await mlRuleTest(rule, '<area href="path/to">', {
+			rule: {
+				options: {
+					ignoreAttrs: ['alt'],
+				},
+			},
+		});
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('still reports non-ignored spec-required attributes', async () => {
+		const { violations } = await mlRuleTest(rule, '<img>', {
+			nodeRule: [
+				{
+					selector: 'img',
+					rule: {
+						value: 'alt',
+						options: {
+							ignoreAttrs: ['src', 'srcset'],
+						},
+					},
+				},
+			],
+		});
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 1,
+				message: 'The "img" element expects the "alt" attribute',
+				raw: '<img>',
+			},
+		]);
+	});
+
+	test('no option behaves the same as before (backward compatibility)', async () => {
+		const { violations } = await mlRuleTest(rule, '<img>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 1,
+				message: 'The "img" element expects the "src" or the "srcset" attribute',
+				raw: '<img>',
+			},
+		]);
+	});
+
+	test('empty ignoreAttrs behaves the same as no option', async () => {
+		const { violations } = await mlRuleTest(rule, '<img>', {
+			rule: {
+				options: {
+					ignoreAttrs: [],
+				},
+			},
+		});
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 1,
+				message: 'The "img" element expects the "src" or the "srcset" attribute',
+				raw: '<img>',
+			},
+		]);
+	});
+
+	test('requiredEither: ignoring one candidate keeps the other required', async () => {
+		const { violations } = await mlRuleTest(rule, '<link rel="stylesheet">', {
+			rule: {
+				options: {
+					ignoreAttrs: ['href'],
+				},
+			},
+		});
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 1,
+				message: 'The "link" element expects the "imagesrcset" attribute',
+				raw: '<link rel="stylesheet">',
+			},
+		]);
+	});
+
+	test('requiredEither: ignoring all candidates suppresses the violation', async () => {
+		const { violations } = await mlRuleTest(rule, '<img>', {
+			rule: {
+				options: {
+					ignoreAttrs: ['src', 'srcset'],
+				},
+			},
+		});
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('ignores custom required attribute specified via value', async () => {
+		const { violations } = await mlRuleTest(rule, '<img src="/path/to/image.png">', {
+			nodeRule: [
+				{
+					selector: 'img',
+					rule: {
+						value: ['alt', 'width'],
+						options: {
+							ignoreAttrs: ['width'],
+						},
+					},
+				},
+			],
+		});
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 1,
+				message: 'The "img" element expects the "alt" attribute',
+				raw: '<img src="/path/to/image.png">',
+			},
+		]);
+	});
+
+	test('ignores value-constrained required attribute', async () => {
+		const { violations } = await mlRuleTest(rule, '<img src="/path/to/image.png">', {
+			nodeRule: [
+				{
+					selector: 'img',
+					rule: {
+						value: [{ name: 'decoding', value: 'async' }, 'alt'],
+						options: {
+							ignoreAttrs: ['decoding'],
+						},
+					},
+				},
+			],
+		});
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 1,
+				message: 'The "img" element expects the "alt" attribute',
+				raw: '<img src="/path/to/image.png">',
+			},
+		]);
+	});
+});

--- a/packages/@markuplint/rules/src/required-attr/index.ts
+++ b/packages/@markuplint/rules/src/required-attr/index.ts
@@ -20,15 +20,24 @@ type Attr = {
 };
 
 /**
+ * Configuration options for the `required-attr` rule.
+ */
+type Options = {
+	/** Attribute names to exclude from required-attribute checks. */
+	readonly ignoreAttrs?: readonly string[];
+};
+
+/**
  * Rule that validates elements have all required attributes.
  *
  * Checks both HTML-spec-defined required attributes and custom required attributes
  * specified in the rule configuration. Also validates that required attribute values
  * match expected patterns when value constraints are provided.
  */
-export default createRule<RequiredAttributes>({
+export default createRule<RequiredAttributes, Options>({
 	meta: meta,
 	defaultValue: [],
+	defaultOptions: {},
 	async verify({ document, report, t }) {
 		await document.walkOn('Element', el => {
 			if (el.hasSpreadAttr) {
@@ -37,6 +46,7 @@ export default createRule<RequiredAttributes>({
 
 			const customRequiredAttrs = typeof el.rule.value === 'string' ? [el.rule.value] : el.rule.value;
 			const attrSpec = getAttrSpecs(el, document.specs);
+			const ignoreAttrs = new Set(el.rule.options.ignoreAttrs);
 
 			const attributeSpecs: Record<
 				string,
@@ -79,6 +89,36 @@ export default createRule<RequiredAttributes>({
 			}
 
 			for (const spec of Object.values(attributeSpecs)) {
+				if (ignoreAttrs.has(spec.name)) {
+					if (spec.requiredEither) {
+						const activeCandidates = spec.requiredEither.filter(n => !ignoreAttrs.has(n));
+						if (activeCandidates.length > 0) {
+							const invalid = !activeCandidates.some(attrName => el.hasAttribute(attrName));
+							if (invalid) {
+								const sortedCandidate = activeCandidates.toSorted();
+								const expects =
+									sortedCandidate.length === 1
+										? t('the "{0*}" {1}', sortedCandidate[0]!, 'attribute')
+										: t(
+												'{0} {1}',
+												sortedCandidate
+													.map(attrName => t('the "{0*}"', attrName))
+													// eslint-disable-next-line unicorn/no-array-reduce
+													.reduce((a, b) => t('{0} or {1}', a, b)),
+												t('attribute'),
+											);
+								const message = t(
+									'{0} expects {1}',
+									t('the "{0*}" {1}', el.localName, 'element'),
+									expects,
+								);
+								report({ scope: el, message });
+							}
+						}
+					}
+					continue;
+				}
+
 				const didntHave = !el.hasAttribute(spec.name);
 
 				const candidate: string[] = [spec.name];
@@ -87,7 +127,9 @@ export default createRule<RequiredAttributes>({
 
 				if (spec.requiredEither) {
 					candidate.push(...spec.requiredEither);
-					invalid = !candidate.some(attrName => el.hasAttribute(attrName));
+
+					const activeCandidates = candidate.filter(n => !ignoreAttrs.has(n));
+					invalid = !activeCandidates.some(attrName => el.hasAttribute(attrName));
 				} else if (spec.required === true) {
 					invalid = attrMatches(el, spec.condition) && didntHave;
 				} else if (spec.required != null && spec.required !== false) {
@@ -95,7 +137,7 @@ export default createRule<RequiredAttributes>({
 					invalid = el.matches(selector) && didntHave;
 				}
 
-				const sortedCandidate = candidate.toSorted();
+				const sortedCandidate = candidate.filter(n => !ignoreAttrs.has(n)).toSorted();
 
 				if (invalid) {
 					const expects =

--- a/packages/@markuplint/rules/src/required-attr/schema.json
+++ b/packages/@markuplint/rules/src/required-attr/schema.json
@@ -37,6 +37,22 @@
 				}
 			],
 			"description": "```ts\ntype Attr = {\n  name: string;\n  value?: string | string[];\n};\n```"
+		},
+		"options": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"ignoreAttrs": {
+					"type": "array",
+					"uniqueItems": true,
+					"minItems": 1,
+					"items": {
+						"type": "string"
+					},
+					"description": "Attribute names to exclude from required-attribute checks. Use this when you want to ignore specific required attributes without disabling the entire rule.",
+					"description:ja": "必須属性チェックから除外する属性名のリスト。ルール全体を無効にせずに特定の必須属性を無視したい場合に使用します。"
+				}
+			}
 		}
 	},
 	"oneOf": [
@@ -51,6 +67,7 @@
 			"additionalProperties": false,
 			"properties": {
 				"value": { "$ref": "#/definitions/value" },
+				"options": { "$ref": "#/definitions/options" },
 				"severity": {
 					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/ml-config/schema.json#/definitions/severity",
 					"default": "error"


### PR DESCRIPTION
## Summary

- Add `ignoreAttrs` option to the `required-attr` rule, allowing users to exclude specific attributes from required-attribute checks without disabling the entire rule (#690)
- When an ignored attribute belongs to a `requiredEither` group (e.g., `src`/`srcset` on `<img>`), the remaining candidates are still enforced
- Includes schema definition, bilingual documentation (EN/JA), and comprehensive test coverage (8 new test cases)

## Test plan

- [x] Verify ignoring a spec-required attribute suppresses the violation (`<area>` without `alt`)
- [x] Verify non-ignored required attributes are still reported
- [x] Verify backward compatibility with no options / empty `ignoreAttrs`
- [x] Verify `requiredEither` interaction: ignoring one candidate keeps remaining candidates required (`<link>` href→imagesrcset)
- [x] Verify `requiredEither` interaction: ignoring all candidates suppresses the violation entirely
- [x] Verify ignoring custom required attributes via rule value
- [x] Verify ignoring value-constrained required attributes
- [x] `yarn lint-check` passes
- [x] `yarn build` passes
- [x] `yarn test` passes (158 passed)

Closes #690

🤖 Generated with [Claude Code](https://claude.com/claude-code)