### PR TITLE
refactor: move directive/IDL resolution from parsers to spec layer

### DIFF
--- a/packages/@markuplint/jsx-parser/ARCHITECTURE.ja.md
+++ b/packages/@markuplint/jsx-parser/ARCHITECTURE.ja.md
@@ -21,7 +21,7 @@ src/
 flowchart TD
     subgraph upstream ["上流"]
         mlAst["@markuplint/ml-ast\n(AST 型定義)"]
-        parserUtils["@markuplint/parser-utils\n(抽象 Parser クラス,\nsearchIDLAttribute)"]
+        parserUtils["@markuplint/parser-utils\n(抽象 Parser クラス)"]
         htmlParser["@markuplint/html-parser\n(getNamespace)"]
         tsEstree["@typescript-eslint/typescript-estree\n(TypeScript/JSX パーサー)"]
         tsTypes["@typescript-eslint/types\n(TSESTree 型定義)"]
@@ -37,7 +37,7 @@ flowchart TD
     end
 
     mlAst -->|"AST 型"| jsxParserClass
-    parserUtils -->|"Parser 基底クラス,\nsearchIDLAttribute"| jsxParserClass
+    parserUtils -->|"Parser 基底クラス"| jsxParserClass
     htmlParser -->|"getNamespace()"| jsxParserClass
     tsEstree -->|"parse()"| jsxModule
     tsTypes -->|"TSESTree 型"| jsxModule
@@ -110,7 +110,7 @@ JSX 式とその包含要素間の親子関係を追跡するプライベート 
 | `afterTraverse()`     | `#parentIdMap` を使用して psblock ノードの親子関係を再構築                                               |
 | `afterFlattenNodes()` | `exposeWhiteSpace: false` と `exposeInvalidNode: false` で親メソッドを呼び出す                           |
 | `visitComment()`      | 全コメントノードを `isBogus: false` にマーク（JSX は HTML bogus コメントではなく JS コメント構文を使用） |
-| `visitAttr()`         | JSX 固有のクォート（`{}`）、IDL 属性マッピング、動的値検出を処理                                         |
+| `visitAttr()`         | JSX 固有のクォート（`{}`）と動的値検出を処理                                                             |
 | `parseCodeFragment()` | `namelessFragment: true` で親メソッドに委譲                                                              |
 | `detectElementType()` | `/^[A-Z]                                                                                                 | \./` 正規表現でコンポーネント vs HTML 要素を検出 |
 
@@ -255,17 +255,7 @@ JSX を返す `.map()` 呼び出し（例: `{items.map(item => <li>{item}</li>)}
 
 ### IDL 属性マッピング
 
-属性パース後、`visitAttr()` は `@markuplint/parser-utils` の `searchIDLAttribute(rawName)` を呼び出して IDL-コンテンツ属性マッピングを解決します。主なマッピング:
-
-| JSX（IDL）属性 | HTML コンテンツ属性 |
-| -------------- | ------------------- |
-| `className`    | `class`             |
-| `htmlFor`      | `for`               |
-| `httpEquiv`    | `http-equiv`        |
-| `tabIndex`     | `tabindex`          |
-| `charSet`      | `charset`           |
-| `autoComplete` | `autocomplete`      |
-| `crossOrigin`  | `crossorigin`       |
+IDL-コンテンツ属性マッピング（例: `className` -> `class`、`htmlFor` -> `for`）はパーサーでは**行いません**。代わりに、ペアとなる spec（`@markuplint/react-spec`）が `useIDLAttributeNames: true` を設定している場合に、`@markuplint/ml-core` の `MLAttr` コンストラクタでコアレベルで宣言的に処理されます。詳細は [MLAttr ドキュメント](../../ml-core/docs/ml-dom/attr.ja.md)を参照してください。
 
 ### 動的値フラグ
 
@@ -316,13 +306,13 @@ flowchart LR
 
 ## 外部依存
 
-| 依存パッケージ                         | 用途                                                                             |
-| -------------------------------------- | -------------------------------------------------------------------------------- |
-| `@markuplint/ml-ast`                   | AST 型定義（`MLASTNodeTreeItem`、`MLASTParentNode`）                             |
-| `@markuplint/parser-utils`             | 抽象 `Parser` クラス、`ParserError`、`searchIDLAttribute`、`ChildToken`、`Token` |
-| `@markuplint/html-parser`              | 名前空間解決用 `getNamespace()`                                                  |
-| `@typescript-eslint/typescript-estree` | `parse()` による TypeScript/JSX パース                                           |
-| `@typescript-eslint/types`             | AST ノードの `TSESTree` 型定義                                                   |
+| 依存パッケージ                         | 用途                                                       |
+| -------------------------------------- | ---------------------------------------------------------- |
+| `@markuplint/ml-ast`                   | AST 型定義（`MLASTNodeTreeItem`、`MLASTParentNode`）       |
+| `@markuplint/parser-utils`             | 抽象 `Parser` クラス、`ParserError`、`ChildToken`、`Token` |
+| `@markuplint/html-parser`              | 名前空間解決用 `getNamespace()`                            |
+| `@typescript-eslint/typescript-estree` | `parse()` による TypeScript/JSX パース                     |
+| `@typescript-eslint/types`             | AST ノードの `TSESTree` 型定義                             |
 
 ## 統合ポイント
 
@@ -350,7 +340,7 @@ flowchart TD
 ### 上流
 
 - **`@markuplint/ml-ast`** -- パーサー全体で使用される AST 型定義
-- **`@markuplint/parser-utils`** -- `JSXParser` が拡張する抽象 `Parser` クラス、IDL 属性マッピング用の `searchIDLAttribute`、エラー処理用の `ParserError`
+- **`@markuplint/parser-utils`** -- `JSXParser` が拡張する抽象 `Parser` クラス、エラー処理用の `ParserError`
 - **`@markuplint/html-parser`** -- 要素の名前空間解決（HTML、SVG、MathML）用の `getNamespace()` を提供
 - **`@typescript-eslint/typescript-estree`** -- AST 生成を行う基盤 TypeScript/JSX パーサー
 - **`@typescript-eslint/types`** -- すべての AST ノード型の TSESTree 型定義

--- a/packages/@markuplint/jsx-parser/ARCHITECTURE.md
+++ b/packages/@markuplint/jsx-parser/ARCHITECTURE.md
@@ -21,7 +21,7 @@ src/
 flowchart TD
     subgraph upstream ["Upstream"]
         mlAst["@markuplint/ml-ast\n(AST types)"]
-        parserUtils["@markuplint/parser-utils\n(Abstract Parser class,\nsearchIDLAttribute)"]
+        parserUtils["@markuplint/parser-utils\n(Abstract Parser class)"]
         htmlParser["@markuplint/html-parser\n(getNamespace)"]
         tsEstree["@typescript-eslint/typescript-estree\n(TypeScript/JSX parser)"]
         tsTypes["@typescript-eslint/types\n(TSESTree type definitions)"]
@@ -37,7 +37,7 @@ flowchart TD
     end
 
     mlAst -->|"AST types"| jsxParserClass
-    parserUtils -->|"Parser base class,\nsearchIDLAttribute"| jsxParserClass
+    parserUtils -->|"Parser base class"| jsxParserClass
     htmlParser -->|"getNamespace()"| jsxParserClass
     tsEstree -->|"parse()"| jsxModule
     tsTypes -->|"TSESTree types"| jsxModule
@@ -110,7 +110,7 @@ A private `WeakMap` that tracks the parent-child relationships between JSX expre
 | `afterTraverse()`     | Rebuilds parent-child relationships for psblock nodes using `#parentIdMap`                                  |
 | `afterFlattenNodes()` | Calls parent with `exposeWhiteSpace: false` and `exposeInvalidNode: false`                                  |
 | `visitComment()`      | Marks all comment nodes as `isBogus: false` (JSX uses JS comment syntax, not HTML bogus comments)           |
-| `visitAttr()`         | Handles JSX-specific quoting (`{}`), IDL attribute mapping, and dynamic value detection                     |
+| `visitAttr()`         | Handles JSX-specific quoting (`{}`) and dynamic value detection                                             |
 | `parseCodeFragment()` | Delegates to parent with `namelessFragment: true`                                                           |
 | `detectElementType()` | Uses `/^[A-Z]                                                                                               | \./` regex to detect component vs HTML element |
 
@@ -337,22 +337,7 @@ When the attribute value is wrapped in `{}`, the `attrParser` function is invoke
 
 ### IDL Attribute Mapping
 
-After parsing the attribute, `visitAttr()` calls `searchIDLAttribute(rawName)` from `@markuplint/parser-utils` to resolve IDL-to-content attribute mappings. Key mappings include:
-
-| JSX (IDL) Attribute | HTML Content Attribute |
-| ------------------- | ---------------------- |
-| `className`         | `class`                |
-| `htmlFor`           | `for`                  |
-| `httpEquiv`         | `http-equiv`           |
-| `tabIndex`          | `tabindex`             |
-| `charSet`           | `charset`              |
-| `autoComplete`      | `autocomplete`         |
-| `crossOrigin`       | `crossorigin`          |
-
-The resolved mapping is applied via `this.updateAttr()`:
-
-- `potentialName` is set to the content attribute name (e.g., `class` for `className`)
-- `candidate` is set to the IDL property name if it differs from the raw name (e.g., `tabIndex` when `tabindex` is written)
+IDL-to-content attribute mapping (e.g., `className` -> `class`, `htmlFor` -> `for`) is **not** performed by the parser. Instead, it is handled declaratively at the core level by `@markuplint/ml-core`'s `MLAttr` constructor when the paired spec (`@markuplint/react-spec`) sets `useIDLAttributeNames: true`. See the [MLAttr documentation](../../ml-core/docs/ml-dom/attr.md) for details.
 
 ### Dynamic Value Flag
 
@@ -403,13 +388,13 @@ The `recursiveSearchJSXElements()` function exhaustively handles all known `AST_
 
 ## External Dependencies
 
-| Dependency                             | Purpose                                                                             |
-| -------------------------------------- | ----------------------------------------------------------------------------------- |
-| `@markuplint/ml-ast`                   | AST type definitions (`MLASTNodeTreeItem`, `MLASTParentNode`)                       |
-| `@markuplint/parser-utils`             | Abstract `Parser` class, `ParserError`, `searchIDLAttribute`, `ChildToken`, `Token` |
-| `@markuplint/html-parser`              | `getNamespace()` for namespace resolution                                           |
-| `@typescript-eslint/typescript-estree` | TypeScript/JSX parsing via `parse()`                                                |
-| `@typescript-eslint/types`             | `TSESTree` type definitions for AST nodes                                           |
+| Dependency                             | Purpose                                                       |
+| -------------------------------------- | ------------------------------------------------------------- |
+| `@markuplint/ml-ast`                   | AST type definitions (`MLASTNodeTreeItem`, `MLASTParentNode`) |
+| `@markuplint/parser-utils`             | Abstract `Parser` class, `ParserError`, `ChildToken`, `Token` |
+| `@markuplint/html-parser`              | `getNamespace()` for namespace resolution                     |
+| `@typescript-eslint/typescript-estree` | TypeScript/JSX parsing via `parse()`                          |
+| `@typescript-eslint/types`             | `TSESTree` type definitions for AST nodes                     |
 
 ## Integration Points
 
@@ -437,7 +422,7 @@ flowchart TD
 ### Upstream
 
 - **`@markuplint/ml-ast`** -- AST type definitions used throughout the parser
-- **`@markuplint/parser-utils`** -- Abstract `Parser` class that `JSXParser` extends, plus `searchIDLAttribute` for IDL attribute mapping and `ParserError` for error handling
+- **`@markuplint/parser-utils`** -- Abstract `Parser` class that `JSXParser` extends, plus `ParserError` for error handling
 - **`@markuplint/html-parser`** -- Provides `getNamespace()` for resolving element namespaces (HTML, SVG, MathML)
 - **`@typescript-eslint/typescript-estree`** -- The underlying TypeScript/JSX parser that performs AST generation
 - **`@typescript-eslint/types`** -- TSESTree type definitions for all AST node types

--- a/packages/@markuplint/jsx-parser/SKILL.md
+++ b/packages/@markuplint/jsx-parser/SKILL.md
@@ -42,12 +42,13 @@ Add a new IDL-to-content attribute mapping for JSX. Follow recipe #1 in `docs/ma
 1. Read `@markuplint/parser-utils/src/idl-attributes.ts`
 2. Add the new entry to the `idlContentMap` object (key = IDL property name, value = content attribute name)
 3. The `searchIDLAttribute()` function will automatically pick up the new mapping
+4. IDL attribute resolution is performed at the core level by `MLAttr` when `@markuplint/react-spec` sets `useIDLAttributeNames: true`
 
 ### Step 2: Verify
 
-1. Build: `yarn build --scope @markuplint/parser-utils --scope @markuplint/jsx-parser`
-2. Add a test case in `src/index.spec.ts` using `attributesToDebugMaps` to verify the `potentialName` is set correctly
-3. Test: `yarn test --scope @markuplint/jsx-parser`
+1. Build: `yarn build --scope @markuplint/parser-utils --scope @markuplint/ml-core`
+2. Add an integration test in `@markuplint/rules/src/invalid-attr/index.spec.ts` to verify the attribute resolves correctly with `react-spec`
+3. Test: `yarn test`
 
 ## Task: add-jsx-node-type-handling
 
@@ -96,7 +97,7 @@ Modify the element type detection regex. Follow recipe #3 in `docs/maintenance.m
 ## Rules
 
 1. **Use `@typescript-eslint/typescript-estree` for parsing** -- never use a custom JSX parser or regex-based approach.
-2. **Use `searchIDLAttribute()` for attribute mapping** -- IDL-to-content attribute mappings live in `@markuplint/parser-utils`, not in this package.
+2. **IDL attribute mapping is a core-level concern** -- IDL-to-content attribute mappings are resolved by `MLAttr` in `@markuplint/ml-core` when the paired spec sets `useIDLAttributeNames: true`. The mappings themselves live in `@markuplint/parser-utils`.
 3. **Test with `nodeListToDebugMaps`** -- all integration tests use this pattern for snapshot-style assertions.
 4. **Handle all AST node types exhaustively** -- `recursiveSearchJSXElements()` must handle every `AST_NODE_TYPES` value; unhandled types throw `'Unsupported node'`.
 5. **Preserve `#parentIdMap` tracking** -- every nodeize branch must register created nodes in the WeakMap for correct parent-child rebuilding.

--- a/packages/@markuplint/jsx-parser/docs/maintenance.ja.md
+++ b/packages/@markuplint/jsx-parser/docs/maintenance.ja.md
@@ -117,11 +117,11 @@ expect(attrMaps).toStrictEqual([
 
 上流パッケージへの変更がこのパーサーに影響を与える可能性があります:
 
-| パッケージ                 | jsx-parser への影響                                              |
-| -------------------------- | ---------------------------------------------------------------- |
-| `@markuplint/parser-utils` | `Parser` 基底クラスの変更、`searchIDLAttribute` マッピングの変更 |
-| `@markuplint/html-parser`  | `getNamespace()` の動作変更                                      |
-| `@markuplint/ml-ast`       | AST 型定義の変更                                                 |
+| パッケージ                 | jsx-parser への影響         |
+| -------------------------- | --------------------------- |
+| `@markuplint/parser-utils` | `Parser` 基底クラスの変更   |
+| `@markuplint/html-parser`  | `getNamespace()` の動作変更 |
+| `@markuplint/ml-ast`       | AST 型定義の変更            |
 
 上流パッケージが更新された際は以下を実行してください:
 
@@ -147,7 +147,7 @@ yarn test --scope @markuplint/jsx-parser
 
 **症状:** `className` のような JSX 属性が AST 出力で `potentialName: class` を取得しない。
 
-**原因:** 属性が `@markuplint/parser-utils/src/idl-attributes.ts` の `idlContentMap` にない、または `searchIDLAttribute()` のルックアップロジックが一致しない。
+**原因:** 属性が `@markuplint/parser-utils/src/idl-attributes.ts` の `idlContentMap` にない、または `@markuplint/react-spec` が `useIDLAttributeNames: true` を設定していない。
 
 **解決策:**
 

--- a/packages/@markuplint/jsx-parser/docs/maintenance.md
+++ b/packages/@markuplint/jsx-parser/docs/maintenance.md
@@ -117,11 +117,11 @@ When `@typescript-eslint` introduces a new `AST_NODE_TYPES` value:
 
 Changes to upstream packages can affect this parser:
 
-| Package                    | Impact on jsx-parser                                              |
-| -------------------------- | ----------------------------------------------------------------- |
-| `@markuplint/parser-utils` | `Parser` base class changes, `searchIDLAttribute` mapping changes |
-| `@markuplint/html-parser`  | `getNamespace()` behavior changes                                 |
-| `@markuplint/ml-ast`       | AST type definition changes                                       |
+| Package                    | Impact on jsx-parser              |
+| -------------------------- | --------------------------------- |
+| `@markuplint/parser-utils` | `Parser` base class changes       |
+| `@markuplint/html-parser`  | `getNamespace()` behavior changes |
+| `@markuplint/ml-ast`       | AST type definition changes       |
 
 When upstream packages are updated, run:
 
@@ -147,7 +147,7 @@ yarn test --scope @markuplint/jsx-parser
 
 **Symptom:** A JSX attribute like `className` does not get `potentialName: class` in the AST output.
 
-**Cause:** The attribute is not in the `idlContentMap` in `@markuplint/parser-utils/src/idl-attributes.ts`, or the `searchIDLAttribute()` lookup logic does not match.
+**Cause:** The attribute is not in the `idlContentMap` in `@markuplint/parser-utils/src/idl-attributes.ts`, or `@markuplint/react-spec` does not set `useIDLAttributeNames: true`.
 
 **Solution:**
 

--- a/packages/@markuplint/jsx-parser/src/index.spec.ts
+++ b/packages/@markuplint/jsx-parser/src/index.spec.ts
@@ -349,7 +349,7 @@ const Component3 = memo(() => <div>Component3</div>);`);
 		]);
 		expect(attrMaps).toStrictEqual([
 			[
-				'[1:12]>[1:27](11,26)class: className="foo"',
+				'[1:12]>[1:27](11,26)className: className="foo"',
 				'  [1:11]>[1:12](10,11)bN: ␣',
 				'  [1:12]>[1:21](11,20)name: className',
 				'  [1:21]>[1:21](20,20)bE: ',
@@ -360,10 +360,9 @@ const Component3 = memo(() => <div>Component3</div>);`);
 				'  [1:26]>[1:27](25,26)eQ: "',
 				'  isDirective: false',
 				'  isDynamicValue: false',
-				'  potentialName: class',
 			],
 			[
-				'[1:28]>[1:41](27,40)tabindex: tabIndex="-1"',
+				'[1:28]>[1:41](27,40)tabIndex: tabIndex="-1"',
 				'  [1:27]>[1:28](26,27)bN: ␣',
 				'  [1:28]>[1:36](27,35)name: tabIndex',
 				'  [1:36]>[1:36](35,35)bE: ',
@@ -374,7 +373,6 @@ const Component3 = memo(() => <div>Component3</div>);`);
 				'  [1:40]>[1:41](39,40)eQ: "',
 				'  isDirective: false',
 				'  isDynamicValue: false',
-				'  potentialName: tabindex',
 			],
 			[
 				'[1:42]>[1:55](41,54)tabindex: tabindex="-1"',
@@ -388,8 +386,6 @@ const Component3 = memo(() => <div>Component3</div>);`);
 				'  [1:54]>[1:55](53,54)eQ: "',
 				'  isDirective: false',
 				'  isDynamicValue: false',
-				'  potentialName: tabindex',
-				'  candidate: tabIndex',
 			],
 			[
 				'[1:56]>[1:76](55,75)aria-label: aria-label="accname"',
@@ -437,7 +433,6 @@ const Component3 = memo(() => <div>Component3</div>);`);
 				'  [1:10]>[1:11](9,10)eQ: "',
 				'  isDirective: false',
 				'  isDynamicValue: false',
-				'  potentialName: href',
 			],
 		]);
 	});
@@ -459,7 +454,6 @@ const Component3 = memo(() => <div>Component3</div>);`);
 				'  [1:10]>[1:11](9,10)eQ: }',
 				'  isDirective: false',
 				'  isDynamicValue: true',
-				'  potentialName: href',
 			],
 		]);
 	});
@@ -630,7 +624,6 @@ describe('Issues', () => {
 			'  [3:33]>[3:34](69,70)eQ: }',
 			'  isDirective: false',
 			'  isDynamicValue: true',
-			'  potentialName: style',
 			'[3:35]>[3:41](71,77)div: </div>',
 		]);
 	});
@@ -738,7 +731,6 @@ const C = () => {
 			'  [1:15]>[1:16](14,15)eQ: "',
 			'  isDirective: false',
 			'  isDynamicValue: false',
-			'  potentialName: lang',
 			'[1:17]>[2:2](16,18)#text: ⏎→',
 			'[2:2]>[2:8](18,24)head: <head>',
 			'[2:8]>[3:3](24,27)#text: ⏎→→',
@@ -747,7 +739,7 @@ const C = () => {
 			'[3:14]>[3:22](38,46)title: </title>',
 			'[3:22]>[4:3](46,49)#text: ⏎→→',
 			'[4:3]>[4:27](49,73)meta: <meta␣charSet="UTF-8"␣/>',
-			'[4:9]>[4:24](55,70)charset: charSet="UTF-8"',
+			'[4:9]>[4:24](55,70)charSet: charSet="UTF-8"',
 			'  [4:8]>[4:9](54,55)bN: ␣',
 			'  [4:9]>[4:16](55,62)name: charSet',
 			'  [4:16]>[4:16](62,62)bE: ',
@@ -758,10 +750,9 @@ const C = () => {
 			'  [4:23]>[4:24](69,70)eQ: "',
 			'  isDirective: false',
 			'  isDynamicValue: false',
-			'  potentialName: charset',
 			'[4:27]>[5:3](73,76)#text: ⏎→→',
 			'[5:3]>[5:57](76,130)meta: <meta␣httpEquiv="x-ua-compatible"␣content="ie=edge"␣/>',
-			'[5:9]>[5:36](82,109)http-equiv: httpEquiv="x-ua-compatible"',
+			'[5:9]>[5:36](82,109)httpEquiv: httpEquiv="x-ua-compatible"',
 			'  [5:8]>[5:9](81,82)bN: ␣',
 			'  [5:9]>[5:18](82,91)name: httpEquiv',
 			'  [5:18]>[5:18](91,91)bE: ',
@@ -772,7 +763,6 @@ const C = () => {
 			'  [5:35]>[5:36](108,109)eQ: "',
 			'  isDirective: false',
 			'  isDynamicValue: false',
-			'  potentialName: http-equiv',
 			'[5:37]>[5:54](110,127)content: content="ie=edge"',
 			'  [5:36]>[5:37](109,110)bN: ␣',
 			'  [5:37]>[5:44](110,117)name: content',
@@ -784,7 +774,6 @@ const C = () => {
 			'  [5:53]>[5:54](126,127)eQ: "',
 			'  isDirective: false',
 			'  isDynamicValue: false',
-			'  potentialName: content',
 			'[5:57]>[6:2](130,132)#text: ⏎→',
 			'[6:2]>[6:9](132,139)head: </head>',
 			'[6:9]>[7:2](139,141)#text: ⏎→',

--- a/packages/@markuplint/jsx-parser/src/parser.ts
+++ b/packages/@markuplint/jsx-parser/src/parser.ts
@@ -2,7 +2,7 @@ import type { JSXComment, JSXNode } from './jsx.js';
 import type { MLASTBlockBehavior, MLASTNodeTreeItem, MLASTParentNode } from '@markuplint/ml-ast';
 import type { ChildToken, Token } from '@markuplint/parser-utils';
 
-import { Parser, ParserError, searchIDLAttribute } from '@markuplint/parser-utils';
+import { Parser, ParserError } from '@markuplint/parser-utils';
 
 import { jsxParser, attrParser, getName } from './jsx.js';
 import { extractJSXFromCall } from './extract-jsx-from-call.js';
@@ -280,8 +280,9 @@ class JSXParser extends Parser<JSXNode, State> {
 	}
 
 	/**
-	 * Visits an attribute token, handling JSX-specific quoting (curly braces for expressions),
-	 * IDL attribute mapping, and dynamic value detection.
+	 * Visits an attribute token, handling JSX-specific quoting (curly braces for expressions)
+	 * and dynamic value detection. IDL attribute name mapping is now handled declaratively
+	 * by react-spec's useIDLAttributeNames and ml-core's attr resolution.
 	 *
 	 * @param token - The token representing the attribute
 	 * @returns The parsed attribute node
@@ -297,19 +298,6 @@ class JSXParser extends Parser<JSXNode, State> {
 
 		if (attr.type === 'spread') {
 			return attr;
-		}
-
-		const rawName = attr.name.raw;
-		const { idlPropName, contentAttrName } = searchIDLAttribute(rawName);
-
-		this.updateAttr(attr, {
-			potentialName: contentAttrName,
-		});
-
-		if (rawName !== idlPropName) {
-			this.updateAttr(attr, {
-				candidate: idlPropName,
-			});
 		}
 
 		if (attr.startQuote.raw === '{' && attr.endQuote.raw === '}') {

--- a/packages/@markuplint/mdx-parser/ARCHITECTURE.md
+++ b/packages/@markuplint/mdx-parser/ARCHITECTURE.md
@@ -96,7 +96,7 @@ Parser<MdastNode>               (from @markuplint/parser-utils)
       |                          - tokenize(): remark-parse + remark-gfm + remark-mdx
       |                          - nodeize(): MDX types first, then Markdown delegation
       |                          - #visitJsxElement(): JSX -> MLASTElement
-      |                          - visitAttr(): JSX attribute handling (quoteSet, IDL mapping)
+      |                          - visitAttr(): JSX attribute handling (quoteSet, dynamic value)
       |                          - detectElementType(): uppercase/dot = authored
 ```
 
@@ -132,7 +132,7 @@ The start tag is parsed by `parseCodeFragment` to extract attributes, then `visi
 | Boolean (no value) | `disabled`                 | Empty value (booleanish) |
 | Spread             | `{...props}`               | `type: 'spread'`         |
 
-IDL attribute mapping (`className` -> `class`, `htmlFor` -> `for`) via `searchIDLAttribute()`.
+IDL attribute mapping (`className` -> `class`, `htmlFor` -> `for`) is handled at the core level by `MLAttr` when paired with `@markuplint/react-spec` (which sets `useIDLAttributeNames: true`).
 
 ### Component Detection
 
@@ -148,7 +148,7 @@ IDL attribute mapping (`className` -> `class`, `htmlFor` -> `for`) via `searchID
 ```mermaid
 flowchart TD
     subgraph upstream ["Upstream"]
-        parserUtils["@markuplint/parser-utils\n(Parser, searchIDLAttribute)"]
+        parserUtils["@markuplint/parser-utils\n(Parser)"]
         mdParser["@markuplint/markdown-parser\n(MarkdownAwareParser)"]
         remark["remark-parse + remark-gfm\n(Markdown + GFM)"]
         remarkMdx["remark-mdx\n(MDX syntax extensions)"]
@@ -182,7 +182,7 @@ flowchart TD
 | ----------------------------- | --------------------------------------------- |
 | `@markuplint/markdown-parser` | MarkdownAwareParser base class                |
 | `@markuplint/ml-ast`          | AST type definitions                          |
-| `@markuplint/parser-utils`    | Parser utilities, `searchIDLAttribute`        |
+| `@markuplint/parser-utils`    | Parser utilities                              |
 | `unified`                     | Processor pipeline for remark                 |
 | `remark-parse`                | Markdown -> mdast parser                      |
 | `remark-gfm`                  | GFM extensions (tables, strikethrough)        |

--- a/packages/@markuplint/mdx-parser/README.md
+++ b/packages/@markuplint/mdx-parser/README.md
@@ -32,7 +32,7 @@ Add `parser` and `specs` options to your [configuration](https://markuplint.dev/
 ## Features
 
 - **JSX elements**: Both self-closing (`<Badge />`) and container (`<Card>...</Card>`) components
-- **IDL attribute conversion**: React-style attributes (e.g., `className`, `htmlFor`) are mapped to their HTML equivalents
+- **IDL attribute conversion**: When paired with `@markuplint/react-spec`, React-style attributes (e.g., `className`, `htmlFor`) are mapped to their HTML equivalents
 - **Expressions**: `{variable}` and `{condition ? a : b}` are treated as dynamic values
 - **ESM imports/exports**: `import` and `export` statements are recognized as blocks
 - **Markdown inside JSX**: Markdown content within JSX containers is recursively parsed

--- a/packages/@markuplint/mdx-parser/src/index.spec.ts
+++ b/packages/@markuplint/mdx-parser/src/index.spec.ts
@@ -746,33 +746,34 @@ describe('MDXParser', () => {
 	});
 
 	describe('IDL attribute name conversion', () => {
-		test('className is mapped to class as potentialName', () => {
+		test('className is kept as-is (IDL resolution handled by ml-core)', () => {
 			const doc = parse('<div className="test">text</div>\n');
 			const div = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'div');
 			expect(div).toBeDefined();
 			const attr = div!.attributes.find(a => a.type === 'attr' && a.name.raw === 'className');
 			expect(attr).toBeDefined();
-			expect(attr!.potentialName).toBe('class');
-			// candidate is not set because rawName === idlPropName ("className")
+			// potentialName is not set by the parser; IDL resolution is handled by ml-core's useIDLAttributeNames
+			expect(attr!.potentialName).toBeUndefined();
 		});
 
-		test('htmlFor is mapped to for as potentialName', () => {
+		test('htmlFor is kept as-is (IDL resolution handled by ml-core)', () => {
 			const doc = parse('<label htmlFor="input-id">Label</label>\n');
 			const label = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'label');
 			expect(label).toBeDefined();
 			const attr = label!.attributes.find(a => a.type === 'attr' && a.name.raw === 'htmlFor');
 			expect(attr).toBeDefined();
-			expect(attr!.potentialName).toBe('for');
-			// candidate is not set because rawName === idlPropName ("htmlFor")
+			// potentialName is not set by the parser; IDL resolution is handled by ml-core's useIDLAttributeNames
+			expect(attr!.potentialName).toBeUndefined();
 		});
 
-		test('class in JSX gets candidate set to className (rawName differs from IDL name)', () => {
+		test('class in JSX is kept as-is (IDL resolution handled by ml-core)', () => {
 			const doc = parse('<div class="test">text</div>\n');
 			const div = doc.nodeList.find(n => n?.type === 'starttag' && n.nodeName === 'div');
 			expect(div).toBeDefined();
 			const attr = div!.attributes.find(a => a.type === 'attr' && a.name.raw === 'class');
 			expect(attr).toBeDefined();
-			expect(attr!.candidate).toBe('className');
+			// candidate is not set by the parser; IDL resolution is handled by ml-core's useIDLAttributeNames
+			expect(attr!.candidate).toBeUndefined();
 		});
 	});
 

--- a/packages/@markuplint/mdx-parser/src/parser.ts
+++ b/packages/@markuplint/mdx-parser/src/parser.ts
@@ -4,7 +4,6 @@ import type { RootContent } from 'mdast';
 import type { MdxJsxFlowElement, MdxJsxTextElement } from 'mdast-util-mdx-jsx';
 
 import { MarkdownAwareParser } from '@markuplint/markdown-parser';
-import { searchIDLAttribute } from '@markuplint/parser-utils';
 import remarkFrontmatter from 'remark-frontmatter';
 import remarkGfm from 'remark-gfm';
 import remarkMdx from 'remark-mdx';
@@ -142,11 +141,9 @@ class MDXParser extends MarkdownAwareParser {
 	}
 
 	/**
-	 * Processes a JSX attribute token with IDL name conversion and dynamic value detection.
-	 *
-	 * Converts React-style IDL property names (e.g., `className`) to their
-	 * HTML content attribute equivalents (e.g., `class`) via `searchIDLAttribute`.
-	 * Marks `{...}` quoted values as dynamic.
+	 * Processes a JSX attribute token with dynamic value detection.
+	 * IDL attribute name mapping is now handled declaratively by the spec's
+	 * useIDLAttributeNames and ml-core's attr resolution.
 	 *
 	 * @param token - The raw attribute token from the source.
 	 * @returns The processed attribute node.
@@ -162,19 +159,6 @@ class MDXParser extends MarkdownAwareParser {
 
 		if (attr.type === 'spread') {
 			return attr;
-		}
-
-		const rawName = attr.name.raw;
-		const { idlPropName, contentAttrName } = searchIDLAttribute(rawName);
-
-		this.updateAttr(attr, {
-			potentialName: contentAttrName,
-		});
-
-		if (rawName !== idlPropName) {
-			this.updateAttr(attr, {
-				candidate: idlPropName,
-			});
 		}
 
 		if (attr.startQuote.raw === '{' && attr.endQuote.raw === '}') {

--- a/packages/@markuplint/ml-core/docs/ml-dom/attr.ja.md
+++ b/packages/@markuplint/ml-core/docs/ml-dom/attr.ja.md
@@ -24,6 +24,14 @@
 - `astToken.potentialName` が存在する場合 → `name` として使用する。そうでなければ `nameNode.raw` を使用する
 - `astToken.potentialValue` が存在する場合 → `value` として使用する。そうでなければ `valueNode.raw` を使用する
 
+### ディレクティブパターン解決
+
+パーサーが `astToken.potentialName` を設定していない場合、`MLAttr` コンストラクタは spec（例: `@markuplint/vue-spec`、`@markuplint/svelte-spec`）からの `directivePatterns` をチェックします。パターンが存在する場合、生の属性名とコンパイル済みパターンで `resolveDirective()` が呼び出されます。最初にマッチしたパターンが `potentialName`、`isDynamicValue`、`isDirective`、`isDuplicatable` を決定します。
+
+### IDL 属性名解決
+
+ディレクティブパターン解決の後、spec が `useIDLAttributeNames: true` を設定しており（例: `@markuplint/react-spec`、`@markuplint/svelte-spec`）、属性がディレクティブでない場合、コンストラクタは `@markuplint/parser-utils` の `searchIDLAttribute()` を呼び出して IDL プロパティ名を HTML コンテンツ属性名にマッピングします（例: `className` → `class`、`htmlFor` → `for`）。これはパーサーレベルではなくコアレベルの関心事です。
+
 ## トークン分解
 
 各属性は個々の `MLToken` インスタンスに分解されます：

--- a/packages/@markuplint/ml-core/docs/ml-dom/attr.md
+++ b/packages/@markuplint/ml-core/docs/ml-dom/attr.md
@@ -24,6 +24,14 @@ The parser may provide resolved "potential" names and values for attributes wher
 - If `astToken.potentialName` exists → use it as `name`; otherwise use `nameNode.raw`
 - If `astToken.potentialValue` exists → use it as `value`; otherwise use `valueNode.raw`
 
+### Directive Pattern Resolution
+
+When `astToken.potentialName` is not set by the parser, the `MLAttr` constructor checks for `directivePatterns` from the spec (e.g., `@markuplint/vue-spec`, `@markuplint/svelte-spec`). If patterns exist, `resolveDirective()` is called with the raw attribute name and the compiled patterns. The first matching pattern determines `potentialName`, `isDynamicValue`, `isDirective`, and `isDuplicatable`.
+
+### IDL Attribute Name Resolution
+
+After directive pattern resolution, if the spec sets `useIDLAttributeNames: true` (e.g., `@markuplint/react-spec`, `@markuplint/svelte-spec`) and the attribute is not a directive, the constructor calls `searchIDLAttribute()` from `@markuplint/parser-utils` to map IDL property names to HTML content attribute names (e.g., `className` -> `class`, `htmlFor` -> `for`). This is a core-level concern, not a parser-level one.
+
 ## Token Decomposition
 
 Each attribute is decomposed into individual `MLToken` instances:

--- a/packages/@markuplint/ml-core/src/index.spec.ts
+++ b/packages/@markuplint/ml-core/src/index.spec.ts
@@ -134,16 +134,19 @@ describe('AST', () => {
 		expect(
 			createTestElement('<label></label>', {
 				parser: await import('@markuplint/jsx-parser'),
+				specs: { ...specs, useIDLAttributeNames: true },
 			}).getAttributeNode('for')?.localName,
 		).toBeUndefined();
 		expect(
 			createTestElement('<label htmlFor></label>', {
 				parser: await import('@markuplint/jsx-parser'),
+				specs: { ...specs, useIDLAttributeNames: true },
 			}).getAttributeNode('for')?.localName,
 		).toBe('for');
 		expect(
 			createTestElement('<label htmlFor></label>', {
 				parser: await import('@markuplint/jsx-parser'),
+				specs: { ...specs, useIDLAttributeNames: true },
 			}).getAttributeNode('htmlFor')?.localName,
 		).toBeUndefined();
 	});
@@ -230,12 +233,14 @@ div#hoge.foo.bar
 		expect(
 			createTestElement('<div tabIndex className><label htmlFor></label></div>', {
 				parser: await import('@markuplint/jsx-parser'),
+				specs: { ...specs, useIDLAttributeNames: true },
 			}).matches('[tabindex][class]:has(>label[for])'),
 		).toBeTruthy();
 
 		expect(
 			createTestElement('<svg><image clipPath /></svg>', {
 				parser: await import('@markuplint/jsx-parser'),
+				specs: { ...specs, useIDLAttributeNames: true },
 			}).matches('svg:has(>image[clip-path])'),
 		).toBeTruthy();
 	});
@@ -576,6 +581,7 @@ describe('Rule', () => {
 					],
 				},
 				parser: await import('@markuplint/jsx-parser'),
+				specs: { ...specs, useIDLAttributeNames: true },
 			},
 		);
 		const ruleA = createRule({

--- a/packages/@markuplint/ml-core/src/ml-dom/node/attr.ts
+++ b/packages/@markuplint/ml-core/src/ml-dom/node/attr.ts
@@ -4,6 +4,7 @@ import type { MLASTAttr } from '@markuplint/ml-ast';
 import type { PlainData, RuleConfigValue } from '@markuplint/ml-config';
 
 import { resolveNamespace, compileDirectivePatterns, resolveDirective } from '@markuplint/ml-spec';
+import { searchIDLAttribute } from '@markuplint/parser-utils';
 
 import { MLToken } from '../token/token.js';
 
@@ -159,6 +160,22 @@ export class MLAttr<T extends RuleConfigValue, O extends PlainData = undefined>
 				this.isDynamicValue = this._astToken.isDynamicValue;
 				this.isDirective = this._astToken.isDirective;
 				this.isDuplicatable = this._astToken.isDuplicatable;
+			}
+
+			// IDL attribute resolution (after directivePatterns)
+			if (ownElement.ownerMLDocument.specs.useIDLAttributeNames && !this.isDirective) {
+				const { contentAttrName, idlPropName } = searchIDLAttribute(this.#potentialName);
+				if (contentAttrName && contentAttrName !== this.#potentialName) {
+					this.#potentialName = contentAttrName;
+				}
+				// Set candidate for IDL naming suggestions (e.g., tabindex → tabIndex in JSX).
+				// Only when no directive pattern transformed the name.
+				if (!resolution && idlPropName) {
+					const rawName = this.nameNode?.raw ?? '';
+					if (rawName !== idlPropName) {
+						this.candidate = idlPropName;
+					}
+				}
 			}
 		} else {
 			// Parser-set potentialName takes precedence

--- a/packages/@markuplint/ml-spec/docs/spec-resolution.ja.md
+++ b/packages/@markuplint/ml-spec/docs/spec-resolution.ja.md
@@ -143,7 +143,35 @@ for (const modelName of keys) {
 （例: `#phrasing` に `<router-link>` を追加）、
 まったく新しいカテゴリを定義したりできます。
 
-#### 5. 要素仕様
+#### 5. ディレクティブパターン
+
+拡張仕様が `directivePatterns` を提供する場合、既存の配列に連結されます：
+
+```ts
+result.directivePatterns = [...(result.directivePatterns ?? []), ...extendedSpec.directivePatterns];
+```
+
+単純な配列結合です。コアエンジンはパターンを順番に評価します
+（最初のマッチが優先）。そのため、フレームワーク spec はパターンを
+最も具体的なものから最も一般的なものの順で定義する必要があります。
+
+#### 6. `useIDLAttributeNames`
+
+拡張仕様が `useIDLAttributeNames` を明示的に設定している場合（`true` または
+`false`）、現在の値を上書きします：
+
+```ts
+if (extendedSpec.useIDLAttributeNames != null) {
+  result.useIDLAttributeNames = extendedSpec.useIDLAttributeNames;
+}
+```
+
+これは明示的な `null` ガード付きの last-write-wins セマンティクスです。
+プロパティを省略しても以前に設定された値はリセットされません。
+このフラグは `@markuplint/ml-core` の `MLAttr` コンストラクタで使用され、
+IDL-コンテンツ属性名解決（例: `className` → `class`）を有効化します。
+
+#### 7. 要素仕様
 
 要素は名前で照合されます（大文字小文字を区別しない比較）。
 ベース仕様の各要素について：

--- a/packages/@markuplint/ml-spec/docs/spec-resolution.md
+++ b/packages/@markuplint/ml-spec/docs/spec-resolution.md
@@ -147,7 +147,36 @@ This means a framework can add its custom elements to existing categories
 (e.g., adding `<router-link>` to `#phrasing`) or define entirely new
 categories.
 
-#### 5. Element Specs
+#### 5. Directive Patterns
+
+If the extended spec provides `directivePatterns`, they are concatenated onto the
+existing array:
+
+```ts
+result.directivePatterns = [...(result.directivePatterns ?? []), ...extendedSpec.directivePatterns];
+```
+
+This is simple array concatenation. The core engine evaluates patterns in order
+(first match wins), so framework specs should define their patterns from most
+specific to most general.
+
+#### 6. `useIDLAttributeNames`
+
+If the extended spec explicitly sets `useIDLAttributeNames` (to `true` or
+`false`), it overrides the current value:
+
+```ts
+if (extendedSpec.useIDLAttributeNames != null) {
+  result.useIDLAttributeNames = extendedSpec.useIDLAttributeNames;
+}
+```
+
+This is a last-write-wins semantic with explicit `null` guard -- omitting the
+property does not reset a previously set value. This flag is consumed by
+`@markuplint/ml-core`'s `MLAttr` constructor to enable IDL-to-content attribute
+name resolution (e.g., `className` -> `class`).
+
+#### 7. Element Specs
 
 Elements are matched by name (case-insensitive comparison). For each element in
 the base spec:

--- a/packages/@markuplint/ml-spec/src/types/index.ts
+++ b/packages/@markuplint/ml-spec/src/types/index.ts
@@ -13,6 +13,7 @@ export interface MLMLSpec {
 	readonly def: SpecDefs;
 	readonly specs: readonly ElementSpec[];
 	readonly directivePatterns?: readonly DirectivePattern[];
+	readonly useIDLAttributeNames?: boolean;
 }
 
 /**
@@ -34,6 +35,7 @@ export type ExtendedSpec = {
 	readonly def?: Partial<SpecDefs>;
 	readonly specs?: readonly ExtendedElementSpec[];
 	readonly directivePatterns?: readonly DirectivePattern[];
+	readonly useIDLAttributeNames?: boolean;
 };
 
 /**

--- a/packages/@markuplint/ml-spec/src/utils/schema-to-spec.spec.ts
+++ b/packages/@markuplint/ml-spec/src/utils/schema-to-spec.spec.ts
@@ -60,6 +60,26 @@ describe('schemaToSpec', () => {
 		expect(mergedSpec.directivePatterns ?? []).toStrictEqual([]);
 	});
 
+	test('useIDLAttributeNames defaults to undefined', () => {
+		const mergedSpec = schemaToSpec([htmlSpec]);
+		expect(mergedSpec.useIDLAttributeNames).toBeUndefined();
+	});
+
+	test('useIDLAttributeNames can be set to true', () => {
+		const mergedSpec = schemaToSpec([htmlSpec, { useIDLAttributeNames: true }]);
+		expect(mergedSpec.useIDLAttributeNames).toBe(true);
+	});
+
+	test('useIDLAttributeNames=false overrides previous true', () => {
+		const mergedSpec = schemaToSpec([htmlSpec, { useIDLAttributeNames: true }, { useIDLAttributeNames: false }]);
+		expect(mergedSpec.useIDLAttributeNames).toBe(false);
+	});
+
+	test('useIDLAttributeNames is not overridden when omitted', () => {
+		const mergedSpec = schemaToSpec([htmlSpec, { useIDLAttributeNames: true }, { specs: [] }]);
+		expect(mergedSpec.useIDLAttributeNames).toBe(true);
+	});
+
 	test('globalAttrs.extends', () => {
 		const keyAttr = {
 			type: 'NoEmptyAny',

--- a/packages/@markuplint/ml-spec/src/utils/schema-to-spec.ts
+++ b/packages/@markuplint/ml-spec/src/utils/schema-to-spec.ts
@@ -89,6 +89,9 @@ export function schemaToSpec(schemas: readonly [MLMLSpec, ...ExtendedSpec[]]) {
 		if (extendedSpec.directivePatterns) {
 			result.directivePatterns = [...(result.directivePatterns ?? []), ...extendedSpec.directivePatterns];
 		}
+		if (extendedSpec.useIDLAttributeNames != null) {
+			result.useIDLAttributeNames = extendedSpec.useIDLAttributeNames;
+		}
 		if (extendedSpec.specs) {
 			const exSpecs = [...extendedSpec.specs];
 			const specs: ElementSpec[] = [];

--- a/packages/@markuplint/parser-utils/ARCHITECTURE.ja.md
+++ b/packages/@markuplint/parser-utils/ARCHITECTURE.ja.md
@@ -148,7 +148,7 @@ ParserError (基底クラス)
 
 ## IDL 属性マッピング
 
-`searchIDLAttribute` は React スタイルの IDL 属性名と HTML コンテンツ属性名の双方向マッピングを提供します（例: `className` → `class`、`htmlFor` → `for`）。JSX パーサーが属性の `potentialName` を解決する際に使用されます。
+`searchIDLAttribute` は React スタイルの IDL 属性名と HTML コンテンツ属性名の双方向マッピングを提供します（例: `className` → `class`、`htmlFor` → `for`）。spec が `useIDLAttributeNames: true` を設定している場合に、`@markuplint/ml-core` の `MLAttr` コンストラクタから呼び出されます。
 
 ## 外部依存
 

--- a/packages/@markuplint/parser-utils/ARCHITECTURE.md
+++ b/packages/@markuplint/parser-utils/ARCHITECTURE.md
@@ -174,7 +174,7 @@ Additionally, `debug.ts` provides `PerformanceTimer` for measuring parse phase d
 
 ## IDL Attribute Mapping
 
-`searchIDLAttribute` maps between React-style IDL attribute names and HTML content attribute names. It maintains a comprehensive mapping table derived from React's `possibleStandardNames.js`, covering:
+`searchIDLAttribute` maps between React-style IDL attribute names and HTML content attribute names. It is called by `@markuplint/ml-core`'s `MLAttr` constructor when the spec sets `useIDLAttributeNames: true`. It maintains a comprehensive mapping table derived from React's `possibleStandardNames.js`, covering:
 
 - HTML attributes (e.g., `className` -> `class`, `htmlFor` -> `for`, `tabIndex` -> `tabindex`)
 - SVG attributes (e.g., `strokeWidth` -> `stroke-width`, `clipPath` -> `clip-path`)

--- a/packages/@markuplint/react-spec/ARCHITECTURE.ja.md
+++ b/packages/@markuplint/react-spec/ARCHITECTURE.ja.md
@@ -8,6 +8,10 @@
 
 ## ExtendedSpec の内容
 
+### `useIDLAttributeNames`
+
+この spec は `useIDLAttributeNames: true` を設定しており、`@markuplint/ml-core` の `MLAttr` コンストラクタに IDL 属性名を HTML コンテンツ属性名に解決するよう指示します（例: `className` -> `class`、`htmlFor` -> `for`）。この解決はパーサーではなくコアレベルで行われます。
+
 ### グローバル属性
 
 グローバル属性は `def['#globalAttrs']['#extends']` の下に定義され、すべての JSX 要素で利用可能です:

--- a/packages/@markuplint/react-spec/ARCHITECTURE.md
+++ b/packages/@markuplint/react-spec/ARCHITECTURE.md
@@ -8,6 +8,10 @@ This package contains no parsing logic -- it is purely a data definition consume
 
 ## ExtendedSpec Content
 
+### `useIDLAttributeNames`
+
+The spec sets `useIDLAttributeNames: true`, which instructs `@markuplint/ml-core`'s `MLAttr` constructor to resolve IDL attribute names to their HTML content attribute equivalents (e.g., `className` -> `class`, `htmlFor` -> `for`). This resolution is performed at the core level, not in the parser.
+
 ### Global Attributes
 
 Global attributes are defined under `def['#globalAttrs']['#extends']` and are available on every JSX element:

--- a/packages/@markuplint/react-spec/src/index.ts
+++ b/packages/@markuplint/react-spec/src/index.ts
@@ -20,6 +20,7 @@ import type { ExtendedSpec } from '@markuplint/ml-spec';
  * `defaultValue`, `value`).
  */
 const spec: ExtendedSpec = {
+	useIDLAttributeNames: true,
 	def: {
 		'#globalAttrs': {
 			'#extends': {

--- a/packages/@markuplint/rules/src/attr-duplication/index.spec.ts
+++ b/packages/@markuplint/rules/src/attr-duplication/index.spec.ts
@@ -88,6 +88,9 @@ test('Vue', async () => {
 		parser: {
 			'.*': '@markuplint/vue-parser',
 		},
+		specs: {
+			'.*': '@markuplint/vue-spec',
+		},
 	});
 
 	expect(violations).toStrictEqual([
@@ -108,6 +111,9 @@ test('Vue (exception)', async () => {
 		{
 			parser: {
 				'.*': '@markuplint/vue-parser',
+			},
+			specs: {
+				'.*': '@markuplint/vue-spec',
 			},
 		},
 	);

--- a/packages/@markuplint/rules/src/character-reference/index.spec.ts
+++ b/packages/@markuplint/rules/src/character-reference/index.spec.ts
@@ -44,6 +44,9 @@ test('in Vue', async () => {
 		parser: {
 			'.*': '@markuplint/vue-parser',
 		},
+		specs: {
+			'.*': '@markuplint/vue-spec',
+		},
 	});
 	expect(violations.length).toBe(0);
 });

--- a/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
@@ -748,6 +748,9 @@ test('Vue', async () => {
 			parser: {
 				'.*': '@markuplint/vue-parser',
 			},
+			specs: {
+				'.*': '@markuplint/vue-spec',
+			},
 		},
 	);
 	const { violations: violations2 } = await mlRuleTest(
@@ -756,6 +759,9 @@ test('Vue', async () => {
 		{
 			parser: {
 				'.*': '@markuplint/vue-parser',
+			},
+			specs: {
+				'.*': '@markuplint/vue-spec',
 			},
 		},
 	);
@@ -811,6 +817,30 @@ test('Vue slot', async () => {
 	expect(violations.length).toBe(0);
 });
 
+test('Vue (.prop shorthand)', async () => {
+	const { violations } = await mlRuleTest(rule, '<template><div .someProp="value"></div></template>', {
+		parser: {
+			'.*': '@markuplint/vue-parser',
+		},
+		specs: {
+			'.*': '@markuplint/vue-spec',
+		},
+	});
+	expect(violations.length).toBe(0);
+});
+
+test('MDX with react-spec (className is valid via IDL resolution)', async () => {
+	const { violations } = await mlRuleTest(rule, '<div className="test">text</div>\n', {
+		parser: {
+			'.*': '@markuplint/mdx-parser',
+		},
+		specs: {
+			'.*': '@markuplint/react-spec',
+		},
+	});
+	expect(violations).toStrictEqual([]);
+});
+
 test('React Component', async () => {
 	const { violations } = await mlRuleTest(
 		rule,
@@ -818,6 +848,9 @@ test('React Component', async () => {
 		{
 			parser: {
 				'.*': '@markuplint/jsx-parser',
+			},
+			specs: {
+				'.*': '@markuplint/react-spec',
 			},
 		},
 	);
@@ -832,6 +865,9 @@ test('React HTML', async () => {
 		{
 			parser: {
 				'.*': '@markuplint/jsx-parser',
+			},
+			specs: {
+				'.*': '@markuplint/react-spec',
 			},
 		},
 	);
@@ -858,6 +894,9 @@ test('React', async () => {
 	const { violations } = await mlRuleTest(rule, '<a href={href} target={target} invalidAttr={invalidAttr} />', {
 		parser: {
 			'.*': '@markuplint/jsx-parser',
+		},
+		specs: {
+			'.*': '@markuplint/react-spec',
 		},
 	});
 
@@ -1371,6 +1410,9 @@ describe('Issues', () => {
 					parser: {
 						'.*': '@markuplint/jsx-parser',
 					},
+					specs: {
+						'.*': '@markuplint/react-spec',
+					},
 				})
 			).violations,
 		).toStrictEqual([]);
@@ -1457,6 +1499,9 @@ describe('Issues', () => {
 			parser: {
 				'.*': '@markuplint/vue-parser',
 			},
+			specs: {
+				'.*': '@markuplint/vue-spec',
+			},
 		};
 
 		expect(
@@ -1468,6 +1513,9 @@ describe('Issues', () => {
 		const vue = {
 			parser: {
 				'.*': '@markuplint/vue-parser',
+			},
+			specs: {
+				'.*': '@markuplint/vue-spec',
 			},
 		};
 

--- a/packages/@markuplint/rules/src/required-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/required-attr/index.spec.ts
@@ -342,6 +342,9 @@ test('Vue', async () => {
 				parser: {
 					'.*': '@markuplint/vue-parser',
 				},
+				specs: {
+					'.*': '@markuplint/vue-spec',
+				},
 			})
 		).violations.length,
 	).toBe(0);
@@ -456,6 +459,9 @@ describe('Issues', () => {
 		const { violations } = await mlRuleTest(rule, '<meta httpEquiv="x-ua-compatible" content="ie=edge" />', {
 			parser: {
 				'.*': '@markuplint/jsx-parser',
+			},
+			specs: {
+				'.*': '@markuplint/react-spec',
 			},
 		});
 		expect(violations).toStrictEqual([]);

--- a/packages/@markuplint/rules/src/srcset-sizes-constraint/index.spec.ts
+++ b/packages/@markuplint/rules/src/srcset-sizes-constraint/index.spec.ts
@@ -370,7 +370,7 @@ describe('Dynamic values', () => {
 				await mlRuleTest(
 					rule,
 					'<template><img :srcset="computedSrcset" sizes="100vw" src="s.png" alt="p"></template>',
-					{ parser: { '.*': '@markuplint/vue-parser' } },
+					{ parser: { '.*': '@markuplint/vue-parser' }, specs: { '.*': '@markuplint/vue-spec' } },
 				)
 			).violations,
 		).toStrictEqual([]);
@@ -382,7 +382,7 @@ describe('Dynamic values', () => {
 				await mlRuleTest(
 					rule,
 					'<template><img srcset="s.png 480w" :sizes="computedSizes" src="s.png" alt="p"></template>',
-					{ parser: { '.*': '@markuplint/vue-parser' } },
+					{ parser: { '.*': '@markuplint/vue-parser' }, specs: { '.*': '@markuplint/vue-spec' } },
 				)
 			).violations,
 		).toStrictEqual([]);

--- a/packages/@markuplint/svelte-parser/ARCHITECTURE.ja.md
+++ b/packages/@markuplint/svelte-parser/ARCHITECTURE.ja.md
@@ -80,17 +80,17 @@ Parser<SvelteNode>  (@markuplint/parser-utils)
 
 ### オーバーライドメソッド
 
-| メソッド              | 用途                                                                                                 |
-| --------------------- | ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `tokenize()`          | `svelteParse()` を呼び出して Svelte AST を生成                                                       |
-| `parse()`             | `ignoreFrontMatter: false` で `super.parse()` に委譲                                                 |
-| `parseError()`        | Svelte コンパイラエラーをエラーフレーム付きの `ParserError` でラップ                                 |
-| `nodeize()`           | Svelte AST ノードを markuplint ノードに変換（テキスト、コメント、要素、式、制御フローブロック）      |
-| `visitText()`         | `researchTags: false` で `super.visitText()` を呼び出し、`<script>` テキストを Script psblock に変換 |
-| `visitPsBlock()`      | `super.visitPsBlock()` に委譲し、結果ノードが正確に1つであることを検証                               |
-| `visitChildren()`     | `super.visitChildren()` に委譲し、異なる階層レベルの兄弟ノードがないことを検証                       |
-| `visitAttr()`         | Svelte 固有の属性構文を処理: ディレクティブ、省略形、スプレッド、波括弧式                            |
-| `detectElementType()` | 正規表現 `/^[A-Z]                                                                                    | \./` でコンポーネント vs HTML 要素を判定（PascalCase またはドット付き名はコンポーネント） |
+| メソッド              | 用途                                                                                                                                          |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `tokenize()`          | `svelteParse()` を呼び出して Svelte AST を生成                                                                                                |
+| `parse()`             | `ignoreFrontMatter: false` で `super.parse()` に委譲                                                                                          |
+| `parseError()`        | Svelte コンパイラエラーをエラーフレーム付きの `ParserError` でラップ                                                                          |
+| `nodeize()`           | Svelte AST ノードを markuplint ノードに変換（テキスト、コメント、要素、式、制御フローブロック）                                               |
+| `visitText()`         | `researchTags: false` で `super.visitText()` を呼び出し、`<script>` テキストを Script psblock に変換                                          |
+| `visitPsBlock()`      | `super.visitPsBlock()` に委譲し、結果ノードが正確に1つであることを検証                                                                        |
+| `visitChildren()`     | `super.visitChildren()` に委譲し、異なる階層レベルの兄弟ノードがないことを検証                                                                |
+| `visitAttr()`         | Svelte 固有の属性構文を処理: 省略形、スプレッド、波括弧式（ディレクティブ処理は `@markuplint/svelte-spec` の `directivePatterns` に移行済み） |
+| `detectElementType()` | 正規表現 `/^[A-Z]                                                                                                                             | \./` でコンポーネント vs HTML 要素を判定（PascalCase またはドット付き名はコンポーネント） |
 
 ## tokenize()
 
@@ -277,7 +277,11 @@ export function svelteParse(template: string): SvelteNode[] {
 
 **重要な注意:** `openToken` は単独の開始タグを保証しません。`EachBlock` や `AwaitBlock` のようなブロックでは、open トークンに中間タグ（`:then`、`:else`）が含まれる可能性があるため、これらのブロックは `openToken` に頼らず独自のトークン分割ロジックを実装しています。`parseBlock()` ユーティリティは主にシンプルな open/close 構造を持つ `KeyBlock` と `SnippetBlock` で使用されます。
 
-## 属性処理（visitAttr）
+## 属性処理（visitAttr）とディレクティブ処理（@markuplint/svelte-spec の directivePatterns）
+
+> **注記:** Svelte ディレクティブ処理（`bind:`、`on:`、`class:`、`style:`、`use:`、`animate:`、`transition:`、`in:`、`out:`、`let:`）は `@markuplint/svelte-spec` の `directivePatterns` で管理されています。このパーサーの `visitAttr()` メソッドは非ディレクティブの属性構文（省略形、スプレッド、波括弧式）を処理します。
+
+> **二段階解決:** パーサーレベルのテスト（`index.spec.ts`）はパーサー自体が設定する raw AST 値を示します（例: 波括弧式のみ `isDynamicValue: true`）。コアレベルのテスト（`ml-core` や `rules`）は `ml-core` の `MLAttr` コンストラクタが `directivePatterns` を適用した後の最終解決値を示します。例えば、値なしの `on:click` はパーサーレベルでは `isDynamicValue: false` ですが、コアレベルでは `directivePatterns` マッチにより `isDynamicValue: true` に解決されます。
 
 ### クォートセット
 
@@ -333,11 +337,11 @@ export function svelteParse(template: string): SvelteNode[] {
 
 ### スプレッド `{...attrs}`
 
-`super.visitAttr()` が `type: 'spread'` の属性を返した場合、追加処理なしでそのまま返されます。
+基底の `visitAttr()` が `type: 'spread'` の属性を返した場合、追加処理なしでそのまま返されます。
 
 ### IDL 属性マッピング
 
-すべてのディレクティブ・省略形処理の後、パーサーは `@markuplint/parser-utils` の `searchIDLAttribute()` を適用して、camelCase の IDL プロパティ名を対応するコンテンツ属性名にマッピングします。例えば、`tabIndex` は `tabindex` に、`contentEditable` は `contenteditable` にマッピングされます。このマッピングは通常の属性と `bind:` ディレクティブのサブ名の両方に適用されます。
+IDL 属性マッピング（例: `tabIndex` → `tabindex`、`contentEditable` → `contenteditable`）は、spec が `useIDLAttributeNames: true` を設定している場合に `ml-core` の `MLAttr` コンストラクタで処理されます。`@markuplint/svelte-spec` はこのフラグを有効化しているため、Svelte ファイルではパーサーレベルではなくコアレベルで IDL 解決が行われます。
 
 マッピングはコンテンツ属性名がルックアップ名と異なる場合にのみ `potentialName` を更新するため、すでにコンテンツ属性形式と一致している属性（例: `value`、`class`）は影響を受けません。対応するコンテンツ属性を持たない IDL 専用プロパティ（例: `defaultValue`、`indeterminate`）はマッピングに含まれず、対となる `@markuplint/svelte-spec` パッケージで処理されます。
 
@@ -424,12 +428,12 @@ class SvelteKitTemplateParser extends HtmlParser {
 
 ## 外部依存
 
-| 依存パッケージ             | 用途                                                                                          |
-| -------------------------- | --------------------------------------------------------------------------------------------- |
-| `@markuplint/ml-ast`       | AST 型定義（`MLASTPreprocessorSpecificBlock` 等）                                             |
-| `@markuplint/parser-utils` | 抽象 `Parser` クラス、`ChildToken`、`Token`、`AttrState`、`ParserError`、`searchIDLAttribute` |
-| `@markuplint/html-parser`  | `HtmlParser`（SvelteKit パーサーの基底）、`getNamespace()`                                    |
-| `svelte`                   | `svelte/compiler` の `parse()` 関数（トークン化用）                                           |
+| 依存パッケージ             | 用途                                                                    |
+| -------------------------- | ----------------------------------------------------------------------- |
+| `@markuplint/ml-ast`       | AST 型定義（`MLASTPreprocessorSpecificBlock` 等）                       |
+| `@markuplint/parser-utils` | 抽象 `Parser` クラス、`ChildToken`、`Token`、`AttrState`、`ParserError` |
+| `@markuplint/html-parser`  | `HtmlParser`（SvelteKit パーサーの基底）、`getNamespace()`              |
+| `svelte`                   | `svelte/compiler` の `parse()` 関数（トークン化用）                     |
 
 ## ドキュメントマップ
 

--- a/packages/@markuplint/svelte-parser/ARCHITECTURE.md
+++ b/packages/@markuplint/svelte-parser/ARCHITECTURE.md
@@ -80,17 +80,17 @@ Parser<SvelteNode>  (from @markuplint/parser-utils)
 
 ### Override Methods
 
-| Method                | Purpose                                                                                                 |
-| --------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
-| `tokenize()`          | Calls `svelteParse()` to produce the Svelte AST                                                         |
-| `parse()`             | Delegates to `super.parse()` with `ignoreFrontMatter: false`                                            |
-| `parseError()`        | Wraps Svelte compiler errors with `ParserError`, including the error frame                              |
-| `nodeize()`           | Converts Svelte AST nodes to markuplint nodes (text, comment, element, expression, control flow blocks) |
-| `visitText()`         | Calls `super.visitText()` with `researchTags: false`; converts `<script>` text to Script psblock        |
-| `visitPsBlock()`      | Delegates to `super.visitPsBlock()` and enforces exactly one result node                                |
-| `visitChildren()`     | Delegates to `super.visitChildren()` and validates no sibling nodes with differing hierarchy levels     |
-| `visitAttr()`         | Handles Svelte-specific attribute syntax: directives, shorthand, spread, curly-brace expressions        |
-| `detectElementType()` | Detects component vs HTML element using the regex `/^[A-Z]                                              | \./` (PascalCase or dotted names are components) |
+| Method                | Purpose                                                                                                                                                             |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| `tokenize()`          | Calls `svelteParse()` to produce the Svelte AST                                                                                                                     |
+| `parse()`             | Delegates to `super.parse()` with `ignoreFrontMatter: false`                                                                                                        |
+| `parseError()`        | Wraps Svelte compiler errors with `ParserError`, including the error frame                                                                                          |
+| `nodeize()`           | Converts Svelte AST nodes to markuplint nodes (text, comment, element, expression, control flow blocks)                                                             |
+| `visitText()`         | Calls `super.visitText()` with `researchTags: false`; converts `<script>` text to Script psblock                                                                    |
+| `visitPsBlock()`      | Delegates to `super.visitPsBlock()` and enforces exactly one result node                                                                                            |
+| `visitChildren()`     | Delegates to `super.visitChildren()` and validates no sibling nodes with differing hierarchy levels                                                                 |
+| `visitAttr()`         | Handles Svelte-specific attribute syntax: shorthand, spread, curly-brace expressions (directive handling moved to `directivePatterns` in `@markuplint/svelte-spec`) |
+| `detectElementType()` | Detects component vs HTML element using the regex `/^[A-Z]                                                                                                          | \./` (PascalCase or dotted names are components) |
 
 ## tokenize()
 
@@ -277,7 +277,11 @@ This shared utility extracts `openToken` and `closeToken` from block constructs:
 
 **Important note:** The `openToken` does not guarantee an isolated opening tag. For blocks like `EachBlock` and `AwaitBlock`, the open token may include intermediate tags (`:then`, `:else`), which is why those blocks implement their own token splitting logic instead of relying on `openToken`. The `parseBlock()` utility is primarily used by `KeyBlock` and `SnippetBlock`, which have simple open/close structures.
 
-## Attribute Processing (visitAttr)
+## Attribute Processing (visitAttr) and Directive Handling (directivePatterns in @markuplint/svelte-spec)
+
+> **Note:** Svelte directive handling (`bind:`, `on:`, `class:`, `style:`, `use:`, `animate:`, `transition:`, `in:`, `out:`, `let:`) is now managed via `directivePatterns` in `@markuplint/svelte-spec`. The `visitAttr()` method in this parser handles non-directive attribute syntax (shorthand, spread, curly-brace expressions).
+
+> **Two-stage resolution:** Parser-level tests (`index.spec.ts`) show raw AST values where `isDynamicValue` and `isDirective` reflect only what the parser itself sets (e.g., curly-brace expressions). Core-level tests (`ml-core` and `rules`) show the final resolved values after `directivePatterns` are applied by `ml-core`'s `MLAttr` constructor. For example, `on:click` without a value shows `isDynamicValue: false` at the parser level, but resolves to `isDynamicValue: true` at the core level via the `directivePatterns` match.
 
 ### Quote Set
 
@@ -333,11 +337,11 @@ When an attribute is a shorthand expression like `{items}`:
 
 ### Spread `{...attrs}`
 
-When `super.visitAttr()` returns an attribute with `type: 'spread'`, it is returned directly without further processing.
+When the base `visitAttr()` returns an attribute with `type: 'spread'`, it is returned directly without further processing.
 
 ### IDL Attribute Mapping
 
-After all directive and shorthand processing, the parser applies `searchIDLAttribute()` from `@markuplint/parser-utils` to map camelCase IDL property names to their corresponding content attribute names. For example, `tabIndex` is mapped to `tabindex` and `contentEditable` to `contenteditable`. This mapping applies to both regular attributes and `bind:` directive sub-names.
+IDL attribute mapping (e.g., `tabIndex` → `tabindex`, `contentEditable` → `contenteditable`) is handled by `ml-core`'s `MLAttr` constructor when the spec sets `useIDLAttributeNames: true`. The `@markuplint/svelte-spec` enables this flag, so Svelte files get IDL resolution at the core level, not the parser level.
 
 The mapping only updates `potentialName` when the content attribute name differs from the looked-up name, so attributes that already match their content attribute form (e.g., `value`, `class`) are unaffected. IDL-only properties that have no corresponding content attribute (e.g., `defaultValue`, `indeterminate`) are not in the mapping and are instead handled by the paired `@markuplint/svelte-spec` package.
 
@@ -424,12 +428,12 @@ These Svelte 5 constructs are handled by the parser: `SnippetBlock` has dedicate
 
 ## External Dependencies
 
-| Dependency                 | Purpose                                                                                          |
-| -------------------------- | ------------------------------------------------------------------------------------------------ |
-| `@markuplint/ml-ast`       | AST type definitions (`MLASTPreprocessorSpecificBlock`, etc.)                                    |
-| `@markuplint/parser-utils` | Abstract `Parser` class, `ChildToken`, `Token`, `AttrState`, `ParserError`, `searchIDLAttribute` |
-| `@markuplint/html-parser`  | `HtmlParser` (base for SvelteKit parser), `getNamespace()`                                       |
-| `svelte`                   | `svelte/compiler` `parse()` function for tokenization                                            |
+| Dependency                 | Purpose                                                                    |
+| -------------------------- | -------------------------------------------------------------------------- |
+| `@markuplint/ml-ast`       | AST type definitions (`MLASTPreprocessorSpecificBlock`, etc.)              |
+| `@markuplint/parser-utils` | Abstract `Parser` class, `ChildToken`, `Token`, `AttrState`, `ParserError` |
+| `@markuplint/html-parser`  | `HtmlParser` (base for SvelteKit parser), `getNamespace()`                 |
+| `svelte`                   | `svelte/compiler` `parse()` function for tokenization                      |
 
 ## Documentation Map
 

--- a/packages/@markuplint/svelte-parser/SKILL.md
+++ b/packages/@markuplint/svelte-parser/SKILL.md
@@ -14,11 +14,11 @@ update SvelteKit placeholders, and modify attribute processing.
 
 `$ARGUMENTS` specifies the task. Supported tasks:
 
-| Task                            | Description                                    |
-| ------------------------------- | ---------------------------------------------- |
-| `add-directive`                 | Add a new Svelte directive to visitAttr()      |
-| `add-control-flow-block`        | Add a new control flow block to nodeize()      |
-| `update-sveltekit-placeholders` | Update SvelteKit template placeholder patterns |
+| Task                            | Description                                                   |
+| ------------------------------- | ------------------------------------------------------------- |
+| `add-directive`                 | Add a new Svelte directive to directivePatterns (svelte-spec) |
+| `add-control-flow-block`        | Add a new control flow block to nodeize()                     |
+| `update-sveltekit-placeholders` | Update SvelteKit template placeholder patterns                |
 
 If omitted, defaults to `add-directive`.
 
@@ -34,19 +34,19 @@ Also read:
 
 ## Task: add-directive
 
-Add a new Svelte directive to `visitAttr()`. Follow recipe #1 in `docs/maintenance.md`.
+Add a new Svelte directive to `directivePatterns` (`@markuplint/svelte-spec`). Follow recipe #1 in `docs/maintenance.md`.
 
 ### Step 1: Understand the current directive handling
 
-1. Read `src/parser.ts` and locate the `visitAttr()` method
+1. Open `@markuplint/svelte-spec` (`packages/@markuplint/svelte-spec/src/index.ts`) and find the `directivePatterns` array
 2. Review the directive table in `ARCHITECTURE.md` to understand existing patterns
 3. Identify whether the new directive should be `isDirective=true`, or requires special processing like `bind:`
 
 ### Step 2: Add the directive
 
-1. Add a new `if (baseName === 'newDirective')` branch in `visitAttr()` after the `split(':')` check
+1. Add a new pattern entry in the `directivePatterns` array in `@markuplint/svelte-spec`
 2. Set the appropriate flags: `isDirective`, `isDynamicValue`, `potentialName`, `isDuplicatable`
-3. If the directive needs special handling like `bind:`, add to `specificBindDirective` in the constructor
+3. For directives that need special attribute processing (e.g., spread, shorthand), also update `visitAttr()` in `src/parser.ts`
 
 ### Step 3: Verify
 

--- a/packages/@markuplint/svelte-parser/docs/maintenance.ja.md
+++ b/packages/@markuplint/svelte-parser/docs/maintenance.ja.md
@@ -36,7 +36,7 @@ expect(debugMaps).toStrictEqual([
 
 ### 1. 新しいディレクティブの追加
 
-1. `src/parser.ts` を読み、`visitAttr()` メソッドを特定
+1. `@markuplint/svelte-spec`（`packages/@markuplint/svelte-spec/src/index.ts`）を開き、`directivePatterns` 配列を確認する
 2. ディレクティブのプレフィックス（例: `newdir:`）を特定し、必要なフラグを決定:
    - `isDirective: true` — 純粋なディレクティブの場合（`on:`、`use:`、`transition:` のように）
    - `isDirective: undefined` + `potentialName` — 属性にマッピングするディレクティブの場合（`bind:value` のように）
@@ -136,11 +136,11 @@ expect(debugMaps).toStrictEqual([
 
 **症状:** Svelte ディレクティブ（例: `bind:value`）が正しい `isDirective` / `potentialName` フラグでパースされない。
 
-**原因:** ディレクティブプレフィックスが `visitAttr()` で処理されていない、または `specificBindDirective` セットにエントリが不足している。
+**原因:** ディレクティブプレフィックスが `directivePatterns`（`@markuplint/svelte-spec` で定義）で処理されていない、または特定の bind ディレクティブパターンが不足している。
 
 **解決策:**
 
-1. `visitAttr()` の `split(':')` ロジックを確認 — ディレクティブプレフィックスが処理されていることを確認
+1. `@markuplint/svelte-spec` の `directivePatterns` 配列を確認 — ディレクティブプレフィックスのパターンが存在することを確認
 2. `specificBindDirective` を確認 — このセット内のエントリは真のディレクティブとして扱われ、セット外のエントリは `potentialName` の動作になる
 3. 特定のディレクティブ構文でテストケースを追加
 

--- a/packages/@markuplint/svelte-parser/docs/maintenance.md
+++ b/packages/@markuplint/svelte-parser/docs/maintenance.md
@@ -36,7 +36,7 @@ expect(debugMaps).toStrictEqual([
 
 ### 1. Adding a New Directive
 
-1. Read `src/parser.ts` and locate the `visitAttr()` method
+1. Open `@markuplint/svelte-spec` (`packages/@markuplint/svelte-spec/src/index.ts`) and find the `directivePatterns` array
 2. Identify the directive prefix (e.g., `newdir:`) and determine the required flags:
    - `isDirective: true` for pure directives (like `on:`, `use:`, `transition:`)
    - `isDirective: undefined` + `potentialName` for directives that map to attributes (like `bind:value`)
@@ -136,11 +136,11 @@ expect(debugMaps).toStrictEqual([
 
 **Symptom:** A Svelte directive (e.g., `bind:value`) is not parsed with the correct `isDirective` / `potentialName` flags.
 
-**Cause:** The directive prefix is not handled in `visitAttr()`, or the `specificBindDirective` set is missing an entry.
+**Cause:** The directive prefix is not handled in `directivePatterns` (defined in `@markuplint/svelte-spec`), or a specific bind directive pattern is missing.
 
 **Solution:**
 
-1. Check the `split(':')` logic in `visitAttr()` — ensure the directive prefix is handled
+1. Check the `directivePatterns` array in `@markuplint/svelte-spec` — ensure the directive prefix pattern is present
 2. Check `specificBindDirective` — entries in this set are treated as true directives; entries not in this set get `potentialName` behavior
 3. Add a test case with the specific directive syntax
 

--- a/packages/@markuplint/svelte-parser/src/index.spec.ts
+++ b/packages/@markuplint/svelte-parser/src/index.spec.ts
@@ -427,7 +427,7 @@ https://svelte.dev/e/expected_token
 				'  [1:18]>[1:19](17,18)sQ: {',
 				'  [1:19]>[1:35](18,34)value: ␣`abc${def}ghi`␣',
 				'  [1:35]>[1:36](34,35)eQ: }',
-				'  isDirective: true',
+				'  isDirective: false',
 				'  isDynamicValue: true',
 			],
 		]);
@@ -447,7 +447,7 @@ https://svelte.dev/e/expected_token
 				'  [1:30]>[1:31](29,30)sQ: {',
 				'  [1:31]>[1:38](30,37)value: handler',
 				'  [1:38]>[1:39](37,38)eQ: }',
-				'  isDirective: true',
+				'  isDirective: false',
 				'  isDynamicValue: true',
 			],
 		]);
@@ -467,7 +467,7 @@ https://svelte.dev/e/expected_token
 				'  [1:17]>[1:17](16,16)sQ: ',
 				'  [1:17]>[1:17](16,16)value: ',
 				'  [1:17]>[1:17](16,16)eQ: ',
-				'  isDirective: true',
+				'  isDirective: false',
 				'  isDynamicValue: false',
 			],
 		]);
@@ -478,7 +478,7 @@ https://svelte.dev/e/expected_token
 		const attr = attributesToDebugMaps(r.nodeList[0].attributes);
 		expect(attr).toStrictEqual([
 			[
-				'[1:5]>[1:29](4,28)property: bind:property={variable}',
+				'[1:5]>[1:29](4,28)bind:property: bind:property={variable}',
 				'  [1:4]>[1:5](3,4)bN: ␣',
 				'  [1:5]>[1:18](4,17)name: bind:property',
 				'  [1:18]>[1:18](17,17)bE: ',
@@ -489,7 +489,6 @@ https://svelte.dev/e/expected_token
 				'  [1:28]>[1:29](27,28)eQ: }',
 				'  isDirective: false',
 				'  isDynamicValue: true',
-				'  potentialName: property',
 			],
 		]);
 	});
@@ -499,7 +498,7 @@ https://svelte.dev/e/expected_token
 		const attr = attributesToDebugMaps(r.nodeList[0].attributes);
 		expect(attr).toStrictEqual([
 			[
-				'[1:5]>[1:18](4,17)property: bind:property',
+				'[1:5]>[1:18](4,17)bind:property: bind:property',
 				'  [1:4]>[1:5](3,4)bN: ␣',
 				'  [1:5]>[1:18](4,17)name: bind:property',
 				'  [1:18]>[1:18](17,17)bE: ',
@@ -509,8 +508,7 @@ https://svelte.dev/e/expected_token
 				'  [1:18]>[1:18](17,17)value: ',
 				'  [1:18]>[1:18](17,17)eQ: ',
 				'  isDirective: false',
-				'  isDynamicValue: true',
-				'  potentialName: property',
+				'  isDynamicValue: false',
 			],
 		]);
 	});
@@ -537,7 +535,7 @@ https://svelte.dev/e/expected_token
 	animate:name2={params}
 />`);
 		const attrs = r.nodeList[0].attributes;
-		expect(attrs.every(attr => (attr.type === 'attr' ? attr.isDirective : false))).toBe(true);
+		expect(attrs.every(attr => (attr.type === 'attr' ? attr.isDirective : false))).toBe(false);
 	});
 
 	test('multiple class directives', () => {
@@ -545,7 +543,7 @@ https://svelte.dev/e/expected_token
 		const attr = attributesToDebugMaps(r.nodeList[0].attributes);
 		expect(attr).toStrictEqual([
 			[
-				'[1:5]>[1:34](4,33)class: class:selected="{isSelected}"',
+				'[1:5]>[1:34](4,33)class:selected: class:selected="{isSelected}"',
 				'  [1:4]>[1:5](3,4)bN: ␣',
 				'  [1:5]>[1:19](4,18)name: class:selected',
 				'  [1:19]>[1:19](18,18)bE: ',
@@ -554,12 +552,11 @@ https://svelte.dev/e/expected_token
 				'  [1:20]>[1:21](19,20)sQ: "',
 				'  [1:21]>[1:33](20,32)value: {isSelected}',
 				'  [1:33]>[1:34](32,33)eQ: "',
-				'  isDirective: true',
-				'  isDynamicValue: true',
-				'  potentialName: class',
+				'  isDirective: false',
+				'  isDynamicValue: false',
 			],
 			[
-				'[1:35]>[1:62](34,61)class: class:focused="{isFocused}"',
+				'[1:35]>[1:62](34,61)class:focused: class:focused="{isFocused}"',
 				'  [1:34]>[1:35](33,34)bN: ␣',
 				'  [1:35]>[1:48](34,47)name: class:focused',
 				'  [1:48]>[1:48](47,47)bE: ',
@@ -568,9 +565,74 @@ https://svelte.dev/e/expected_token
 				'  [1:49]>[1:50](48,49)sQ: "',
 				'  [1:50]>[1:61](49,60)value: {isFocused}',
 				'  [1:61]>[1:62](60,61)eQ: "',
-				'  isDirective: true',
+				'  isDirective: false',
+				'  isDynamicValue: false',
+			],
+		]);
+	});
+
+	test('style directive', () => {
+		const r = parse('<el style:color="red" style:background-color={bg} />');
+		const attr = attributesToDebugMaps(r.nodeList[0].attributes);
+		expect(attr).toStrictEqual([
+			[
+				'[1:5]>[1:22](4,21)style:color: style:color="red"',
+				'  [1:4]>[1:5](3,4)bN: ␣',
+				'  [1:5]>[1:16](4,15)name: style:color',
+				'  [1:16]>[1:16](15,15)bE: ',
+				'  [1:16]>[1:17](15,16)equal: =',
+				'  [1:17]>[1:17](16,16)aE: ',
+				'  [1:17]>[1:18](16,17)sQ: "',
+				'  [1:18]>[1:21](17,20)value: red',
+				'  [1:21]>[1:22](20,21)eQ: "',
+				'  isDirective: false',
+				'  isDynamicValue: false',
+			],
+			[
+				'[1:23]>[1:50](22,49)style:background-color: style:background-color={bg}',
+				'  [1:22]>[1:23](21,22)bN: ␣',
+				'  [1:23]>[1:45](22,44)name: style:background-color',
+				'  [1:45]>[1:45](44,44)bE: ',
+				'  [1:45]>[1:46](44,45)equal: =',
+				'  [1:46]>[1:46](45,45)aE: ',
+				'  [1:46]>[1:47](45,46)sQ: {',
+				'  [1:47]>[1:49](46,48)value: bg',
+				'  [1:49]>[1:50](48,49)eQ: }',
+				'  isDirective: false',
 				'  isDynamicValue: true',
-				'  potentialName: class',
+			],
+		]);
+	});
+
+	test('let directive', () => {
+		const r = parse('<el let:item let:index={i} />');
+		const attr = attributesToDebugMaps(r.nodeList[0].attributes);
+		expect(attr).toStrictEqual([
+			[
+				'[1:5]>[1:13](4,12)let:item: let:item',
+				'  [1:4]>[1:5](3,4)bN: ␣',
+				'  [1:5]>[1:13](4,12)name: let:item',
+				'  [1:13]>[1:13](12,12)bE: ',
+				'  [1:13]>[1:13](12,12)equal: ',
+				'  [1:13]>[1:13](12,12)aE: ',
+				'  [1:13]>[1:13](12,12)sQ: ',
+				'  [1:13]>[1:13](12,12)value: ',
+				'  [1:13]>[1:13](12,12)eQ: ',
+				'  isDirective: false',
+				'  isDynamicValue: false',
+			],
+			[
+				'[1:14]>[1:27](13,26)let:index: let:index={i}',
+				'  [1:13]>[1:14](12,13)bN: ␣',
+				'  [1:14]>[1:23](13,22)name: let:index',
+				'  [1:23]>[1:23](22,22)bE: ',
+				'  [1:23]>[1:24](22,23)equal: =',
+				'  [1:24]>[1:24](23,23)aE: ',
+				'  [1:24]>[1:25](23,24)sQ: {',
+				'  [1:25]>[1:26](24,25)value: i',
+				'  [1:26]>[1:27](25,26)eQ: }',
+				'  isDirective: false',
+				'  isDynamicValue: true',
 			],
 		]);
 	});

--- a/packages/@markuplint/svelte-parser/src/parser.ts
+++ b/packages/@markuplint/svelte-parser/src/parser.ts
@@ -7,7 +7,7 @@ import type {
 } from '@markuplint/ml-ast';
 import type { ChildToken, ParseOptions, Token } from '@markuplint/parser-utils';
 
-import { ParserError, Parser, AttrState, searchIDLAttribute } from '@markuplint/parser-utils';
+import { ParserError, Parser, AttrState } from '@markuplint/parser-utils';
 
 import { parseBlock } from './parse-block.js';
 import { svelteParse } from './svelte-parser/index.js';
@@ -20,8 +20,6 @@ import { svelteParse } from './svelte-parser/index.js';
  * and shorthand attribute syntax.
  */
 export class SvelteParser extends Parser<SvelteNode> {
-	readonly specificBindDirective: ReadonlySet<string> = new Set(['group', 'this']);
-
 	constructor() {
 		super({
 			endTagType: 'xml',
@@ -357,9 +355,10 @@ export class SvelteParser extends Parser<SvelteNode> {
 
 	/**
 	 * Visits an attribute token, handling Svelte-specific syntax including
-	 * curly-brace expression values, shorthand attributes (`{name}`),
-	 * `bind:` / `class:` directives, duplicatable class attributes,
-	 * and IDL-to-content attribute name mapping via `searchIDLAttribute`.
+	 * curly-brace expression values and shorthand attributes (`{name}`).
+	 * Directive resolution (`bind:`, `class:`, `on:`, etc.) and IDL attribute
+	 * mapping are now handled declaratively by svelte-spec's directivePatterns
+	 * and ml-core's useIDLAttributeNames.
 	 *
 	 * @param token - The token representing the attribute
 	 * @returns The parsed attribute node with Svelte-specific metadata
@@ -381,51 +380,21 @@ export class SvelteParser extends Parser<SvelteNode> {
 		}
 
 		let isDynamicValue = attr.startQuote.raw === '{' || undefined;
-
 		let potentialName: string | undefined;
-		let isDirective: true | undefined;
-		let isDuplicatable = false;
 
+		// Shorthand {name} → potentialName = value
 		if (isDynamicValue && attr.name.raw === '') {
 			potentialName = attr.value.raw;
 		}
 
-		const [baseName, subName] = attr.name.raw.split(':');
-
-		if (subName) {
-			isDirective = true;
-
-			if (baseName === 'bind' && !this.specificBindDirective.has(subName)) {
-				potentialName = subName;
-				isDirective = undefined;
-				isDynamicValue = true;
-			}
-		}
-
-		if (baseName?.toLowerCase() === 'class') {
-			isDuplicatable = true;
-
-			if (subName) {
-				potentialName = 'class';
-				isDynamicValue = true;
-			}
-		}
-
+		// Final curly brace check
 		if (attr.startQuote.raw === '{' && attr.endQuote.raw === '}') {
 			isDynamicValue = true;
-		}
-
-		const nameForLookup = potentialName ?? attr.name.raw;
-		const { contentAttrName } = searchIDLAttribute(nameForLookup);
-		if (contentAttrName && contentAttrName !== nameForLookup) {
-			potentialName = contentAttrName;
 		}
 
 		return {
 			...attr,
 			isDynamicValue,
-			isDirective,
-			isDuplicatable,
 			potentialName,
 		};
 	}

--- a/packages/@markuplint/svelte-spec/ARCHITECTURE.ja.md
+++ b/packages/@markuplint/svelte-spec/ARCHITECTURE.ja.md
@@ -6,7 +6,22 @@
 
 ## ExtendedSpec の内容
 
-パッケージは `specs` 配列に要素固有のオーバーライドを含む単一の `ExtendedSpec` オブジェクトをエクスポートします:
+### `useIDLAttributeNames`
+
+この spec は `useIDLAttributeNames: true` を設定しており、`@markuplint/ml-core` の `MLAttr` コンストラクタに IDL 属性名を HTML コンテンツ属性名に解決するよう指示します（例: `defaultValue` → 対応するコンテンツ属性）。この解決はパーサーではなくコアレベルで行われます。
+
+### `directivePatterns`
+
+この spec は Svelte ディレクティブ属性を解決するための `directivePatterns` 配列を宣言します。パターンは順番に評価されます（最初のマッチが優先）:
+
+| パターン                                       | 結果                                                                            |
+| ---------------------------------------------- | ------------------------------------------------------------------------------- |
+| `^bind:(?:group\|this)$`                       | `bind:group` / `bind:this` → `isDirective`、`isDynamicValue`                    |
+| `^bind:(.+)$`                                  | `bind:name` → `potentialName=$1`、`isDynamicValue`                              |
+| `^on:.+$`                                      | `on:event`（Svelte 4 レガシー）→ `isDirective`、`isDynamicValue`                |
+| `^class:`                                      | `class:name` → `potentialName=class`、`isDuplicatable`、`isDynamicValue`        |
+| `^style:`                                      | `style:property` → `potentialName=style`、`isDuplicatable`、`isDynamicValue`    |
+| `^(?:animate\|transition\|in\|out\|use\|let):` | アニメーション/トランジション/アクション/スロットディレクティブ → `isDirective` |
 
 ### 要素固有のオーバーライド
 

--- a/packages/@markuplint/svelte-spec/ARCHITECTURE.md
+++ b/packages/@markuplint/svelte-spec/ARCHITECTURE.md
@@ -6,7 +6,22 @@
 
 ## ExtendedSpec Content
 
-The package exports a single `ExtendedSpec` object with element-specific overrides in the `specs` array:
+### `useIDLAttributeNames`
+
+The spec sets `useIDLAttributeNames: true`, which instructs `@markuplint/ml-core`'s `MLAttr` constructor to resolve IDL attribute names to their HTML content attribute equivalents (e.g., `defaultValue` -> the corresponding content attribute). This resolution is performed at the core level, not in the parser.
+
+### `directivePatterns`
+
+The spec declares a `directivePatterns` array that the core engine uses to resolve Svelte directive attributes. Patterns are evaluated in order (first match wins):
+
+| Pattern                                        | Result                                                                        |
+| ---------------------------------------------- | ----------------------------------------------------------------------------- |
+| `^bind:(?:group\|this)$`                       | `bind:group` / `bind:this` -> `isDirective`, `isDynamicValue`                 |
+| `^bind:(.+)$`                                  | `bind:name` -> `potentialName=$1`, `isDynamicValue`                           |
+| `^on:.+$`                                      | `on:event` (Svelte 4 legacy) -> `isDirective`, `isDynamicValue`               |
+| `^class:`                                      | `class:name` -> `potentialName=class`, `isDuplicatable`, `isDynamicValue`     |
+| `^style:`                                      | `style:property` -> `potentialName=style`, `isDuplicatable`, `isDynamicValue` |
+| `^(?:animate\|transition\|in\|out\|use\|let):` | Animation/transition/action/slot directives -> `isDirective`                  |
 
 ### Element-Specific Overrides
 

--- a/packages/@markuplint/svelte-spec/src/index.ts
+++ b/packages/@markuplint/svelte-spec/src/index.ts
@@ -17,6 +17,46 @@ import type { ExtendedSpec } from '@markuplint/ml-spec';
  * attributes on form elements.
  */
 const spec: ExtendedSpec = {
+	useIDLAttributeNames: true,
+	directivePatterns: [
+		// bind:group, bind:this → true directives
+		{
+			pattern: '^bind:(?:group|this)$',
+			isDirective: true,
+			isDynamicValue: true,
+		},
+		// bind:name → potentialName=name, isDynamicValue
+		{
+			pattern: '^bind:(.+)$',
+			potentialName: '$1',
+			isDynamicValue: true,
+		},
+		// on:event (Svelte 4 legacy)
+		{
+			pattern: '^on:.+$',
+			isDirective: true,
+			isDynamicValue: true,
+		},
+		// class:name → potentialName=class, isDuplicatable
+		{
+			pattern: '^class:',
+			potentialName: 'class',
+			isDuplicatable: true,
+			isDynamicValue: true,
+		},
+		// style:property → potentialName=style, isDuplicatable
+		{
+			pattern: '^style:',
+			potentialName: 'style',
+			isDuplicatable: true,
+			isDynamicValue: true,
+		},
+		// animate:, transition:, in:, out:, use:, let: → isDirective
+		{
+			pattern: '^(?:animate|transition|in|out|use|let):',
+			isDirective: true,
+		},
+	],
 	specs: [
 		{
 			name: 'input',

--- a/packages/@markuplint/vue-parser/ARCHITECTURE.ja.md
+++ b/packages/@markuplint/vue-parser/ARCHITECTURE.ja.md
@@ -79,8 +79,9 @@ Parser<ASTNode, State>  (@markuplint/parser-utils)
 | `nodeize()`           | vue-eslint-parser AST ノード（VText、VElement、VExpressionContainer）を markuplint AST に変換 |
 | `flattenNodes()`      | 基底のフラット化を拡張し、兄弟ノード間にテンプレートコメントを注入                            |
 | `afterFlattenNodes()` | `exposeWhiteSpace: false`、`exposeInvalidNode: false`、`concatText: false` で基底を呼び出す   |
-| `visitAttr()`         | Vue ディレクティブの省略形を `potentialName`/`isDirective` メタデータに解決                   |
 | `detectElementType()` | PascalCase コンポーネントと Vue 組み込みコンポーネントを検出                                  |
+
+> **注記:** `visitAttr()` オーバーライドは削除されました。Vue ディレクティブ処理（`v-bind`、`v-on`、`v-model`、`v-slot` など）は `@markuplint/vue-spec` の `directivePatterns` で管理されています。
 
 ### `duplicatableAttrs`
 
@@ -134,9 +135,11 @@ Parser<ASTNode, State>  (@markuplint/parser-utils)
 
 この2パスアプローチが必要な理由は、vue-eslint-parser がコメントをメインノードツリーとは別に提供するため、正しい位置にインターリーブする必要があるからです。
 
-## 属性処理（visitAttr）
+## ディレクティブ処理（@markuplint/vue-spec の directivePatterns）
 
-`visitAttr()` メソッドはまず `super.visitAttr(token)` を呼び出し、その後 Vue 固有のディレクティブ解決を適用します。
+Vue ディレクティブの解決はパーサー自体ではなく、`@markuplint/vue-spec` で定義された `directivePatterns` によって管理されています。spec がディレクティブを `potentialName`、`isDirective`、`isDynamicValue` メタデータにマッピングするパターンを宣言します。
+
+> **二段階解決:** パーサーレベルのテスト（`index.spec.ts`）はパーサー自体が設定する raw AST 値を示します（例: 波括弧式のみ `isDynamicValue: true`）。コアレベルのテスト（`ml-core` や `rules`）は `ml-core` の `MLAttr` コンストラクタが `directivePatterns` を適用した後の最終解決値を示します。例えば、値なしの `on:click` はパーサーレベルでは `isDynamicValue: false` ですが、コアレベルでは `directivePatterns` マッチにより `isDynamicValue: true` に解決されます。
 
 ### クォートセット
 

--- a/packages/@markuplint/vue-parser/ARCHITECTURE.md
+++ b/packages/@markuplint/vue-parser/ARCHITECTURE.md
@@ -79,8 +79,9 @@ The parser maintains internal state through the `State` type:
 | `nodeize()`           | Converts vue-eslint-parser AST nodes (VText, VElement, VExpressionContainer) to markuplint AST |
 | `flattenNodes()`      | Extends base flattening to inject template comments between sibling nodes                      |
 | `afterFlattenNodes()` | Calls base with `exposeWhiteSpace: false`, `exposeInvalidNode: false`, `concatText: false`     |
-| `visitAttr()`         | Resolves Vue directive shorthands to `potentialName`/`isDirective` metadata                    |
 | `detectElementType()` | Detects PascalCase components and Vue built-in components                                      |
+
+> **Note:** The `visitAttr()` override has been removed. Vue directive handling (`v-bind`, `v-on`, `v-model`, `v-slot`, etc.) is now managed via `directivePatterns` in `@markuplint/vue-spec`.
 
 ### `duplicatableAttrs`
 
@@ -134,9 +135,11 @@ The `flattenNodes()` method extends the base `Parser.flattenNodes()` to inject t
 
 This two-pass approach is necessary because vue-eslint-parser provides comments separately from the main node tree, and they must be interleaved at the correct positions.
 
-## Attribute Processing (visitAttr)
+## Directive Handling (directivePatterns in @markuplint/vue-spec)
 
-The `visitAttr()` method calls `super.visitAttr(token)` first, then applies Vue-specific directive resolution.
+Vue directive resolution is managed by `directivePatterns` defined in `@markuplint/vue-spec`, not by the parser itself. The spec declares patterns that the core engine uses to map directives to `potentialName`, `isDirective`, and `isDynamicValue` metadata.
+
+> **Two-stage resolution:** Parser-level tests (`index.spec.ts`) show raw AST values where `isDynamicValue` and `isDirective` reflect only what the parser itself sets (e.g., curly-brace expressions). Core-level tests (`ml-core` and `rules`) show the final resolved values after `directivePatterns` are applied by `ml-core`'s `MLAttr` constructor. For example, `on:click` without a value shows `isDynamicValue: false` at the parser level, but resolves to `isDynamicValue: true` at the core level via the `directivePatterns` match.
 
 ### Quote Set
 

--- a/packages/@markuplint/vue-parser/SKILL.md
+++ b/packages/@markuplint/vue-parser/SKILL.md
@@ -14,12 +14,12 @@ detection, update vue-eslint-parser version support, and fix comment injection.
 
 `$ARGUMENTS` specifies the task. Supported tasks:
 
-| Task                            | Description                                      |
-| ------------------------------- | ------------------------------------------------ |
-| `add-directive`                 | Add or modify a Vue directive in visitAttr()     |
-| `modify-element-type-detection` | Update detectElementType() matchers              |
-| `update-vue-version-support`    | Handle vue-eslint-parser API changes             |
-| `fix-comment-injection`         | Fix template comment injection in flattenNodes() |
+| Task                            | Description                                                   |
+| ------------------------------- | ------------------------------------------------------------- |
+| `add-directive`                 | Add or modify a Vue directive in directivePatterns (vue-spec) |
+| `modify-element-type-detection` | Update detectElementType() matchers                           |
+| `update-vue-version-support`    | Handle vue-eslint-parser API changes                          |
+| `fix-comment-injection`         | Fix template comment injection in flattenNodes()              |
 
 If omitted, defaults to `add-directive`.
 
@@ -35,11 +35,11 @@ Also read:
 
 ## Task: add-directive
 
-Add or modify a Vue directive in `visitAttr()`. Follow recipe #1 in `docs/maintenance.md`.
+Add or modify a Vue directive in `directivePatterns` (`@markuplint/vue-spec`). Follow recipe #1 in `docs/maintenance.md`.
 
 ### Step 1: Understand the directive
 
-1. Read `src/parser.ts` and find the `visitAttr()` method
+1. Open `@markuplint/vue-spec` (`packages/@markuplint/vue-spec/src/index.ts`) and find the `directivePatterns` array
 2. Identify where in the priority chain the new directive should be processed
 3. Determine whether the directive needs `potentialName`, `isDirective`, or `isDynamicValue`
 
@@ -134,4 +134,4 @@ Fix template comment injection in `flattenNodes()`. Follow recipe #4 in `docs/ma
 3. **Use `isDirective: true`** for directives with no HTML equivalent (e.g., `v-if`, `v-for`).
 4. **Test with `nodeListToDebugMaps`** — this is the standard assertion pattern for parser tests.
 5. **Add JSDoc comments** to all new public methods and properties.
-6. **Preserve directive priority order** in `visitAttr()` — `v-on` before `v-bind` before `v-model` before `v-slot` before generic `v-`.
+6. **Preserve directive priority order** in `directivePatterns` — `.prop` shorthand before `v-bind` with modifiers before `v-bind`/`:` before `v-on`/`@` before `v-model` before `v-slot`/`#` before generic `v-`.

--- a/packages/@markuplint/vue-parser/docs/maintenance.ja.md
+++ b/packages/@markuplint/vue-parser/docs/maintenance.ja.md
@@ -49,7 +49,7 @@ expect(doc.nodeList[0].elementType).toBe('authored');
 
 ### 1. Vue ディレクティブの追加・変更
 
-1. `src/parser.ts` を読み、`visitAttr()` メソッドを見つける
+1. `@markuplint/vue-spec`（`packages/@markuplint/vue-spec/src/index.ts`）を開き、`directivePatterns` 配列を確認する
 2. 優先チェーン内の正しい位置を特定:
    - `v-on` / `@`（イベントバインディング） — 最初
    - `v-bind` / `:`（プロパティバインディング） — 2番目
@@ -158,12 +158,12 @@ yarn test --scope @markuplint/vue-parser
 
 **症状:** `v-custom` のような Vue ディレクティブが `isDirective: true` としてマークされず、通常の HTML 属性として扱われる。
 
-**原因:** `visitAttr()` でディレクティブパターンがマッチしないか、新しいディレクティブブロックが汎用 `v-*` キャッチオールの後に配置されている。
+**原因:** `directivePatterns`（`@markuplint/vue-spec` で定義）でディレクティブパターンがマッチしないか、新しいパターンが汎用 `v-*` キャッチオールの後に配置されている。
 
 **解決策:**
 
 1. ディレクティブブロックの正規表現パターンを確認 — 完全な属性名にマッチすることを確認
-2. ブロックが `visitAttr()` 末尾の汎用 `v-*` キャッチオールの前に配置されていることを確認
+2. パターンが `directivePatterns` 配列内の汎用 `v-*` キャッチオールの前に配置されていることを確認
 3. 返却オブジェクトに `isDirective: true as const` が含まれていることを検証
 
 ### テンプレートコメントが AST に含まれていない

--- a/packages/@markuplint/vue-parser/docs/maintenance.md
+++ b/packages/@markuplint/vue-parser/docs/maintenance.md
@@ -49,7 +49,7 @@ expect(doc.nodeList[0].elementType).toBe('authored');
 
 ### 1. Adding or Modifying a Vue Directive
 
-1. Read `src/parser.ts` and find the `visitAttr()` method
+1. Open `@markuplint/vue-spec` (`packages/@markuplint/vue-spec/src/index.ts`) and find the `directivePatterns` array
 2. Identify the correct position in the priority chain:
    - `v-on` / `@` (event binding) — first
    - `v-bind` / `:` (property binding) — second
@@ -158,12 +158,12 @@ yarn test --scope @markuplint/vue-parser
 
 **Symptom:** A Vue directive like `v-custom` is treated as a regular HTML attribute instead of being marked as `isDirective: true`.
 
-**Cause:** The directive pattern does not match in `visitAttr()`, or the new directive block is placed after the generic `v-*` catch-all.
+**Cause:** The directive pattern does not match in `directivePatterns` (defined in `@markuplint/vue-spec`), or the new pattern is placed after the generic `v-*` catch-all.
 
 **Solution:**
 
 1. Check the regex pattern in your directive block — ensure it matches the full attribute name
-2. Ensure the block is placed before the generic `v-*` catch-all at the end of `visitAttr()`
+2. Ensure the pattern is placed before the generic `v-*` catch-all in the `directivePatterns` array
 3. Verify the return object includes `isDirective: true as const`
 
 ### Template comments are missing from the AST

--- a/packages/@markuplint/vue-parser/src/index.spec.ts
+++ b/packages/@markuplint/vue-parser/src/index.spec.ts
@@ -347,13 +347,15 @@ describe('parser', () => {
 			'<template><div v-if="bool" data-attr v-bind:data-attr2="variable" @click.once="event" v-on:click.foobar="event"></div></template>',
 		);
 		expect(doc.nodeList[0].attributes[0].raw).toBe('v-if="bool"');
-		expect(doc.nodeList[0].attributes[0].isDirective).toBeTruthy();
+		// Directive resolution now handled by vue-spec's directivePatterns, not parser
+		expect(doc.nodeList[0].attributes[0].isDirective).toBeUndefined();
 		expect(doc.nodeList[0].attributes[1].raw).toBe('data-attr');
 		expect(doc.nodeList[0].attributes[1].isDirective).toBeUndefined();
 		expect(doc.nodeList[0].attributes[2].raw).toBe('v-bind:data-attr2="variable"');
-		expect(doc.nodeList[0].attributes[2].potentialName).toBe('data-attr2');
-		expect(doc.nodeList[0].attributes[3].isDirective).toBeFalsy();
-		expect(doc.nodeList[0].attributes[4].isDirective).toBeFalsy();
+		// potentialName resolution now handled by vue-spec's directivePatterns
+		expect(doc.nodeList[0].attributes[2].potentialName).toBeUndefined();
+		expect(doc.nodeList[0].attributes[3].isDirective).toBeUndefined();
+		expect(doc.nodeList[0].attributes[4].isDirective).toBeUndefined();
 	});
 
 	test('namespace', () => {
@@ -396,7 +398,7 @@ describe('parser', () => {
 			'[3:3]>[3:8](15,20)div: <div>',
 			'[3:8]>[4:4](20,24)#text: ⏎→→→',
 			'[4:4]>[4:22](24,42)template: <template␣#header>',
-			'[4:14]>[4:21](34,41)v-slot:header: #header',
+			'[4:14]>[4:21](34,41)#header: #header',
 			'  [4:13]>[4:14](33,34)bN: ␣',
 			'  [4:14]>[4:21](34,41)name: #header',
 			'  [4:21]>[4:21](41,41)bE: ',
@@ -405,9 +407,8 @@ describe('parser', () => {
 			'  [4:21]>[4:21](41,41)sQ: ',
 			'  [4:21]>[4:21](41,41)value: ',
 			'  [4:21]>[4:21](41,41)eQ: ',
-			'  isDirective: true',
+			'  isDirective: false',
 			'  isDynamicValue: false',
-			'  potentialName: v-slot:header',
 			'[4:22]>[4:33](42,53)template: </template>',
 			'[4:33]>[5:3](53,56)#text: ⏎→→',
 			'[5:3]>[5:9](56,62)div: </div>',
@@ -438,11 +439,11 @@ bool
 			'  [4:2]>[4:3](25,26)sQ: "',
 			'  [4:3]>[6:1](26,34)value: ␣⏎bool␣⏎',
 			'  [6:1]>[6:2](34,35)eQ: "',
-			'  isDirective: true',
+			'  isDirective: false',
 			'  isDynamicValue: false',
 			'[6:3]>[7:1](36,38)#text: ␣⏎',
 			'[7:1]>[8:2](38,58)template: <template␣#header␣⏎>',
-			'[7:11]>[7:18](48,55)v-slot:header: #header',
+			'[7:11]>[7:18](48,55)#header: #header',
 			'  [7:10]>[7:11](47,48)bN: ␣',
 			'  [7:11]>[7:18](48,55)name: #header',
 			'  [7:18]>[7:18](55,55)bE: ',
@@ -451,9 +452,8 @@ bool
 			'  [7:18]>[7:18](55,55)sQ: ',
 			'  [7:18]>[7:18](55,55)value: ',
 			'  [7:18]>[7:18](55,55)eQ: ',
-			'  isDirective: true',
+			'  isDirective: false',
 			'  isDynamicValue: false',
-			'  potentialName: v-slot:header',
 			'[8:2]>[8:13](58,69)template: </template>',
 			'[8:13]>[9:1](69,71)#text: ␣⏎',
 			'[9:1]>[9:7](71,77)div: </div>',
@@ -472,7 +472,7 @@ describe('Issues', () => {
 		expect(map).toStrictEqual([
 			'[2:12]>[3:3](12,15)#text: ⏎→→',
 			'[3:3]>[3:51](15,63)button: <button␣@click.stop="foo"␣v-on:click.stop="bar">',
-			'[3:11]>[3:28](23,40)onclick: @click.stop="foo"',
+			'[3:11]>[3:28](23,40)@click.stop: @click.stop="foo"',
 			'  [3:10]>[3:11](22,23)bN: ␣',
 			'  [3:11]>[3:22](23,34)name: @click.stop',
 			'  [3:22]>[3:22](34,34)bE: ',
@@ -482,9 +482,8 @@ describe('Issues', () => {
 			'  [3:24]>[3:27](36,39)value: foo',
 			'  [3:27]>[3:28](39,40)eQ: "',
 			'  isDirective: false',
-			'  isDynamicValue: true',
-			'  potentialName: onclick',
-			'[3:29]>[3:50](41,62)onclick: v-on:click.stop="bar"',
+			'  isDynamicValue: false',
+			'[3:29]>[3:50](41,62)v-on:click.stop: v-on:click.stop="bar"',
 			'  [3:28]>[3:29](40,41)bN: ␣',
 			'  [3:29]>[3:44](41,56)name: v-on:click.stop',
 			'  [3:44]>[3:44](56,56)bE: ',
@@ -494,8 +493,7 @@ describe('Issues', () => {
 			'  [3:46]>[3:49](58,61)value: bar',
 			'  [3:49]>[3:50](61,62)eQ: "',
 			'  isDirective: false',
-			'  isDynamicValue: true',
-			'  potentialName: onclick',
+			'  isDynamicValue: false',
 			'[3:51]>[3:54](63,66)#text: ...',
 			'[3:54]>[3:63](66,75)button: </button>',
 			'[3:63]>[4:2](75,77)#text: ⏎→',

--- a/packages/@markuplint/vue-parser/src/parser.ts
+++ b/packages/@markuplint/vue-parser/src/parser.ts
@@ -1,6 +1,5 @@
 import type { ASTNode, ASTComment } from './vue-parser/index.js';
 import type { MLASTParentNode, MLASTNodeTreeItem } from '@markuplint/ml-ast';
-import type { Token } from '@markuplint/parser-utils';
 
 import { ParserError, Parser } from '@markuplint/parser-utils';
 
@@ -17,8 +16,6 @@ type State = {
  * Recognizes Vue built-in components and PascalCase user components.
  */
 class VueParser extends Parser<ASTNode, State> {
-	readonly duplicatableAttrs = new Set(['class', 'style']);
-
 	constructor() {
 		super(
 			{
@@ -177,119 +174,6 @@ class VueParser extends Parser<ASTNode, State> {
 			exposeWhiteSpace: false,
 			concatText: false,
 		});
-	}
-
-	/**
-	 * Visits an attribute token and resolves Vue-specific directive shorthands.
-	 * Handles `v-on` / `@` (event binding), `v-bind` / `:` (property binding),
-	 * `v-model`, `v-slot` / `#`, and other `v-` prefixed directives.
-	 *
-	 * @param token - The token representing the attribute
-	 * @returns The parsed attribute node with Vue-specific metadata
-	 */
-	visitAttr(token: Token) {
-		const attr = super.visitAttr(token);
-
-		if (attr.type === 'spread') {
-			return attr;
-		}
-
-		{
-			/**
-			 * `v-on`
-			 */
-			const [, directive, potentialName] = attr.name.raw.match(/^(v-on:|@)([^.]+)(?:\.([^.]+))?$/i) ?? [];
-			if (directive && potentialName) {
-				return {
-					...attr,
-					potentialName: `on${potentialName.toLowerCase()}`,
-					isDynamicValue: true as const,
-				};
-			}
-		}
-
-		{
-			/**
-			 * `v-bind`
-			 */
-			const [, directive, potentialName, modifier] =
-				attr.name.raw.match(/^(v-bind:|:)([^.]+)(?:\.([^.]+))?$/i) ?? [];
-			if (directive && potentialName) {
-				if (this.duplicatableAttrs.has(potentialName.toLowerCase())) {
-					this.updateAttr(attr, { isDuplicatable: true });
-				}
-
-				if (!modifier) {
-					return {
-						...attr,
-						potentialName,
-						isDynamicValue: true as const,
-					};
-				}
-
-				switch (modifier) {
-					case '.attr': {
-						return {
-							...attr,
-							potentialName,
-							isDynamicValue: true as const,
-						};
-					}
-					/* eslint-disable unicorn/no-useless-switch-case */
-					case '.prop':
-					case '.camel':
-					default: {
-						const name = `v-bind:${potentialName}${modifier ?? ''}`;
-						return {
-							...attr,
-							potentialName: attr.name.raw === name ? undefined : name,
-							isDirective: true as const,
-						};
-					}
-					/* eslint-enable unicorn/no-useless-switch-case */
-				}
-			}
-		}
-
-		{
-			/**
-			 * `v-model`
-			 */
-			const [, directive] = attr.name.raw.match(/^(v-model)(?:\.([^.]+))?$/i) ?? [];
-			if (directive) {
-				return {
-					...attr,
-					isDirective: true as const,
-				};
-			}
-		}
-
-		{
-			/**
-			 * `v-slot`
-			 */
-			const slotName = (attr.name.raw.match(/^(v-slot:|#)(.+)$/i) ?? [])[2];
-			const name = `v-slot:${slotName}`;
-			if (slotName) {
-				return {
-					...attr,
-					potentialName: attr.name.raw === name ? undefined : name,
-					isDirective: true as const,
-				};
-			}
-		}
-
-		/**
-		 * If directives
-		 */
-		if (attr.name.raw.startsWith('v-')) {
-			return {
-				...attr,
-				isDirective: true as const,
-			};
-		}
-
-		return attr;
 	}
 
 	/**

--- a/packages/@markuplint/vue-spec/ARCHITECTURE.ja.md
+++ b/packages/@markuplint/vue-spec/ARCHITECTURE.ja.md
@@ -6,6 +6,23 @@
 
 ## ExtendedSpec の内容
 
+### `directivePatterns`
+
+この spec は Vue ディレクティブ属性を解決するための `directivePatterns` 配列を宣言します。パターンは順番に評価されます（最初のマッチが優先）:
+
+| パターン                          | 結果                                                                         |
+| --------------------------------- | ---------------------------------------------------------------------------- |
+| `^\\.(.+)$`                       | `.prop` ショートハンド (Vue 3.2+) → `isDirective`、`isDynamicValue`          |
+| `^(?:v-bind:\|:)([^.]+)\\..+$`    | `v-bind` + 修飾子（`.prop`、`.camel`）→ `isDirective`、`isDynamicValue`      |
+| `^(?:v-bind:\|:\|v-on:\|@)\\[`    | 動的属性/イベント名（`:[expr]`、`@[expr]`）→ `isDirective`、`isDynamicValue` |
+| `^(?:v-bind:\|:)([^.]+)$`         | `v-bind:attr` / `:attr` → `potentialName=$1`、`isDynamicValue`               |
+| `^(?:v-on:\|@)([^.]+)(?:\\..+)?$` | `v-on:event` / `@event` → `potentialName=on$1`、`isDynamicValue`             |
+| `^v-model(?:$\|\\.)`              | `v-model` → `isDirective`、`isDynamicValue`                                  |
+| `^(?:v-slot:\|#)`                 | `v-slot` / `#` ショートハンド → `isDirective`、`isDynamicValue`              |
+| `^v-`                             | その他の `v-*` ディレクティブ → `isDirective`、`isDynamicValue`              |
+
+`v-bind:attr` パターンは `isDuplicatable: ['class', 'style']` も設定しており、これらの属性がバインドされた同等物と並んで出現できるようにします。
+
 ### グローバル属性
 
 以下のグローバル属性が `def['#globalAttrs']['#extends']` 配下に登録されています:

--- a/packages/@markuplint/vue-spec/ARCHITECTURE.md
+++ b/packages/@markuplint/vue-spec/ARCHITECTURE.md
@@ -6,6 +6,23 @@
 
 ## ExtendedSpec Content
 
+### `directivePatterns`
+
+The spec declares a `directivePatterns` array that the core engine uses to resolve Vue directive attributes. Patterns are evaluated in order (first match wins):
+
+| Pattern                           | Result                                                                                 |
+| --------------------------------- | -------------------------------------------------------------------------------------- |
+| `^\\.(.+)$`                       | `.prop` shorthand (Vue 3.2+) -> `isDirective`, `isDynamicValue`                        |
+| `^(?:v-bind:\|:)([^.]+)\\..+$`    | `v-bind` with modifier (`.prop`, `.camel`) -> `isDirective`, `isDynamicValue`          |
+| `^(?:v-bind:\|:\|v-on:\|@)\\[`    | Dynamic attribute/event name (`:[expr]`, `@[expr]`) -> `isDirective`, `isDynamicValue` |
+| `^(?:v-bind:\|:)([^.]+)$`         | `v-bind:attr` / `:attr` -> `potentialName=$1`, `isDynamicValue`                        |
+| `^(?:v-on:\|@)([^.]+)(?:\\..+)?$` | `v-on:event` / `@event` -> `potentialName=on$1`, `isDynamicValue`                      |
+| `^v-model(?:$\|\\.)`              | `v-model` -> `isDirective`, `isDynamicValue`                                           |
+| `^(?:v-slot:\|#)`                 | `v-slot` / `#` shorthand -> `isDirective`, `isDynamicValue`                            |
+| `^v-`                             | Other `v-*` directives -> `isDirective`, `isDynamicValue`                              |
+
+The `v-bind:attr` pattern also sets `isDuplicatable: ['class', 'style']`, allowing these attributes to appear alongside their bound equivalents.
+
 ### Global Attributes
 
 The following global attributes are registered under `def['#globalAttrs']['#extends']`:

--- a/packages/@markuplint/vue-spec/src/index.ts
+++ b/packages/@markuplint/vue-spec/src/index.ts
@@ -19,6 +19,57 @@ import type { ExtendedSpec } from '@markuplint/ml-spec';
  * element is marked as allowing additional dynamic properties.
  */
 const spec: ExtendedSpec = {
+	directivePatterns: [
+		// .propName shorthand (Vue 3.2+, equivalent to v-bind:propName.prop)
+		{
+			pattern: '^\\.(.+)$',
+			isDirective: true,
+			isDynamicValue: true,
+		},
+		// v-bind/: with .prop or .camel modifier → isDirective
+		{
+			pattern: '^(?:v-bind:|:)([^.]+)\\..+$',
+			isDirective: true,
+			isDynamicValue: true,
+		},
+		// Dynamic attribute/event names with brackets (e.g., :[dynamicAttr], @[dynamicEvent])
+		{
+			pattern: '^(?:v-bind:|:|v-on:|@)\\[',
+			isDirective: true,
+			isDynamicValue: true,
+		},
+		// v-bind:attr or :attr (no modifier) → potentialName=attr, isDynamicValue
+		{
+			pattern: '^(?:v-bind:|:)([^.]+)$',
+			potentialName: '$1',
+			isDynamicValue: true,
+			isDuplicatable: ['class', 'style'],
+		},
+		// v-on:event or @event (with optional modifiers)
+		{
+			pattern: '^(?:v-on:|@)([^.]+)(?:\\..+)?$',
+			potentialName: 'on$1',
+			isDynamicValue: true,
+		},
+		// v-model (with optional modifiers)
+		{
+			pattern: '^v-model(?:$|\\.)',
+			isDirective: true,
+			isDynamicValue: true,
+		},
+		// v-slot:name or #name shorthand
+		{
+			pattern: '^(?:v-slot:|#)',
+			isDirective: true,
+			isDynamicValue: true,
+		},
+		// Other v-* directives (v-show, v-if, v-for, v-text, v-html, etc.)
+		{
+			pattern: '^v-',
+			isDirective: true,
+			isDynamicValue: true,
+		},
+	],
 	def: {
 		'#globalAttrs': {
 			'#extends': {


### PR DESCRIPTION
## Summary

- Move directive attribute resolution (v-bind, v-on, bind:, class:, etc.) from parser `visitAttr` methods to declarative `directivePatterns` arrays in spec packages (vue-spec, svelte-spec)
- Move IDL attribute name resolution (className→class, htmlFor→for, etc.) from parser `visitAttr` to ml-core's `MLAttr` constructor, controlled by `useIDLAttributeNames` flag in spec packages (react-spec, svelte-spec)
- Add `useIDLAttributeNames` property to `ExtendedSpec` type with null-guard merge semantics in `schemaToSpec`
- Add Vue `.prop` shorthand support (Vue 3.2+) and Svelte `let:` directive support

## Motivation

Directive and IDL attribute handling was previously implemented imperatively in each parser's `visitAttr` method. This caused:
- Code duplication across parsers (jsx-parser and mdx-parser both called `searchIDLAttribute`)
- Tight coupling between parsers and attribute semantics
- Difficulty adding new directive patterns without modifying parser code

Moving to declarative patterns in spec packages aligns with the existing `directivePatterns` infrastructure and makes the system more maintainable.

## Changes by package

| Package | Change |
|---------|--------|
| `@markuplint/ml-spec` | Add `useIDLAttributeNames` to types; update `schemaToSpec` merge |
| `@markuplint/react-spec` | Add `useIDLAttributeNames: true` |
| `@markuplint/vue-spec` | Add `directivePatterns` (8 patterns incl. `.prop` shorthand) |
| `@markuplint/svelte-spec` | Add `directivePatterns` (6 patterns) + `useIDLAttributeNames: true` |
| `@markuplint/jsx-parser` | Remove `searchIDLAttribute` from `visitAttr` |
| `@markuplint/mdx-parser` | Remove `searchIDLAttribute` from `visitAttr` |
| `@markuplint/vue-parser` | Remove directive handling from `visitAttr` |
| `@markuplint/svelte-parser` | Remove directive + IDL handling from `visitAttr` |
| `@markuplint/ml-core` | Add `resolveDirective()` and `searchIDLAttribute()` to `MLAttr` constructor |
| `@markuplint/rules` | Add `specs` config to tests for directive/IDL resolution |
| docs (10+ files) | Update ARCHITECTURE, SKILL, maintenance docs |

## Test plan

- [x] `yarn build` — 40 projects pass
- [x] `yarn test` — 2358 tests pass (159 files)
- [x] `yarn lint-check` — 0 issues
- [x] Vue directive tests (v-bind, v-on, v-model, v-slot, .prop shorthand)
- [x] Svelte directive tests (bind:, on:, class:, style:, let:)
- [x] JSX/MDX IDL attribute tests (className, htmlFor, tabIndex)
- [x] `useIDLAttributeNames` merge logic tests (true/false/omit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)