### PR TITLE
feat: add link-types rule for rel attribute validation

### DIFF
--- a/packages/@markuplint/config-presets/README.md
+++ b/packages/@markuplint/config-presets/README.md
@@ -61,6 +61,7 @@ Need **placeholder label option**| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|
 Require the `datetime` attribute if the content of the `time` element is invalid| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
 Specify required attr| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
 [Enforce WHATWG constraints between `srcset`, `sizes`, and `loading` attributes](https://html.spec.whatwg.org/multipage/images.html#srcset-attributes)| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
+[Validate link type keywords](https://html.spec.whatwg.org/multipage/links.html#linkTypes)|Validates that `rel` attribute keywords are allowed on the given element and context (e.g., body-ok for `<link>` inside `<body>`).|✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
 [Specify `charset=UTF-8`](https://html.spec.whatwg.org/multipage/semantics.html#charset)| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
 [No use `<small>` as **subheadings**](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-small-element)|The small element must not be used for subheadings.|✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
 [No use `<caption>` within `<figure>`](https://html.spec.whatwg.org/multipage/tables.html#the-caption-element)|When `<table>` is the only content in `<figure>` other than `<figcaption>`, `<caption>` should be omitted in favor of `<figcaption>`.|✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|

--- a/packages/@markuplint/config-presets/src/preset.html-standard.jsonc
+++ b/packages/@markuplint/config-presets/src/preset.html-standard.jsonc
@@ -175,6 +175,23 @@
 			"rules": {
 				"srcset-sizes-constraint": true
 			}
+		},
+
+		/**
+		 * Validate link type keywords
+		 *
+		 * Validates that `rel` attribute keywords are allowed on the given element
+		 * and context (e.g., body-ok for `<link>` inside `<body>`).
+		 *
+		 * @see https://html.spec.whatwg.org/multipage/links.html#linkTypes
+		 */
+		"html-standard/link-types": {
+			"specConformance": "normative",
+			"rules": {
+				"link-types": {
+					"options": { "allowMicroformats": true }
+				}
+			}
 		}
 	},
 	"nodeRules": [

--- a/packages/@markuplint/rules/schema.json
+++ b/packages/@markuplint/rules/schema.json
@@ -60,6 +60,9 @@
 				"landmark-roles": {
 					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/landmark-roles/schema.json"
 				},
+				"link-types": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/link-types/schema.json"
+				},
 				"neighbor-popovers": {
 					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/neighbor-popovers/schema.json"
 				},

--- a/packages/@markuplint/rules/src/index.ts
+++ b/packages/@markuplint/rules/src/index.ts
@@ -27,6 +27,7 @@ import IneffectiveAttr from './ineffective-attr/index.js';
 import InvalidAttr from './invalid-attr/index.js';
 import LabelHasControl from './label-has-control/index.js';
 import LandmarkRoles from './landmark-roles/index.js';
+import LinkTypes from './link-types/index.js';
 import NeighborPopovers from './neighbor-popovers/index.js';
 import NoAmbiguousNavigableTargetNames from './no-ambiguous-navigable-target-names/index.js';
 import NoBooleanAttrValue from './no-boolean-attr-value/index.js';
@@ -76,6 +77,7 @@ const rules = {
 	'invalid-attr': InvalidAttr,
 	'label-has-control': LabelHasControl,
 	'landmark-roles': LandmarkRoles,
+	'link-types': LinkTypes,
 	'neighbor-popovers': NeighborPopovers,
 	'no-ambiguous-navigable-target-names': NoAmbiguousNavigableTargetNames,
 	'no-boolean-attr-value': NoBooleanAttrValue,

--- a/packages/@markuplint/rules/src/link-types/README.ja.md
+++ b/packages/@markuplint/rules/src/link-types/README.ja.md
@@ -1,0 +1,103 @@
+---
+id: link-types
+description: WHATWG標準に対して`rel`属性のリンクタイプキーワードを検証します。
+---
+
+# `link-types`
+
+<!-- textlint-disable ja-technical-writing/ja-no-mixed-period -->
+
+`<link>`、`<a>`、`<area>`、`<form>`要素の`rel`属性のリンクタイプキーワードを[WHATWG標準](https://html.spec.whatwg.org/multipage/links.html#linkTypes)に対して検証します。
+
+このルールは以下をチェックします:
+
+- キーワードが特定の要素で許可されているかどうか（例: `bookmark`は`<a>`では許可されているが`<link>`では不許可）
+- `<body>`内の`<link>`要素が[body-ok](https://html.spec.whatwg.org/multipage/links.html#body-ok)キーワードのみを使用しているかどうか
+- キーワードがMicroformatsレジストリで[ドロップ、リジェクト、または非HTML](https://microformats.org/wiki/existing-rel-values)とされたキーワードかどうか
+
+:::note
+
+`invalid-attr`ルールも型システム経由で`rel`属性値を検証しますが、body-okコンテキストはチェックせず、Microformatsキーワードを常に許可します。`link-types`ルールはbody-okチェックとMicroformats制御をより詳細なエラーメッセージとともに提供します。両方のルールを併用でき、チェック内容は補完的です。
+
+:::
+
+❌ 間違ったコード例
+
+```html
+<!-- "bookmark" は <link> では不許可 -->
+<link rel="bookmark" />
+
+<!-- "canonical" は body-ok ではないため <body> 内では不許可 -->
+<html>
+  <head></head>
+  <body>
+    <link rel="canonical" href="https://example.com/" />
+  </body>
+</html>
+
+<!-- "stylesheet" は <a> では不許可 -->
+<a rel="stylesheet" href="/style.css">link</a>
+```
+
+✅ 正しいコード例
+
+```html
+<link rel="stylesheet" href="/style.css" />
+<link rel="canonical" href="https://example.com/" />
+<a rel="noopener noreferrer" href="https://example.com/">link</a>
+<form rel="nofollow" action="/submit"></form>
+```
+
+---
+
+## 設定例
+
+### デフォルト（WHATWG標準のみ）
+
+```json class=config
+{
+  "rules": {
+    "link-types": true
+  }
+}
+```
+
+### `allowMicroformats`
+
+型: `boolean | string[]`
+
+[Microformats](https://microformats.org/wiki/existing-rel-values)リンクタイプキーワードを許可するかどうかを制御します。Microformatsキーワードリストは[microformats.org wiki](https://microformats.org/wiki/existing-rel-values)の登録済みキーワードに基づいています。
+
+Microformatsキーワードが許可されている場合でも、要素コンテキストの検証は適用されます。例えば、`<a>`専用のキーワードは`<link>`では拒否されます。Microformatsレジストリはフォームコンテキストを定義していないため、`<form>`ではMicroformatsキーワードは常に拒否されます。
+
+#### `true` — 登録済みのすべてのMicroformatsキーワードを許可
+
+```json class=config
+{
+  "rules": {
+    "link-types": {
+      "options": {
+        "allowMicroformats": true
+      }
+    }
+  }
+}
+```
+
+#### `string[]` — 指定されたキーワードのみ許可
+
+指定されたキーワードのみを許可します。レジストリに登録されていないカスタムキーワードも指定できます。
+
+```json class=config
+{
+  "rules": {
+    "link-types": {
+      "options": {
+        "allowMicroformats": ["apple-touch-icon", "mask-icon"]
+      }
+    }
+  }
+}
+```
+
+<!-- textlint-enable ja-technical-writing/ja-no-mixed-period -->

--- a/packages/@markuplint/rules/src/link-types/README.md
+++ b/packages/@markuplint/rules/src/link-types/README.md
@@ -1,0 +1,99 @@
+---
+id: link-types
+description: Validates link type keywords in the `rel` attribute against the WHATWG standard.
+---
+
+# `link-types`
+
+Validates link type keywords in the `rel` attribute on `<link>`, `<a>`, `<area>`, and `<form>` elements against the [WHATWG standard](https://html.spec.whatwg.org/multipage/links.html#linkTypes).
+
+This rule checks:
+
+- Whether the keyword is allowed on the specific element (e.g., `bookmark` is allowed on `<a>` but not on `<link>`)
+- Whether a `<link>` element inside `<body>` uses only [body-ok](https://html.spec.whatwg.org/multipage/links.html#body-ok) keywords
+- Whether the keyword is a [dropped, rejected, or non-HTML](https://microformats.org/wiki/existing-rel-values) keyword from the Microformats registry
+
+:::note
+
+The `invalid-attr` rule also validates `rel` attribute values via the type system, but it does not check body-ok context and always permits Microformats keywords. The `link-types` rule provides body-ok checking and Microformats control with more detailed error messages. Both rules can be used together; their checks are complementary.
+
+:::
+
+❌ Examples of **incorrect** code for this rule
+
+```html
+<!-- "bookmark" is not allowed on <link> -->
+<link rel="bookmark" />
+
+<!-- "canonical" is not body-ok, so it's not allowed inside <body> -->
+<html>
+  <head></head>
+  <body>
+    <link rel="canonical" href="https://example.com/" />
+  </body>
+</html>
+
+<!-- "stylesheet" is not allowed on <a> -->
+<a rel="stylesheet" href="/style.css">link</a>
+```
+
+✅ Examples of **correct** code for this rule
+
+```html
+<link rel="stylesheet" href="/style.css" />
+<link rel="canonical" href="https://example.com/" />
+<a rel="noopener noreferrer" href="https://example.com/">link</a>
+<form rel="nofollow" action="/submit"></form>
+```
+
+---
+
+## Configuration Example
+
+### Default (WHATWG standard only)
+
+```json class=config
+{
+  "rules": {
+    "link-types": true
+  }
+}
+```
+
+### `allowMicroformats`
+
+type: `boolean | string[]`
+
+Controls whether [Microformats](https://microformats.org/wiki/existing-rel-values) link type keywords are allowed. The Microformats keyword list is based on the [microformats.org wiki](https://microformats.org/wiki/existing-rel-values) registered keywords.
+
+Even when Microformats keywords are allowed, element context is still enforced. For example, keywords defined only for `<a>` are rejected on `<link>`. Microformats keywords are always rejected on `<form>` because the Microformats registry does not define form context.
+
+#### `true` — Allow all registered Microformats keywords
+
+```json class=config
+{
+  "rules": {
+    "link-types": {
+      "options": {
+        "allowMicroformats": true
+      }
+    }
+  }
+}
+```
+
+#### `string[]` — Allow only specified keywords
+
+Allows only the specified keywords. You can also specify custom keywords that are not in any registry.
+
+```json class=config
+{
+  "rules": {
+    "link-types": {
+      "options": {
+        "allowMicroformats": ["apple-touch-icon", "mask-icon"]
+      }
+    }
+  }
+}
+```

--- a/packages/@markuplint/rules/src/link-types/index.spec.ts
+++ b/packages/@markuplint/rules/src/link-types/index.spec.ts
@@ -1,0 +1,297 @@
+import { mlRuleTest } from 'markuplint';
+import { describe, test, expect } from 'vitest';
+
+import rule from './index.js';
+
+describe('Element context', () => {
+	test('<link rel="stylesheet"> — allowed on link', async () => {
+		const { violations } = await mlRuleTest(rule, '<link rel="stylesheet">');
+		expect(violations.length).toBe(0);
+	});
+
+	test('<link rel="bookmark"> — not allowed on link', async () => {
+		const { violations } = await mlRuleTest(rule, '<link rel="bookmark">');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 12,
+				raw: 'bookmark',
+				message: 'The "bookmark" keyword is not allowed on the "link" element',
+			},
+		]);
+	});
+
+	test('<a rel="bookmark"> — allowed on a', async () => {
+		const { violations } = await mlRuleTest(rule, '<a rel="bookmark">link</a>');
+		expect(violations.length).toBe(0);
+	});
+
+	test('<a rel="canonical"> — not allowed on a', async () => {
+		const { violations } = await mlRuleTest(rule, '<a rel="canonical">link</a>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 9,
+				raw: 'canonical',
+				message: 'The "canonical" keyword is not allowed on the "a" element',
+			},
+		]);
+	});
+
+	test('<form rel="nofollow"> — allowed on form', async () => {
+		const { violations } = await mlRuleTest(rule, '<form rel="nofollow"></form>');
+		expect(violations.length).toBe(0);
+	});
+
+	test('<form rel="stylesheet"> — not allowed on form', async () => {
+		const { violations } = await mlRuleTest(rule, '<form rel="stylesheet"></form>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 12,
+				raw: 'stylesheet',
+				message: 'The "stylesheet" keyword is not allowed on the "form" element',
+			},
+		]);
+	});
+
+	test('<area rel="noopener"> — allowed on area', async () => {
+		const { violations } = await mlRuleTest(rule, '<area rel="noopener">');
+		expect(violations.length).toBe(0);
+	});
+
+	test('<area rel="canonical"> — not allowed on area (same as a)', async () => {
+		const { violations } = await mlRuleTest(rule, '<area rel="canonical">');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 12,
+				raw: 'canonical',
+				message: 'The "canonical" keyword is not allowed on the "a" element',
+			},
+		]);
+	});
+});
+
+describe('Body-ok', () => {
+	test('<link rel="canonical"> in head — allowed', async () => {
+		const { violations } = await mlRuleTest(rule, '<html><head><link rel="canonical"></head><body></body></html>');
+		expect(violations.length).toBe(0);
+	});
+
+	test('<link rel="stylesheet"> in body — allowed (bodyOk=Yes)', async () => {
+		const { violations } = await mlRuleTest(rule, '<html><head></head><body><link rel="stylesheet"></body></html>');
+		expect(violations.length).toBe(0);
+	});
+
+	test('<link rel="canonical"> in body — not allowed (not body-ok)', async () => {
+		const { violations } = await mlRuleTest(rule, '<html><head></head><body><link rel="canonical"></body></html>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 37,
+				raw: 'canonical',
+				message: 'The "canonical" keyword is not allowed on the "link" element inside the "body" element',
+			},
+		]);
+	});
+
+	test('<link rel="icon"> in body — not allowed (not body-ok)', async () => {
+		const { violations } = await mlRuleTest(rule, '<html><head></head><body><link rel="icon"></body></html>');
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.message).toBe(
+			'The "icon" keyword is not allowed on the "link" element inside the "body" element',
+		);
+	});
+
+	test('<link rel="bookmark"> in body — "not allowed on link" takes precedence over body-ok', async () => {
+		const { violations } = await mlRuleTest(rule, '<html><head></head><body><link rel="bookmark"></body></html>');
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.message).toBe('The "bookmark" keyword is not allowed on the "link" element');
+	});
+});
+
+describe('Body-ok: fragment mode', () => {
+	test('<link rel="canonical"> in fragment — allowed (no body-ok check)', async () => {
+		const { violations } = await mlRuleTest(rule, '<link rel="canonical">');
+		expect(violations.length).toBe(0);
+	});
+
+	test('<link rel="stylesheet"> in fragment — allowed', async () => {
+		const { violations } = await mlRuleTest(rule, '<link rel="stylesheet">');
+		expect(violations.length).toBe(0);
+	});
+});
+
+describe('Microformats control', () => {
+	test('default: <link rel="apple-touch-icon"> — not allowed', async () => {
+		const { violations } = await mlRuleTest(rule, '<link rel="apple-touch-icon">');
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.message).toBe('The "apple-touch-icon" keyword is not allowed');
+	});
+
+	test('allowMicroformats: true — <link rel="apple-touch-icon"> — allowed', async () => {
+		const { violations } = await mlRuleTest(rule, '<link rel="apple-touch-icon">', {
+			rule: {
+				options: { allowMicroformats: true },
+			},
+		});
+		expect(violations.length).toBe(0);
+	});
+
+	test('allowMicroformats: true — <a rel="disclosure"> — allowed (a-ok microformat)', async () => {
+		const { violations } = await mlRuleTest(rule, '<a rel="disclosure">link</a>', {
+			rule: {
+				options: { allowMicroformats: true },
+			},
+		});
+		expect(violations.length).toBe(0);
+	});
+
+	test('allowMicroformats: true — <link rel="disclosure"> — not allowed (link not ok)', async () => {
+		const { violations } = await mlRuleTest(rule, '<link rel="disclosure">', {
+			rule: {
+				options: { allowMicroformats: true },
+			},
+		});
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.message).toBe('The "disclosure" keyword is not allowed on the "link" element');
+	});
+
+	test('allowMicroformats: true — <link rel="ikon"> — not allowed (unregistered)', async () => {
+		const { violations } = await mlRuleTest(rule, '<link rel="ikon">', {
+			rule: {
+				options: { allowMicroformats: true },
+			},
+		});
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.message).toBe('The "ikon" keyword is not allowed');
+	});
+
+	test('allowMicroformats: true — <form rel="apple-touch-icon"> — rejected (microformats not on form)', async () => {
+		const { violations } = await mlRuleTest(rule, '<form rel="apple-touch-icon"></form>', {
+			rule: {
+				options: { allowMicroformats: true },
+			},
+		});
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.message).toBe('The "apple-touch-icon" keyword is not allowed on the "form" element');
+	});
+
+	test('allowMicroformats: ["apple-touch-icon"] — <link rel="apple-touch-icon"> — allowed', async () => {
+		const { violations } = await mlRuleTest(rule, '<link rel="apple-touch-icon">', {
+			rule: {
+				options: { allowMicroformats: ['apple-touch-icon'] },
+			},
+		});
+		expect(violations.length).toBe(0);
+	});
+
+	test('allowMicroformats: ["apple-touch-icon"] — <link rel="mask-icon"> — not allowed', async () => {
+		const { violations } = await mlRuleTest(rule, '<link rel="mask-icon">', {
+			rule: {
+				options: { allowMicroformats: ['apple-touch-icon'] },
+			},
+		});
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.message).toBe('The "mask-icon" keyword is not allowed');
+	});
+
+	test('allowMicroformats: ["disclosure"] — <link rel="disclosure"> — rejected (link not ok)', async () => {
+		const { violations } = await mlRuleTest(rule, '<link rel="disclosure">', {
+			rule: {
+				options: { allowMicroformats: ['disclosure'] },
+			},
+		});
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.message).toBe('The "disclosure" keyword is not allowed on the "link" element');
+	});
+
+	test('allowMicroformats: ["my-custom-rel"] — <link rel="my-custom-rel"> — allowed (custom keyword)', async () => {
+		const { violations } = await mlRuleTest(rule, '<link rel="my-custom-rel">', {
+			rule: {
+				options: { allowMicroformats: ['my-custom-rel'] },
+			},
+		});
+		expect(violations.length).toBe(0);
+	});
+});
+
+describe('Dropped/Rejected/Non-HTML', () => {
+	test('<link rel="banner"> — dropped', async () => {
+		const { violations } = await mlRuleTest(rule, '<link rel="banner">');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 12,
+				raw: 'banner',
+				message: '"banner" is dropped',
+			},
+		]);
+	});
+
+	test('<a rel="logo"> — rejected', async () => {
+		const { violations } = await mlRuleTest(rule, '<a rel="logo">link</a>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 9,
+				raw: 'logo',
+				message: '"logo" is rejected',
+			},
+		]);
+	});
+
+	test('<link rel="first"> — dropped without prejudice', async () => {
+		const { violations } = await mlRuleTest(rule, '<link rel="first">');
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.message).toBe('"first" is dropped');
+	});
+
+	test('<link rel="self"> — non-HTML rel value', async () => {
+		const { violations } = await mlRuleTest(rule, '<link rel="self">');
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.message).toBe('"self" is not allowed');
+	});
+});
+
+describe('Edge cases', () => {
+	test('<div rel="whatever"> — skip (non-target element)', async () => {
+		const { violations } = await mlRuleTest(rule, '<div rel="whatever"></div>');
+		expect(violations.length).toBe(0);
+	});
+
+	test('<a rel="NoOpener"> — case-insensitive', async () => {
+		const { violations } = await mlRuleTest(rule, '<a rel="NoOpener">link</a>');
+		expect(violations.length).toBe(0);
+	});
+
+	test('<a rel="noopener noreferrer"> — multiple keywords OK', async () => {
+		const { violations } = await mlRuleTest(rule, '<a rel="noopener noreferrer">link</a>');
+		expect(violations.length).toBe(0);
+	});
+
+	test('<a rel="noopener foobar"> — one error for unknown keyword', async () => {
+		const { violations } = await mlRuleTest(rule, '<a rel="noopener foobar">link</a>');
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.raw).toBe('foobar');
+		expect(violations[0]?.message).toBe('The "foobar" keyword is not allowed');
+	});
+
+	test('<link rel=""> — skip (empty)', async () => {
+		const { violations } = await mlRuleTest(rule, '<link rel="">');
+		expect(violations.length).toBe(0);
+	});
+
+	test('<link rel="  "> — skip (whitespace only)', async () => {
+		const { violations } = await mlRuleTest(rule, '<link rel="  ">');
+		expect(violations.length).toBe(0);
+	});
+});

--- a/packages/@markuplint/rules/src/link-types/index.ts
+++ b/packages/@markuplint/rules/src/link-types/index.ts
@@ -1,0 +1,245 @@
+import type { Element } from '@markuplint/ml-core';
+import type { Translator } from '@markuplint/i18n';
+
+import { createRule } from '@markuplint/ml-core';
+import {
+	DEF_LINK_TYPE_WHATWG,
+	ALLOWED_LINK_TYPE_MICROFORMATS,
+	DEF_LINK_TYPE_MICROFORMATS_DROPPED,
+	DEF_LINK_TYPE_MICROFORMATS_DROPPED_WITHOUT_PREJUDICE,
+	DEF_LINK_TYPE_MICROFORMATS_REJECTED,
+	DEF_LINK_TYPE_MICROFORMATS_NON_HTML_REL_VALUES,
+} from '@markuplint/types';
+
+import meta from './meta.js';
+
+type Options = {
+	readonly allowMicroformats?: boolean | readonly string[];
+};
+
+type ElementContext = 'link' | 'body-link' | 'a-area' | 'form';
+
+const TARGET_ELEMENTS = new Set(['link', 'a', 'area', 'form']);
+
+/**
+ * Rule that validates link type keywords in the `rel` attribute on
+ * `<link>`, `<a>`, `<area>`, and `<form>` elements against the WHATWG
+ * standard and optionally the Microformats registry.
+ */
+export default createRule<boolean, Options>({
+	meta: meta,
+	defaultOptions: {
+		allowMicroformats: false,
+	},
+	async verify({ document, report, t }) {
+		await document.walkOn('Element', el => {
+			if (!TARGET_ELEMENTS.has(el.localName)) {
+				return;
+			}
+
+			const relAttr = el.getAttributeNode('rel');
+			if (!relAttr) {
+				return;
+			}
+
+			if (relAttr.isDynamicValue) {
+				return;
+			}
+
+			const tokenList = relAttr.tokenList;
+			if (!tokenList || tokenList.length === 0) {
+				return;
+			}
+
+			const context = getElementContext(el);
+			if (!context) {
+				return;
+			}
+
+			const options = el.rule.options;
+
+			for (const tokenInfo of tokenList.allTokens()) {
+				const keyword = tokenInfo.raw;
+				const keywordLower = keyword.toLowerCase();
+
+				const message = validateKeyword(keywordLower, context, options, t);
+
+				if (message) {
+					report({
+						scope: el,
+						line: tokenInfo.startLine,
+						col: tokenInfo.startCol,
+						raw: keyword,
+						message,
+					});
+				}
+			}
+		});
+	},
+});
+
+function getElementContext(
+	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+	el: Element<boolean, Options>,
+): ElementContext | null {
+	const tagName = el.localName;
+
+	switch (tagName) {
+		case 'link': {
+			if (el.closest('body') !== null) {
+				return 'body-link';
+			}
+			return 'link';
+		}
+		case 'a':
+		case 'area': {
+			return 'a-area';
+		}
+		case 'form': {
+			return 'form';
+		}
+		default: {
+			return null;
+		}
+	}
+}
+
+function validateKeyword(
+	keyword: string,
+	context: ElementContext,
+
+	options: Options,
+	t: Translator,
+): string | null {
+	// Check WHATWG standard keywords
+	const whatwgDef = DEF_LINK_TYPE_WHATWG.find(def => def.keyword.toLowerCase() === keyword);
+	if (whatwgDef) {
+		return validateWhatwgKeyword(whatwgDef, context, t);
+	}
+
+	// Check dropped keywords
+	if (DEF_LINK_TYPE_MICROFORMATS_DROPPED.some(def => def.keyword.toLowerCase() === keyword)) {
+		return t('{0} is {1:c}', `"${keyword}"`, 'dropped');
+	}
+
+	// Check dropped without prejudice keywords
+	if (DEF_LINK_TYPE_MICROFORMATS_DROPPED_WITHOUT_PREJUDICE.some(def => def.keyword.toLowerCase() === keyword)) {
+		return t('{0} is {1:c}', `"${keyword}"`, 'dropped');
+	}
+
+	// Check rejected keywords
+	if (DEF_LINK_TYPE_MICROFORMATS_REJECTED.some(def => def.keyword.toLowerCase() === keyword)) {
+		return t('{0} is {1:c}', `"${keyword}"`, 'rejected');
+	}
+
+	// Check non-HTML rel values
+	if (DEF_LINK_TYPE_MICROFORMATS_NON_HTML_REL_VALUES.some(def => def.keyword.toLowerCase() === keyword)) {
+		return t('{0} is {1:c}', `"${keyword}"`, 'not allowed');
+	}
+
+	// Handle Microformats
+	const { allowMicroformats } = options;
+
+	if (allowMicroformats === false || allowMicroformats === undefined) {
+		return t('The "{0*}" {1} is {2:c}', keyword, 'keyword', 'not allowed');
+	}
+
+	if (allowMicroformats === true) {
+		return validateMicroformatKeyword(keyword, context, t);
+	}
+
+	// allowMicroformats is string[]
+	if (Array.isArray(allowMicroformats)) {
+		const isAllowed = allowMicroformats.some(allowed => allowed.toLowerCase() === keyword);
+		if (!isAllowed) {
+			return t('The "{0*}" {1} is {2:c}', keyword, 'keyword', 'not allowed');
+		}
+
+		// Even if in the allow list, check element context
+		const microDef = ALLOWED_LINK_TYPE_MICROFORMATS.find(def => def.keyword.toLowerCase() === keyword);
+		if (microDef) {
+			return validateMicroformatContext(microDef, context, t);
+		}
+
+		// Keyword is in the user's allow list but not in any registry — allow it
+		return null;
+	}
+
+	return null;
+}
+
+function validateWhatwgKeyword(
+	def: (typeof DEF_LINK_TYPE_WHATWG)[number],
+	context: ElementContext,
+	t: Translator,
+): string | null {
+	switch (context) {
+		case 'link': {
+			if (def.link === 'not allowed') {
+				return t('The "{0*}" {1} is not allowed on the {2}', def.keyword, 'keyword', '"link" element');
+			}
+			return null;
+		}
+		case 'body-link': {
+			if (def.link === 'not allowed') {
+				return t('The "{0*}" {1} is not allowed on the {2}', def.keyword, 'keyword', '"link" element');
+			}
+			if (def.bodyOk !== 'Yes') {
+				return t(
+					'The "{0*}" {1} is not allowed on the {2} inside the {3}',
+					def.keyword,
+					'keyword',
+					'"link" element',
+					'"body" element',
+				);
+			}
+			return null;
+		}
+		case 'a-area': {
+			if (def.a === 'not allowed') {
+				return t('The "{0*}" {1} is not allowed on the {2}', def.keyword, 'keyword', '"a" element');
+			}
+			return null;
+		}
+		case 'form': {
+			if (def.form === 'not allowed') {
+				return t('The "{0*}" {1} is not allowed on the {2}', def.keyword, 'keyword', '"form" element');
+			}
+			return null;
+		}
+	}
+}
+
+function validateMicroformatKeyword(keyword: string, context: ElementContext, t: Translator): string | null {
+	const microDef = ALLOWED_LINK_TYPE_MICROFORMATS.find(def => def.keyword.toLowerCase() === keyword);
+	if (!microDef) {
+		return t('The "{0*}" {1} is {2:c}', keyword, 'keyword', 'not allowed');
+	}
+	return validateMicroformatContext(microDef, context, t);
+}
+
+function validateMicroformatContext(
+	def: (typeof ALLOWED_LINK_TYPE_MICROFORMATS)[number],
+	context: ElementContext,
+	t: Translator,
+): string | null {
+	switch (context) {
+		case 'link':
+		case 'body-link': {
+			if (!def.link) {
+				return t('The "{0*}" {1} is not allowed on the {2}', def.keyword, 'keyword', '"link" element');
+			}
+			return null;
+		}
+		case 'a-area': {
+			if (!def.a) {
+				return t('The "{0*}" {1} is not allowed on the {2}', def.keyword, 'keyword', '"a" element');
+			}
+			return null;
+		}
+		case 'form': {
+			// Microformats don't define form context; reject
+			return t('The "{0*}" {1} is not allowed on the {2}', def.keyword, 'keyword', '"form" element');
+		}
+	}
+}

--- a/packages/@markuplint/rules/src/link-types/meta.ts
+++ b/packages/@markuplint/rules/src/link-types/meta.ts
@@ -1,0 +1,4 @@
+/** Rule metadata for the `link-types` rule, categorized as validation. */
+export default {
+	category: 'validation',
+} as const;

--- a/packages/@markuplint/rules/src/link-types/schema.json
+++ b/packages/@markuplint/rules/src/link-types/schema.json
@@ -1,0 +1,54 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"value": {
+			"type": "boolean",
+			"description": "Validates link type keywords in the `rel` attribute against the WHATWG standard and optionally the Microformats registry.",
+			"description:ja": "`rel`属性のリンクタイプキーワードをWHATWG標準およびオプションでMicroformatsレジストリに対して検証します。"
+		},
+		"options": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"allowMicroformats": {
+					"oneOf": [
+						{
+							"type": "boolean"
+						},
+						{
+							"type": "array",
+							"uniqueItems": true,
+							"minItems": 1,
+							"items": {
+								"type": "string"
+							}
+						}
+					],
+					"default": false,
+					"description": "Whether to allow Microformats link type keywords. `false` allows only WHATWG standard keywords. `true` allows all registered Microformats keywords. An array of strings allows only the specified keywords.",
+					"description:ja": "Microformatsのリンクタイプキーワードを許可するかどうか。`false`はWHATWG標準キーワードのみを許可します。`true`は登録済みのすべてのMicroformatsキーワードを許可します。文字列の配列は指定されたキーワードのみを許可します。"
+				}
+			}
+		}
+	},
+	"oneOf": [
+		{
+			"$ref": "#/definitions/value"
+		},
+		{
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"value": { "$ref": "#/definitions/value" },
+				"options": { "$ref": "#/definitions/options" },
+				"severity": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/ml-config/schema.json#/definitions/severity",
+					"default": "error"
+				},
+				"reason": {
+					"type": "string"
+				}
+			}
+		}
+	]
+}

--- a/packages/@markuplint/types/src/index.ts
+++ b/packages/@markuplint/types/src/index.ts
@@ -6,6 +6,7 @@
  */
 
 export * from './whatwg/is-custom-element-name.js';
+export * from './whatwg/check-link-type.js';
 export * from './check.js';
 export * from './check-base.js';
 export { getCandidate } from './get-candidate.js';

--- a/packages/@markuplint/types/src/whatwg/check-link-type.ts
+++ b/packages/@markuplint/types/src/whatwg/check-link-type.ts
@@ -3,7 +3,12 @@ import type { CustomSyntaxChecker } from '../types.js';
 import { checkList } from '../list.js';
 import { TokenCollection } from '../token/token-collection.js';
 
-type DefLinkTypeWhatwg = {
+/**
+ * A WHATWG-defined link type keyword with per-element context and body-ok flag.
+ *
+ * @see https://html.spec.whatwg.org/multipage/links.html#linkTypes
+ */
+export type DefLinkTypeWhatwg = {
 	readonly keyword: string;
 	readonly link: string;
 	readonly a: string;
@@ -11,13 +16,23 @@ type DefLinkTypeWhatwg = {
 	readonly bodyOk: string;
 };
 
-type DefLinkTypeMicroformats = {
+/**
+ * A Microformats-registered link type keyword with per-element context flags.
+ *
+ * @see https://microformats.org/wiki/existing-rel-values
+ */
+export type DefLinkTypeMicroformats = {
 	readonly keyword: string;
 	readonly link: boolean;
 	readonly a: boolean;
 };
 
-type DefLinkTypeMicroformatsDropped = {
+/**
+ * A dropped, rejected, or non-HTML link type keyword from the Microformats registry.
+ *
+ * @see https://microformats.org/wiki/existing-rel-values
+ */
+export type DefLinkTypeMicroformatsDropped = {
 	readonly keyword: string;
 };
 
@@ -36,7 +51,7 @@ type DefLinkTypeMicroformatsDropped = {
  * }));
  * ```
  */
-const DEF_LINK_TYPE_WHATWG: DefLinkTypeWhatwg[] = [
+export const DEF_LINK_TYPE_WHATWG: DefLinkTypeWhatwg[] = [
 	{ keyword: 'alternate', link: 'Hyperlink', a: 'Hyperlink', form: 'not allowed', bodyOk: '·' },
 	{ keyword: 'canonical', link: 'Hyperlink', a: 'not allowed', form: 'not allowed', bodyOk: '·' },
 	{ keyword: 'author', link: 'Hyperlink', a: 'Hyperlink', form: 'not allowed', bodyOk: '·' },
@@ -381,7 +396,7 @@ const DEF_LINK_TYPE_MICROFORMATS_DUBLIN_CORE: DefLinkTypeMicroformats[] = [
  *     return { keyword, link: true, a: true }
  * }));
  */
-const DEF_LINK_TYPE_MICROFORMATS_NON_HTML_REL_VALUES: DefLinkTypeMicroformatsDropped[] = [
+export const DEF_LINK_TYPE_MICROFORMATS_NON_HTML_REL_VALUES: DefLinkTypeMicroformatsDropped[] = [
 	{ keyword: 'self' },
 	{ keyword: 'http://gdata.youtube.com/schemas/2007#in-reply-to' },
 	{ keyword: 'collection' },
@@ -423,7 +438,7 @@ const DEF_LINK_TYPE_MICROFORMATS_NON_HTML_REL_VALUES: DefLinkTypeMicroformatsDro
  *     return { keyword }
  * }));
  */
-const DEF_LINK_TYPE_MICROFORMATS_DROPPED: DefLinkTypeMicroformatsDropped[] = [
+export const DEF_LINK_TYPE_MICROFORMATS_DROPPED: DefLinkTypeMicroformatsDropped[] = [
 	{ keyword: 'banner' },
 	{ keyword: 'begin' },
 	{ keyword: 'biblioentry' }, // cspell:disable-line
@@ -460,7 +475,7 @@ const DEF_LINK_TYPE_MICROFORMATS_DROPPED: DefLinkTypeMicroformatsDropped[] = [
  * }));
  * ```
  */
-const DEF_LINK_TYPE_MICROFORMATS_DROPPED_WITHOUT_PREJUDICE: DefLinkTypeMicroformatsDropped[] = [
+export const DEF_LINK_TYPE_MICROFORMATS_DROPPED_WITHOUT_PREJUDICE: DefLinkTypeMicroformatsDropped[] = [
 	{ keyword: 'first' },
 	{ keyword: 'index' },
 	{ keyword: 'last' },
@@ -479,12 +494,18 @@ const DEF_LINK_TYPE_MICROFORMATS_DROPPED_WITHOUT_PREJUDICE: DefLinkTypeMicroform
  * }));
  * ```
  */
-const DEF_LINK_TYPE_MICROFORMATS_REJECTED: DefLinkTypeMicroformatsDropped[] = [
+export const DEF_LINK_TYPE_MICROFORMATS_REJECTED: DefLinkTypeMicroformatsDropped[] = [
 	{ keyword: 'logo' },
 	{ keyword: 'pavatar' }, // cspell:disable-line
 ];
 
-const ALLOWED_LINK_TYPE_MICROFORMATS = [
+/**
+ * Combined list of all allowed Microformats link type keywords,
+ * excluding any that overlap with WHATWG standard keywords.
+ *
+ * @see https://microformats.org/wiki/existing-rel-values
+ */
+export const ALLOWED_LINK_TYPE_MICROFORMATS = [
 	...DEF_LINK_TYPE_MICROFORMATS_FORMATS,
 	...DEF_LINK_TYPE_MICROFORMATS_PROPOSALS,
 	...DEF_LINK_TYPE_MICROFORMATS_HTML5_LINK_TYPE_EXTENSIONS,

--- a/packages/markuplint/src/cli/init/get-default-rules.spec.ts
+++ b/packages/markuplint/src/cli/init/get-default-rules.spec.ts
@@ -77,6 +77,10 @@ test('default-rules', () => {
 			category: 'a11y',
 			defaultValue: false,
 		},
+		'link-types': {
+			category: 'validation',
+			defaultValue: true,
+		},
 		'neighbor-popovers': {
 			category: 'a11y',
 			defaultValue: true,


### PR DESCRIPTION
## Summary

Closes #719, Closes #1511

- Add new `link-types` rule that validates `rel` attribute keywords on `<link>`, `<a>`, `<area>`, and `<form>` elements against the [WHATWG standard](https://html.spec.whatwg.org/multipage/links.html#linkTypes)
- Check body-ok constraints for `<link>` elements inside `<body>` (only `dns-prefetch`, `modulepreload`, `pingback`, `preconnect`, `prefetch`, `preload`, `stylesheet` are allowed)
- Detect dropped, rejected, and non-HTML keywords from the [Microformats registry](https://microformats.org/wiki/existing-rel-values)
- Add `allowMicroformats` option (`boolean | string[]`) to control Microformats keyword acceptance
- Include the rule in the `html-standard` preset with `allowMicroformats: true`

### `allowMicroformats` option

| Value | Behavior |
|-------|----------|
| `false` (default) | Only WHATWG standard keywords allowed |
| `true` | WHATWG + all registered Microformats keywords allowed (element context enforced) |
| `string[]` | WHATWG + specified keywords only (supports custom unregistered keywords) |

### Packages changed

| Package | Change |
|---------|--------|
| `@markuplint/types` | Export link type data arrays and types |
| `@markuplint/rules` | New `link-types` rule with 35 tests |
| `@markuplint/config-presets` | Add rule to `html-standard` preset |
| `markuplint` | Update `get-default-rules` snapshot |

## Test plan

- [x] 35 unit tests covering element context, body-ok, fragment mode, Microformats control, dropped/rejected/non-HTML keywords, and edge cases
- [x] Full test suite passes (2399 tests)
- [x] `yarn lint-check` passes (0 errors, 0 warnings)
- [x] `yarn build` succeeds for all 40 packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)