### PR TITLE
fix(github): use local vitest instead of npm: specifier in Deno CI

### DIFF
--- a/.github/workflows/test-deno.yml
+++ b/.github/workflows/test-deno.yml
@@ -159,4 +159,4 @@ jobs:
               run: deno --version
 
             - name: Test with Deno
-              run: deno run -A --node-modules-dir npm:vitest run
+              run: deno run -A --unstable-detect-cjs node_modules/vitest/vitest.mjs run

--- a/cspell.json
+++ b/cspell.json
@@ -35,6 +35,7 @@
 		"bday",
 		"bunx",
 		"deno",
+		"denoland",
 		"biblioentry",
 		"biblioref",
 		"checkings",


### PR DESCRIPTION
## Summary

- Replace `deno run -A --node-modules-dir npm:vitest run` with `deno run -A --unstable-detect-cjs node_modules/vitest/vitest.mjs run` in the Deno CI workflow
- Add "denoland" to cspell dictionary

## Root Cause

The `npm:vitest` specifier caused Deno to resolve **all** `@markuplint/*` dependencies from the npm registry into `node_modules/.deno/`, bypassing Yarn workspace symlinks. This resulted in stale published versions being used (e.g., `html-spec@4.15.0` from npm instead of `4.17.0` from workspace), causing **202 test failures**.

## Fix

- **Use local vitest directly** (`node_modules/vitest/vitest.mjs`) so Deno uses the workspace-resolved packages
- **Add `--unstable-detect-cjs`** flag to properly handle CJS modules (e.g., `@markuplint/html-spec/index.js`)

## Local Verification

Full Deno test suite passes locally:
- 159 test files
- 2372 tests passed
- 0 failures

## Test plan

- [ ] Verify Deno CI job passes on this PR
- [ ] Confirm all 159 test files pass in Deno environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)