### PR TITLE
refactor: rename useIDLAttributeNames to acceptedAttrNames and add contenteditable inherit support

### DIFF
--- a/packages/@markuplint/jsx-parser/ARCHITECTURE.ja.md
+++ b/packages/@markuplint/jsx-parser/ARCHITECTURE.ja.md
@@ -255,7 +255,7 @@ JSX を返す `.map()` 呼び出し（例: `{items.map(item => <li>{item}</li>)}
 
 ### IDL 属性マッピング
 
-IDL-コンテンツ属性マッピング（例: `className` -> `class`、`htmlFor` -> `for`）はパーサーでは**行いません**。代わりに、ペアとなる spec（`@markuplint/react-spec`）が `useIDLAttributeNames: true` を設定している場合に、`@markuplint/ml-core` の `MLAttr` コンストラクタでコアレベルで宣言的に処理されます。詳細は [MLAttr ドキュメント](../../ml-core/docs/ml-dom/attr.ja.md)を参照してください。
+IDL-コンテンツ属性マッピング（例: `className` -> `class`、`htmlFor` -> `for`）はパーサーでは**行いません**。代わりに、ペアとなる spec（`@markuplint/react-spec`）が `acceptedAttrNames: 'idl'` を設定している場合に、`@markuplint/ml-core` の `MLAttr` コンストラクタでコアレベルで宣言的に処理されます。詳細は [MLAttr ドキュメント](../../ml-core/docs/ml-dom/attr.ja.md)を参照してください。
 
 ### 動的値フラグ
 

--- a/packages/@markuplint/jsx-parser/ARCHITECTURE.md
+++ b/packages/@markuplint/jsx-parser/ARCHITECTURE.md
@@ -337,7 +337,7 @@ When the attribute value is wrapped in `{}`, the `attrParser` function is invoke
 
 ### IDL Attribute Mapping
 
-IDL-to-content attribute mapping (e.g., `className` -> `class`, `htmlFor` -> `for`) is **not** performed by the parser. Instead, it is handled declaratively at the core level by `@markuplint/ml-core`'s `MLAttr` constructor when the paired spec (`@markuplint/react-spec`) sets `useIDLAttributeNames: true`. See the [MLAttr documentation](../../ml-core/docs/ml-dom/attr.md) for details.
+IDL-to-content attribute mapping (e.g., `className` -> `class`, `htmlFor` -> `for`) is **not** performed by the parser. Instead, it is handled declaratively at the core level by `@markuplint/ml-core`'s `MLAttr` constructor when the paired spec (`@markuplint/react-spec`) sets `acceptedAttrNames: 'idl'`. See the [MLAttr documentation](../../ml-core/docs/ml-dom/attr.md) for details.
 
 ### Dynamic Value Flag
 

--- a/packages/@markuplint/jsx-parser/SKILL.md
+++ b/packages/@markuplint/jsx-parser/SKILL.md
@@ -42,7 +42,7 @@ Add a new IDL-to-content attribute mapping for JSX. Follow recipe #1 in `docs/ma
 1. Read `@markuplint/parser-utils/src/idl-attributes.ts`
 2. Add the new entry to the `idlContentMap` object (key = IDL property name, value = content attribute name)
 3. The `searchIDLAttribute()` function will automatically pick up the new mapping
-4. IDL attribute resolution is performed at the core level by `MLAttr` when `@markuplint/react-spec` sets `useIDLAttributeNames: true`
+4. IDL attribute resolution is performed at the core level by `MLAttr` when `@markuplint/react-spec` sets `acceptedAttrNames: 'idl'`
 
 ### Step 2: Verify
 
@@ -97,7 +97,7 @@ Modify the element type detection regex. Follow recipe #3 in `docs/maintenance.m
 ## Rules
 
 1. **Use `@typescript-eslint/typescript-estree` for parsing** -- never use a custom JSX parser or regex-based approach.
-2. **IDL attribute mapping is a core-level concern** -- IDL-to-content attribute mappings are resolved by `MLAttr` in `@markuplint/ml-core` when the paired spec sets `useIDLAttributeNames: true`. The mappings themselves live in `@markuplint/parser-utils`.
+2. **IDL attribute mapping is a core-level concern** -- IDL-to-content attribute mappings are resolved by `MLAttr` in `@markuplint/ml-core` when the paired spec sets `acceptedAttrNames: 'idl'`. The mappings themselves live in `@markuplint/parser-utils`.
 3. **Test with `nodeListToDebugMaps`** -- all integration tests use this pattern for snapshot-style assertions.
 4. **Handle all AST node types exhaustively** -- `recursiveSearchJSXElements()` must handle every `AST_NODE_TYPES` value; unhandled types throw `'Unsupported node'`.
 5. **Preserve `#parentIdMap` tracking** -- every nodeize branch must register created nodes in the WeakMap for correct parent-child rebuilding.

--- a/packages/@markuplint/jsx-parser/docs/maintenance.ja.md
+++ b/packages/@markuplint/jsx-parser/docs/maintenance.ja.md
@@ -147,7 +147,7 @@ yarn test --scope @markuplint/jsx-parser
 
 **症状:** `className` のような JSX 属性が AST 出力で `potentialName: class` を取得しない。
 
-**原因:** 属性が `@markuplint/parser-utils/src/idl-attributes.ts` の `idlContentMap` にない、または `@markuplint/react-spec` が `useIDLAttributeNames: true` を設定していない。
+**原因:** 属性が `@markuplint/parser-utils/src/idl-attributes.ts` の `idlContentMap` にない、または `@markuplint/react-spec` が `acceptedAttrNames: 'idl'` を設定していない。
 
 **解決策:**
 

--- a/packages/@markuplint/jsx-parser/docs/maintenance.md
+++ b/packages/@markuplint/jsx-parser/docs/maintenance.md
@@ -147,7 +147,7 @@ yarn test --scope @markuplint/jsx-parser
 
 **Symptom:** A JSX attribute like `className` does not get `potentialName: class` in the AST output.
 
-**Cause:** The attribute is not in the `idlContentMap` in `@markuplint/parser-utils/src/idl-attributes.ts`, or `@markuplint/react-spec` does not set `useIDLAttributeNames: true`.
+**Cause:** The attribute is not in the `idlContentMap` in `@markuplint/parser-utils/src/idl-attributes.ts`, or `@markuplint/react-spec` does not set `acceptedAttrNames: 'idl'`.
 
 **Solution:**
 

--- a/packages/@markuplint/jsx-parser/src/parser.ts
+++ b/packages/@markuplint/jsx-parser/src/parser.ts
@@ -282,7 +282,7 @@ class JSXParser extends Parser<JSXNode, State> {
 	/**
 	 * Visits an attribute token, handling JSX-specific quoting (curly braces for expressions)
 	 * and dynamic value detection. IDL attribute name mapping is now handled declaratively
-	 * by react-spec's useIDLAttributeNames and ml-core's attr resolution.
+	 * by react-spec's acceptedAttrNames and ml-core's attr resolution.
 	 *
 	 * @param token - The token representing the attribute
 	 * @returns The parsed attribute node

--- a/packages/@markuplint/mdx-parser/ARCHITECTURE.md
+++ b/packages/@markuplint/mdx-parser/ARCHITECTURE.md
@@ -132,7 +132,7 @@ The start tag is parsed by `parseCodeFragment` to extract attributes, then `visi
 | Boolean (no value) | `disabled`                 | Empty value (booleanish) |
 | Spread             | `{...props}`               | `type: 'spread'`         |
 
-IDL attribute mapping (`className` -> `class`, `htmlFor` -> `for`) is handled at the core level by `MLAttr` when paired with `@markuplint/react-spec` (which sets `useIDLAttributeNames: true`).
+IDL attribute mapping (`className` -> `class`, `htmlFor` -> `for`) is handled at the core level by `MLAttr` when paired with `@markuplint/react-spec` (which sets `acceptedAttrNames: 'idl'`).
 
 ### Component Detection
 

--- a/packages/@markuplint/mdx-parser/src/index.spec.ts
+++ b/packages/@markuplint/mdx-parser/src/index.spec.ts
@@ -752,7 +752,7 @@ describe('MDXParser', () => {
 			expect(div).toBeDefined();
 			const attr = div!.attributes.find(a => a.type === 'attr' && a.name.raw === 'className');
 			expect(attr).toBeDefined();
-			// potentialName is not set by the parser; IDL resolution is handled by ml-core's useIDLAttributeNames
+			// potentialName is not set by the parser; IDL resolution is handled by ml-core's acceptedAttrNames
 			expect(attr!.potentialName).toBeUndefined();
 		});
 
@@ -762,7 +762,7 @@ describe('MDXParser', () => {
 			expect(label).toBeDefined();
 			const attr = label!.attributes.find(a => a.type === 'attr' && a.name.raw === 'htmlFor');
 			expect(attr).toBeDefined();
-			// potentialName is not set by the parser; IDL resolution is handled by ml-core's useIDLAttributeNames
+			// potentialName is not set by the parser; IDL resolution is handled by ml-core's acceptedAttrNames
 			expect(attr!.potentialName).toBeUndefined();
 		});
 
@@ -772,7 +772,7 @@ describe('MDXParser', () => {
 			expect(div).toBeDefined();
 			const attr = div!.attributes.find(a => a.type === 'attr' && a.name.raw === 'class');
 			expect(attr).toBeDefined();
-			// candidate is not set by the parser; IDL resolution is handled by ml-core's useIDLAttributeNames
+			// candidate is not set by the parser; IDL resolution is handled by ml-core's acceptedAttrNames
 			expect(attr!.candidate).toBeUndefined();
 		});
 	});

--- a/packages/@markuplint/mdx-parser/src/parser.ts
+++ b/packages/@markuplint/mdx-parser/src/parser.ts
@@ -143,7 +143,7 @@ class MDXParser extends MarkdownAwareParser {
 	/**
 	 * Processes a JSX attribute token with dynamic value detection.
 	 * IDL attribute name mapping is now handled declaratively by the spec's
-	 * useIDLAttributeNames and ml-core's attr resolution.
+	 * acceptedAttrNames and ml-core's attr resolution.
 	 *
 	 * @param token - The raw attribute token from the source.
 	 * @returns The processed attribute node.

--- a/packages/@markuplint/ml-core/docs/ml-dom/attr.ja.md
+++ b/packages/@markuplint/ml-core/docs/ml-dom/attr.ja.md
@@ -30,7 +30,7 @@
 
 ### IDL 属性名解決
 
-ディレクティブパターン解決の後、spec が `useIDLAttributeNames: true` を設定しており（例: `@markuplint/react-spec`、`@markuplint/svelte-spec`）、属性がディレクティブでない場合、コンストラクタは `@markuplint/parser-utils` の `searchIDLAttribute()` を呼び出して IDL プロパティ名を HTML コンテンツ属性名にマッピングします（例: `className` → `class`、`htmlFor` → `for`）。これはパーサーレベルではなくコアレベルの関心事です。
+ディレクティブパターン解決の後、spec が `acceptedAttrNames` を設定しており（例: `@markuplint/react-spec` では `'idl'`、`@markuplint/svelte-spec` では `'both'`）、属性がディレクティブでない場合、コンストラクタは `@markuplint/parser-utils` の `searchIDLAttribute()` を呼び出して IDL プロパティ名を HTML コンテンツ属性名にマッピングします（例: `className` → `class`、`htmlFor` → `for`）。`'idl'` モードでは、IDL プロパティ名が候補として設定されます（例: `tabindex` → 「`tabIndex` の間違いでは？」）。`'both'` モードでは、コンテンツ名と IDL 名の両方が候補提案なしで受け入れられます。これはパーサーレベルではなくコアレベルの関心事です。
 
 ## トークン分解
 

--- a/packages/@markuplint/ml-core/docs/ml-dom/attr.md
+++ b/packages/@markuplint/ml-core/docs/ml-dom/attr.md
@@ -30,7 +30,7 @@ When `astToken.potentialName` is not set by the parser, the `MLAttr` constructor
 
 ### IDL Attribute Name Resolution
 
-After directive pattern resolution, if the spec sets `useIDLAttributeNames: true` (e.g., `@markuplint/react-spec`, `@markuplint/svelte-spec`) and the attribute is not a directive, the constructor calls `searchIDLAttribute()` from `@markuplint/parser-utils` to map IDL property names to HTML content attribute names (e.g., `className` -> `class`, `htmlFor` -> `for`). This is a core-level concern, not a parser-level one.
+After directive pattern resolution, if the spec sets `acceptedAttrNames` (e.g., `'idl'` in `@markuplint/react-spec`, `'both'` in `@markuplint/svelte-spec`) and the attribute is not a directive, the constructor calls `searchIDLAttribute()` from `@markuplint/parser-utils` to map IDL property names to HTML content attribute names (e.g., `className` -> `class`, `htmlFor` -> `for`). In `'idl'` mode, the IDL property name is set as a candidate for suggestion (e.g., `tabindex` -> "Did you mean `tabIndex`?"). In `'both'` mode, both content and IDL names are accepted without suggestions. This is a core-level concern, not a parser-level one.
 
 ## Token Decomposition
 

--- a/packages/@markuplint/ml-core/src/index.spec.ts
+++ b/packages/@markuplint/ml-core/src/index.spec.ts
@@ -151,6 +151,22 @@ describe('AST', () => {
 		).toBeUndefined();
 	});
 
+	test('IDL attribute candidate in idl mode vs both mode', async () => {
+		// In 'idl' mode, using content name suggests the IDL name
+		const idlEl = createTestElement('<div tabindex="0"></div>', {
+			parser: await import('@markuplint/jsx-parser'),
+			specs: { ...specs, acceptedAttrNames: 'idl' },
+		});
+		expect(idlEl.getAttributeNode('tabindex')?.candidate).toBe('tabIndex');
+
+		// In 'both' mode, no candidate is set (both names are accepted)
+		const bothEl = createTestElement('<div tabindex="0"></div>', {
+			parser: await import('@markuplint/jsx-parser'),
+			specs: { ...specs, acceptedAttrNames: 'both' },
+		});
+		expect(bothEl.getAttributeNode('tabindex')?.candidate).toBeUndefined();
+	});
+
 	test('rule', () => {
 		const document = createTestDocument('<div><span>text</span></div>', {
 			config: {

--- a/packages/@markuplint/ml-core/src/index.spec.ts
+++ b/packages/@markuplint/ml-core/src/index.spec.ts
@@ -134,19 +134,19 @@ describe('AST', () => {
 		expect(
 			createTestElement('<label></label>', {
 				parser: await import('@markuplint/jsx-parser'),
-				specs: { ...specs, useIDLAttributeNames: true },
+				specs: { ...specs, acceptedAttrNames: 'idl' },
 			}).getAttributeNode('for')?.localName,
 		).toBeUndefined();
 		expect(
 			createTestElement('<label htmlFor></label>', {
 				parser: await import('@markuplint/jsx-parser'),
-				specs: { ...specs, useIDLAttributeNames: true },
+				specs: { ...specs, acceptedAttrNames: 'idl' },
 			}).getAttributeNode('for')?.localName,
 		).toBe('for');
 		expect(
 			createTestElement('<label htmlFor></label>', {
 				parser: await import('@markuplint/jsx-parser'),
-				specs: { ...specs, useIDLAttributeNames: true },
+				specs: { ...specs, acceptedAttrNames: 'idl' },
 			}).getAttributeNode('htmlFor')?.localName,
 		).toBeUndefined();
 	});
@@ -233,14 +233,14 @@ div#hoge.foo.bar
 		expect(
 			createTestElement('<div tabIndex className><label htmlFor></label></div>', {
 				parser: await import('@markuplint/jsx-parser'),
-				specs: { ...specs, useIDLAttributeNames: true },
+				specs: { ...specs, acceptedAttrNames: 'idl' },
 			}).matches('[tabindex][class]:has(>label[for])'),
 		).toBeTruthy();
 
 		expect(
 			createTestElement('<svg><image clipPath /></svg>', {
 				parser: await import('@markuplint/jsx-parser'),
-				specs: { ...specs, useIDLAttributeNames: true },
+				specs: { ...specs, acceptedAttrNames: 'idl' },
 			}).matches('svg:has(>image[clip-path])'),
 		).toBeTruthy();
 	});
@@ -581,7 +581,7 @@ describe('Rule', () => {
 					],
 				},
 				parser: await import('@markuplint/jsx-parser'),
-				specs: { ...specs, useIDLAttributeNames: true },
+				specs: { ...specs, acceptedAttrNames: 'idl' },
 			},
 		);
 		const ruleA = createRule({

--- a/packages/@markuplint/ml-core/src/ml-dom/node/attr.ts
+++ b/packages/@markuplint/ml-core/src/ml-dom/node/attr.ts
@@ -163,14 +163,14 @@ export class MLAttr<T extends RuleConfigValue, O extends PlainData = undefined>
 			}
 
 			// IDL attribute resolution (after directivePatterns)
-			if (ownElement.ownerMLDocument.specs.useIDLAttributeNames && !this.isDirective) {
+			if (ownElement.ownerMLDocument.specs.acceptedAttrNames && !this.isDirective) {
 				const { contentAttrName, idlPropName } = searchIDLAttribute(this.#potentialName);
 				if (contentAttrName && contentAttrName !== this.#potentialName) {
 					this.#potentialName = contentAttrName;
 				}
 				// Set candidate for IDL naming suggestions (e.g., tabindex → tabIndex in JSX).
-				// Only when no directive pattern transformed the name.
-				if (!resolution && idlPropName) {
+				// Only in 'idl' mode (React). In 'both' mode (Svelte), both content and IDL names are accepted.
+				if (!resolution && idlPropName && ownElement.ownerMLDocument.specs.acceptedAttrNames === 'idl') {
 					const rawName = this.nameNode?.raw ?? '';
 					if (rawName !== idlPropName) {
 						this.candidate = idlPropName;

--- a/packages/@markuplint/ml-spec/docs/spec-resolution.ja.md
+++ b/packages/@markuplint/ml-spec/docs/spec-resolution.ja.md
@@ -155,21 +155,28 @@ result.directivePatterns = [...(result.directivePatterns ?? []), ...extendedSpec
 （最初のマッチが優先）。そのため、フレームワーク spec はパターンを
 最も具体的なものから最も一般的なものの順で定義する必要があります。
 
-#### 6. `useIDLAttributeNames`
+#### 6. `acceptedAttrNames`
 
-拡張仕様が `useIDLAttributeNames` を明示的に設定している場合（`true` または
-`false`）、現在の値を上書きします：
+拡張仕様が `acceptedAttrNames` を明示的に設定している場合、
+現在の値を上書きします：
 
 ```ts
-if (extendedSpec.useIDLAttributeNames != null) {
-  result.useIDLAttributeNames = extendedSpec.useIDLAttributeNames;
+if (extendedSpec.acceptedAttrNames != null) {
+  result.acceptedAttrNames = extendedSpec.acceptedAttrNames;
 }
 ```
 
 これは明示的な `null` ガード付きの last-write-wins セマンティクスです。
 プロパティを省略しても以前に設定された値はリセットされません。
-このフラグは `@markuplint/ml-core` の `MLAttr` コンストラクタで使用され、
-IDL-コンテンツ属性名解決（例: `className` → `class`）を有効化します。
+この値は `@markuplint/ml-core` の `MLAttr` コンストラクタで使用され、
+属性名の解決方法を制御します：
+
+- `'idl'` -- IDL-コンテンツ属性名解決を有効化（例: `className` → `class`）し、
+  コンテンツ属性名が使用された場合にIDL名を候補として提案します
+  （例: `tabindex` → 「`tabIndex` の間違いでは？」）。Reactで使用されます。
+- `'both'` -- IDL-コンテンツ属性名解決を有効化しますが、IDL名を候補として
+  提案**しません**。コンテンツ属性名（例: `class`）とIDLプロパティ名
+  （例: `className`）の両方が警告なしで受け入れられます。Svelteで使用されます。
 
 #### 7. 要素仕様
 

--- a/packages/@markuplint/ml-spec/docs/spec-resolution.md
+++ b/packages/@markuplint/ml-spec/docs/spec-resolution.md
@@ -160,21 +160,29 @@ This is simple array concatenation. The core engine evaluates patterns in order
 (first match wins), so framework specs should define their patterns from most
 specific to most general.
 
-#### 6. `useIDLAttributeNames`
+#### 6. `acceptedAttrNames`
 
-If the extended spec explicitly sets `useIDLAttributeNames` (to `true` or
-`false`), it overrides the current value:
+If the extended spec explicitly sets `acceptedAttrNames`, it overrides the
+current value:
 
 ```ts
-if (extendedSpec.useIDLAttributeNames != null) {
-  result.useIDLAttributeNames = extendedSpec.useIDLAttributeNames;
+if (extendedSpec.acceptedAttrNames != null) {
+  result.acceptedAttrNames = extendedSpec.acceptedAttrNames;
 }
 ```
 
 This is a last-write-wins semantic with explicit `null` guard -- omitting the
-property does not reset a previously set value. This flag is consumed by
-`@markuplint/ml-core`'s `MLAttr` constructor to enable IDL-to-content attribute
-name resolution (e.g., `className` -> `class`).
+property does not reset a previously set value. The value controls how
+`@markuplint/ml-core`'s `MLAttr` constructor resolves attribute names:
+
+- `'idl'` -- Enables IDL-to-content attribute name resolution (e.g.,
+  `className` -> `class`) and suggests IDL names as candidates when the
+  content attribute name is used (e.g., `tabindex` -> "Did you mean
+  `tabIndex`?"). Used by React, where only IDL property names are accepted.
+- `'both'` -- Enables IDL-to-content attribute name resolution but does
+  **not** suggest IDL names as candidates. Both content attribute names
+  (e.g., `class`) and IDL property names (e.g., `className`) are accepted
+  without warnings. Used by Svelte.
 
 #### 7. Element Specs
 

--- a/packages/@markuplint/ml-spec/src/types/index.ts
+++ b/packages/@markuplint/ml-spec/src/types/index.ts
@@ -13,7 +13,7 @@ export interface MLMLSpec {
 	readonly def: SpecDefs;
 	readonly specs: readonly ElementSpec[];
 	readonly directivePatterns?: readonly DirectivePattern[];
-	readonly useIDLAttributeNames?: boolean;
+	readonly acceptedAttrNames?: 'idl' | 'both';
 }
 
 /**
@@ -35,7 +35,7 @@ export type ExtendedSpec = {
 	readonly def?: Partial<SpecDefs>;
 	readonly specs?: readonly ExtendedElementSpec[];
 	readonly directivePatterns?: readonly DirectivePattern[];
-	readonly useIDLAttributeNames?: boolean;
+	readonly acceptedAttrNames?: 'idl' | 'both';
 };
 
 /**

--- a/packages/@markuplint/ml-spec/src/utils/schema-to-spec.spec.ts
+++ b/packages/@markuplint/ml-spec/src/utils/schema-to-spec.spec.ts
@@ -60,24 +60,29 @@ describe('schemaToSpec', () => {
 		expect(mergedSpec.directivePatterns ?? []).toStrictEqual([]);
 	});
 
-	test('useIDLAttributeNames defaults to undefined', () => {
+	test('acceptedAttrNames defaults to undefined', () => {
 		const mergedSpec = schemaToSpec([htmlSpec]);
-		expect(mergedSpec.useIDLAttributeNames).toBeUndefined();
+		expect(mergedSpec.acceptedAttrNames).toBeUndefined();
 	});
 
-	test('useIDLAttributeNames can be set to true', () => {
-		const mergedSpec = schemaToSpec([htmlSpec, { useIDLAttributeNames: true }]);
-		expect(mergedSpec.useIDLAttributeNames).toBe(true);
+	test('acceptedAttrNames can be set to idl', () => {
+		const mergedSpec = schemaToSpec([htmlSpec, { acceptedAttrNames: 'idl' }]);
+		expect(mergedSpec.acceptedAttrNames).toBe('idl');
 	});
 
-	test('useIDLAttributeNames=false overrides previous true', () => {
-		const mergedSpec = schemaToSpec([htmlSpec, { useIDLAttributeNames: true }, { useIDLAttributeNames: false }]);
-		expect(mergedSpec.useIDLAttributeNames).toBe(false);
+	test('acceptedAttrNames can be set to both', () => {
+		const mergedSpec = schemaToSpec([htmlSpec, { acceptedAttrNames: 'both' }]);
+		expect(mergedSpec.acceptedAttrNames).toBe('both');
 	});
 
-	test('useIDLAttributeNames is not overridden when omitted', () => {
-		const mergedSpec = schemaToSpec([htmlSpec, { useIDLAttributeNames: true }, { specs: [] }]);
-		expect(mergedSpec.useIDLAttributeNames).toBe(true);
+	test('acceptedAttrNames is overridden by later spec', () => {
+		const mergedSpec = schemaToSpec([htmlSpec, { acceptedAttrNames: 'idl' }, { acceptedAttrNames: 'both' }]);
+		expect(mergedSpec.acceptedAttrNames).toBe('both');
+	});
+
+	test('acceptedAttrNames is not overridden when omitted', () => {
+		const mergedSpec = schemaToSpec([htmlSpec, { acceptedAttrNames: 'idl' }, { specs: [] }]);
+		expect(mergedSpec.acceptedAttrNames).toBe('idl');
 	});
 
 	test('globalAttrs.extends', () => {

--- a/packages/@markuplint/ml-spec/src/utils/schema-to-spec.ts
+++ b/packages/@markuplint/ml-spec/src/utils/schema-to-spec.ts
@@ -89,8 +89,8 @@ export function schemaToSpec(schemas: readonly [MLMLSpec, ...ExtendedSpec[]]) {
 		if (extendedSpec.directivePatterns) {
 			result.directivePatterns = [...(result.directivePatterns ?? []), ...extendedSpec.directivePatterns];
 		}
-		if (extendedSpec.useIDLAttributeNames != null) {
-			result.useIDLAttributeNames = extendedSpec.useIDLAttributeNames;
+		if (extendedSpec.acceptedAttrNames != null) {
+			result.acceptedAttrNames = extendedSpec.acceptedAttrNames;
 		}
 		if (extendedSpec.specs) {
 			const exSpecs = [...extendedSpec.specs];

--- a/packages/@markuplint/parser-utils/ARCHITECTURE.ja.md
+++ b/packages/@markuplint/parser-utils/ARCHITECTURE.ja.md
@@ -148,7 +148,7 @@ ParserError (基底クラス)
 
 ## IDL 属性マッピング
 
-`searchIDLAttribute` は React スタイルの IDL 属性名と HTML コンテンツ属性名の双方向マッピングを提供します（例: `className` → `class`、`htmlFor` → `for`）。spec が `useIDLAttributeNames: true` を設定している場合に、`@markuplint/ml-core` の `MLAttr` コンストラクタから呼び出されます。
+`searchIDLAttribute` は React スタイルの IDL 属性名と HTML コンテンツ属性名の双方向マッピングを提供します（例: `className` → `class`、`htmlFor` → `for`）。spec が `acceptedAttrNames`（`'idl'` または `'both'`）を設定している場合に、`@markuplint/ml-core` の `MLAttr` コンストラクタから呼び出されます。
 
 ## 外部依存
 

--- a/packages/@markuplint/parser-utils/ARCHITECTURE.md
+++ b/packages/@markuplint/parser-utils/ARCHITECTURE.md
@@ -174,7 +174,7 @@ Additionally, `debug.ts` provides `PerformanceTimer` for measuring parse phase d
 
 ## IDL Attribute Mapping
 
-`searchIDLAttribute` maps between React-style IDL attribute names and HTML content attribute names. It is called by `@markuplint/ml-core`'s `MLAttr` constructor when the spec sets `useIDLAttributeNames: true`. It maintains a comprehensive mapping table derived from React's `possibleStandardNames.js`, covering:
+`searchIDLAttribute` maps between React-style IDL attribute names and HTML content attribute names. It is called by `@markuplint/ml-core`'s `MLAttr` constructor when the spec sets `acceptedAttrNames` (either `'idl'` or `'both'`). It maintains a comprehensive mapping table derived from React's `possibleStandardNames.js`, covering:
 
 - HTML attributes (e.g., `className` -> `class`, `htmlFor` -> `for`, `tabIndex` -> `tabindex`)
 - SVG attributes (e.g., `strokeWidth` -> `stroke-width`, `clipPath` -> `clip-path`)

--- a/packages/@markuplint/react-spec/ARCHITECTURE.ja.md
+++ b/packages/@markuplint/react-spec/ARCHITECTURE.ja.md
@@ -8,9 +8,13 @@
 
 ## ExtendedSpec の内容
 
-### `useIDLAttributeNames`
+### `acceptedAttrNames`
 
-この spec は `useIDLAttributeNames: true` を設定しており、`@markuplint/ml-core` の `MLAttr` コンストラクタに IDL 属性名を HTML コンテンツ属性名に解決するよう指示します（例: `className` -> `class`、`htmlFor` -> `for`）。この解決はパーサーではなくコアレベルで行われます。
+この spec は `acceptedAttrNames: 'idl'` を設定しており、`@markuplint/ml-core` の `MLAttr` コンストラクタに IDL 属性名を HTML コンテンツ属性名に解決するよう指示します（例: `className` -> `class`、`htmlFor` -> `for`）。`'idl'` モードでは IDL 名のみが受け入れられ、コンテンツ属性名を使うと候補として IDL 名が提示されます。この解決はパーサーではなくコアレベルで行われます。
+
+### `contenteditable` オーバーライド
+
+React は `contentEditable` 属性の値として `"inherit"` を受け付けます（ContentEditable インターフェースの IDL 状態値）。この仕様はグローバル属性 `contenteditable` の型を拡張し、`"inherit"` を有効な列挙値として追加します。
 
 ### グローバル属性
 

--- a/packages/@markuplint/react-spec/ARCHITECTURE.md
+++ b/packages/@markuplint/react-spec/ARCHITECTURE.md
@@ -8,21 +8,22 @@ This package contains no parsing logic -- it is purely a data definition consume
 
 ## ExtendedSpec Content
 
-### `useIDLAttributeNames`
+### `acceptedAttrNames`
 
-The spec sets `useIDLAttributeNames: true`, which instructs `@markuplint/ml-core`'s `MLAttr` constructor to resolve IDL attribute names to their HTML content attribute equivalents (e.g., `className` -> `class`, `htmlFor` -> `for`). This resolution is performed at the core level, not in the parser.
+The spec sets `acceptedAttrNames: 'idl'`, which instructs `@markuplint/ml-core`'s `MLAttr` constructor to resolve IDL attribute names to their HTML content attribute equivalents (e.g., `className` -> `class`, `htmlFor` -> `for`) and to suggest IDL names as candidates when content attribute names are used (e.g., `tabindex` -> "Did you mean `tabIndex`?"). This resolution is performed at the core level, not in the parser.
 
 ### Global Attributes
 
 Global attributes are defined under `def['#globalAttrs']['#extends']` and are available on every JSX element:
 
-| Attribute                        | Type      | Description                                                               |
-| -------------------------------- | --------- | ------------------------------------------------------------------------- |
-| `key`                            | `Any`     | Special attribute for list rendering to help React identify changed items |
-| `ref`                            | `Any`     | Attribute for accessing child component instances and DOM elements        |
-| `dangerouslySetInnerHTML`        | `Any`     | React's replacement for using `innerHTML` in the browser DOM              |
-| `suppressContentEditableWarning` | `Boolean` | Suppresses the warning when an element with children is `contentEditable` |
-| `suppressHydrationWarning`       | `Boolean` | Suppresses React hydration mismatch warnings for attributes and content   |
+| Attribute                        | Type              | Description                                                               |
+| -------------------------------- | ----------------- | ------------------------------------------------------------------------- |
+| `key`                            | `Any`             | Special attribute for list rendering to help React identify changed items |
+| `ref`                            | `Any`             | Attribute for accessing child component instances and DOM elements        |
+| `dangerouslySetInnerHTML`        | `Any`             | React's replacement for using `innerHTML` in the browser DOM              |
+| `suppressContentEditableWarning` | `Boolean`         | Suppresses the warning when an element with children is `contentEditable` |
+| `suppressHydrationWarning`       | `Boolean`         | Suppresses React hydration mismatch warnings for attributes and content   |
+| `contenteditable`                | `Enum` (extended) | Overrides the HTML spec to accept `"inherit"` as a valid IDL state value  |
 
 ### Element-Specific Overrides
 

--- a/packages/@markuplint/react-spec/src/index.ts
+++ b/packages/@markuplint/react-spec/src/index.ts
@@ -20,7 +20,7 @@ import type { ExtendedSpec } from '@markuplint/ml-spec';
  * `defaultValue`, `value`).
  */
 const spec: ExtendedSpec = {
-	useIDLAttributeNames: true,
+	acceptedAttrNames: 'idl',
 	def: {
 		'#globalAttrs': {
 			'#extends': {
@@ -38,14 +38,14 @@ const spec: ExtendedSpec = {
 					type: 'Any',
 				},
 				/**
-				 * React’s replacement for using innerHTML in the browser DOM
+				 * React's replacement for using innerHTML in the browser DOM
 				 */
 				dangerouslySetInnerHTML: {
 					type: 'Any',
 				},
 				/**
 				 * Normally, there is a warning when an element with children
-				 * is also marked as contentEditable, because it won’t work.
+				 * is also marked as contentEditable, because it won't work.
 				 * This attribute suppresses that warning.
 				 */
 				suppressContentEditableWarning: {
@@ -58,6 +58,19 @@ const spec: ExtendedSpec = {
 				 */
 				suppressHydrationWarning: {
 					type: 'Boolean',
+				},
+				/**
+				 * React accepts "inherit" as a valid contentEditable value
+				 * (IDL state value from the ContentEditable interface).
+				 */
+				contenteditable: {
+					type: {
+						enum: ['', 'true', 'false', 'plaintext-only', 'inherit'],
+						disallowToSurroundBySpaces: true,
+						invalidValueDefault: 'inherit',
+						missingValueDefault: 'inherit',
+						sameStates: { true: [''] },
+					},
 				},
 			},
 		},

--- a/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
@@ -1350,6 +1350,7 @@ describe('contentEditable "inherit" (Issue #525)', () => {
 		const { violations } = await mlRuleTest(rule, '<div contenteditable="inherit"></div>');
 		expect(violations.length).toBe(1);
 		expect(violations[0].raw).toBe('inherit');
+		expect(violations[0].message).toMatch(/contenteditable/);
 	});
 
 	test('React: contentEditable="inherit" is valid via react-spec override', async () => {
@@ -1375,10 +1376,23 @@ describe('contentEditable "inherit" (Issue #525)', () => {
 		});
 		expect(violations.length).toBe(1);
 		expect(violations[0].raw).toBe('banana');
+		expect(violations[0].message).toMatch(/contenteditable/);
 	});
 
 	test('Svelte: contentEditable="inherit" is valid via svelte-spec override', async () => {
 		const { violations } = await mlRuleTest(rule, '<div contentEditable="inherit"></div>', {
+			parser: {
+				'.*': '@markuplint/svelte-parser',
+			},
+			specs: {
+				'.*': '@markuplint/svelte-spec',
+			},
+		});
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('Svelte: contenteditable="inherit" is valid (lowercase content attribute name)', async () => {
+		const { violations } = await mlRuleTest(rule, '<div contenteditable="inherit"></div>', {
 			parser: {
 				'.*': '@markuplint/svelte-parser',
 			},
@@ -1405,6 +1419,18 @@ describe('Svelte acceptedAttrNames: both (Issue #525)', () => {
 
 	test('Svelte: className="foo" is valid (IDL attribute name accepted in both mode)', async () => {
 		const { violations } = await mlRuleTest(rule, '<div className="foo"></div>', {
+			parser: {
+				'.*': '@markuplint/svelte-parser',
+			},
+			specs: {
+				'.*': '@markuplint/svelte-spec',
+			},
+		});
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('Svelte: tabIndex is valid (IDL name accepted in both mode)', async () => {
+		const { violations } = await mlRuleTest(rule, '<div tabIndex="0"></div>', {
 			parser: {
 				'.*': '@markuplint/svelte-parser',
 			},

--- a/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
@@ -1345,6 +1345,77 @@ test('Booleanish', async () => {
 	).toStrictEqual([]);
 });
 
+describe('contentEditable "inherit" (Issue #525)', () => {
+	test('HTML: contenteditable="inherit" is invalid (no spec override)', async () => {
+		const { violations } = await mlRuleTest(rule, '<div contenteditable="inherit"></div>');
+		expect(violations.length).toBe(1);
+		expect(violations[0].raw).toBe('inherit');
+	});
+
+	test('React: contentEditable="inherit" is valid via react-spec override', async () => {
+		const { violations } = await mlRuleTest(rule, '<div contentEditable="inherit"></div>', {
+			parser: {
+				'.*': '@markuplint/jsx-parser',
+			},
+			specs: {
+				'.*': '@markuplint/react-spec',
+			},
+		});
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('React: contentEditable="banana" is still invalid', async () => {
+		const { violations } = await mlRuleTest(rule, '<div contentEditable="banana"></div>', {
+			parser: {
+				'.*': '@markuplint/jsx-parser',
+			},
+			specs: {
+				'.*': '@markuplint/react-spec',
+			},
+		});
+		expect(violations.length).toBe(1);
+		expect(violations[0].raw).toBe('banana');
+	});
+
+	test('Svelte: contentEditable="inherit" is valid via svelte-spec override', async () => {
+		const { violations } = await mlRuleTest(rule, '<div contentEditable="inherit"></div>', {
+			parser: {
+				'.*': '@markuplint/svelte-parser',
+			},
+			specs: {
+				'.*': '@markuplint/svelte-spec',
+			},
+		});
+		expect(violations).toStrictEqual([]);
+	});
+});
+
+describe('Svelte acceptedAttrNames: both (Issue #525)', () => {
+	test('Svelte: class="foo" is valid (content attribute name accepted)', async () => {
+		const { violations } = await mlRuleTest(rule, '<div class="foo"></div>', {
+			parser: {
+				'.*': '@markuplint/svelte-parser',
+			},
+			specs: {
+				'.*': '@markuplint/svelte-spec',
+			},
+		});
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('Svelte: className="foo" is valid (IDL attribute name accepted in both mode)', async () => {
+		const { violations } = await mlRuleTest(rule, '<div className="foo"></div>', {
+			parser: {
+				'.*': '@markuplint/svelte-parser',
+			},
+			specs: {
+				'.*': '@markuplint/svelte-spec',
+			},
+		});
+		expect(violations).toStrictEqual([]);
+	});
+});
+
 test('WAI-Adapt', async () => {
 	expect((await mlRuleTest(rule, '<p adapt-simplification="critical"></p>')).violations).toStrictEqual([]);
 

--- a/packages/@markuplint/svelte-parser/ARCHITECTURE.ja.md
+++ b/packages/@markuplint/svelte-parser/ARCHITECTURE.ja.md
@@ -341,7 +341,7 @@ export function svelteParse(template: string): SvelteNode[] {
 
 ### IDL 属性マッピング
 
-IDL 属性マッピング（例: `tabIndex` → `tabindex`、`contentEditable` → `contenteditable`）は、spec が `useIDLAttributeNames: true` を設定している場合に `ml-core` の `MLAttr` コンストラクタで処理されます。`@markuplint/svelte-spec` はこのフラグを有効化しているため、Svelte ファイルではパーサーレベルではなくコアレベルで IDL 解決が行われます。
+IDL 属性マッピング（例: `tabIndex` → `tabindex`、`contentEditable` → `contenteditable`）は、spec が `acceptedAttrNames`（`'idl'` または `'both'`）を設定している場合に `ml-core` の `MLAttr` コンストラクタで処理されます。`@markuplint/svelte-spec` は `acceptedAttrNames: 'both'` を設定しているため、Svelte ファイルではパーサーレベルではなくコアレベルで IDL 解決が行われ、コンテンツ属性名と IDL 属性名の両方が受け入れられます。
 
 マッピングはコンテンツ属性名がルックアップ名と異なる場合にのみ `potentialName` を更新するため、すでにコンテンツ属性形式と一致している属性（例: `value`、`class`）は影響を受けません。対応するコンテンツ属性を持たない IDL 専用プロパティ（例: `defaultValue`、`indeterminate`）はマッピングに含まれず、対となる `@markuplint/svelte-spec` パッケージで処理されます。
 

--- a/packages/@markuplint/svelte-parser/ARCHITECTURE.md
+++ b/packages/@markuplint/svelte-parser/ARCHITECTURE.md
@@ -341,7 +341,7 @@ When the base `visitAttr()` returns an attribute with `type: 'spread'`, it is re
 
 ### IDL Attribute Mapping
 
-IDL attribute mapping (e.g., `tabIndex` → `tabindex`, `contentEditable` → `contenteditable`) is handled by `ml-core`'s `MLAttr` constructor when the spec sets `useIDLAttributeNames: true`. The `@markuplint/svelte-spec` enables this flag, so Svelte files get IDL resolution at the core level, not the parser level.
+IDL attribute mapping (e.g., `tabIndex` → `tabindex`, `contentEditable` → `contenteditable`) is handled by `ml-core`'s `MLAttr` constructor when the spec sets `acceptedAttrNames` (either `'idl'` or `'both'`). The `@markuplint/svelte-spec` sets `acceptedAttrNames: 'both'`, so Svelte files get IDL resolution at the core level (not the parser level) while accepting both content and IDL attribute names.
 
 The mapping only updates `potentialName` when the content attribute name differs from the looked-up name, so attributes that already match their content attribute form (e.g., `value`, `class`) are unaffected. IDL-only properties that have no corresponding content attribute (e.g., `defaultValue`, `indeterminate`) are not in the mapping and are instead handled by the paired `@markuplint/svelte-spec` package.
 

--- a/packages/@markuplint/svelte-parser/src/parser.ts
+++ b/packages/@markuplint/svelte-parser/src/parser.ts
@@ -358,7 +358,7 @@ export class SvelteParser extends Parser<SvelteNode> {
 	 * curly-brace expression values and shorthand attributes (`{name}`).
 	 * Directive resolution (`bind:`, `class:`, `on:`, etc.) and IDL attribute
 	 * mapping are now handled declaratively by svelte-spec's directivePatterns
-	 * and ml-core's useIDLAttributeNames.
+	 * and ml-core's acceptedAttrNames.
 	 *
 	 * @param token - The token representing the attribute
 	 * @returns The parsed attribute node with Svelte-specific metadata

--- a/packages/@markuplint/svelte-spec/ARCHITECTURE.ja.md
+++ b/packages/@markuplint/svelte-spec/ARCHITECTURE.ja.md
@@ -6,9 +6,13 @@
 
 ## ExtendedSpec の内容
 
-### `useIDLAttributeNames`
+### `acceptedAttrNames`
 
-この spec は `useIDLAttributeNames: true` を設定しており、`@markuplint/ml-core` の `MLAttr` コンストラクタに IDL 属性名を HTML コンテンツ属性名に解決するよう指示します（例: `defaultValue` → 対応するコンテンツ属性）。この解決はパーサーではなくコアレベルで行われます。
+この spec は `acceptedAttrNames: 'both'` を設定しており、`@markuplint/ml-core` の `MLAttr` コンストラクタに IDL 属性名を HTML コンテンツ属性名に解決するよう指示します（例: `defaultValue` → 対応するコンテンツ属性）。`'both'` モードではコンテンツ属性名と IDL 名の両方が受け入れられ、リネーム候補は提示されません。この解決はパーサーではなくコアレベルで行われます。
+
+### `contenteditable` オーバーライド
+
+Svelte は `contentEditable` 属性の値として `"inherit"` を受け付けます（ContentEditable インターフェースの IDL 状態値）。この仕様はグローバル属性 `contenteditable` の型を拡張し、`"inherit"` を有効な列挙値として追加します。
 
 ### `directivePatterns`
 

--- a/packages/@markuplint/svelte-spec/ARCHITECTURE.md
+++ b/packages/@markuplint/svelte-spec/ARCHITECTURE.md
@@ -6,9 +6,13 @@
 
 ## ExtendedSpec Content
 
-### `useIDLAttributeNames`
+### `acceptedAttrNames`
 
-The spec sets `useIDLAttributeNames: true`, which instructs `@markuplint/ml-core`'s `MLAttr` constructor to resolve IDL attribute names to their HTML content attribute equivalents (e.g., `defaultValue` -> the corresponding content attribute). This resolution is performed at the core level, not in the parser.
+The spec sets `acceptedAttrNames: 'both'`, which instructs `@markuplint/ml-core`'s `MLAttr` constructor to resolve IDL attribute names to their HTML content attribute equivalents (e.g., `defaultValue` -> the corresponding content attribute). In `'both'` mode, both content attribute names and IDL names are accepted without suggesting a rename. This resolution is performed at the core level, not in the parser.
+
+### `contenteditable` Override
+
+Svelte accepts `"inherit"` as a valid `contentEditable` value (IDL state value from the ContentEditable interface). This spec extends the global `contenteditable` attribute type to include `"inherit"` as a valid enum value.
 
 ### `directivePatterns`
 

--- a/packages/@markuplint/svelte-spec/src/index.ts
+++ b/packages/@markuplint/svelte-spec/src/index.ts
@@ -17,7 +17,26 @@ import type { ExtendedSpec } from '@markuplint/ml-spec';
  * attributes on form elements.
  */
 const spec: ExtendedSpec = {
-	useIDLAttributeNames: true,
+	acceptedAttrNames: 'both',
+	def: {
+		'#globalAttrs': {
+			'#extends': {
+				/**
+				 * Svelte accepts "inherit" as a valid contentEditable value
+				 * (IDL state value from the ContentEditable interface).
+				 */
+				contenteditable: {
+					type: {
+						enum: ['', 'true', 'false', 'plaintext-only', 'inherit'],
+						disallowToSurroundBySpaces: true,
+						invalidValueDefault: 'inherit',
+						missingValueDefault: 'inherit',
+						sameStates: { true: [''] },
+					},
+				},
+			},
+		},
+	},
 	directivePatterns: [
 		// bind:group, bind:this → true directives
 		{


### PR DESCRIPTION
## Summary

Closes #525

- Rename `useIDLAttributeNames: boolean` to `acceptedAttrNames?: 'idl' | 'both'` across the codebase
- `'idl'` mode (React): only IDL attribute names accepted, content names get "Did you mean?" `candidate` suggestion
- `'both'` mode (Svelte): both content and IDL attribute names accepted, no `candidate` suggestion
- Add `contenteditable` spec override in react-spec and svelte-spec to allow `"inherit"` as a valid value
- Update all documentation and comments referencing the old property name

## Changes by package

| Package | Change |
|---|---|
| `@markuplint/ml-spec` | Rename type `useIDLAttributeNames` → `acceptedAttrNames` in `MLMLSpec` and `ExtendedSpec`, update `schemaToSpec` merge logic |
| `@markuplint/ml-core` | Update `MLAttr` to use `acceptedAttrNames`, set `candidate` only in `'idl'` mode |
| `@markuplint/react-spec` | `acceptedAttrNames: 'idl'`, add contenteditable override with `"inherit"` |
| `@markuplint/svelte-spec` | `acceptedAttrNames: 'both'`, add contenteditable override with `"inherit"` |
| `@markuplint/rules` | Add invalid-attr tests for contentEditable inherit and Svelte both mode |
| `@markuplint/jsx-parser` | Doc/comment updates |
| `@markuplint/svelte-parser` | Doc/comment updates |
| `@markuplint/mdx-parser` | Doc/comment updates |
| `@markuplint/parser-utils` | Doc updates |

## Test plan

- [x] `contenteditable="inherit"` is invalid in plain HTML
- [x] `contentEditable="inherit"` is valid in React (react-spec)
- [x] `contentEditable="banana"` is invalid in React
- [x] `contentEditable="inherit"` is valid in Svelte (camelCase)
- [x] `contenteditable="inherit"` is valid in Svelte (lowercase)
- [x] `class="foo"` is valid in Svelte (both mode accepts content names)
- [x] `className="foo"` is valid in Svelte (both mode accepts IDL names)
- [x] `tabIndex="0"` is valid in Svelte (both mode)
- [x] `candidate` is set to IDL name in `'idl'` mode, undefined in `'both'` mode
- [x] `yarn build` passes
- [x] `yarn test` passes (2420 tests)
- [x] `yarn lint` passes (0 errors, 0 warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)