### PR TITLE
feat!: update default ARIA version to 1.3 and add conditional aside mapping

### DIFF
--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -48976,7 +48976,22 @@
 			},
 			"aria": {
 				"implicitRole": "complementary",
-				"permittedRoles": ["feed", "none", "note", "presentation", "region", "search"]
+				"permittedRoles": ["feed", "none", "note", "presentation", "region", "search"],
+				"conditions": {
+					":is(article, aside, nav, section, blockquote, details, dialog, fieldset, figure, td) *": {
+						"implicitRole": "generic",
+						"namingProhibited": true
+					},
+					":is(article, aside, nav, section, blockquote, details, dialog, fieldset, figure, td) *:aria(has name)": {
+						"implicitRole": "complementary"
+					}
+				},
+				"1.2": {
+					"conditions": false
+				},
+				"1.1": {
+					"conditions": false
+				}
 			},
 			"omission": false,
 			"globalAttrs": {

--- a/packages/@markuplint/html-spec/src/spec.aside.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.aside.jsonc
@@ -17,21 +17,22 @@
 	},
 	"attributes": {},
 	"aria": {
-		// v1.2 later
-		// 	"implicitRole": "generic",
-		// 	"conditions": [
-		// 		{
-		// 			"condition": ":is(body, main) aside",
-		// 			"role": "complementary"
-		// 		},
-		// 		{
-		// 			// Sectioning content elements are: article, aside, nav, section
-		// 			// Sectioning root elements are: blockquote, body, details, dialog, fieldset, figure, td
-		// 			"condition": ":is(article, aside, nav, section, blockquote, details, dialog, fieldset, figure, td) aside:hasaccname",
-		// 			"role": "complementary"
-		// 		}
-		// 	]
 		"implicitRole": "complementary",
-		"permittedRoles": ["feed", "none", "note", "presentation", "region", "search"]
+		"permittedRoles": ["feed", "none", "note", "presentation", "region", "search"],
+		"conditions": {
+			":is(article, aside, nav, section, blockquote, details, dialog, fieldset, figure, td) *": {
+				"implicitRole": "generic",
+				"namingProhibited": true
+			},
+			":is(article, aside, nav, section, blockquote, details, dialog, fieldset, figure, td) *:aria(has name)": {
+				"implicitRole": "complementary"
+			}
+		},
+		"1.2": {
+			"conditions": false
+		},
+		"1.1": {
+			"conditions": false
+		}
 	}
 }

--- a/packages/@markuplint/ml-spec/schemas/aria.schema.json
+++ b/packages/@markuplint/ml-spec/schemas/aria.schema.json
@@ -165,6 +165,27 @@
 				}
 			}
 		},
+		"Conditions": {
+			"type": "object",
+			"minProperties": 1,
+			"patternProperties": {
+				".+": {
+					"type": "object",
+					"minProperties": 1,
+					"additionalProperties": false,
+					"properties": {
+						"implicitRole": { "$ref": "#/definitions/ImplicitRole" },
+						"permittedRoles": { "$ref": "#/definitions/PermittedRoles" },
+						"namingProhibited": { "type": "boolean", "enum": [true] },
+						"implicitProperties": { "$ref": "#/definitions/ImplicitProperties" },
+						"properties": { "$ref": "#/definitions/PermittedARIAProperties" }
+					}
+				}
+			}
+		},
+		"ConditionsOrFalse": {
+			"oneOf": [{ "type": "boolean", "enum": [false] }, { "$ref": "#/definitions/Conditions" }]
+		},
 		"ARIA": {
 			"type": "object",
 			"additionalProperties": false,
@@ -175,24 +196,7 @@
 				"namingProhibited": { "type": "boolean", "enum": [true] },
 				"implicitProperties": { "$ref": "#/definitions/ImplicitProperties" },
 				"properties": { "$ref": "#/definitions/PermittedARIAProperties" },
-				"conditions": {
-					"type": "object",
-					"minProperties": 1,
-					"patternProperties": {
-						".+": {
-							"type": "object",
-							"minProperties": 1,
-							"additionalProperties": false,
-							"properties": {
-								"implicitRole": { "$ref": "#/definitions/ImplicitRole" },
-								"permittedRoles": { "$ref": "#/definitions/PermittedRoles" },
-								"namingProhibited": { "type": "boolean", "enum": [true] },
-								"implicitProperties": { "$ref": "#/definitions/ImplicitProperties" },
-								"properties": { "$ref": "#/definitions/PermittedARIAProperties" }
-							}
-						}
-					}
-				},
+				"conditions": { "$ref": "#/definitions/Conditions" },
 				"1.3": {
 					"type": "object",
 					"additionalProperties": false,
@@ -203,24 +207,7 @@
 						"namingProhibited": { "type": "boolean", "enum": [true] },
 						"implicitProperties": { "$ref": "#/definitions/ImplicitProperties" },
 						"properties": { "$ref": "#/definitions/PermittedARIAProperties" },
-						"conditions": {
-							"type": "object",
-							"minProperties": 1,
-							"patternProperties": {
-								".+": {
-									"type": "object",
-									"minProperties": 1,
-									"additionalProperties": false,
-									"properties": {
-										"implicitRole": { "$ref": "#/definitions/ImplicitRole" },
-										"permittedRoles": { "$ref": "#/definitions/PermittedRoles" },
-										"namingProhibited": { "type": "boolean", "enum": [true] },
-										"implicitProperties": { "$ref": "#/definitions/ImplicitProperties" },
-										"properties": { "$ref": "#/definitions/PermittedARIAProperties" }
-									}
-								}
-							}
-						}
+						"conditions": { "$ref": "#/definitions/ConditionsOrFalse" }
 					}
 				},
 				"1.2": {
@@ -233,24 +220,7 @@
 						"namingProhibited": { "type": "boolean", "enum": [true] },
 						"implicitProperties": { "$ref": "#/definitions/ImplicitProperties" },
 						"properties": { "$ref": "#/definitions/PermittedARIAProperties" },
-						"conditions": {
-							"type": "object",
-							"minProperties": 1,
-							"patternProperties": {
-								".+": {
-									"type": "object",
-									"minProperties": 1,
-									"additionalProperties": false,
-									"properties": {
-										"implicitRole": { "$ref": "#/definitions/ImplicitRole" },
-										"permittedRoles": { "$ref": "#/definitions/PermittedRoles" },
-										"namingProhibited": { "type": "boolean", "enum": [true] },
-										"implicitProperties": { "$ref": "#/definitions/ImplicitProperties" },
-										"properties": { "$ref": "#/definitions/PermittedARIAProperties" }
-									}
-								}
-							}
-						}
+						"conditions": { "$ref": "#/definitions/ConditionsOrFalse" }
 					}
 				},
 				"1.1": {
@@ -262,23 +232,7 @@
 						"permittedRoles": { "$ref": "#/definitions/PermittedRoles" },
 						"implicitProperties": { "$ref": "#/definitions/ImplicitProperties" },
 						"properties": { "$ref": "#/definitions/PermittedARIAProperties" },
-						"conditions": {
-							"type": "object",
-							"minProperties": 1,
-							"patternProperties": {
-								".+": {
-									"type": "object",
-									"minProperties": 1,
-									"additionalProperties": false,
-									"properties": {
-										"implicitRole": { "$ref": "#/definitions/ImplicitRole" },
-										"permittedRoles": { "$ref": "#/definitions/PermittedRoles" },
-										"implicitProperties": { "$ref": "#/definitions/ImplicitProperties" },
-										"properties": { "$ref": "#/definitions/PermittedARIAProperties" }
-									}
-								}
-							}
-						}
+						"conditions": { "$ref": "#/definitions/ConditionsOrFalse" }
 					}
 				}
 			}

--- a/packages/@markuplint/ml-spec/src/algorithm/aria/get-implicit-role-spec.spec.ts
+++ b/packages/@markuplint/ml-spec/src/algorithm/aria/get-implicit-role-spec.spec.ts
@@ -7,14 +7,14 @@ import { describe, test, expect } from 'vitest';
 
 import { getImplicitRole } from './get-implicit-role-spec.js';
 
-function c(html: string, version: ARIAVersion) {
-	const el = createJSDOMElement(html);
+function c(html: string, version: ARIAVersion, selector?: string) {
+	const el = createJSDOMElement(html, selector);
 	return getImplicitRole(
 		specs,
 		el.localName,
 		el.namespaceURI,
 		version,
-		selector => createSelector(selector, specs).match(el) !== false,
+		sel => createSelector(sel, specs).match(el) !== false,
 	);
 }
 
@@ -42,7 +42,14 @@ describe('getImplicitRole', () => {
 	});
 
 	test('the aside element', () => {
+		// ARIA 1.2: always complementary
 		expect(c('<aside></aside>', '1.2')).toBe('complementary');
+		expect(c('<article><aside></aside></article>', '1.2', 'aside')).toBe('complementary');
+		// ARIA 1.3: conditional
+		expect(c('<aside></aside>', '1.3')).toBe('complementary');
+		expect(c('<article><aside></aside></article>', '1.3', 'aside')).toBe('generic');
+		expect(c('<article><aside aria-label="sidebar"></aside></article>', '1.3', 'aside')).toBe('complementary');
+		expect(c('<section><aside></aside></section>', '1.3', 'aside')).toBe('generic');
 	});
 
 	test('the audio element', () => {

--- a/packages/@markuplint/ml-spec/src/types/aria.ts
+++ b/packages/@markuplint/ml-spec/src/types/aria.ts
@@ -107,19 +107,21 @@ export interface ARIA {
 		namingProhibited?: true;
 		implicitProperties?: ImplicitProperties;
 		properties?: PermittedARIAProperties;
-		conditions?: {
-			/**
-			 * This interface was referenced by `undefined`'s JSON-Schema definition
-			 * via the `patternProperty` ".+".
-			 */
-			[k: string]: {
-				implicitRole?: ImplicitRole;
-				permittedRoles?: PermittedRoles;
-				namingProhibited?: true;
-				implicitProperties?: ImplicitProperties;
-				properties?: PermittedARIAProperties;
-			};
-		};
+		conditions?:
+			| false
+			| {
+					/**
+					 * This interface was referenced by `undefined`'s JSON-Schema definition
+					 * via the `patternProperty` ".+".
+					 */
+					[k: string]: {
+						implicitRole?: ImplicitRole;
+						permittedRoles?: PermittedRoles;
+						namingProhibited?: true;
+						implicitProperties?: ImplicitProperties;
+						properties?: PermittedARIAProperties;
+					};
+			  };
 	};
 	'1.2'?: {
 		implicitRole?: ImplicitRole;
@@ -127,37 +129,41 @@ export interface ARIA {
 		namingProhibited?: true;
 		implicitProperties?: ImplicitProperties;
 		properties?: PermittedARIAProperties;
-		conditions?: {
-			/**
-			 * This interface was referenced by `undefined`'s JSON-Schema definition
-			 * via the `patternProperty` ".+".
-			 */
-			[k: string]: {
-				implicitRole?: ImplicitRole;
-				permittedRoles?: PermittedRoles;
-				namingProhibited?: true;
-				implicitProperties?: ImplicitProperties;
-				properties?: PermittedARIAProperties;
-			};
-		};
+		conditions?:
+			| false
+			| {
+					/**
+					 * This interface was referenced by `undefined`'s JSON-Schema definition
+					 * via the `patternProperty` ".+".
+					 */
+					[k: string]: {
+						implicitRole?: ImplicitRole;
+						permittedRoles?: PermittedRoles;
+						namingProhibited?: true;
+						implicitProperties?: ImplicitProperties;
+						properties?: PermittedARIAProperties;
+					};
+			  };
 	};
 	'1.1'?: {
 		implicitRole?: ImplicitRole;
 		permittedRoles?: PermittedRoles;
 		implicitProperties?: ImplicitProperties;
 		properties?: PermittedARIAProperties;
-		conditions?: {
-			/**
-			 * This interface was referenced by `undefined`'s JSON-Schema definition
-			 * via the `patternProperty` ".+".
-			 */
-			[k: string]: {
-				implicitRole?: ImplicitRole;
-				permittedRoles?: PermittedRoles;
-				implicitProperties?: ImplicitProperties;
-				properties?: PermittedARIAProperties;
-			};
-		};
+		conditions?:
+			| false
+			| {
+					/**
+					 * This interface was referenced by `undefined`'s JSON-Schema definition
+					 * via the `patternProperty` ".+".
+					 */
+					[k: string]: {
+						implicitRole?: ImplicitRole;
+						permittedRoles?: PermittedRoles;
+						implicitProperties?: ImplicitProperties;
+						properties?: PermittedARIAProperties;
+					};
+			  };
 	};
 }
 export interface PermittedARIAAAMInfo {

--- a/packages/@markuplint/ml-spec/src/utils/aria-version.ts
+++ b/packages/@markuplint/ml-spec/src/utils/aria-version.ts
@@ -6,4 +6,4 @@ export const ariaVersions = ['1.1', '1.2', '1.3'] as const;
 /**
  * The recommended default ARIA specification version to use when none is explicitly specified.
  */
-export const ARIA_RECOMMENDED_VERSION = '1.2';
+export const ARIA_RECOMMENDED_VERSION = '1.3';

--- a/packages/@markuplint/ml-spec/src/utils/resolve-version.ts
+++ b/packages/@markuplint/ml-spec/src/utils/resolve-version.ts
@@ -20,7 +20,8 @@ export function resolveVersion(aria: ReadonlyDeep<ARIA>, version: ARIAVersion): 
 	const properties = aria[version]?.properties ?? aria.properties;
 	const namingProhibited =
 		version === '1.1' ? aria.namingProhibited : (aria[version]?.namingProhibited ?? aria.namingProhibited);
-	const conditions = aria[version]?.conditions ?? aria.conditions;
+	const versionConditions = aria[version]?.conditions;
+	const conditions = versionConditions === false ? undefined : (versionConditions ?? aria.conditions);
 	return {
 		implicitRole,
 		permittedRoles,

--- a/packages/@markuplint/rules/src/landmark-roles/index.spec.ts
+++ b/packages/@markuplint/rules/src/landmark-roles/index.spec.ts
@@ -44,15 +44,7 @@ test('Top level landmarks', async () => {
 `,
 	);
 
-	expect(violations).toStrictEqual([
-		{
-			severity: 'warning',
-			line: 9,
-			col: 3,
-			raw: '<aside>',
-			message: 'The "complementary" role should be top level',
-		},
-	]);
+	expect(violations).toStrictEqual([]);
 });
 
 test('Top level landmarks: disabled', async () => {
@@ -203,13 +195,5 @@ test('The `as` attribute', async () => {
 `,
 			)
 		).violations,
-	).toStrictEqual([
-		{
-			severity: 'warning',
-			line: 5,
-			col: 3,
-			message: 'The "complementary" role should be top level',
-			raw: '<x-aside as="aside">',
-		},
-	]);
+	).toStrictEqual([]);
 });

--- a/packages/@markuplint/rules/src/landmark-roles/index.ts
+++ b/packages/@markuplint/rules/src/landmark-roles/index.ts
@@ -15,10 +15,10 @@ type Options = {
 };
 
 /** Landmark roles that should appear at the top level of the document. */
-type TopLevelRoles = 'banner' | 'main' | 'complementary' | 'contentinfo';
+type TopLevelRoles = 'banner' | 'main' | 'contentinfo';
 
 /** All recognized ARIA landmark roles for this rule. */
-type Roles = TopLevelRoles | 'form' | 'navigation' | 'region';
+type Roles = TopLevelRoles | 'complementary' | 'form' | 'navigation' | 'region';
 
 /** A mapping from each landmark role to its matched elements in the document. */
 type RoleSet = {
@@ -37,12 +37,12 @@ const selectors: { readonly [role in Roles]: string[] } = {
 };
 
 /** Roles that are required to be top-level landmarks per WAI-ARIA practices. */
-const topLevelRoles: TopLevelRoles[] = ['banner', 'main', 'complementary', 'contentinfo'];
+const topLevelRoles: TopLevelRoles[] = ['banner', 'main', 'contentinfo'];
 
 /**
  * Rule that validates proper usage of ARIA landmark roles.
  *
- * Checks that `banner`, `main`, `complementary`, and `contentinfo` landmarks are
+ * Checks that `banner`, `main`, and `contentinfo` landmarks are
  * top-level (not nested inside other landmarks), and that when duplicate landmarks
  * of the same role exist, each has a unique accessible name.
  */

--- a/packages/@markuplint/rules/src/require-accessible-name/index.spec.ts
+++ b/packages/@markuplint/rules/src/require-accessible-name/index.spec.ts
@@ -480,8 +480,9 @@ describe('Issues', () => {
 
 	// https://github.com/markuplint/markuplint/issues/658
 	test('#658', async () => {
-		expect((await mlRuleTest(rule, '<dialog></dialog>')).violations.length).toBe(1);
-		expect((await mlRuleTest(rule, '<div role="dialog"></div>')).violations.length).toBe(1);
+		// ARIA 1.3: dialog no longer requires an accessible name
+		expect((await mlRuleTest(rule, '<dialog></dialog>')).violations.length).toBe(0);
+		expect((await mlRuleTest(rule, '<div role="dialog"></div>')).violations.length).toBe(0);
 	});
 
 	test('#1018', async () => {

--- a/packages/@markuplint/rules/src/wai-aria/index.spec.ts
+++ b/packages/@markuplint/rules/src/wai-aria/index.spec.ts
@@ -567,7 +567,7 @@ describe('Allowed Accessibility Child Roles', () => {
 				severity: 'error',
 				line: 1,
 				col: 1,
-				message: 'The "table" role expects the roles: "row", "rowgroup > row"',
+				message: 'The "table" role expects the roles: "caption", "row", "rowgroup > row"',
 				raw: '<table>',
 			},
 			{
@@ -1097,13 +1097,6 @@ describe('Issues', () => {
 				)
 			).violations,
 		).toStrictEqual([
-			{
-				severity: 'error',
-				line: 1,
-				col: 1,
-				message: 'The "table" role expects the roles: "row", "rowgroup > row"',
-				raw: '<table>',
-			},
 			{
 				severity: 'error',
 				line: 5,


### PR DESCRIPTION
## Summary

Closes #3280

- **Update default ARIA version from 1.2 to 1.3** — `ARIA_RECOMMENDED_VERSION` now defaults to `'1.3'`, which may produce different lint results for version-dependent rules
- **Support `conditions: false` in ARIA version blocks** — allows version-specific overrides to explicitly disable conditional role mappings for older ARIA versions
- **Add conditional aside role mapping per HTML-AAM** — `<aside>` scoped to `body`/`main` maps to `complementary`; scoped to sectioning content maps to `generic` (or `complementary` if it has an accessible name)
- **Remove `complementary` from top-level landmark check** — aligns with axe-core's deprecation of `landmark-complementary-is-top-level`

## Breaking Changes

- Default ARIA version changes from 1.2 to 1.3 (users can pin `ariaVersion: "1.2"` in rule options to restore previous behavior)
- `landmark-roles` rule no longer warns when `complementary` landmarks are nested inside other landmarks

## Test plan

- [x] `yarn build` passes
- [x] `yarn test` passes (2423 tests, 160 test files)
- [x] `yarn lint-check` passes
- [x] Verify aside implicit role resolves to `complementary` at top level, `generic` inside sectioning content, and `complementary` inside sectioning content with accessible name (ARIA 1.3)
- [x] Verify aside implicit role resolves to `complementary` unconditionally for ARIA 1.2 and 1.1
- [x] Verify `landmark-roles` no longer reports complementary top-level violations
- [x] Verify ARIA 1.3 test expectation updates: dialog accessible name, table requiredOwnedElements

🤖 Generated with [Claude Code](https://claude.com/claude-code)