### PR TITLE
fix(ml-spec): collect label text from child elements without accessible names

### DIFF
--- a/packages/@markuplint/ml-spec/src/algorithm/aria/accname/label-steps.ts
+++ b/packages/@markuplint/ml-spec/src/algorithm/aria/accname/label-steps.ts
@@ -88,7 +88,16 @@ function collectLabelText(
 				continue;
 			}
 			const result = computeFn(childEl, resolver, inLabelledbyTraversal, visited);
-			parts.push(result.name);
+			if (result.name) {
+				parts.push(result.name);
+			} else {
+				// Transparent traversal: when the child element has no accessible name
+				// (e.g., <span> with role="generic"), recursively collect its descendant text.
+				// This matches the behavior of resolveNameFromContent's fallback.
+				parts.push(
+					collectLabelText(childEl, labeledElement, resolver, visited, computeFn, inLabelledbyTraversal),
+				);
+			}
 		}
 	}
 	return parts.join(' ');

--- a/packages/@markuplint/rules/src/require-accessible-name/index.spec.ts
+++ b/packages/@markuplint/rules/src/require-accessible-name/index.spec.ts
@@ -528,6 +528,23 @@ describe('Issues', () => {
 		).toStrictEqual([]);
 	});
 
+	// https://github.com/markuplint/markuplint/issues/3283
+	test('#3283', async () => {
+		// Implicit label with text only inside child elements
+		expect((await mlRuleTest(rule, '<label><span>label</span> <input /></label>')).violations).toStrictEqual([]);
+
+		// Explicit label with text only inside child elements
+		expect(
+			(await mlRuleTest(rule, '<label for="label"><span>label</span></label> <input id="label" />')).violations,
+		).toStrictEqual([]);
+
+		// These should still work (direct text nodes)
+		expect((await mlRuleTest(rule, '<label>label <input /></label>')).violations).toStrictEqual([]);
+		expect((await mlRuleTest(rule, '<label>label <span>label</span> <input /></label>')).violations).toStrictEqual(
+			[],
+		);
+	});
+
 	test('#2394', async () => {
 		expect(
 			(


### PR DESCRIPTION
## Summary

- Fix `collectLabelText` in accname computation to add transparent traversal fallback when child elements (e.g., `<span>`) return no accessible name
- This resolves false positives from `require-accessible-name` when `<label>` contains text only inside child elements

Closes #3283

## Details

When computing the accessible name for a labeled element (e.g., `<input>`) via its `<label>`, the `collectLabelText` function calls `computeFn` on each child element. For elements like `<span>` (role `generic`, no `nameFrom: content`), `computeFn` returns an empty name. Previously, this empty result was used as-is, causing the label to appear empty.

The fix adds a transparent traversal fallback (matching `resolveNameFromContent`'s existing behavior): when `computeFn` returns empty, recursively collect descendant text content from the child element.

## Test plan

- [x] Added test for `<label><span>label</span> <input /></label>` (implicit label)
- [x] Added test for `<label for="id"><span>label</span></label> <input id="id" />` (explicit label)
- [x] Verified existing label tests still pass (direct text nodes)
- [x] Full test suite passes (2424 tests)
- [x] Lint passes (0 errors, 0 warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)