### PR TITLE
fix(file-resolver): fix Windows path normalization for non-C: drives

### DIFF
--- a/packages/@markuplint/file-resolver/src/force-import-json-in-module.ts
+++ b/packages/@markuplint/file-resolver/src/force-import-json-in-module.ts
@@ -1,7 +1,8 @@
 import { readFile } from 'node:fs/promises';
-import path from 'node:path';
 
 import { log } from './debug.js';
+
+import { fromFileURL } from './path-utils.js';
 
 const fLog = log.extend('force-import-json-in-module');
 
@@ -28,11 +29,7 @@ export async function forceImportJsonInModule(modPath: string) {
 			return error;
 		}
 
-		const normalizePath = absPath
-			.replace(/^file:\/\//, '')
-			.replaceAll('/', path.sep)
-			// Windows
-			.replace(/^[/\\](?=[a-z]:)/i, ''); // only remove a leading slash
+		const normalizePath = absPath.startsWith('file:') ? fromFileURL(absPath) : absPath;
 		fLog('Find JSON file path: %s', normalizePath);
 
 		const fileContent = await readFile(normalizePath, { encoding: 'utf8' });

--- a/packages/@markuplint/file-resolver/src/general-import.ts
+++ b/packages/@markuplint/file-resolver/src/general-import.ts
@@ -6,6 +6,7 @@ import { pathToFileURL } from 'node:url';
 import { resolve } from 'import-meta-resolve';
 
 import { log } from './debug.js';
+import { fromFileURL } from './path-utils.js';
 
 const gLog = log.extend('general-import');
 const gLogSuccess = gLog.extend('success');
@@ -63,7 +64,8 @@ export async function generalImport<T>(name: string): Promise<T | null> {
 					?.groups ?? {};
 			if (filePath && packageName) {
 				const modFile = resolve(packageName, import.meta.url);
-				const modPath = path.dirname(modFile);
+				const modNativePath = modFile.startsWith('file:') ? fromFileURL(modFile) : modFile;
+				const modPath = path.dirname(modNativePath);
 				const candidate = path.join(modPath, filePath);
 				gLog('Try import absolute path: "%s"', candidate);
 				const result = await generalImport<T>(candidate);

--- a/packages/@markuplint/file-resolver/src/ml-file/get-files.ts
+++ b/packages/@markuplint/file-resolver/src/ml-file/get-files.ts
@@ -3,6 +3,7 @@ import type { MLFile } from './ml-file.js';
 import { glob } from 'glob';
 import { minimatch } from 'minimatch';
 
+import { normalizeForGlob } from '../path-utils.js';
 import { getFile } from './get-file.js';
 
 /**
@@ -13,7 +14,7 @@ import { getFile } from './get-file.js';
  * @param filePathOrGlob
  */
 export async function getFiles(filePathOrGlob: string, ignoreGlob?: string): Promise<MLFile[]> {
-	const fileList = await glob(filePathOrGlob, {}).catch<string[]>(() => []);
+	const fileList = await glob(normalizeForGlob(filePathOrGlob), {}).catch<string[]>(() => []);
 	const filtered = fileList.filter(fileName => !minimatch(fileName, ignoreGlob ?? ''));
 	return filtered.map(fileName => getFile(fileName));
 }

--- a/packages/@markuplint/file-resolver/src/ml-file/get-files.ts
+++ b/packages/@markuplint/file-resolver/src/ml-file/get-files.ts
@@ -15,6 +15,6 @@ import { getFile } from './get-file.js';
  */
 export async function getFiles(filePathOrGlob: string, ignoreGlob?: string): Promise<MLFile[]> {
 	const fileList = await glob(normalizeForGlob(filePathOrGlob), {}).catch<string[]>(() => []);
-	const filtered = fileList.filter(fileName => !minimatch(fileName, ignoreGlob ?? ''));
+	const filtered = fileList.filter(fileName => !minimatch(fileName, normalizeForGlob(ignoreGlob ?? '')));
 	return filtered.map(fileName => getFile(fileName));
 }

--- a/packages/@markuplint/file-resolver/src/ml-file/ml-file.spec.ts
+++ b/packages/@markuplint/file-resolver/src/ml-file/ml-file.spec.ts
@@ -42,6 +42,15 @@ test('ignored', () => {
 	expect(file.ignored(['*', '!dir', 'dir/*', '!dir/file'])).toBeFalsy();
 });
 
+test('ignored with absolute path patterns', () => {
+	const file = new MLFile('/project/src/file.html');
+	// gitignore-style: pattern must match from the root of the relative path
+	expect(file.ignored(['project/src/file.html'])).toBeTruthy();
+	expect(file.ignored(['project'])).toBeTruthy();
+	expect(file.ignored(['**/file.html'])).toBeTruthy();
+	expect(file.ignored(['!project/src/file.html'])).toBeFalsy();
+});
+
 test('file exists', async () => {
 	const file = new MLFile({ sourceCode: '<html></html>' });
 	expect(await file.isExist()).toBeTruthy();

--- a/packages/@markuplint/file-resolver/src/ml-file/ml-file.ts
+++ b/packages/@markuplint/file-resolver/src/ml-file/ml-file.ts
@@ -7,6 +7,8 @@ import path from 'node:path';
 import ignore from 'ignore';
 import { minimatch } from 'minimatch';
 
+import { normalizeForGlob, normalizeForIgnore } from '../path-utils.js';
+
 export class MLFile {
 	#basename: string;
 	#code: string | null;
@@ -46,14 +48,14 @@ export class MLFile {
 	 * Normalized `MLFile.dirname`
 	 */
 	get nDirname() {
-		return pathNormalize(this.dirname);
+		return normalizeForIgnore(this.dirname);
 	}
 
 	/**
 	 * Normalized `MLFile.path`
 	 */
 	get nPath() {
-		return pathNormalize(this.path);
+		return normalizeForIgnore(this.path);
 	}
 
 	get path() {
@@ -76,10 +78,10 @@ export class MLFile {
 
 	ignored(globPath: string | readonly string[]) {
 		globPath = typeof globPath === 'string' ? [globPath] : globPath;
-		const normalizedPaths = globPath.map(p => pathNormalize(p, true));
+		const normalizedPaths = globPath.map(p => normalizeForIgnore(p, true));
 		// @ts-ignore
 		const ig = ignore().add(normalizedPaths);
-		const ignored = ig.ignores(pathNormalize(this.nPath, true));
+		const ignored = ig.ignores(normalizeForIgnore(this.path, true));
 		return ignored;
 	}
 
@@ -100,7 +102,7 @@ export class MLFile {
 	}
 
 	matches(globPath: string) {
-		return minimatch(this.nPath, pathNormalize(globPath));
+		return minimatch(normalizeForIgnore(this.path), normalizeForGlob(globPath));
 	}
 
 	setCode(code: string) {
@@ -139,29 +141,4 @@ async function stat(filePath: string) {
 		}
 		throw error;
 	}
-}
-
-function pathNormalize(filePath: string, relative = false) {
-	const hasBang = filePath.startsWith('!');
-	if (hasBang) {
-		filePath = filePath.slice(1);
-	}
-
-	// Remove the local disk scheme of Windows OS
-	if (path.isAbsolute(filePath)) {
-		filePath = filePath.replace(/^[a-z]+:/i, '');
-
-		if (relative) {
-			filePath = path.relative(path.sep, filePath);
-		}
-	}
-
-	// Replace the separator of Windows OS
-	filePath = filePath.split(path.sep).join('/');
-
-	if (hasBang) {
-		filePath = `!${filePath}`;
-	}
-
-	return filePath;
 }

--- a/packages/@markuplint/file-resolver/src/ml-file/ml-file.ts
+++ b/packages/@markuplint/file-resolver/src/ml-file/ml-file.ts
@@ -7,7 +7,7 @@ import path from 'node:path';
 import ignore from 'ignore';
 import { minimatch } from 'minimatch';
 
-import { normalizeForGlob, normalizeForIgnore } from '../path-utils.js';
+import { normalizeForIgnore } from '../path-utils.js';
 
 export class MLFile {
 	#basename: string;
@@ -102,7 +102,7 @@ export class MLFile {
 	}
 
 	matches(globPath: string) {
-		return minimatch(normalizeForIgnore(this.path), normalizeForGlob(globPath));
+		return minimatch(normalizeForIgnore(this.path), normalizeForIgnore(globPath));
 	}
 
 	setCode(code: string) {

--- a/packages/@markuplint/file-resolver/src/path-utils.spec.ts
+++ b/packages/@markuplint/file-resolver/src/path-utils.spec.ts
@@ -58,10 +58,70 @@ test('normalizeForGlob: converts backslashes', () => {
 	expect(normalizeForGlob('src\\**\\*.html')).toBe('src/**/*.html');
 });
 
+test('normalizeForIgnore: lowercase drive letter', () => {
+	expect(normalizeForIgnore('c:\\Users\\file.html', true)).toBe('Users/file.html');
+});
+
+test('normalizeForIgnore: D: drive', () => {
+	expect(normalizeForIgnore('D:\\Data\\file.html')).toBe('/Data/file.html');
+});
+
+test('normalizeForIgnore: forward-slash Windows path', () => {
+	expect(normalizeForIgnore('C:/Users/project/file.html')).toBe('/Users/project/file.html');
+});
+
+test('normalizeForIgnore: does not strip non-drive-letter prefixes', () => {
+	expect(normalizeForIgnore('npm:package')).toBe('npm:package');
+});
+
+test('normalizeForIgnore: empty string', () => {
+	expect(normalizeForIgnore('')).toBe('');
+});
+
+test('normalizeForIgnore: POSIX root only', () => {
+	expect(normalizeForIgnore('/')).toBe('/');
+});
+
+test('normalizeForIgnore: POSIX root with relative', () => {
+	expect(normalizeForIgnore('/', true)).toBe('');
+});
+
+test('normalizeForIgnore: path with spaces', () => {
+	expect(normalizeForIgnore('C:\\Program Files\\app\\file.html', true)).toBe('Program Files/app/file.html');
+});
+
+test('normalizeForIgnore: path with CJK characters', () => {
+	expect(normalizeForIgnore('C:\\Users\\日本語\\file.html', true)).toBe('Users/日本語/file.html');
+});
+
+test('normalizeForIgnore: bang prefix with Windows drive', () => {
+	expect(normalizeForIgnore('!C:\\Users\\file.html', true)).toBe('!Users/file.html');
+});
+
+test('normalizeForIgnore: UNC-style backslash path', () => {
+	expect(normalizeForIgnore('\\\\server\\share\\file.html')).toBe('//server/share/file.html');
+});
+
+test('normalizeForIgnore: UNC-style backslash path with relative', () => {
+	expect(normalizeForIgnore('\\\\server\\share\\file.html', true)).toBe('server/share/file.html');
+});
+
+test('normalizeForGlob: preserves drive letter', () => {
+	expect(normalizeForGlob('C:\\Users\\**\\*.html')).toBe('C:/Users/**/*.html');
+});
+
 test('fromFileURL: POSIX file URL', () => {
 	expect(fromFileURL('file:///home/user/file')).toBe('/home/user/file');
 });
 
 test('fromFileURL: handles URL-encoded characters', () => {
 	expect(fromFileURL('file:///home/user/my%20file')).toBe('/home/user/my file');
+});
+
+test('fromFileURL: throws on non-file protocol', () => {
+	expect(() => fromFileURL('http://example.com')).toThrow();
+});
+
+test('fromFileURL: throws on invalid URL', () => {
+	expect(() => fromFileURL('not-a-url')).toThrow();
 });

--- a/packages/@markuplint/file-resolver/src/path-utils.spec.ts
+++ b/packages/@markuplint/file-resolver/src/path-utils.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from 'vitest';
+
+import { toSlash, fromFileURL, normalizeForIgnore, normalizeForGlob } from './path-utils.js';
+
+test('toSlash: converts backslashes to forward slashes', () => {
+	expect(toSlash('C:\\Users\\foo\\file.html')).toBe('C:/Users/foo/file.html');
+});
+
+test('toSlash: preserves POSIX paths', () => {
+	expect(toSlash('/unix/path')).toBe('/unix/path');
+});
+
+test('toSlash: handles mixed separators', () => {
+	expect(toSlash('C:\\path/mixed\\file')).toBe('C:/path/mixed/file');
+});
+
+test('toSlash: handles empty string', () => {
+	expect(toSlash('')).toBe('');
+});
+
+test('normalizeForIgnore: POSIX absolute path without relative', () => {
+	expect(normalizeForIgnore('/Users/project/file.html')).toBe('/Users/project/file.html');
+});
+
+test('normalizeForIgnore: POSIX absolute path with relative', () => {
+	expect(normalizeForIgnore('/Users/project/file.html', true)).toBe('Users/project/file.html');
+});
+
+test('normalizeForIgnore: preserves bang prefix', () => {
+	expect(normalizeForIgnore('!dir/file')).toBe('!dir/file');
+});
+
+test('normalizeForIgnore: preserves bang prefix with relative', () => {
+	expect(normalizeForIgnore('!/dir/file', true)).toBe('!dir/file');
+});
+
+test('normalizeForIgnore: preserves glob wildcard', () => {
+	expect(normalizeForIgnore('*')).toBe('*');
+});
+
+test('normalizeForIgnore: Windows backslash path with relative', () => {
+	expect(normalizeForIgnore('C:\\Users\\project\\file.html', true)).toBe('Users/project/file.html');
+});
+
+test('normalizeForIgnore: Windows backslash path without relative', () => {
+	expect(normalizeForIgnore('C:\\Users\\project\\file.html')).toBe('/Users/project/file.html');
+});
+
+test('normalizeForIgnore: Windows P: drive path', () => {
+	expect(normalizeForIgnore('P:\\project\\src\\file.html', true)).toBe('project/src/file.html');
+});
+
+test('normalizeForGlob: POSIX path unchanged', () => {
+	expect(normalizeForGlob('src/**/*.html')).toBe('src/**/*.html');
+});
+
+test('normalizeForGlob: converts backslashes', () => {
+	expect(normalizeForGlob('src\\**\\*.html')).toBe('src/**/*.html');
+});
+
+test('fromFileURL: POSIX file URL', () => {
+	expect(fromFileURL('file:///home/user/file')).toBe('/home/user/file');
+});
+
+test('fromFileURL: handles URL-encoded characters', () => {
+	expect(fromFileURL('file:///home/user/my%20file')).toBe('/home/user/my file');
+});

--- a/packages/@markuplint/file-resolver/src/path-utils.spec.ts
+++ b/packages/@markuplint/file-resolver/src/path-utils.spec.ts
@@ -110,12 +110,18 @@ test('normalizeForGlob: preserves drive letter', () => {
 	expect(normalizeForGlob('C:\\Users\\**\\*.html')).toBe('C:/Users/**/*.html');
 });
 
-test('fromFileURL: POSIX file URL', () => {
+// fileURLToPath requires a drive letter on Windows (e.g. file:///C:/...),
+// so POSIX-style file URLs are only valid on non-Windows platforms.
+test.skipIf(process.platform === 'win32')('fromFileURL: POSIX file URL', () => {
 	expect(fromFileURL('file:///home/user/file')).toBe('/home/user/file');
 });
 
-test('fromFileURL: handles URL-encoded characters', () => {
+test.skipIf(process.platform === 'win32')('fromFileURL: handles URL-encoded characters', () => {
 	expect(fromFileURL('file:///home/user/my%20file')).toBe('/home/user/my file');
+});
+
+test.skipIf(process.platform !== 'win32')('fromFileURL: Windows file URL with drive letter', () => {
+	expect(fromFileURL('file:///C:/Users/project/file.html')).toBe('C:\\Users\\project\\file.html');
 });
 
 test('fromFileURL: throws on non-file protocol', () => {

--- a/packages/@markuplint/file-resolver/src/path-utils.ts
+++ b/packages/@markuplint/file-resolver/src/path-utils.ts
@@ -29,7 +29,7 @@ export function normalizeForIgnore(filePath: string, relative = false): string {
 
 	// Remove the local disk scheme of Windows OS (e.g. "C:", "P:")
 	if (path.isAbsolute(filePath) || /^[a-z]:/i.test(filePath)) {
-		filePath = filePath.replace(/^[a-z]+:/i, '');
+		filePath = filePath.replace(/^[a-z]:/i, '');
 	}
 
 	// Convert backslashes to forward slashes

--- a/packages/@markuplint/file-resolver/src/path-utils.ts
+++ b/packages/@markuplint/file-resolver/src/path-utils.ts
@@ -1,0 +1,55 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Convert OS-native separators to forward slashes.
+ * Identity function on POSIX.
+ */
+export function toSlash(filePath: string): string {
+	return filePath.replaceAll('\\', '/');
+}
+
+/**
+ * Convert a `file://` URL to a native file path using Node.js built-in.
+ * Correctly handles URL encoding, UNC paths, and all drive letters.
+ */
+export function fromFileURL(fileUrl: string): string {
+	return fileURLToPath(fileUrl);
+}
+
+/**
+ * Normalize a path for the `ignore` library (gitignore-style matching).
+ * Removes drive letters, converts to forward slashes, and optionally makes relative.
+ */
+export function normalizeForIgnore(filePath: string, relative = false): string {
+	const hasBang = filePath.startsWith('!');
+	if (hasBang) {
+		filePath = filePath.slice(1);
+	}
+
+	// Remove the local disk scheme of Windows OS (e.g. "C:", "P:")
+	if (path.isAbsolute(filePath) || /^[a-z]:/i.test(filePath)) {
+		filePath = filePath.replace(/^[a-z]+:/i, '');
+	}
+
+	// Convert backslashes to forward slashes
+	filePath = toSlash(filePath);
+
+	if (relative) {
+		// Strip leading slashes to make the path relative
+		filePath = filePath.replace(/^\/+/, '');
+	}
+
+	if (hasBang) {
+		filePath = `!${filePath}`;
+	}
+
+	return filePath;
+}
+
+/**
+ * Normalize a path for glob libraries (forward slashes required).
+ */
+export function normalizeForGlob(filePath: string): string {
+	return toSlash(filePath);
+}

--- a/packages/@markuplint/file-resolver/src/resolve-pretenders.spec.ts
+++ b/packages/@markuplint/file-resolver/src/resolve-pretenders.spec.ts
@@ -21,16 +21,15 @@ test('files', async () => {
 	]);
 });
 
-// Skip #2423
-// test('imports', async () => {
-// 	const pretenders = await resolvePretenders({
-// 		imports: ['@markuplint-test/react'],
-// 	});
-// 	expect(pretenders).toStrictEqual([
-// 		{
-// 			selector: 'Sample',
-// 			as: 'div',
-// 			filePath: 'sample.jsx:1:16',
-// 		},
-// 	]);
-// });
+test('imports', async () => {
+	const pretenders = await resolvePretenders({
+		imports: ['@markuplint-test/react'],
+	});
+	expect(pretenders).toStrictEqual([
+		{
+			selector: 'Sample',
+			as: 'div',
+			filePath: 'sample.jsx:1:16',
+		},
+	]);
+});


### PR DESCRIPTION
## Summary

- Fix Windows path normalization bugs in `@markuplint/file-resolver` that caused VS Code extension crashes on non-C: drives (e.g. P:\, D:\)
- Extract cross-platform path utilities into `path-utils.ts` and replace broken manual path parsing across 4 files
- Re-enable the pretender imports test that was skipped due to #2423

## Changes

### New files
- **`path-utils.ts`** — Cross-platform path utilities (`toSlash`, `fromFileURL`, `normalizeForIgnore`, `normalizeForGlob`)
- **`path-utils.spec.ts`** — 31 test cases covering drive letters, UNC paths, CJK chars, edge cases

### Bug fixes
- **`ml-file.ts`**: Replace broken `pathNormalize()` (used `path.relative(path.sep, ...)`) with `normalizeForIgnore()` using simple leading-slash stripping; fix double-normalization bug in `ignored()`; fix `matches()` normalization asymmetry
- **`force-import-json-in-module.ts`**: Use Node.js `fileURLToPath()` instead of manual `file://` URL parsing that failed on Windows
- **`general-import.ts`**: Convert `file://` URLs from `import-meta-resolve` to native paths before `path.dirname()`
- **`get-files.ts`**: Normalize backslash paths and ignore globs for cross-platform glob matching

### Tests
- 31 new tests in `path-utils.spec.ts` (drive letters, UNC paths, CJK, empty strings, error cases)
- 1 new test in `ml-file.spec.ts` (absolute path `ignored()` patterns)
- Re-enabled skipped pretender `imports` test (#2423)

## Test plan

- [x] `yarn lint-check` — 0 errors, 0 issues
- [x] `yarn build` — 40 projects passed
- [x] `yarn test` — 2457 passed, 0 failed
- [ ] Manual verification on Windows with non-C: drive project

Closes #1806
Closes #2423

🤖 Generated with [Claude Code](https://claude.com/claude-code)