### PR TITLE
feat(vscode): add workingDirectories option for monorepo support

### DIFF
--- a/vscode/README.md
+++ b/vscode/README.md
@@ -8,8 +8,49 @@
 - `markuplint.debug`: Enable debug mode
 - `markuplint.defaultConfig`: It's the configuration specified if configuration files do not exist
 - `markuplint.targetLanguages`: Specify the target languages
+- `markuplint.workingDirectories`: Specify working directories for config resolution (see [Working Directories](#working-directories))
 - `markuplint.hover.accessibility.enable`: Enable the feature that **popup Accessibility Object**
-- `markuplint.hover.accessibility.ariaVersion`: Set `1.1` or `1.2` WAI-ARIA version; Default is `1.2`.
+- `markuplint.hover.accessibility.ariaVersion`: Set `1.1`, `1.2`, or `1.3` WAI-ARIA version; Default is `1.2`.
+
+## Working Directories
+
+In monorepo setups where each sub-package has its own `.markuplintrc`, you may need to configure `markuplint.workingDirectories` so that markuplint resolves configuration files from the correct directory.
+
+### Examples
+
+**Explicit directories:**
+
+```json
+{
+  "markuplint.workingDirectories": ["./client", "./server"]
+}
+```
+
+**Glob pattern** (recommended for monorepos with many packages):
+
+```json
+{
+  "markuplint.workingDirectories": [{ "pattern": "./packages/*/" }]
+}
+```
+
+**Auto-detection** from `package.json` or `.markuplintrc`:
+
+```json
+{
+  "markuplint.workingDirectories": [{ "mode": "auto" }]
+}
+```
+
+**Use workspace folder** (falls back to workspace folder, but prefers a directory containing `.markuplintrc`):
+
+```json
+{
+  "markuplint.workingDirectories": [{ "mode": "location" }]
+}
+```
+
+If not set, markuplint uses the parent directory of each file as the working directory (default behavior).
 
 ## Release
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -77,6 +77,69 @@
 						]
 					}
 				},
+				"markuplint.workingDirectories": {
+					"type": "array",
+					"markdownDescription": "Specifies working directories for markuplint config resolution. Useful for **monorepos** where each sub-package has its own `.markuplintrc`.\n\nExamples:\n- `[\"./client\", \"./server\"]` — explicit directories\n- `[{ \"pattern\": \"./packages/*/\" }]` — glob pattern\n- `[{ \"mode\": \"auto\" }]` — auto-detect from `package.json` / `.markuplintrc`",
+					"items": {
+						"anyOf": [
+							{
+								"type": "string",
+								"description": "A directory path relative to the workspace folder."
+							},
+							{
+								"type": "object",
+								"properties": {
+									"directory": {
+										"type": "string",
+										"description": "A directory path relative to the workspace folder."
+									},
+									"!cwd": {
+										"type": "boolean",
+										"description": "If true, does not change the process working directory."
+									}
+								},
+								"required": [
+									"directory"
+								],
+								"additionalProperties": false
+							},
+							{
+								"type": "object",
+								"properties": {
+									"pattern": {
+										"type": "string",
+										"description": "A glob pattern to match working directories (e.g. \"./packages/*/\")."
+									},
+									"!cwd": {
+										"type": "boolean",
+										"description": "If true, does not change the process working directory."
+									}
+								},
+								"required": [
+									"pattern"
+								],
+								"additionalProperties": false
+							},
+							{
+								"type": "object",
+								"properties": {
+									"mode": {
+										"type": "string",
+										"enum": [
+											"auto",
+											"location"
+										],
+										"description": "\"auto\" detects from package.json/.markuplintrc; \"location\" uses workspace folder."
+									}
+								},
+								"required": [
+									"mode"
+								],
+								"additionalProperties": false
+							}
+						]
+					}
+				},
 				"markuplint.hover.accessibility.enable": {
 					"type": "boolean",
 					"markdownDescription": "Enable the feature that **popup Accessibility Object**",

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -1,4 +1,4 @@
-import type { Config, LangConfigs } from './types.js';
+import type { Config, InitializationOptions, LangConfigs } from './types.js';
 import type { ExtensionContext } from 'vscode';
 import type { LanguageClientOptions, ServerOptions } from 'vscode-languageclient/node.js';
 
@@ -108,6 +108,16 @@ export function activate(
 		};
 	}
 
+	const workingDirectories: InitializationOptions['workingDirectories'] =
+		config.get('workingDirectories') ?? undefined;
+	const workspaceFolders = (workspace.workspaceFolders ?? []).map(f => f.uri.fsPath);
+
+	const initializationOptions: InitializationOptions = {
+		langConfigs,
+		workingDirectories,
+		workspaceFolders,
+	};
+
 	const clientOptions: LanguageClientOptions = {
 		documentSelector: [
 			...languageList.map(language => ({ language, scheme: 'file' })),
@@ -119,9 +129,7 @@ export function activate(
 		},
 		outputChannel: logger.outputChannel,
 		revealOutputChannelOn: RevealOutputChannelOn.Error,
-		initializationOptions: {
-			langConfigs,
-		},
+		initializationOptions,
 	};
 
 	client = new LanguageClient(ID, OUTPUT_CHANNEL_PRIMARY_CHANNEL_NAME, serverOptions, clientOptions);

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -31,6 +31,14 @@ let client: LanguageClient;
 let logger: Logger;
 let diagnosticsLogger: Logger;
 
+/**
+ * Activates the markuplint VS Code extension.
+ *
+ * Registers commands, reads user configuration (including `workingDirectories`),
+ * starts the language server, and sets up event handlers.
+ *
+ * @param context - The VS Code extension context
+ */
 export function activate(
 	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
 	context: ExtensionContext,
@@ -166,6 +174,11 @@ export function activate(
 	});
 }
 
+/**
+ * Deactivates the markuplint VS Code extension by stopping the language client.
+ *
+ * @returns A promise that resolves when the client has stopped
+ */
 export function deactivate() {
 	return client.stop();
 }

--- a/vscode/src/server/document-events.ts
+++ b/vscode/src/server/document-events.ts
@@ -1,5 +1,6 @@
 import type { Module } from './get-module.js';
 import type { LangConfigs, Log } from '../types.js';
+import type { WorkingDirectoryEntry } from '../utils/resolve-working-directory.js';
 import type { PublishDiagnosticsParams, HoverParams } from 'vscode-languageserver/node.js';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 
@@ -21,6 +22,8 @@ export type EventHandlerOptions = {
 	mod: Module;
 	locale: string;
 	langConfigs: LangConfigs;
+	workingDirectories?: readonly WorkingDirectoryEntry[];
+	workspaceFolders: readonly string[];
 	log: Log;
 	diagnosticsLog: Log;
 	errorLog: Log;
@@ -62,6 +65,9 @@ export function createEventHandlers(
 					options.locale,
 					options.sendDiagnostics,
 					notFoundParserError(languageId, options.errorLog),
+					options.workingDirectories,
+					options.workspaceFolders,
+					options.log,
 				);
 				return;
 			}
@@ -76,6 +82,8 @@ export function createEventHandlers(
 					options.diagnosticsLog,
 					options.sendDiagnostics,
 					notFoundParserError(languageId, options.errorLog),
+					options.workingDirectories,
+					options.workspaceFolders,
 				);
 				return;
 			}
@@ -89,6 +97,8 @@ export function createEventHandlers(
 				options.diagnosticsLog,
 				options.sendDiagnostics,
 				notFoundParserError(languageId, options.errorLog),
+				options.workingDirectories,
+				options.workspaceFolders,
 			);
 		},
 

--- a/vscode/src/server/document-events.ts
+++ b/vscode/src/server/document-events.ts
@@ -13,16 +13,27 @@ import * as v2 from './v2.js';
 import * as v3 from './v3.js';
 import * as v4 from './v4.js';
 
+/**
+ * Callback for publishing diagnostics from the language server to the client.
+ */
 export type SendDiagnostics = (
 	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
 	params: PublishDiagnosticsParams,
 ) => void;
 
+/**
+ * Options for creating the document event handlers.
+ */
 export type EventHandlerOptions = {
+	/** The resolved markuplint module (local or bundled) */
 	mod: Module;
+	/** The user's locale (e.g. `"en"`, `"ja"`) */
 	locale: string;
+	/** Per-language configuration from VS Code settings */
 	langConfigs: LangConfigs;
+	/** User-configured working directories for monorepo support */
 	workingDirectories?: readonly WorkingDirectoryEntry[];
+	/** Absolute paths of VS Code workspace folders */
 	workspaceFolders: readonly string[];
 	log: Log;
 	diagnosticsLog: Log;
@@ -31,6 +42,15 @@ export type EventHandlerOptions = {
 	initUI: () => void;
 };
 
+/**
+ * Creates version-aware event handlers for document open, change, and hover events.
+ *
+ * Dispatches to the appropriate version handler (v2, v3, or v4) based on the
+ * resolved markuplint module version.
+ *
+ * @param options - Configuration including the markuplint module, locale, and settings
+ * @returns An object containing `onDidOpen`, `onDidChangeContent`, and `onHover` handlers
+ */
 export function createEventHandlers(
 	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
 	options: EventHandlerOptions,

--- a/vscode/src/server/server.ts
+++ b/vscode/src/server/server.ts
@@ -1,5 +1,5 @@
 import type { SendDiagnostics } from './document-events.js';
-import type { LangConfigs, Log } from '../types.js';
+import type { InitializationOptions, Log } from '../types.js';
 import type { InitializeResult } from 'vscode-languageserver/node.js';
 
 import { createConnection, TextDocuments, TextDocumentSyncKind, ProposedFeatures } from 'vscode-languageserver/node.js';
@@ -49,7 +49,8 @@ export function bootServer() {
 		log('onInitialize');
 
 		const locale = params.locale ?? 'en';
-		const langConfigs: LangConfigs = params.initializationOptions.langConfigs;
+		const initOptions: InitializationOptions = params.initializationOptions;
+		const { langConfigs, workingDirectories, workspaceFolders } = initOptions;
 
 		connection.onInitialized(async () => {
 			log('onInitialized');
@@ -63,10 +64,16 @@ export function bootServer() {
 			log(`Found version: ${mod.version} (isLocalModule: ${mod.isLocalModule})`, 'info');
 			log(`Locale: ${locale}`, 'info');
 
+			if (workingDirectories) {
+				log(`Working directories: ${JSON.stringify(workingDirectories)}`, 'info');
+			}
+
 			const { onDidOpen, onDidChangeContent, onHover } = createEventHandlers({
 				mod,
 				locale,
 				langConfigs,
+				workingDirectories,
+				workspaceFolders: workspaceFolders ?? [],
 				log,
 				diagnosticsLog,
 				errorLog,

--- a/vscode/src/server/v2.ts
+++ b/vscode/src/server/v2.ts
@@ -1,9 +1,11 @@
 import type { SendDiagnostics } from './document-events.js';
-import type { Config } from '../types.js';
+import type { Config, Log } from '../types.js';
+import type { WorkingDirectoryEntry } from '../utils/resolve-working-directory.js';
 import type { MLEngine as _MLEngine } from 'markuplint';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 
 import { getFilePath } from '../utils/get-file-path.js';
+import { resolveWorkingDirectory } from '../utils/resolve-working-directory.js';
 
 import { convertDiagnostics } from './convert-diagnostics.js';
 
@@ -19,6 +21,9 @@ export async function onDidOpen(
 	locale: string,
 	sendDiagnostics: SendDiagnostics,
 	notFoundParserError: (e: unknown) => void,
+	workingDirectories?: readonly WorkingDirectoryEntry[],
+	workspaceFolders?: readonly string[],
+	log?: Log,
 ) {
 	const key = document.uri;
 	console.log(`Opened: ${key}`);
@@ -32,8 +37,15 @@ export async function onDidOpen(
 		console.log(filePath);
 	}
 
+	const absoluteFilePath = `${filePath.dirname}/${filePath.basename}`;
+	const resolved = resolveWorkingDirectory(absoluteFilePath, workspaceFolders ?? [], workingDirectories);
+	const workspace = resolved?.directory ?? filePath.dirname;
+	if (resolved) {
+		log?.(`Resolved working directory: ${workspace} (for ${filePath.basename})`, 'debug');
+	}
+
 	const sourceCode = document.getText();
-	const file = await MLEngine.toMLFile({ sourceCode, name: filePath.basename, workspace: filePath.dirname });
+	const file = await MLEngine.toMLFile({ sourceCode, name: filePath.basename, workspace });
 
 	if (!file) {
 		console.warn(`File not found: ${filePath.basename}`);

--- a/vscode/src/server/v3.ts
+++ b/vscode/src/server/v3.ts
@@ -1,5 +1,6 @@
 import type { SendDiagnostics } from './document-events.js';
 import type { Config, Log } from '../types.js';
+import type { WorkingDirectoryEntry } from '../utils/resolve-working-directory.js';
 import type { ConfigSet } from '@markuplint/file-resolver';
 import type { ARIAVersion } from '@markuplint/ml-spec';
 import type { MLEngine as _MLEngine } from 'markuplint';
@@ -7,6 +8,7 @@ import type { Position, TextDocumentIdentifier } from 'vscode-languageserver';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 
 import { getFilePath } from '../utils/get-file-path.js';
+import { resolveWorkingDirectory } from '../utils/resolve-working-directory.js';
 
 import { convertDiagnostics } from './convert-diagnostics.js';
 
@@ -24,6 +26,8 @@ export async function onDidOpen(
 	diagnosticsLog: Log,
 	sendDiagnostics: SendDiagnostics,
 	notFoundParserError: (e: unknown) => void,
+	workingDirectories?: readonly WorkingDirectoryEntry[],
+	workspaceFolders?: readonly string[],
 ) {
 	const key = document.uri;
 	log(`Opened: ${key}`, 'debug');
@@ -35,8 +39,15 @@ export async function onDidOpen(
 	const filePath = getFilePath(document.uri, document.languageId);
 	log(`${filePath.dirname}/${filePath.basename}`, 'debug');
 
+	const absoluteFilePath = `${filePath.dirname}/${filePath.basename}`;
+	const resolved = resolveWorkingDirectory(absoluteFilePath, workspaceFolders ?? [], workingDirectories);
+	const workspace = resolved?.directory ?? filePath.dirname;
+	if (resolved) {
+		log(`Resolved working directory: ${workspace} (for ${filePath.basename})`, 'debug');
+	}
+
 	const sourceCode = document.getText();
-	const file = await MLEngine.toMLFile({ sourceCode, name: filePath.basename, workspace: filePath.dirname });
+	const file = await MLEngine.toMLFile({ sourceCode, name: filePath.basename, workspace });
 
 	if (!file) {
 		log(`File not found: ${filePath.basename}`, 'warn');

--- a/vscode/src/server/v4.ts
+++ b/vscode/src/server/v4.ts
@@ -1,5 +1,6 @@
 import type { SendDiagnostics } from './document-events.js';
 import type { Config, Log } from '../types.js';
+import type { WorkingDirectoryEntry } from '../utils/resolve-working-directory.js';
 import type { ConfigSet } from '@markuplint/file-resolver';
 import type { ARIAVersion } from '@markuplint/ml-spec';
 import type { MLEngine as _MLEngine } from 'markuplint';
@@ -8,6 +9,7 @@ import type { TextDocument } from 'vscode-languageserver-textdocument';
 
 import { t } from '../i18n.js';
 import { getFilePath } from '../utils/get-file-path.js';
+import { resolveWorkingDirectory } from '../utils/resolve-working-directory.js';
 
 import { convertDiagnostics } from './convert-diagnostics.js';
 import { getAccessibilityByLocation } from './get-accessibility-by-location.js';
@@ -26,6 +28,8 @@ export async function onDidOpen(
 	diagnosticsLog: Log,
 	sendDiagnostics: SendDiagnostics,
 	notFoundParserError: (e: unknown) => void,
+	workingDirectories?: readonly WorkingDirectoryEntry[],
+	workspaceFolders?: readonly string[],
 ) {
 	const key = document.uri;
 	log(`Opened: ${key}`, 'debug');
@@ -37,8 +41,15 @@ export async function onDidOpen(
 	const filePath = getFilePath(document.uri, document.languageId);
 	log(`${filePath.dirname}/${filePath.basename}`, 'debug');
 
+	const absoluteFilePath = `${filePath.dirname}/${filePath.basename}`;
+	const resolved = resolveWorkingDirectory(absoluteFilePath, workspaceFolders ?? [], workingDirectories);
+	const workspace = resolved?.directory ?? filePath.dirname;
+	if (resolved) {
+		log(`Resolved working directory: ${workspace} (for ${filePath.basename})`, 'debug');
+	}
+
 	const sourceCode = document.getText();
-	const file = await MLEngine.toMLFile({ sourceCode, name: filePath.basename, workspace: filePath.dirname });
+	const file = await MLEngine.toMLFile({ sourceCode, name: filePath.basename, workspace });
 
 	if (!file) {
 		log(`File not found: ${filePath.basename}`, 'warn');

--- a/vscode/src/types.ts
+++ b/vscode/src/types.ts
@@ -1,6 +1,8 @@
 import type { Config as MLConfig } from '@markuplint/ml-config';
 import type { ARIAVersion } from '@markuplint/ml-spec';
 
+import type { WorkingDirectoryEntry } from './utils/resolve-working-directory.js';
+
 export type Config = {
 	enable: boolean;
 	debug: boolean;
@@ -20,6 +22,12 @@ export type Status = {
 };
 
 export type LangConfigs = Record<string, Config>;
+
+export type InitializationOptions = {
+	readonly langConfigs: LangConfigs;
+	readonly workingDirectories?: readonly WorkingDirectoryEntry[];
+	readonly workspaceFolders?: readonly string[];
+};
 
 export type Log = (...args: LogArg) => void;
 

--- a/vscode/src/types.ts
+++ b/vscode/src/types.ts
@@ -3,6 +3,9 @@ import type { ARIAVersion } from '@markuplint/ml-spec';
 
 import type { WorkingDirectoryEntry } from './utils/resolve-working-directory.js';
 
+/**
+ * Per-language configuration for the markuplint VS Code extension.
+ */
 export type Config = {
 	enable: boolean;
 	debug: boolean;
@@ -15,22 +18,43 @@ export type Config = {
 	};
 };
 
+/**
+ * Status information sent from the language server to the client for the status bar.
+ */
 export type Status = {
 	readonly version: string;
 	readonly isLocalModule: boolean;
 	readonly message: string | null;
 };
 
+/**
+ * A map of VS Code language IDs to their markuplint configuration.
+ */
 export type LangConfigs = Record<string, Config>;
 
+/**
+ * Options passed from the VS Code client to the language server during initialization.
+ */
 export type InitializationOptions = {
+	/** Per-language configuration for markuplint */
 	readonly langConfigs: LangConfigs;
+	/** User-configured working directories for monorepo support */
 	readonly workingDirectories?: readonly WorkingDirectoryEntry[];
+	/** Absolute paths of VS Code workspace folders */
 	readonly workspaceFolders?: readonly string[];
 };
 
+/**
+ * A logging function that writes to an output channel.
+ */
 export type Log = (...args: LogArg) => void;
 
+/**
+ * Log severity levels for the output channels.
+ */
 export type LogType = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'clear';
 
+/**
+ * Arguments for a log call: a message string and an optional log type.
+ */
 export type LogArg = readonly [message: string, type?: LogType];

--- a/vscode/src/utils/get-file-path.ts
+++ b/vscode/src/utils/get-file-path.ts
@@ -1,6 +1,17 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+/**
+ * Extracts a directory name and base file name from a VS Code document URI.
+ *
+ * Handles `file:` and `untitled:` URI schemes. For untitled documents,
+ * appends the language ID as a file extension so markuplint can detect
+ * the correct parser.
+ *
+ * @param uri - The document URI (e.g. `"file:///path/to/file.html"`)
+ * @param langId - The VS Code language identifier (e.g. `"html"`, `"vue"`)
+ * @returns An object with `dirname` (absolute directory path) and `basename` (file name)
+ */
 export function getFilePath(uri: string, langId: string) {
 	if (/^untitled:/i.test(uri)) {
 		const name = uri.replace(/^untitled:/i, '');

--- a/vscode/src/utils/resolve-working-directory.spec.ts
+++ b/vscode/src/utils/resolve-working-directory.spec.ts
@@ -1,0 +1,204 @@
+import path from 'node:path';
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { resolveWorkingDirectory, convertGlobToRegex } from './resolve-working-directory.js';
+import type { WorkingDirectoryEntry } from './resolve-working-directory.js';
+
+// Mock fs.existsSync for auto/location mode tests
+vi.mock('node:fs', () => ({
+	default: {
+		existsSync: vi.fn(() => false),
+	},
+}));
+
+// Import fs after mocking so we can set up return values
+const fs = await import('node:fs');
+const existsSyncMock = vi.mocked(fs.default.existsSync);
+
+describe('convertGlobToRegex', () => {
+	it('converts a simple wildcard pattern', () => {
+		const regex = convertGlobToRegex('./packages/*/');
+		expect(regex.test('./packages/foo/')).toBe(true);
+		expect(regex.test('./packages/bar/')).toBe(true);
+		expect(regex.test('./packages/foo/src/file.ts')).toBe(true);
+		expect(regex.test('./other/foo/')).toBe(false);
+	});
+
+	it('converts a double wildcard pattern', () => {
+		const regex = convertGlobToRegex('./apps/**/');
+		expect(regex.test('./apps/foo/')).toBe(true);
+		expect(regex.test('./apps/foo/bar/')).toBe(true);
+		expect(regex.test('./other/foo/')).toBe(false);
+	});
+
+	it('handles patterns without trailing slash', () => {
+		const regex = convertGlobToRegex('./packages/*');
+		expect(regex.test('./packages/foo')).toBe(true);
+		expect(regex.test('./packages/foo/src')).toBe(true);
+	});
+});
+
+describe('resolveWorkingDirectory', () => {
+	const workspaceFolders = ['/workspace/monorepo'];
+
+	beforeEach(() => {
+		existsSyncMock.mockReset();
+	});
+
+	describe('when workingDirectories is undefined or empty', () => {
+		it('returns undefined', () => {
+			const result = resolveWorkingDirectory('/workspace/monorepo/src/file.html', workspaceFolders);
+			expect(result).toBeUndefined();
+		});
+
+		it('returns undefined for empty array', () => {
+			const result = resolveWorkingDirectory('/workspace/monorepo/src/file.html', workspaceFolders, []);
+			expect(result).toBeUndefined();
+		});
+	});
+
+	describe('string entries', () => {
+		it('matches a file inside a specified directory', () => {
+			const entries: WorkingDirectoryEntry[] = ['./client', './server'];
+			const result = resolveWorkingDirectory(
+				'/workspace/monorepo/client/src/index.html',
+				workspaceFolders,
+				entries,
+			);
+			expect(result).toEqual({ directory: path.resolve('/workspace/monorepo', './client') });
+		});
+
+		it('matches the deepest directory when multiple match', () => {
+			const entries: WorkingDirectoryEntry[] = ['./packages', './packages/ui'];
+			const result = resolveWorkingDirectory(
+				'/workspace/monorepo/packages/ui/src/index.html',
+				workspaceFolders,
+				entries,
+			);
+			expect(result).toEqual({ directory: path.resolve('/workspace/monorepo', './packages/ui') });
+		});
+
+		it('returns undefined when no directory matches', () => {
+			const entries: WorkingDirectoryEntry[] = ['./client'];
+			const result = resolveWorkingDirectory(
+				'/workspace/monorepo/server/src/index.html',
+				workspaceFolders,
+				entries,
+			);
+			expect(result).toBeUndefined();
+		});
+	});
+
+	describe('directory object entries', () => {
+		it('matches a file inside a specified directory object', () => {
+			const entries: WorkingDirectoryEntry[] = [{ directory: './client' }];
+			const result = resolveWorkingDirectory(
+				'/workspace/monorepo/client/src/index.html',
+				workspaceFolders,
+				entries,
+			);
+			expect(result).toEqual({ directory: path.resolve('/workspace/monorepo', './client') });
+		});
+
+		it('handles absolute directory paths', () => {
+			const entries: WorkingDirectoryEntry[] = [{ directory: '/absolute/path/project' }];
+			const result = resolveWorkingDirectory('/absolute/path/project/src/index.html', workspaceFolders, entries);
+			expect(result).toEqual({ directory: '/absolute/path/project' });
+		});
+	});
+
+	describe('pattern entries', () => {
+		it('matches files against a glob pattern', () => {
+			const entries: WorkingDirectoryEntry[] = [{ pattern: './packages/*/' }];
+			const result = resolveWorkingDirectory(
+				'/workspace/monorepo/packages/ui/src/index.html',
+				workspaceFolders,
+				entries,
+			);
+			expect(result).toBeDefined();
+			expect(result!.directory).toBe('/workspace/monorepo/packages/ui');
+		});
+
+		it('returns undefined when pattern does not match', () => {
+			const entries: WorkingDirectoryEntry[] = [{ pattern: './packages/*/' }];
+			const result = resolveWorkingDirectory(
+				'/workspace/monorepo/other/src/index.html',
+				workspaceFolders,
+				entries,
+			);
+			expect(result).toBeUndefined();
+		});
+	});
+
+	describe('mode: "location"', () => {
+		it('returns workspace folder when no config file is found', () => {
+			existsSyncMock.mockReturnValue(false);
+			const entries: WorkingDirectoryEntry[] = [{ mode: 'location' }];
+			const result = resolveWorkingDirectory('/workspace/monorepo/src/index.html', workspaceFolders, entries);
+			expect(result).toEqual({ directory: '/workspace/monorepo' });
+		});
+
+		it('returns config directory when a markuplint config is found', () => {
+			existsSyncMock.mockImplementation((p: unknown) => {
+				return (p as string) === path.join('/workspace/monorepo/packages/ui', '.markuplintrc');
+			});
+			const entries: WorkingDirectoryEntry[] = [{ mode: 'location' }];
+			const result = resolveWorkingDirectory(
+				'/workspace/monorepo/packages/ui/src/index.html',
+				workspaceFolders,
+				entries,
+			);
+			expect(result).toEqual({ directory: '/workspace/monorepo/packages/ui' });
+		});
+	});
+
+	describe('mode: "auto"', () => {
+		it('returns the closest directory with package.json', () => {
+			existsSyncMock.mockImplementation((p: unknown) => {
+				return (p as string) === path.join('/workspace/monorepo/packages/ui', 'package.json');
+			});
+			const entries: WorkingDirectoryEntry[] = [{ mode: 'auto' }];
+			const result = resolveWorkingDirectory(
+				'/workspace/monorepo/packages/ui/src/index.html',
+				workspaceFolders,
+				entries,
+			);
+			expect(result).toEqual({ directory: '/workspace/monorepo/packages/ui' });
+		});
+
+		it('returns the closest directory with a markuplint config', () => {
+			existsSyncMock.mockImplementation((p: unknown) => {
+				return (p as string) === path.join('/workspace/monorepo/packages/ui', '.markuplintrc');
+			});
+			const entries: WorkingDirectoryEntry[] = [{ mode: 'auto' }];
+			const result = resolveWorkingDirectory(
+				'/workspace/monorepo/packages/ui/src/index.html',
+				workspaceFolders,
+				entries,
+			);
+			expect(result).toEqual({ directory: '/workspace/monorepo/packages/ui' });
+		});
+
+		it('returns undefined when no root indicator is found', () => {
+			existsSyncMock.mockReturnValue(false);
+			const entries: WorkingDirectoryEntry[] = [{ mode: 'auto' }];
+			const result = resolveWorkingDirectory('/tmp/orphan/file.html', [], entries);
+			expect(result).toBeUndefined();
+		});
+	});
+
+	describe('mixed entries (priority)', () => {
+		it('prefers the deepest match across entry types', () => {
+			const entries: WorkingDirectoryEntry[] = ['./packages', { pattern: './packages/*/' }];
+			const result = resolveWorkingDirectory(
+				'/workspace/monorepo/packages/ui/src/index.html',
+				workspaceFolders,
+				entries,
+			);
+			// Pattern match for packages/ui is deeper than string match for packages
+			expect(result).toBeDefined();
+			expect(result!.directory).toBe('/workspace/monorepo/packages/ui');
+		});
+	});
+});

--- a/vscode/src/utils/resolve-working-directory.ts
+++ b/vscode/src/utils/resolve-working-directory.ts
@@ -1,0 +1,329 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * A working directory entry configuration, modeled after the ESLint VS Code extension.
+ *
+ * Supports:
+ * - Plain string: a directory path relative to the workspace folder
+ * - `{ directory, "!cwd"? }`: explicit directory with optional process.cwd control
+ * - `{ pattern, "!cwd"? }`: glob pattern for dynamic directory detection
+ * - `{ mode: "auto" | "location" }`: automatic working directory detection
+ */
+export type WorkingDirectoryEntry =
+	| string
+	| { readonly directory: string; readonly '!cwd'?: boolean }
+	| { readonly pattern: string; readonly '!cwd'?: boolean }
+	| { readonly mode: 'auto' | 'location' };
+
+/**
+ * The result of resolving a working directory for a file.
+ */
+export type ResolvedWorkingDirectory = {
+	/** The resolved working directory path */
+	readonly directory: string;
+};
+
+/**
+ * Markuplint configuration file names used for auto-detection.
+ */
+const MARKUPLINT_CONFIG_FILES = [
+	'.markuplintrc',
+	'.markuplintrc.json',
+	'.markuplintrc.yaml',
+	'.markuplintrc.yml',
+	'.markuplintrc.js',
+	'.markuplintrc.cjs',
+	'.markuplintrc.mjs',
+	'.markuplintrc.ts',
+	'markuplint.config.js',
+	'markuplint.config.cjs',
+	'markuplint.config.mjs',
+	'markuplint.config.ts',
+] as const;
+
+/**
+ * Files that indicate a project root boundary.
+ */
+const ROOT_INDICATOR_FILES = ['package.json', ...MARKUPLINT_CONFIG_FILES] as const;
+
+/**
+ * Converts a simple glob pattern (supporting `*` and `**`) into a RegExp.
+ *
+ * This is a simplified implementation for matching directory paths against
+ * patterns like `./packages/* /` or `./apps/** /`.
+ */
+export function convertGlobToRegex(pattern: string): RegExp {
+	// Normalize and remove trailing slash
+	let normalized = pattern.replaceAll('\\', '/');
+	if (normalized.endsWith('/')) {
+		normalized = normalized.slice(0, -1);
+	}
+
+	// Escape special regex chars except * and **
+	let regexStr = '';
+	let i = 0;
+	while (i < normalized.length) {
+		const char = normalized[i];
+		if (char === '*') {
+			if (normalized[i + 1] === '*') {
+				regexStr += '.*';
+				i += 2;
+				// Skip optional trailing /
+				if (normalized[i] === '/') {
+					i++;
+				}
+			} else {
+				regexStr += '[^/]*';
+				i++;
+			}
+		} else if ('.+^${}()|[]\\'.includes(char!)) {
+			regexStr += '\\' + char;
+			i++;
+		} else {
+			regexStr += char;
+			i++;
+		}
+	}
+
+	return new RegExp('^' + regexStr + '(?:/|$)');
+}
+
+/**
+ * Resolves the working directory for a given file based on workingDirectories configuration.
+ *
+ * @param filePath - Absolute file path of the document being linted
+ * @param workspaceFolders - VS Code workspace folder paths (absolute)
+ * @param workingDirectories - The user-configured working directories
+ * @returns The resolved working directory, or `undefined` to use the default behavior
+ */
+export function resolveWorkingDirectory(
+	filePath: string,
+	workspaceFolders: readonly string[],
+	workingDirectories: readonly WorkingDirectoryEntry[] | undefined,
+): ResolvedWorkingDirectory | undefined {
+	if (!workingDirectories || workingDirectories.length === 0) {
+		return undefined;
+	}
+
+	const normalizedFilePath = filePath.replaceAll('\\', '/');
+	let bestMatch: ResolvedWorkingDirectory | undefined;
+	let bestMatchLength = -1;
+
+	for (const entry of workingDirectories) {
+		if (typeof entry === 'string') {
+			const resolved = resolveDirectoryEntry(entry, workspaceFolders);
+			if (resolved) {
+				const match = matchDirectory(normalizedFilePath, resolved);
+				if (match > bestMatchLength) {
+					bestMatchLength = match;
+					bestMatch = { directory: resolved };
+				}
+			}
+			continue;
+		}
+
+		if ('mode' in entry) {
+			const result = resolveByMode(filePath, workspaceFolders, entry.mode);
+			if (result) {
+				return result;
+			}
+			continue;
+		}
+
+		if ('directory' in entry) {
+			const resolved = resolveDirectoryEntry(entry.directory, workspaceFolders);
+			if (resolved) {
+				const match = matchDirectory(normalizedFilePath, resolved);
+				if (match > bestMatchLength) {
+					bestMatchLength = match;
+					bestMatch = { directory: resolved };
+				}
+			}
+			continue;
+		}
+
+		if ('pattern' in entry) {
+			const result = resolveByPattern(normalizedFilePath, workspaceFolders, entry.pattern);
+			if (result && result.directory.length > bestMatchLength) {
+				bestMatchLength = result.directory.length;
+				bestMatch = result;
+			}
+		}
+	}
+
+	return bestMatch;
+}
+
+/**
+ * Resolves a directory path relative to workspace folders.
+ * Returns the first existing absolute path found.
+ */
+function resolveDirectoryEntry(directory: string, workspaceFolders: readonly string[]): string | undefined {
+	// If already absolute and exists, use it directly
+	if (path.isAbsolute(directory)) {
+		return directory;
+	}
+
+	// Resolve relative to each workspace folder
+	for (const folder of workspaceFolders) {
+		const resolved = path.resolve(folder, directory);
+		return resolved;
+	}
+
+	return undefined;
+}
+
+/**
+ * Checks if a file path is inside a directory.
+ * Returns the directory path length if matched, -1 otherwise.
+ */
+function matchDirectory(normalizedFilePath: string, directory: string): number {
+	const normalizedDir = directory.replaceAll('\\', '/');
+	const dirWithSlash = normalizedDir.endsWith('/') ? normalizedDir : normalizedDir + '/';
+	if (normalizedFilePath.startsWith(dirWithSlash)) {
+		return dirWithSlash.length;
+	}
+	return -1;
+}
+
+/**
+ * Resolves working directory by glob pattern matching against workspace folders.
+ */
+function resolveByPattern(
+	normalizedFilePath: string,
+	workspaceFolders: readonly string[],
+	pattern: string,
+): ResolvedWorkingDirectory | undefined {
+	for (const folder of workspaceFolders) {
+		const normalizedFolder = folder.replaceAll('\\', '/');
+		const fullPattern = pattern.startsWith('./')
+			? normalizedFolder + pattern.slice(1)
+			: path.posix.join(normalizedFolder, pattern);
+
+		const regex = convertGlobToRegex(fullPattern);
+		if (regex.test(normalizedFilePath)) {
+			// Extract the matched directory portion
+			const match = regex.exec(normalizedFilePath);
+			if (match) {
+				let matchedDir = match[0];
+				if (matchedDir.endsWith('/')) {
+					matchedDir = matchedDir.slice(0, -1);
+				}
+				return { directory: matchedDir };
+			}
+		}
+	}
+
+	return undefined;
+}
+
+/**
+ * Resolves working directory by mode ("auto" or "location").
+ */
+function resolveByMode(
+	filePath: string,
+	workspaceFolders: readonly string[],
+	mode: 'auto' | 'location',
+): ResolvedWorkingDirectory | undefined {
+	if (mode === 'location') {
+		// Use workspace folder path. If a markuplint config is found closer to the file,
+		// use that directory instead.
+		const configDir = findClosestConfigDir(filePath, workspaceFolders);
+		if (configDir) {
+			return { directory: configDir };
+		}
+
+		// Fall back to workspace folder containing the file
+		for (const folder of workspaceFolders) {
+			const normalizedFolder = folder.replaceAll('\\', '/');
+			const normalizedFilePath = filePath.replaceAll('\\', '/');
+			if (
+				normalizedFilePath.startsWith(normalizedFolder + '/') ||
+				normalizedFilePath.startsWith(normalizedFolder + '\\')
+			) {
+				return { directory: folder };
+			}
+		}
+		return undefined;
+	}
+
+	// mode === 'auto'
+	// Walk up from the file's directory to find the closest project root
+	// (indicated by package.json or markuplint config files)
+	const autoDir = findAutoWorkingDirectory(filePath, workspaceFolders);
+	if (autoDir) {
+		return { directory: autoDir };
+	}
+
+	return undefined;
+}
+
+/**
+ * Finds the closest directory containing a markuplint config file,
+ * walking up from the file's parent directory to the workspace root.
+ */
+function findClosestConfigDir(filePath: string, workspaceFolders: readonly string[]): string | undefined {
+	const fileDir = path.dirname(filePath);
+	const workspaceRoot = findContainingWorkspace(filePath, workspaceFolders);
+	const stopDir = workspaceRoot ?? path.parse(fileDir).root;
+
+	let current = fileDir;
+	while (current.length >= stopDir.length) {
+		for (const configFile of MARKUPLINT_CONFIG_FILES) {
+			if (fs.existsSync(path.join(current, configFile))) {
+				return current;
+			}
+		}
+
+		const parent = path.dirname(current);
+		if (parent === current) {
+			break;
+		}
+		current = parent;
+	}
+
+	return undefined;
+}
+
+/**
+ * Finds the closest directory containing a root indicator file (package.json or markuplint config),
+ * walking up from the file's parent directory to the workspace root.
+ * Used by "auto" mode.
+ */
+function findAutoWorkingDirectory(filePath: string, workspaceFolders: readonly string[]): string | undefined {
+	const fileDir = path.dirname(filePath);
+	const workspaceRoot = findContainingWorkspace(filePath, workspaceFolders);
+	const stopDir = workspaceRoot ?? path.parse(fileDir).root;
+
+	let current = fileDir;
+	while (current.length >= stopDir.length) {
+		for (const rootFile of ROOT_INDICATOR_FILES) {
+			if (fs.existsSync(path.join(current, rootFile))) {
+				return current;
+			}
+		}
+
+		const parent = path.dirname(current);
+		if (parent === current) {
+			break;
+		}
+		current = parent;
+	}
+
+	return undefined;
+}
+
+/**
+ * Finds the workspace folder that contains the given file path.
+ */
+function findContainingWorkspace(filePath: string, workspaceFolders: readonly string[]): string | undefined {
+	const normalizedFilePath = filePath.replaceAll('\\', '/');
+	for (const folder of workspaceFolders) {
+		const normalizedFolder = folder.replaceAll('\\', '/');
+		if (normalizedFilePath.startsWith(normalizedFolder + '/')) {
+			return folder;
+		}
+	}
+	return undefined;
+}

--- a/vscode/src/utils/resolve-working-directory.ts
+++ b/vscode/src/utils/resolve-working-directory.ts
@@ -52,6 +52,9 @@ const ROOT_INDICATOR_FILES = ['package.json', ...MARKUPLINT_CONFIG_FILES] as con
  *
  * This is a simplified implementation for matching directory paths against
  * patterns like `./packages/* /` or `./apps/** /`.
+ *
+ * @param pattern - A glob pattern string (e.g. `"./packages/* /"`)
+ * @returns A RegExp anchored at the start that matches directory paths
  */
 export function convertGlobToRegex(pattern: string): RegExp {
 	// Normalize and remove trailing slash

--- a/vscode/vitest.config.ts
+++ b/vscode/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		include: ['./src/**/*.spec.ts'],
+		testTimeout: 10_000,
+	},
+});


### PR DESCRIPTION
## Summary

- Add a new `markuplint.workingDirectories` VS Code setting for monorepo config resolution
- Support four entry types: string paths, directory objects, glob patterns, and auto-detection modes
- Wire the setting through the full LSP pipeline (client → server → v2/v3/v4 handlers)
- Add 18 unit tests for the working directory resolution logic
- Add JSDoc to all exported functions and types in changed files
- Document the new option in `vscode/README.md`

Closes #1287

## Test plan

- [x] `yarn lint-check` passes (0 errors, 0 issues)
- [x] `yarn build` passes (40 projects)
- [x] `yarn test` passes (2457 passed, 2 skipped)
- [x] 18 unit tests for `resolveWorkingDirectory` covering string, directory object, pattern, mode:auto, mode:location, and mixed entries
- [ ] Manual: configure `markuplint.workingDirectories` in a monorepo and verify config resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)