### PR TITLE
feat: add multi-pass fix loop and expand rule fix coverage

### DIFF
--- a/docs/migration/v4-v5/rule-fix-function.ja.md
+++ b/docs/migration/v4-v5/rule-fix-function.ja.md
@@ -1,0 +1,156 @@
+# ルール Fix 関数: v4 から v5 マイグレーションガイド
+
+## 対象読者
+
+- カスタムルールに自動修正機能を追加したい**カスタムルール作者**
+- サードパーティの markuplint ルールを開発する**プラグイン開発者**
+
+> これは v5 の**新機能**であり、v4 に対応する機能はありません。既存のルールは変更なしで動作し続けます。このガイドは新しい fix API の使い方を説明します。
+
+## 概要
+
+v5 では ESLint の `SourceCodeFixer` に着想を得た自動修正システムが導入されました。ルールは `report()` 呼び出しに `fix` コールバックを付与できるようになりました。ユーザーが `fix=true` で markuplint を実行すると、これらのコールバックが `TextEdit` オブジェクトを生成し、ソースコードに適用されます。
+
+## Fix コールバックの追加
+
+### 基本的な使い方
+
+`report()` 呼び出しに `fix` プロパティを追加します。コールバックは `IRuleFixer` インスタンスを受け取り、1つ以上の `TextEdit` オブジェクトを返します:
+
+```typescript
+context.report({
+  scope: node,
+  message: 'タグ名は小文字にすべきです',
+  fix: fixer => fixer.replaceText(
+    { startOffset: nameOffset, raw: node.rawName },
+    node.rawName.toLowerCase(),
+  ),
+});
+```
+
+`fix` コールバックは検証中には**実行されません** — 保存されるだけで、`MLCore.verify()` に `fix=true` が渡された場合にのみ呼び出されます。
+
+## IRuleFixer API
+
+`IRuleFixer` インターフェース（`@markuplint/ml-config` から提供）は 6 つのメソッドを持ちます:
+
+| メソッド | 説明 |
+|----------|------|
+| `replaceText(token, text)` | トークンのテキストを新しい内容に置換 |
+| `replaceRange(range, text)` | 明示的な `[start, end)` レンジを置換 |
+| `insertBefore(token, text)` | トークンの前にテキストを挿入 |
+| `insertAfter(token, text)` | トークンの後にテキストを挿入 |
+| `remove(token)` | トークンを完全に削除 |
+| `removeRange(range)` | 明示的な `[start, end)` レンジを削除 |
+
+### token パラメータ
+
+`token` パラメータを受け付けるメソッドは `FixToken` 型を満たすオブジェクトが必要です:
+
+```typescript
+type FixToken = {
+  readonly startOffset: number;
+  readonly raw: string;
+};
+```
+
+すべての MLDOM トークン（`MLToken`、`MLAttr`、`nameNode`、`valueNode` などの属性サブトークン）はこのインターフェースを満たします。アドホックなトークンを構築することも可能です:
+
+```typescript
+fix: fixer => fixer.replaceText(
+  { startOffset: 42, raw: 'old-text' },
+  'new-text',
+),
+```
+
+### 複数の編集を返す
+
+fix コールバックは単一の `TextEdit` または `TextEdit` の配列を返すことができます。単一コールバック内の複数の編集はアトミックに適用されます — いずれかの編集が他のルールの fix と重複すると、グループ内のすべての編集がスキップされます:
+
+```typescript
+fix: fixer => [
+  fixer.remove(attr.spacesBeforeEqual),
+  fixer.remove(attr.equal),
+  fixer.remove(attr.valueNode),
+],
+```
+
+## 実装例
+
+### テキストの置換
+
+タグ名を小文字に変換:
+
+```typescript
+fix: fixer => fixer.replaceText(
+  { startOffset: nameOffset, raw: el.rawName },
+  el.rawName.toLowerCase(),
+),
+```
+
+### トークンの削除
+
+孤立した終了タグを削除:
+
+```typescript
+fix: fixer => fixer.remove(
+  { startOffset: text.startOffset, raw: text.raw },
+),
+```
+
+### レンジによる削除
+
+属性全体を削除（先頭の空白から閉じ引用符まで）:
+
+```typescript
+fix: fixer => fixer.removeRange([
+  firstToken.startOffset,
+  lastToken.startOffset + lastToken.raw.length,
+]),
+```
+
+## ルール作者向けヘルパー関数
+
+`@markuplint/rules` の `src/helpers.ts` に属性削除パターン用の共有ヘルパーが提供されています:
+
+| ヘルパー | 説明 |
+|----------|------|
+| `removeAttr(fixer, attr)` | 属性全体を削除（属性名 + 値 + 前後の空白） |
+| `removeAttrValue(fixer, attr)` | 値部分のみ削除（等号、引用符、値）、属性名は残す |
+
+これらは標準的な属性トークンプロパティ（`spacesBeforeName`、`nameNode`、`equal`、`valueNode` 等）を受け付け、null/空トークンを自動的に処理します。
+
+## マルチパス Fix の動作
+
+複数のルールが重複する fix を生成した場合、エンジンは反復的に適用します:
+
+1. すべての fix を収集し、1パスで適用
+2. 重複する fix はスキップ
+3. スキップされた fix がある場合、ソースを再パース・再検証
+4. スキップされた fix がなくなるまで繰り返す（最大10パス）
+
+**ルール作者がこれを処理する必要はありません** — エンジンが重複解決を透過的に管理します。
+
+## 自動修正をサポートする組み込みルール
+
+v5 で自動修正をサポートする組み込みルール:
+
+| ルール | 修正内容 |
+|--------|----------|
+| `case-sensitive-tag-name` | 設定されたケースにタグ名を変換 |
+| `case-sensitive-attr-name` | 設定されたケースに属性名を変換 |
+| `attr-value-quotes` | 設定されたスタイルに属性引用符を変換 |
+| `no-boolean-attr-value` | 真偽値属性から値を削除 |
+| `no-default-value` | デフォルト値を持つ属性を削除 |
+| `attr-duplication` | 重複属性を削除 |
+| `ineffective-attr` | 無効な属性を削除 |
+| `no-orphaned-end-tag` | 孤立した終了タグを削除 |
+| `no-consecutive-br` | 連続する `<br>` 要素を削除 |
+
+## 型のインポート
+
+```typescript
+import type { IRuleFixer, TextEdit, FixToken } from '@markuplint/ml-config';
+```
+
+これらの型は `@markuplint/ml-config` から再エクスポートされています。`IRuleFixer` はコールバックに渡されるため、自分でインスタンス化する必要はありません。

--- a/docs/migration/v4-v5/rule-fix-function.md
+++ b/docs/migration/v4-v5/rule-fix-function.md
@@ -1,0 +1,156 @@
+# Rule Fix Function: v4 to v5 Migration Guide
+
+## Who This Guide Is For
+
+- **Custom rule authors** who want to add auto-fix capability to their rules
+- **Plugin developers** who maintain third-party markuplint rules
+
+> This is a **new feature** in v5 — there is no v4 equivalent. Existing rules continue to work without changes. This guide explains how to opt into the new fix API.
+
+## Overview
+
+v5 introduces an auto-fix system inspired by ESLint's `SourceCodeFixer`. Rules can now provide a `fix` callback on `report()` calls. When the user runs markuplint with `fix=true`, these callbacks produce `TextEdit` objects that are applied to the source code.
+
+## Adding a Fix Callback
+
+### Basic Usage
+
+Add a `fix` property to your `report()` call. The callback receives an `IRuleFixer` instance and returns one or more `TextEdit` objects:
+
+```typescript
+context.report({
+  scope: node,
+  message: 'Tag name should be lowercase',
+  fix: fixer => fixer.replaceText(
+    { startOffset: nameOffset, raw: node.rawName },
+    node.rawName.toLowerCase(),
+  ),
+});
+```
+
+The `fix` callback is **not** executed during verification — it is stored and only invoked when `fix=true` is passed to `MLCore.verify()`.
+
+## IRuleFixer API
+
+The `IRuleFixer` interface (from `@markuplint/ml-config`) provides six methods:
+
+| Method | Description |
+|--------|-------------|
+| `replaceText(token, text)` | Replace a token's text with new content |
+| `replaceRange(range, text)` | Replace an explicit `[start, end)` range |
+| `insertBefore(token, text)` | Insert text before a token |
+| `insertAfter(token, text)` | Insert text after a token |
+| `remove(token)` | Remove a token entirely |
+| `removeRange(range)` | Remove an explicit `[start, end)` range |
+
+### Token Parameter
+
+Methods that accept a `token` parameter require an object satisfying the `FixToken` type:
+
+```typescript
+type FixToken = {
+  readonly startOffset: number;
+  readonly raw: string;
+};
+```
+
+All MLDOM tokens (`MLToken`, `MLAttr`, attribute sub-tokens like `nameNode`, `valueNode`, etc.) satisfy this interface. You can also construct ad-hoc tokens:
+
+```typescript
+fix: fixer => fixer.replaceText(
+  { startOffset: 42, raw: 'old-text' },
+  'new-text',
+),
+```
+
+### Returning Multiple Edits
+
+A fix callback can return a single `TextEdit` or an array of `TextEdit` objects. Multiple edits within a single callback are applied atomically — if any edit overlaps with another rule's fix, all edits in the group are skipped:
+
+```typescript
+fix: fixer => [
+  fixer.remove(attr.spacesBeforeEqual),
+  fixer.remove(attr.equal),
+  fixer.remove(attr.valueNode),
+],
+```
+
+## Examples
+
+### Replace Text
+
+Convert a tag name to lowercase:
+
+```typescript
+fix: fixer => fixer.replaceText(
+  { startOffset: nameOffset, raw: el.rawName },
+  el.rawName.toLowerCase(),
+),
+```
+
+### Remove a Token
+
+Remove an orphaned end tag:
+
+```typescript
+fix: fixer => fixer.remove(
+  { startOffset: text.startOffset, raw: text.raw },
+),
+```
+
+### Remove by Range
+
+Remove an entire attribute (from leading whitespace through the closing quote):
+
+```typescript
+fix: fixer => fixer.removeRange([
+  firstToken.startOffset,
+  lastToken.startOffset + lastToken.raw.length,
+]),
+```
+
+## Helper Functions for Rule Authors
+
+`@markuplint/rules` provides shared helpers in `src/helpers.ts` for common attribute removal patterns:
+
+| Helper | Description |
+|--------|-------------|
+| `removeAttr(fixer, attr)` | Remove an entire attribute (name + value + surrounding whitespace) |
+| `removeAttrValue(fixer, attr)` | Remove only the value portion (equals, quotes, value), keeping the name |
+
+These accept the standard attribute token properties (`spacesBeforeName`, `nameNode`, `equal`, `valueNode`, etc.) and handle null/empty tokens automatically.
+
+## Multi-Pass Fix Behavior
+
+When multiple rules produce overlapping fixes, the engine applies them iteratively:
+
+1. All fixes are collected and applied in a single pass
+2. Overlapping fixes are skipped
+3. If any fixes were skipped, the source is re-parsed and rules are re-run
+4. This repeats until no more skipped fixes remain (up to 10 passes)
+
+**Rule authors do not need to handle this** — the engine manages overlap resolution transparently.
+
+## Built-in Rules with Fix Support
+
+The following built-in rules support auto-fix in v5:
+
+| Rule | Fix behavior |
+|------|-------------|
+| `case-sensitive-tag-name` | Converts tag name to configured case |
+| `case-sensitive-attr-name` | Converts attribute name to configured case |
+| `attr-value-quotes` | Converts attribute quotes to configured style |
+| `no-boolean-attr-value` | Removes value from boolean attributes |
+| `no-default-value` | Removes attribute with default value |
+| `attr-duplication` | Removes duplicate attribute |
+| `ineffective-attr` | Removes ineffective attribute |
+| `no-orphaned-end-tag` | Removes orphaned end tag |
+| `no-consecutive-br` | Removes consecutive `<br>` elements |
+
+## Type Imports
+
+```typescript
+import type { IRuleFixer, TextEdit, FixToken } from '@markuplint/ml-config';
+```
+
+These types are re-exported from `@markuplint/ml-config`. The `IRuleFixer` is passed to your callback — you do not need to instantiate it.

--- a/packages/@markuplint/ml-config/ARCHITECTURE.ja.md
+++ b/packages/@markuplint/ml-config/ARCHITECTURE.ja.md
@@ -96,6 +96,13 @@ type RuleConfig<T, O> = {
 - `OriginalNode` -- 要素名、スロット、名前空間、属性、継承属性、ARIA プロパティを定義
 - `PretenderDetails` -- マージ後に使用される正規化形式 `{data?, files?, imports?}`
 
+### 自動修正型
+
+- `TextEdit` -- ソースコードの単一置換: `{ range: [start, end), text }`。`text` が空文字列の場合は削除を意味する
+- `FixData` -- 1つ以上の `TextEdit` をアトミックに適用する単位。`FixData` 内のいずれかの edit が他の `FixData` と重複すると、グループ全体がスキップされる
+- `FixToken` -- `IRuleFixer` メソッドが受け付ける最小トークン型（`{ startOffset, raw }`）。すべての MLDOM トークンはこの制約を満たす
+- `IRuleFixer` -- fix コールバック内で `TextEdit` を構築するためのインターフェース。`replaceText`、`replaceRange`、`insertBefore`、`insertAfter`、`remove`、`removeRange` を提供
+
 ## マージアルゴリズム
 
 このパッケージの中核です。`mergeConfig()` 関数はプロパティごとの戦略で2つの設定を統合します。
@@ -225,7 +232,7 @@ Mustache テンプレート文字列を提供されたデータでレンダリ�
 
 | ファイル              | 目的                                                                                                    |
 | --------------------- | ------------------------------------------------------------------------------------------------------- |
-| `src/types.ts`        | 全型定義（Config, Rule, Pretender, Violation 等）                                                       |
+| `src/types.ts`        | 全型定義（Config, Rule, Pretender, Violation, FixToken, IRuleFixer 等）                                 |
 | `src/merge-config.ts` | `mergeConfig()`、`mergeRule()`、全ヘルパー関数                                                          |
 | `src/utils.ts`        | `provideValue()`、`exchangeValueOnRule()`、`cleanOptions()`、`isRuleConfigValue()`、`deleteUndefProp()` |
 | `src/index.ts`        | 全公開 API の再エクスポート                                                                             |

--- a/packages/@markuplint/ml-config/ARCHITECTURE.md
+++ b/packages/@markuplint/ml-config/ARCHITECTURE.md
@@ -96,6 +96,13 @@ type RuleConfig<T, O> = {
 - `OriginalNode` -- Defines an element's name, slots, namespace, attributes, inherited attributes, and ARIA properties
 - `PretenderDetails` -- Normalized form `{data?, files?, imports?}` used after merging
 
+### Autofix Types
+
+- `TextEdit` -- A single source code replacement: `{ range: [start, end), text }`. An empty `text` means deletion
+- `FixData` -- Contains one or more `TextEdit`s to apply atomically. If any edit in a `FixData` overlaps with another `FixData`, the entire group is skipped
+- `FixToken` -- Minimal token shape (`{ startOffset, raw }`) accepted by `IRuleFixer` methods. Any MLDOM token satisfies this constraint
+- `IRuleFixer` -- Interface for building `TextEdit`s inside fix callbacks. Provides `replaceText`, `replaceRange`, `insertBefore`, `insertAfter`, `remove`, and `removeRange`
+
 ## Merge Algorithm
 
 This is the core of the package. The `mergeConfig()` function combines two configurations with property-specific strategies.
@@ -225,7 +232,7 @@ This function is used by `nodeRules` and `childNodeRules` with `regexSelector`, 
 
 | File                  | Purpose                                                                                                 |
 | --------------------- | ------------------------------------------------------------------------------------------------------- |
-| `src/types.ts`        | All type definitions (Config, Rule, Pretender, Violation, etc.)                                         |
+| `src/types.ts`        | All type definitions (Config, Rule, Pretender, Violation, FixToken, IRuleFixer, etc.)                   |
 | `src/merge-config.ts` | `mergeConfig()`, `mergeRule()`, and all helper functions                                                |
 | `src/utils.ts`        | `provideValue()`, `exchangeValueOnRule()`, `cleanOptions()`, `isRuleConfigValue()`, `deleteUndefProp()` |
 | `src/index.ts`        | Re-exports all public APIs                                                                              |

--- a/packages/@markuplint/ml-config/src/types.ts
+++ b/packages/@markuplint/ml-config/src/types.ts
@@ -539,15 +539,69 @@ export type FixData = {
 };
 
 /**
+ * Minimal token shape required by {@link IRuleFixer} methods.
+ * Any object with a character offset and raw source text satisfies this constraint.
+ */
+export type FixToken = {
+	readonly startOffset: number;
+	readonly raw: string;
+};
+
+/**
  * A helper interface for building {@link TextEdit}s inside a fix callback.
  * Passed to the `fix` function on {@link Report1} and {@link Report2}.
  */
 export interface IRuleFixer {
-	replaceText(token: { readonly startOffset: number; readonly raw: string }, text: string): TextEdit;
+	/**
+	 * Replaces a token's entire text with new content.
+	 *
+	 * @param token - The token whose range will be replaced
+	 * @param text - The replacement text
+	 * @returns A TextEdit spanning the token's range
+	 */
+	replaceText(token: FixToken, text: string): TextEdit;
+
+	/**
+	 * Replaces an explicit character range with new content.
+	 *
+	 * @param range - The `[start, end)` character offsets to replace
+	 * @param text - The replacement text
+	 * @returns A TextEdit spanning the given range
+	 */
 	replaceRange(range: readonly [number, number], text: string): TextEdit;
-	insertBefore(token: { readonly startOffset: number }, text: string): TextEdit;
-	insertAfter(token: { readonly startOffset: number; readonly raw: string }, text: string): TextEdit;
-	remove(token: { readonly startOffset: number; readonly raw: string }): TextEdit;
+
+	/**
+	 * Inserts text immediately before a token.
+	 *
+	 * @param token - The token before which to insert
+	 * @param text - The text to insert
+	 * @returns A zero-width TextEdit at the token's start offset
+	 */
+	insertBefore(token: Pick<FixToken, 'startOffset'>, text: string): TextEdit;
+
+	/**
+	 * Inserts text immediately after a token.
+	 *
+	 * @param token - The token after which to insert
+	 * @param text - The text to insert
+	 * @returns A zero-width TextEdit at the token's end offset
+	 */
+	insertAfter(token: FixToken, text: string): TextEdit;
+
+	/**
+	 * Removes a token's entire text from the source.
+	 *
+	 * @param token - The token to remove
+	 * @returns A TextEdit that replaces the token's range with an empty string
+	 */
+	remove(token: FixToken): TextEdit;
+
+	/**
+	 * Removes an explicit character range from the source.
+	 *
+	 * @param range - The `[start, end)` character offsets to remove
+	 * @returns A TextEdit that replaces the range with an empty string
+	 */
 	removeRange(range: readonly [number, number]): TextEdit;
 }
 

--- a/packages/@markuplint/ml-core/ARCHITECTURE.ja.md
+++ b/packages/@markuplint/ml-core/ARCHITECTURE.ja.md
@@ -439,7 +439,7 @@ sequenceDiagram
 | `remove(token)`             | `startOffset` + `raw` を持つトークン | `range: [start, start+len], text: ""`   |
 | `removeRange(range)`        | 明示的な `[start, end)` レンジ       | `range: [start, end], text: ""`         |
 
-`token` パラメータは `startOffset` と `raw` プロパティを持つ任意のオブジェクトを受け付けます。MLDOM トークン（`MLToken`, `MLAttr` 等）は自然にこの要件を満たします。
+`token` パラメータは `FixToken` 型（`@markuplint/ml-config` で定義）を満たす任意のオブジェクト — つまり `{ startOffset: number; raw: string }` — を受け付けます。MLDOM トークン（`MLToken`, `MLAttr` 等）は自然にこの要件を満たします。
 
 ### FixApplier アルゴリズム
 
@@ -467,6 +467,39 @@ flowchart TD
 - 1 つの `FixData` 内の edit は互いに重複してはならない
 - `FixData` 間の重複はスキップ機構で処理される
 - `FixData` 内のいずれかの edit がスキップされると、その `FixData` 全体がスキップとして分類される
+
+### マルチパス Fix ループ
+
+`applyFixes()` がレンジの重複により一部の fix をスキップした場合、エンジンはマルチパスループ（`_multiPassFix()`）に入り、再パース・再検証を繰り返して修正可能な違反をすべて解決します:
+
+```mermaid
+flowchart TD
+    A["violations から fix を抽出"] --> B["applyFixes(code, fixes)"]
+    B --> C{"applied.length === 0?"}
+    C -- Yes --> Z["現在のコードを返す"]
+    C -- No --> D{"output === currentCode?"}
+    D -- Yes --> Z
+    D -- No --> E{"サイクル検出?\n(2パス前の出力と一致)"}
+    E -- Yes --> Z
+    E -- No --> F{"skipped.length === 0?"}
+    F -- Yes --> Z["修正済みコードを返す\n(全 fix 適用完了)"]
+    F -- No --> G["再パース + 再検証"]
+    G --> H{"ParserError?"}
+    H -- Yes --> Z["最後の正常なコードに戻す"]
+    H -- No --> I{"新たな修正可能な違反?"}
+    I -- No --> Z
+    I -- Yes --> B
+```
+
+主な設計ポイント:
+
+- **ゼロコストパス**: fix を持つ violation がなければ、マルチパスループは完全にスキップされる
+- **シングルパス高速パス**: `skipped.length === 0` のとき即座にループを抜ける（Phase 1 と同等の動作）
+- **サイクル検出**: 2パス前の出力と比較し、A→B→A の振動パターンを検出
+- **安全上限**: 最大10パス（ESLint の `SourceCodeFixer` と同じ）
+- **状態復元**: `verify()` は `try/finally` で `#sourceCode`、`#ast`、`#document` を保存・復元
+
+**重要**: `VerifyResult` の `violations` 配列は初回パスの結果のみを反映し、`fixedCode` は複数パスの結果である場合があります。修正後コードの正確な違反リストが必要な場合は、出力を再検証してください。
 
 ### 実例: ルールの Fix 実装
 

--- a/packages/@markuplint/ml-core/ARCHITECTURE.md
+++ b/packages/@markuplint/ml-core/ARCHITECTURE.md
@@ -439,7 +439,7 @@ sequenceDiagram
 | `remove(token)`             | Token with `startOffset` + `raw` | `range: [start, start+len], text: ""`      |
 | `removeRange(range)`        | Explicit `[start, end)` range    | `range: [start, end], text: ""`            |
 
-The `token` parameter accepts any object with `startOffset` and `raw` properties. MLDOM tokens (`MLToken`, `MLAttr`, etc.) satisfy this naturally.
+The `token` parameter accepts any object satisfying the `FixToken` type (defined in `@markuplint/ml-config`) — i.e., `{ startOffset: number; raw: string }`. MLDOM tokens (`MLToken`, `MLAttr`, etc.) satisfy this naturally.
 
 ### FixApplier Algorithm
 
@@ -467,6 +467,39 @@ Key constraints:
 - Edits within a single `FixData` must not overlap each other
 - Inter-`FixData` overlap is handled by the skip mechanism
 - If any edit in a `FixData` is skipped, the entire `FixData` is classified as skipped
+
+### Multi-Pass Fix Loop
+
+When `applyFixes()` skips some fixes due to range overlap, the engine enters a multi-pass loop (`_multiPassFix()`) that re-parses and re-verifies until all fixable violations are resolved:
+
+```mermaid
+flowchart TD
+    A["Extract fixes from violations"] --> B["applyFixes(code, fixes)"]
+    B --> C{"applied.length === 0?"}
+    C -- Yes --> Z["Return current code"]
+    C -- No --> D{"output === currentCode?"}
+    D -- Yes --> Z
+    D -- No --> E{"Cycle detected?\n(output === code from 2 passes ago)"}
+    E -- Yes --> Z
+    E -- No --> F{"skipped.length === 0?"}
+    F -- Yes --> Z["Return fixed code\n(all fixes applied)"]
+    F -- No --> G["Re-parse + re-verify"]
+    G --> H{"ParserError?"}
+    H -- Yes --> Z["Revert to last good code"]
+    H -- No --> I{"New fixable violations?"}
+    I -- No --> Z
+    I -- Yes --> B
+```
+
+Key design points:
+
+- **Zero-cost path**: If no violations have fixes, the multi-pass loop is skipped entirely
+- **Single-pass fast path**: When `skipped.length === 0`, the loop exits immediately — equivalent to Phase 1 behavior
+- **Cycle detection**: Compares current output against the output from two passes ago to detect A→B→A oscillation
+- **Safety cap**: Maximum 10 passes (same as ESLint's `SourceCodeFixer`)
+- **State restoration**: `verify()` saves and restores `#sourceCode`, `#ast`, and `#document` via `try/finally`
+
+**Important**: The `violations` array in `VerifyResult` reflects the first pass only, while `fixedCode` may be the result of multiple passes. Callers needing an accurate violation list for the fixed code should re-verify the output.
 
 ### Example: Rule Fix in Practice
 

--- a/packages/@markuplint/ml-core/src/ml-core.ts
+++ b/packages/@markuplint/ml-core/src/ml-core.ts
@@ -217,10 +217,16 @@ export class MLCore {
 	 * (unless parse errors are suppressed via severity options).
 	 *
 	 * When `fix` is true, fix callbacks are executed and the resulting TextEdits
-	 * are applied to produce `fixedCode`.
+	 * are applied via a multi-pass loop to produce `fixedCode`.
+	 *
+	 * **Important**: `violations` reflects the *first* pass only, while `fixedCode`
+	 * may be the result of multiple fix passes. This means some violations in the
+	 * array may already be resolved in `fixedCode`, and new violations introduced
+	 * during later passes are not included in the array. Callers needing an accurate
+	 * violation list for the fixed code should re-verify the output.
 	 *
 	 * @param fix - Whether to attempt auto-fixing violations
-	 * @returns Violations and the (possibly fixed) source code
+	 * @returns Violations from the initial analysis and the (possibly fixed) source code
 	 */
 	async verify(fix = false): Promise<VerifyResult> {
 		log('verify: start');
@@ -278,46 +284,9 @@ export class MLCore {
 			});
 		}
 
-		for (const rule of this.#rules) {
-			// For virtual rules, check disable conditions:
-			// 1. Exact name match: rules["alias/name"]: false
-			// 2. Group disable: rules["groupName"]: false (multi-entry named nodeRules)
-			// 3. Namespace wildcard: rules["scope/*"]: false
-			// Note: base rule name disable (rules["baseRuleName"]: false) is handled
-			// during expandNamedRules for named rule groups in the rules section.
-			if (
-				rule.baseRuleId &&
-				(this.#ruleset.rules[rule.name] === false ||
-					(rule.groupName && this.#ruleset.rules[rule.groupName] === false) ||
-					this.#disabledNamespaces.some(ns => rule.name.startsWith(ns)))
-			) {
-				continue;
-			}
+		const ruleViolations = await this._runAllRules(fix);
+		violations.push(...ruleViolations);
 
-			const ruleInfo = rule.getRuleInfo(this.#ruleset, rule.name);
-			if (ruleInfo.disabled && ruleInfo.nodeRules.length === 0 && ruleInfo.childNodeRules.length === 0) {
-				continue;
-			}
-
-			log('%s Rule: verify', rule.name);
-			const results = await rule.verify(this.#document, this.#locale, fix).catch(error => {
-				if (error instanceof ParserError) {
-					return error;
-				}
-				throw error;
-			});
-
-			if (results instanceof ParserError) {
-				const parseError = this._createParseError(results.message, results.line, results.col, results.raw);
-				if (parseError) {
-					log('%s Rule: verify error %o', rule.name, results.message);
-					violations.push(parseError);
-				}
-			} else {
-				violations.push(...results);
-			}
-			log('%s Rule: verify end', rule.name);
-		}
 		if (resultLog.enabled) {
 			// eslint-disable-next-line unicorn/no-array-reduce
 			const { e, w, i } = violations.reduce(
@@ -337,18 +306,22 @@ export class MLCore {
 		// Apply fixes if enabled
 		let fixedCode: string | undefined;
 		if (fix) {
-			fixedCode = this.#sourceCode;
-			const allFixes: FixData[] = [];
-			for (const v of violations) {
-				if (v.fix) {
-					allFixes.push(v.fix);
+			const hasFixes = violations.some(v => v.fix);
+			if (hasFixes) {
+				const originalSourceCode = this.#sourceCode;
+				const originalAst = this.#ast;
+				const originalDocument = this.#document;
+
+				try {
+					fixedCode = await this._multiPassFix(violations);
+				} finally {
+					// Restore original state - verify() must be non-mutating
+					this.#sourceCode = originalSourceCode;
+					this.#ast = originalAst;
+					this.#document = originalDocument;
 				}
-			}
-			if (allFixes.length > 0) {
-				const result = applyFixes(this.#sourceCode, allFixes);
-				fixedCode = result.output;
-				// TODO(Phase 2): If skipped fixes exist, implement multi-pass re-verify loop
-				// (similar to ESLint's 10-pass fix loop) to resolve conflicts iteratively.
+			} else {
+				fixedCode = this.#sourceCode;
 			}
 		}
 
@@ -398,6 +371,137 @@ export class MLCore {
 		};
 	}
 
+	/**
+	 * Iteratively applies fixes, re-parses, and re-verifies until no overlapping
+	 * fixes remain or the maximum pass count is reached (ESLint-style multi-pass loop).
+	 *
+	 * **Callers must save/restore `#sourceCode`, `#ast`, and `#document`** because
+	 * this method mutates them during intermediate re-parse steps.
+	 *
+	 * @param initialViolations - Violations from the first verification pass
+	 * @returns The final fixed source code
+	 */
+	private async _multiPassFix(initialViolations: readonly Violation[]): Promise<string> {
+		const MAX_FIX_PASSES = 10;
+		let currentCode = this.#sourceCode;
+		let previousCode: string | undefined;
+		let fixes = extractFixes(initialViolations);
+
+		let pass = 0;
+		for (; pass < MAX_FIX_PASSES; pass++) {
+			log('fix pass %d: %d fixes', pass, fixes.length);
+			const result = applyFixes(currentCode, fixes);
+
+			if (result.applied.length === 0) {
+				log('fix pass %d: no fixes applied, stopping', pass);
+				break;
+			}
+
+			if (result.output === currentCode) {
+				log('fix pass %d: output unchanged, stopping', pass);
+				break;
+			}
+
+			// Cycle detection: if the output matches the code from two passes ago,
+			// fixes are oscillating (A → B → A) and will never converge.
+			if (previousCode !== undefined && result.output === previousCode) {
+				log('fix pass %d: cycle detected (output matches pass %d), stopping', pass, pass - 2);
+				currentCode = result.output;
+				break;
+			}
+
+			previousCode = currentCode;
+			currentCode = result.output;
+
+			if (result.skipped.length === 0) {
+				log('fix pass %d: all fixes applied, stopping', pass);
+				break;
+			}
+
+			// --- Multi-pass path (only when overlapping fixes exist) ---
+			log('fix pass %d: %d skipped, re-parsing for next pass', pass, result.skipped.length);
+			const previousGoodCode = currentCode;
+
+			this.#sourceCode = currentCode;
+			this._parse();
+			this._createDocument();
+
+			if (this.#document instanceof ParserError) {
+				log('fix pass %d: produced unparsable code, reverting to previous state', pass);
+				currentCode = previousGoodCode;
+				break;
+			}
+
+			const newViolations = await this._runAllRules(true);
+			fixes = extractFixes(newViolations);
+			if (fixes.length === 0) {
+				log('fix pass %d: no more fixable violations, stopping', pass);
+				break;
+			}
+		}
+
+		if (pass === MAX_FIX_PASSES) {
+			log('fix: reached maximum number of passes (%d), some fixes may not have been applied', MAX_FIX_PASSES);
+		}
+
+		return currentCode;
+	}
+
+	/**
+	 * Executes all configured rules against the current document and collects violations.
+	 * Skips disabled rules and handles virtual rule disable conditions.
+	 *
+	 * @param fix - Whether to execute fix callbacks on violations
+	 * @returns All violations produced by the rule set
+	 */
+	private async _runAllRules(fix: boolean): Promise<Violation[]> {
+		const violations: Violation[] = [];
+		if (this.#document instanceof ParserError) {
+			return violations;
+		}
+		for (const rule of this.#rules) {
+			// For virtual rules, check disable conditions:
+			// 1. Exact name match: rules["alias/name"]: false
+			// 2. Group disable: rules["groupName"]: false (multi-entry named nodeRules)
+			// 3. Namespace wildcard: rules["scope/*"]: false
+			// Note: base rule name disable (rules["baseRuleName"]: false) is handled
+			// during expandNamedRules for named rule groups in the rules section.
+			if (
+				rule.baseRuleId &&
+				(this.#ruleset.rules[rule.name] === false ||
+					(rule.groupName && this.#ruleset.rules[rule.groupName] === false) ||
+					this.#disabledNamespaces.some(ns => rule.name.startsWith(ns)))
+			) {
+				continue;
+			}
+
+			const ruleInfo = rule.getRuleInfo(this.#ruleset, rule.name);
+			if (ruleInfo.disabled && ruleInfo.nodeRules.length === 0 && ruleInfo.childNodeRules.length === 0) {
+				continue;
+			}
+
+			log('%s Rule: verify', rule.name);
+			const results = await rule.verify(this.#document, this.#locale, fix).catch(error => {
+				if (error instanceof ParserError) {
+					return error;
+				}
+				throw error;
+			});
+
+			if (results instanceof ParserError) {
+				const parseError = this._createParseError(results.message, results.line, results.col, results.raw);
+				if (parseError) {
+					log('%s Rule: verify error %o', rule.name, results.message);
+					violations.push(parseError);
+				}
+			} else {
+				violations.push(...results);
+			}
+			log('%s Rule: verify end', rule.name);
+		}
+		return violations;
+	}
+
 	private _parse() {
 		try {
 			this.#ast = this.#parser.parse(this.#sourceCode, this.#parserOptions);
@@ -421,4 +525,20 @@ function extractDisabledNamespaces(rules: { readonly [key: string]: unknown }): 
 	return Object.entries(rules)
 		.filter(([key, value]) => key.endsWith('/*') && value === false)
 		.map(([key]) => key.slice(0, -1)); // "a11y/*" → "a11y/"
+}
+
+/**
+ * Collects all `FixData` from violations that have a fix callback result.
+ *
+ * @param violations - The violations to extract fixes from
+ * @returns An array of `FixData` objects ready for `applyFixes()`
+ */
+function extractFixes(violations: readonly Violation[]): FixData[] {
+	const fixes: FixData[] = [];
+	for (const v of violations) {
+		if (v.fix) {
+			fixes.push(v.fix);
+		}
+	}
+	return fixes;
 }

--- a/packages/@markuplint/ml-core/src/ml-rule/rule-fixer.ts
+++ b/packages/@markuplint/ml-core/src/ml-rule/rule-fixer.ts
@@ -1,4 +1,4 @@
-import type { IRuleFixer, TextEdit } from '@markuplint/ml-config';
+import type { FixToken, IRuleFixer, TextEdit } from '@markuplint/ml-config';
 
 /**
  * Stateless implementation of {@link IRuleFixer}.
@@ -6,33 +6,39 @@ import type { IRuleFixer, TextEdit } from '@markuplint/ml-config';
  * inside rule fix callbacks.
  */
 export class RuleFixer implements IRuleFixer {
-	replaceText(token: { readonly startOffset: number; readonly raw: string }, text: string): TextEdit {
+	/** @see {@link IRuleFixer.replaceText} */
+	replaceText(token: FixToken, text: string): TextEdit {
 		return {
 			range: [token.startOffset, token.startOffset + token.raw.length],
 			text,
 		};
 	}
 
+	/** @see {@link IRuleFixer.replaceRange} */
 	replaceRange(range: readonly [number, number], text: string): TextEdit {
 		return { range, text };
 	}
 
-	insertBefore(token: { readonly startOffset: number }, text: string): TextEdit {
+	/** @see {@link IRuleFixer.insertBefore} */
+	insertBefore(token: Pick<FixToken, 'startOffset'>, text: string): TextEdit {
 		return { range: [token.startOffset, token.startOffset], text };
 	}
 
-	insertAfter(token: { readonly startOffset: number; readonly raw: string }, text: string): TextEdit {
+	/** @see {@link IRuleFixer.insertAfter} */
+	insertAfter(token: FixToken, text: string): TextEdit {
 		const end = token.startOffset + token.raw.length;
 		return { range: [end, end], text };
 	}
 
-	remove(token: { readonly startOffset: number; readonly raw: string }): TextEdit {
+	/** @see {@link IRuleFixer.remove} */
+	remove(token: FixToken): TextEdit {
 		return {
 			range: [token.startOffset, token.startOffset + token.raw.length],
 			text: '',
 		};
 	}
 
+	/** @see {@link IRuleFixer.removeRange} */
 	removeRange(range: readonly [number, number]): TextEdit {
 		return { range, text: '' };
 	}

--- a/packages/@markuplint/rules/src/attr-duplication/index.spec.ts
+++ b/packages/@markuplint/rules/src/attr-duplication/index.spec.ts
@@ -1,5 +1,5 @@
 import { mlRuleTest } from 'markuplint';
-import { test, expect } from 'vitest';
+import { describe, test, expect } from 'vitest';
 
 import rule from './index.js';
 
@@ -174,4 +174,26 @@ test('Astro', async () => {
 	});
 
 	expect(violations.length).toBe(1);
+});
+
+describe('fix', () => {
+	test('remove duplicate attribute', async () => {
+		const { fixedCode } = await mlRuleTest(rule, '<div class="a" class="b"></div>', undefined, true);
+		expect(fixedCode).toBe('<div class="a"></div>');
+	});
+
+	test('remove duplicate boolean attribute', async () => {
+		const { fixedCode } = await mlRuleTest(rule, '<input disabled disabled />', undefined, true);
+		expect(fixedCode).toBe('<input disabled />');
+	});
+
+	test('remove third duplicate attribute', async () => {
+		const { fixedCode } = await mlRuleTest(
+			rule,
+			'<div data-attr="value" data-Attr=\'db\' data-attR=tr></div>',
+			undefined,
+			true,
+		);
+		expect(fixedCode).toBe('<div data-attr="value"></div>');
+	});
 });

--- a/packages/@markuplint/rules/src/attr-duplication/index.ts
+++ b/packages/@markuplint/rules/src/attr-duplication/index.ts
@@ -1,5 +1,7 @@
 import { createRule } from '@markuplint/ml-core';
 
+import { removeAttr } from '../helpers.js';
+
 import meta from './meta.js';
 
 /**
@@ -31,6 +33,7 @@ export default createRule({
 							raw: scope.raw,
 						},
 						message,
+						fix: fixer => removeAttr(fixer, attr),
 					});
 				} else {
 					attrNameStack.push(name);

--- a/packages/@markuplint/rules/src/helpers.ts
+++ b/packages/@markuplint/rules/src/helpers.ts
@@ -1,6 +1,6 @@
 import type { Log } from './debug.js';
 import type { Translator } from '@markuplint/i18n';
-import type { PlainData } from '@markuplint/ml-config';
+import type { FixToken, IRuleFixer, PlainData, TextEdit } from '@markuplint/ml-config';
 import type { Element, RuleConfigValue, Document } from '@markuplint/ml-core';
 import type { Attribute } from '@markuplint/ml-spec';
 import type { WritableDeep } from 'type-fest';
@@ -303,4 +303,95 @@ export class Collection<T> {
  */
 export function deepCopy<T>(value: T): WritableDeep<T> {
 	return structuredClone(value as any) as WritableDeep<T>;
+}
+
+/**
+ * Computes a removal range from a list of nullable tokens.
+ * Filters out null/undefined tokens and tokens with empty `raw`,
+ * then returns the range spanning from the first to the last token.
+ *
+ * @param tokens - An array of nullable tokens to compute the range from
+ * @returns `[start, end]` tuple, or `null` if no valid tokens
+ */
+function tokenRange(tokens: readonly (FixToken | null | undefined)[]): readonly [number, number] | null {
+	const valid = tokens.filter((t): t is FixToken => t != null && t.raw.length > 0);
+	const first = valid[0];
+	const last = valid.at(-1);
+	if (!first || !last) {
+		return null;
+	}
+	return [first.startOffset, last.startOffset + last.raw.length];
+}
+
+/**
+ * Creates a fix that removes an entire attribute (name + value + surrounding whitespace).
+ * Used by rules that need to remove a whole attribute from an element.
+ *
+ * @param fixer - The rule fixer instance for building TextEdits
+ * @param attr - The attribute token parts to remove (from `spacesBeforeName` through `endQuote`)
+ * @returns A TextEdit (or empty array if no valid tokens exist) that removes the attribute
+ */
+export function removeAttr(
+	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+	fixer: IRuleFixer,
+	attr: {
+		readonly spacesBeforeName: FixToken | null;
+		readonly nameNode: FixToken | null;
+		readonly spacesBeforeEqual: FixToken | null;
+		readonly equal: FixToken | null;
+		readonly spacesAfterEqual: FixToken | null;
+		readonly startQuote: FixToken | null;
+		readonly valueNode: FixToken | null;
+		readonly endQuote: FixToken | null;
+	},
+): TextEdit | TextEdit[] {
+	const range = tokenRange([
+		attr.spacesBeforeName,
+		attr.nameNode,
+		attr.spacesBeforeEqual,
+		attr.equal,
+		attr.spacesAfterEqual,
+		attr.startQuote,
+		attr.valueNode,
+		attr.endQuote,
+	]);
+	if (!range) {
+		return [];
+	}
+	return fixer.removeRange(range);
+}
+
+/**
+ * Creates a fix that removes only the value portion of an attribute
+ * (equals sign, quotes, and value), keeping the attribute name.
+ * Used by `no-boolean-attr-value` to convert `disabled="disabled"` to `disabled`.
+ *
+ * @param fixer - The rule fixer instance for building TextEdits
+ * @param attr - The attribute token parts to remove (from `spacesBeforeEqual` through `endQuote`)
+ * @returns A TextEdit (or empty array if no valid tokens exist) that removes the value portion
+ */
+export function removeAttrValue(
+	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+	fixer: IRuleFixer,
+	attr: {
+		readonly spacesBeforeEqual: FixToken | null;
+		readonly equal: FixToken | null;
+		readonly spacesAfterEqual: FixToken | null;
+		readonly startQuote: FixToken | null;
+		readonly valueNode: FixToken | null;
+		readonly endQuote: FixToken | null;
+	},
+): TextEdit | TextEdit[] {
+	const range = tokenRange([
+		attr.spacesBeforeEqual,
+		attr.equal,
+		attr.spacesAfterEqual,
+		attr.startQuote,
+		attr.valueNode,
+		attr.endQuote,
+	]);
+	if (!range) {
+		return [];
+	}
+	return fixer.removeRange(range);
 }

--- a/packages/@markuplint/rules/src/ineffective-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/ineffective-attr/index.spec.ts
@@ -1,5 +1,5 @@
 import { mlRuleTest } from 'markuplint';
-import { test, expect } from 'vitest';
+import { describe, test, expect } from 'vitest';
 
 import rule from './index.js';
 
@@ -29,4 +29,21 @@ test('script[src][type=module][defer]', async () => {
 			raw: 'defer',
 		},
 	]);
+});
+
+describe('fix', () => {
+	test('remove ineffective defer from inline script', async () => {
+		const { fixedCode } = await mlRuleTest(rule, '<script defer>const foo = "foo";</script>', undefined, true);
+		expect(fixedCode).toBe('<script>const foo = "foo";</script>');
+	});
+
+	test('remove ineffective defer from module script', async () => {
+		const { fixedCode } = await mlRuleTest(
+			rule,
+			'<script type="module" src="path/to" defer></script>',
+			undefined,
+			true,
+		);
+		expect(fixedCode).toBe('<script type="module" src="path/to"></script>');
+	});
 });

--- a/packages/@markuplint/rules/src/ineffective-attr/index.ts
+++ b/packages/@markuplint/rules/src/ineffective-attr/index.ts
@@ -1,6 +1,8 @@
 import { createRule, getAttrSpecs } from '@markuplint/ml-core';
 import { toNoEmptyStringArrayFromStringOrArray } from '@markuplint/shared';
 
+import { removeAttr } from '../helpers.js';
+
 import meta from './meta.js';
 
 /**
@@ -36,6 +38,7 @@ export default createRule({
 						t('{0} is {1:c}', t('the "{0*}" {1}', name, 'attribute'), 'ineffective') +
 						t('. ') +
 						t("It doesn't need {0}", t('the {0}', 'attribute')),
+					fix: fixer => removeAttr(fixer, attr),
 				});
 			}
 		});

--- a/packages/@markuplint/rules/src/multi-pass-fix.spec.ts
+++ b/packages/@markuplint/rules/src/multi-pass-fix.spec.ts
@@ -1,0 +1,73 @@
+import { mlTest } from 'markuplint';
+import { describe, test, expect } from 'vitest';
+
+describe('multi-pass fix', () => {
+	test('no overlap (single pass resolves all)', async () => {
+		const { fixedCode } = await mlTest(
+			"<DIV CLASS='a'></DIV>",
+			{
+				rules: {
+					'case-sensitive-tag-name': true,
+					'attr-value-quotes': true,
+				},
+			},
+			undefined,
+			'en',
+			true,
+		);
+		expect(fixedCode).toBe('<div CLASS="a"></div>');
+	});
+
+	test('overlap resolved in multi-pass', async () => {
+		const { fixedCode } = await mlTest(
+			"<DIV DATA-FOO='val'></DIV>",
+			{
+				rules: {
+					'case-sensitive-tag-name': true,
+					'case-sensitive-attr-name': true,
+					'attr-value-quotes': true,
+				},
+			},
+			undefined,
+			'en',
+			true,
+		);
+		expect(fixedCode).toBe('<div data-foo="val"></div>');
+	});
+
+	test('fix produces no changes on valid code', async () => {
+		const { fixedCode } = await mlTest(
+			'<div></div>',
+			{
+				rules: {
+					'case-sensitive-tag-name': true,
+					'case-sensitive-attr-name': true,
+					'attr-value-quotes': true,
+				},
+			},
+			undefined,
+			'en',
+			true,
+		);
+		expect(fixedCode).toBe('<div></div>');
+	});
+
+	test('5+ rules applied together (overlap only, no cascading)', async () => {
+		const { fixedCode } = await mlTest(
+			"<DIV CLASS='a' CLASS='b' DATA-FOO='val'></DIV>",
+			{
+				rules: {
+					'case-sensitive-tag-name': true,
+					'case-sensitive-attr-name': true,
+					'attr-value-quotes': true,
+					'attr-duplication': true,
+				},
+			},
+			undefined,
+			'en',
+			true,
+		);
+		// Tag name lowered, attr names lowered, quotes normalized, duplicate removed
+		expect(fixedCode).toBe('<div class="a" data-foo="val"></div>');
+	});
+});

--- a/packages/@markuplint/rules/src/no-boolean-attr-value/index.spec.ts
+++ b/packages/@markuplint/rules/src/no-boolean-attr-value/index.spec.ts
@@ -1,5 +1,5 @@
 import { mlRuleTest } from 'markuplint';
-import { test, expect } from 'vitest';
+import { describe, test, expect } from 'vitest';
 
 import rule from './index.js';
 
@@ -56,4 +56,36 @@ test('The `as` attribute', async () => {
 			raw: '="required"',
 		},
 	]);
+});
+
+describe('fix', () => {
+	test('remove value from boolean attribute', async () => {
+		const { fixedCode } = await mlRuleTest(rule, '<input type="text" required="required" />', undefined, true);
+		expect(fixedCode).toBe('<input type="text" required />');
+	});
+
+	test('multiple boolean attributes', async () => {
+		const { fixedCode } = await mlRuleTest(
+			rule,
+			'<input disabled="disabled" required="required" />',
+			undefined,
+			true,
+		);
+		expect(fixedCode).toBe('<input disabled required />');
+	});
+
+	test('spaces around equals', async () => {
+		const { fixedCode } = await mlRuleTest(rule, '<input required = "required" />', undefined, true);
+		expect(fixedCode).toBe('<input required />');
+	});
+
+	test('single-quoted value', async () => {
+		const { fixedCode } = await mlRuleTest(rule, "<input required='required' />", undefined, true);
+		expect(fixedCode).toBe('<input required />');
+	});
+
+	test('unquoted value', async () => {
+		const { fixedCode } = await mlRuleTest(rule, '<input required=required />', undefined, true);
+		expect(fixedCode).toBe('<input required />');
+	});
 });

--- a/packages/@markuplint/rules/src/no-boolean-attr-value/index.ts
+++ b/packages/@markuplint/rules/src/no-boolean-attr-value/index.ts
@@ -1,5 +1,7 @@
 import { createRule, getAttrSpecs } from '@markuplint/ml-core';
 
+import { removeAttrValue } from '../helpers.js';
+
 import meta from './meta.js';
 
 /**
@@ -55,6 +57,7 @@ export default createRule({
 						t('{0} is {1}', t('the "{0*}" {1}', name, 'attribute'), t('a {0}', 'boolean attribute')) +
 						t('. ') +
 						t("It doesn't need {0}", t('the {0}', 'value')),
+					fix: fixer => removeAttrValue(fixer, attr),
 				});
 			}
 		});

--- a/packages/@markuplint/rules/src/no-consecutive-br/index.spec.ts
+++ b/packages/@markuplint/rules/src/no-consecutive-br/index.spec.ts
@@ -1,5 +1,5 @@
 import { mlRuleTest } from 'markuplint';
-import { test, expect } from 'vitest';
+import { describe, test, expect } from 'vitest';
 
 import rule from './index.js';
 
@@ -19,4 +19,21 @@ test('Consecutive', async () => {
 test('No consecutive', async () => {
 	const { violations } = await mlRuleTest(rule, '<p>A<br data-first>B<br data-second>C</p>');
 	expect(violations.length).toBe(0);
+});
+
+describe('fix', () => {
+	test('remove second consecutive br', async () => {
+		const { fixedCode } = await mlRuleTest(rule, '<p>text<br><br></p>', undefined, true);
+		expect(fixedCode).toBe('<p>text<br></p>');
+	});
+
+	test('three consecutive br elements', async () => {
+		const { fixedCode } = await mlRuleTest(rule, '<p>text<br><br><br></p>', undefined, true);
+		expect(fixedCode).toBe('<p>text<br></p>');
+	});
+
+	test('consecutive br with whitespace between', async () => {
+		const { fixedCode } = await mlRuleTest(rule, '<p>text<br>  \n  <br></p>', undefined, true);
+		expect(fixedCode).toBe('<p>text<br>  \n  </p>');
+	});
 });

--- a/packages/@markuplint/rules/src/no-consecutive-br/index.ts
+++ b/packages/@markuplint/rules/src/no-consecutive-br/index.ts
@@ -22,9 +22,11 @@ export default createRule({
 				next = next.nextSibling;
 			}
 			if (next && next.nodeName === 'BR') {
+				const target = next;
 				report({
-					scope: next,
+					scope: target,
 					message: t('{0} detected', t('Consecutive {0}', t('"{0*}" {1}', 'br', 'elements'))),
+					fix: fixer => fixer.remove({ startOffset: target.startOffset, raw: target.raw }),
 				});
 			}
 		}

--- a/packages/@markuplint/rules/src/no-default-value/index.spec.ts
+++ b/packages/@markuplint/rules/src/no-default-value/index.spec.ts
@@ -1,5 +1,5 @@
 import { mlRuleTest } from 'markuplint';
-import { test, expect } from 'vitest';
+import { describe, test, expect } from 'vitest';
 
 import rule from './index.js';
 
@@ -92,4 +92,11 @@ test('The `as` attribute', async () => {
 			message: 'It is the default value',
 		},
 	]);
+});
+
+describe('fix', () => {
+	test('remove default value attribute', async () => {
+		const { fixedCode } = await mlRuleTest(rule, '<canvas width="300" height="150"></canvas>', undefined, true);
+		expect(fixedCode).toBe('<canvas></canvas>');
+	});
 });

--- a/packages/@markuplint/rules/src/no-default-value/index.ts
+++ b/packages/@markuplint/rules/src/no-default-value/index.ts
@@ -1,6 +1,6 @@
 import { createRule, getAttrSpecs } from '@markuplint/ml-core';
 
-import { toNormalizedValue } from '../helpers.js';
+import { removeAttr, toNormalizedValue } from '../helpers.js';
 
 import meta from './meta.js';
 
@@ -42,6 +42,7 @@ export default createRule({
 					col: attr.valueNode?.startCol,
 					raw: attr.valueNode?.raw,
 					message: t('It is {0}', t('the {0}', 'default value')),
+					fix: fixer => removeAttr(fixer, attr),
 				});
 			}
 		});

--- a/packages/@markuplint/rules/src/no-orphaned-end-tag/index.spec.ts
+++ b/packages/@markuplint/rules/src/no-orphaned-end-tag/index.spec.ts
@@ -1,5 +1,5 @@
 import { mlRuleTest } from 'markuplint';
-import { test, expect } from 'vitest';
+import { describe, test, expect } from 'vitest';
 
 import rule from './index.js';
 
@@ -41,4 +41,16 @@ test('#1575: orphaned end tag with newlines', async () => {
 			message: 'Orphaned end tag detected',
 		},
 	]);
+});
+
+describe('fix', () => {
+	test('remove orphaned end tag', async () => {
+		const { fixedCode } = await mlRuleTest(rule, '<div></div></span>', undefined, true);
+		expect(fixedCode).toBe('<div></div>');
+	});
+
+	test('remove multiple orphaned end tags', async () => {
+		const { fixedCode } = await mlRuleTest(rule, '<div></p></br><p></span></p></div>', undefined, true);
+		expect(fixedCode).toBe('<div><p></p></div>');
+	});
 });

--- a/packages/@markuplint/rules/src/no-orphaned-end-tag/index.ts
+++ b/packages/@markuplint/rules/src/no-orphaned-end-tag/index.ts
@@ -17,6 +17,7 @@ export default createRule<boolean, null>({
 				report({
 					scope: text,
 					message: t('{0} detected', t('Orphaned end tag')),
+					fix: fixer => fixer.remove({ startOffset: text.startOffset, raw: text.raw }),
 				});
 			}
 		});

--- a/packages/markuplint/src/cli/index.spec.ts
+++ b/packages/markuplint/src/cli/index.spec.ts
@@ -295,9 +295,14 @@ describe('Issues', () => {
 		const fixedFilePath = path.resolve(__dirname, '../../test/fix/fixed.html');
 		const originContent = await readFile(originFilePath, { encoding: 'utf8' });
 
-		await execa(entryFilePath, ['--fix', escape(fixedFilePath)], {
-			reject: false,
-		});
+		const configFilePath = path.resolve(__dirname, '../../test/fix/fix-test.markuplintrc');
+		await execa(
+			entryFilePath,
+			['--fix', escape(fixedFilePath), '--config', escape(configFilePath), '--no-search-config'],
+			{
+				reject: false,
+			},
+		);
 
 		const fixedContent = await readFile(fixedFilePath, { encoding: 'utf8' });
 		expect(originContent).toBe(fixedContent);

--- a/packages/markuplint/test/fix/fix-test.markuplintrc
+++ b/packages/markuplint/test/fix/fix-test.markuplintrc
@@ -1,0 +1,6 @@
+{
+	"extends": ["markuplint:recommended"],
+	"parserOptions": {
+		"ignoreFrontMatter": true
+	}
+}


### PR DESCRIPTION
## Summary

- Add ESLint-style multi-pass fix loop to `MLCore.verify()` — when overlapping fixes are skipped, the engine re-parses and re-verifies up to 10 passes until all fixable violations are resolved
- Add `FixToken` type to `@markuplint/ml-config` as the shared token interface for `IRuleFixer` methods
- Add fix callbacks to 6 additional rules: `no-boolean-attr-value`, `no-default-value`, `attr-duplication`, `ineffective-attr`, `no-orphaned-end-tag`, `no-consecutive-br`
- Extract shared `removeAttr()` / `removeAttrValue()` helpers in `@markuplint/rules` for DRY attribute removal
- Add cycle detection to prevent infinite fix loops (A→B→A oscillation)
- Add multi-pass integration tests and per-rule fix tests
- Add migration guide for rule fix function API (`docs/migration/v4-v5/`)

## Test plan

- [x] `yarn lint-check` — 0 errors, 0 warnings
- [x] `yarn build` — all 40 packages build successfully
- [x] `yarn test` — 2502 passed, 0 failed
- [x] Multi-pass integration tests verify overlap resolution across 4 rules
- [x] Per-rule fix tests cover standard cases, edge cases (single-quoted, unquoted, whitespace-separated, triple duplicates)
- [x] CLI #1042 regression test passes with dedicated config

Closes #3292

🤖 Generated with [Claude Code](https://claude.com/claude-code)