### PR TITLE
feat(vscode): add Code Action support for autofix (#3294)

### DIFF
--- a/packages/@markuplint/ml-core/src/fix-applier.spec.ts
+++ b/packages/@markuplint/ml-core/src/fix-applier.spec.ts
@@ -166,6 +166,43 @@ describe('applyFixes appliedEdits', () => {
 	});
 });
 
+describe('applyFixes atomic FixData', () => {
+	test('sibling edit at boundary is skipped when another sibling was skipped', () => {
+		// Simulates: no-default-value removes " type=text" [6,16]
+		// attr-value-quotes inserts quotes at [12,12] and [16,16]
+		// Edit [12,12] is inside [6,16] → skipped, so [16,16] must also be skipped
+		const source = '<input type=text name=field>';
+		const fixRemove: FixData = { edits: [{ range: [6, 16], text: '' }] };
+		const fixQuotes: FixData = {
+			edits: [
+				{ range: [12, 12], text: '"' },
+				{ range: [16, 16], text: '"' },
+			],
+		};
+		const result = applyFixes(source, [fixRemove, fixQuotes]);
+		expect(result.output).toBe('<input name=field>');
+		expect(result.applied).toStrictEqual([fixRemove]);
+		expect(result.skipped).toStrictEqual([fixQuotes]);
+	});
+
+	test('all edits of a FixData are skipped if any one overlaps', () => {
+		// fix1 covers [0,10], fix2 has edits at [5,5] and [20,20]
+		// [5,5] overlaps with [0,10] → fix2 entirely skipped including [20,20]
+		const source = '0123456789----------ABCDE';
+		const fix1: FixData = { edits: [{ range: [0, 10], text: 'X' }] };
+		const fix2: FixData = {
+			edits: [
+				{ range: [5, 5], text: 'Y' },
+				{ range: [20, 20], text: 'Z' },
+			],
+		};
+		const result = applyFixes(source, [fix1, fix2]);
+		expect(result.output).toBe('X----------ABCDE');
+		expect(result.applied).toStrictEqual([fix1]);
+		expect(result.skipped).toStrictEqual([fix2]);
+	});
+});
+
 describe('applyFixes edge cases', () => {
 	test('edit at end of source string (append)', () => {
 		const fix: FixData = { edits: [{ range: [11, 11], text: '!' }] };

--- a/packages/@markuplint/ml-core/src/fix-applier.ts
+++ b/packages/@markuplint/ml-core/src/fix-applier.ts
@@ -61,8 +61,10 @@ export function applyFixes(sourceCode: string, fixes: readonly FixData[]): FixRe
 	for (const { edit, fixIndex } of taggedEdits) {
 		const [start, end] = edit.range;
 
-		// Overlap check: if this edit starts before the end of the last applied edit, skip it
-		if (start < lastAppliedEnd) {
+		// Overlap check: if this edit starts before the end of the last applied edit, skip it.
+		// Also skip if a sibling edit from the same FixData was already skipped —
+		// edits within a single FixData are atomic (all-or-nothing).
+		if (start < lastAppliedEnd || skippedFixIndices.has(fixIndex)) {
 			skippedFixIndices.add(fixIndex);
 			continue;
 		}

--- a/packages/@markuplint/parser-utils/package.json
+++ b/packages/@markuplint/parser-utils/package.json
@@ -33,6 +33,7 @@
 	"dependencies": {
 		"@markuplint/ml-ast": "5.0.0-alpha.2",
 		"@markuplint/ml-spec": "5.0.0-alpha.2",
+		"@markuplint/shared": "5.0.0-alpha.2",
 		"@markuplint/types": "5.0.0-alpha.2",
 		"debug": "4.4.3",
 		"espree": "11.1.1",

--- a/packages/@markuplint/parser-utils/src/get-location.ts
+++ b/packages/@markuplint/parser-utils/src/get-location.ts
@@ -1,3 +1,5 @@
+export { getPosition } from '@markuplint/shared';
+
 const LINE_BREAK = '\n';
 
 /**
@@ -13,20 +15,6 @@ export function getLine(rawCodeFragment: string, startOffset: number) {
 export function getCol(rawCodeFragment: string, startOffset: number) {
 	const lines = rawCodeFragment.slice(0, startOffset).split(LINE_BREAK);
 	return (lines.at(-1) ?? '').length + 1;
-}
-
-/**
- * Computes the line and column of a position within a code fragment.
- *
- * @param rawCodeFragment - The full raw source text
- * @param startOffset - The zero-based byte offset to compute the position of
- * @returns An object containing one-based `line` and `column`
- */
-export function getPosition(rawCodeFragment: string, startOffset: number) {
-	const lines = rawCodeFragment.slice(0, startOffset).split(LINE_BREAK);
-	const line = lines.length;
-	const column = (lines.at(-1) ?? '').length + 1;
-	return { line, column } as const;
 }
 
 export function getEndLine(rawCodeFragment: string, startLine: number) {

--- a/packages/@markuplint/rules/src/attr-duplication/index.spec.ts
+++ b/packages/@markuplint/rules/src/attr-duplication/index.spec.ts
@@ -197,3 +197,26 @@ describe('fix', () => {
 		expect(fixedCode).toBe('<div data-attr="value"></div>');
 	});
 });
+
+describe('fix with parsers', () => {
+	test('fix: Pug duplicate attr (no fix — Pug merges class attributes)', async () => {
+		const { fixedCode } = await mlRuleTest(
+			rule,
+			'div(class="a" class="b")',
+			{ parser: { '.*': '@markuplint/pug-parser' } },
+			true,
+		);
+		// Pug parser merges duplicate class attributes, so no violation is detected
+		expect(fixedCode).toBe('div(class="a" class="b")');
+	});
+
+	test('fix: Vue remove duplicate attr', async () => {
+		const { fixedCode } = await mlRuleTest(
+			rule,
+			'<template><div class="a" class="b"></div></template>',
+			{ parser: { '.*': '@markuplint/vue-parser' } },
+			true,
+		);
+		expect(fixedCode).toBe('<template><div class="a"></div></template>');
+	});
+});

--- a/packages/@markuplint/rules/src/attr-value-quotes/index.spec.ts
+++ b/packages/@markuplint/rules/src/attr-value-quotes/index.spec.ts
@@ -151,4 +151,14 @@ describe('fix with parsers', () => {
 		);
 		expect(fixedCode).toBe('<template><div :class="foo"></div></template>');
 	});
+
+	test('fix: Markdown raw HTML single → double', async () => {
+		const { fixedCode } = await mlRuleTest(
+			rule,
+			"Some text\n\n<div data-attr='value'>content</div>\n",
+			{ rule: { severity: 'error', value: 'double' }, parser: { '.*': '@markuplint/markdown-parser' } },
+			true,
+		);
+		expect(fixedCode).toBe('Some text\n\n<div data-attr="value">content</div>\n');
+	});
 });

--- a/packages/@markuplint/rules/src/attr-value-quotes/index.spec.ts
+++ b/packages/@markuplint/rules/src/attr-value-quotes/index.spec.ts
@@ -130,3 +130,25 @@ describe('fix', () => {
 		expect(fixedCode).toEqual("<div attr noop='noop' foo='bar' hoge='fuga'>");
 	});
 });
+
+describe('fix with parsers', () => {
+	test('fix: Pug single → double', async () => {
+		const { fixedCode } = await mlRuleTest(
+			rule,
+			"div(class='foo')",
+			{ rule: { severity: 'error', value: 'double' }, parser: { '.*': '@markuplint/pug-parser' } },
+			true,
+		);
+		expect(fixedCode).toBe('div(class="foo")');
+	});
+
+	test('fix: Vue single → double', async () => {
+		const { fixedCode } = await mlRuleTest(
+			rule,
+			"<template><div :class='foo'></div></template>",
+			{ rule: { severity: 'error', value: 'double' }, parser: { '.*': '@markuplint/vue-parser' } },
+			true,
+		);
+		expect(fixedCode).toBe('<template><div :class="foo"></div></template>');
+	});
+});

--- a/packages/@markuplint/rules/src/multi-pass-fix.spec.ts
+++ b/packages/@markuplint/rules/src/multi-pass-fix.spec.ts
@@ -160,4 +160,21 @@ describe('multi-pass fix with parsers', () => {
 		);
 		expect(fixedCode).toBe('<><input disabled required /></>');
 	});
+
+	test('Markdown: attr-value-quotes + no-boolean-attr-value on raw HTML', async () => {
+		const { fixedCode } = await mlTest(
+			"Some text\n\n<input disabled='disabled' data-foo='bar' />\n",
+			{
+				parser: { '.*': '@markuplint/markdown-parser' },
+				rules: {
+					'attr-value-quotes': { severity: 'error', value: 'double' },
+					'no-boolean-attr-value': true,
+				},
+			},
+			undefined,
+			'en',
+			true,
+		);
+		expect(fixedCode).toBe('Some text\n\n<input disabled data-foo="bar" />\n');
+	});
 });

--- a/packages/@markuplint/rules/src/multi-pass-fix.spec.ts
+++ b/packages/@markuplint/rules/src/multi-pass-fix.spec.ts
@@ -71,3 +71,93 @@ describe('multi-pass fix', () => {
 		expect(fixedCode).toBe('<div class="a" data-foo="val"></div>');
 	});
 });
+
+describe('multi-pass fix with parsers', () => {
+	test('Pug: attr-value-quotes + no-boolean-attr-value', async () => {
+		const { fixedCode } = await mlTest(
+			"input(disabled='disabled' type='text')",
+			{
+				parser: { '.*': '@markuplint/pug-parser' },
+				rules: {
+					'attr-value-quotes': { severity: 'error', value: 'double' },
+					'no-boolean-attr-value': true,
+				},
+			},
+			undefined,
+			'en',
+			true,
+		);
+		// disabled='disabled' → disabled (boolean fix), type='text' → type="text" (quote fix)
+		expect(fixedCode).toBe('input(disabled type="text")');
+	});
+
+	test('Pug: attr-value-quotes + no-default-value', async () => {
+		const { fixedCode } = await mlTest(
+			"input(type='text' placeholder='enter')",
+			{
+				parser: { '.*': '@markuplint/pug-parser' },
+				rules: {
+					'attr-value-quotes': { severity: 'error', value: 'double' },
+					'no-default-value': true,
+				},
+			},
+			undefined,
+			'en',
+			true,
+		);
+		// type='text' → removed (default value), placeholder='enter' → placeholder="enter" (quote fix)
+		// Leading space remains after attribute removal in Pug bracket syntax
+		expect(fixedCode).toBe('input( placeholder="enter")');
+	});
+
+	test('Vue: attr-value-quotes + no-boolean-attr-value', async () => {
+		const { fixedCode } = await mlTest(
+			"<template><input disabled='disabled' data-foo='bar' /></template>",
+			{
+				parser: { '.*': '@markuplint/vue-parser' },
+				rules: {
+					'attr-value-quotes': { severity: 'error', value: 'double' },
+					'no-boolean-attr-value': true,
+				},
+			},
+			undefined,
+			'en',
+			true,
+		);
+		expect(fixedCode).toBe('<template><input disabled data-foo="bar" /></template>');
+	});
+
+	test('Vue: attr-value-quotes + attr-duplication', async () => {
+		const { fixedCode } = await mlTest(
+			"<template><div class='a' class='b'></div></template>",
+			{
+				parser: { '.*': '@markuplint/vue-parser' },
+				rules: {
+					'attr-value-quotes': { severity: 'error', value: 'double' },
+					'attr-duplication': true,
+				},
+			},
+			undefined,
+			'en',
+			true,
+		);
+		// Duplicate removed + quotes normalized
+		expect(fixedCode).toBe('<template><div class="a"></div></template>');
+	});
+
+	test('JSX: no-boolean-attr-value on element with multiple attrs', async () => {
+		const { fixedCode } = await mlTest(
+			'<><input disabled="disabled" required="required" /></>',
+			{
+				parser: { '.*': '@markuplint/jsx-parser' },
+				rules: {
+					'no-boolean-attr-value': true,
+				},
+			},
+			undefined,
+			'en',
+			true,
+		);
+		expect(fixedCode).toBe('<><input disabled required /></>');
+	});
+});

--- a/packages/@markuplint/rules/src/no-boolean-attr-value/index.spec.ts
+++ b/packages/@markuplint/rules/src/no-boolean-attr-value/index.spec.ts
@@ -120,4 +120,14 @@ describe('fix with parsers', () => {
 		);
 		expect(fixedCode).toBe('<template><input disabled /></template>');
 	});
+
+	test('fix: Markdown raw HTML remove boolean attr value', async () => {
+		const { fixedCode } = await mlRuleTest(
+			rule,
+			'Some text\n\n<input disabled="disabled" />\n',
+			{ parser: { '.*': '@markuplint/markdown-parser' } },
+			true,
+		);
+		expect(fixedCode).toBe('Some text\n\n<input disabled />\n');
+	});
 });

--- a/packages/@markuplint/rules/src/no-boolean-attr-value/index.spec.ts
+++ b/packages/@markuplint/rules/src/no-boolean-attr-value/index.spec.ts
@@ -89,3 +89,35 @@ describe('fix', () => {
 		expect(fixedCode).toBe('<input required />');
 	});
 });
+
+describe('fix with parsers', () => {
+	test('fix: Pug remove boolean attr value', async () => {
+		const { fixedCode } = await mlRuleTest(
+			rule,
+			'input(disabled="disabled")',
+			{ parser: { '.*': '@markuplint/pug-parser' } },
+			true,
+		);
+		expect(fixedCode).toBe('input(disabled)');
+	});
+
+	test('fix: JSX remove boolean attr value', async () => {
+		const { fixedCode } = await mlRuleTest(
+			rule,
+			'<><input disabled="disabled" /></>',
+			{ parser: { '.*': '@markuplint/jsx-parser' } },
+			true,
+		);
+		expect(fixedCode).toBe('<><input disabled /></>');
+	});
+
+	test('fix: Vue remove boolean attr value', async () => {
+		const { fixedCode } = await mlRuleTest(
+			rule,
+			'<template><input disabled="disabled" /></template>',
+			{ parser: { '.*': '@markuplint/vue-parser' } },
+			true,
+		);
+		expect(fixedCode).toBe('<template><input disabled /></template>');
+	});
+});

--- a/packages/@markuplint/rules/src/no-consecutive-br/index.spec.ts
+++ b/packages/@markuplint/rules/src/no-consecutive-br/index.spec.ts
@@ -37,3 +37,16 @@ describe('fix', () => {
 		expect(fixedCode).toBe('<p>text<br>  \n  </p>');
 	});
 });
+
+describe('fix with parsers', () => {
+	test('fix: Pug remove consecutive br', async () => {
+		const { fixedCode } = await mlRuleTest(
+			rule,
+			'p\n\tbr\n\tbr',
+			{ parser: { '.*': '@markuplint/pug-parser' } },
+			true,
+		);
+		// The br tag is removed but the preceding whitespace (newline + tab) remains
+		expect(fixedCode).toBe('p\n\tbr\n\t');
+	});
+});

--- a/packages/@markuplint/rules/src/no-consecutive-br/index.spec.ts
+++ b/packages/@markuplint/rules/src/no-consecutive-br/index.spec.ts
@@ -49,4 +49,14 @@ describe('fix with parsers', () => {
 		// The br tag is removed but the preceding whitespace (newline + tab) remains
 		expect(fixedCode).toBe('p\n\tbr\n\t');
 	});
+
+	test('fix: Markdown raw HTML remove consecutive br', async () => {
+		const { fixedCode } = await mlRuleTest(
+			rule,
+			'Paragraph\n\n<p>text<br><br></p>\n',
+			{ parser: { '.*': '@markuplint/markdown-parser' } },
+			true,
+		);
+		expect(fixedCode).toBe('Paragraph\n\n<p>text<br></p>\n');
+	});
 });

--- a/packages/@markuplint/rules/src/no-default-value/index.spec.ts
+++ b/packages/@markuplint/rules/src/no-default-value/index.spec.ts
@@ -100,3 +100,16 @@ describe('fix', () => {
 		expect(fixedCode).toBe('<canvas></canvas>');
 	});
 });
+
+describe('fix with parsers', () => {
+	test('fix: Pug remove default value', async () => {
+		const { fixedCode } = await mlRuleTest(
+			rule,
+			'input(type="text")',
+			{ parser: { '.*': '@markuplint/pug-parser' } },
+			true,
+		);
+		// Empty parentheses remain after removing the only attribute in Pug
+		expect(fixedCode).toBe('input()');
+	});
+});

--- a/packages/@markuplint/shared/src/functions.ts
+++ b/packages/@markuplint/shared/src/functions.ts
@@ -136,6 +136,20 @@ export function branchesToPatterns<T>(branches: ReadonlyArray<Nullable<T> | Read
  * @param regexpLikeString - The regular expression pattern to parse.
  * @returns - The parsed regular expression or null if the pattern is invalid.
  */
+/**
+ * Computes the line and column of a position within a code fragment.
+ *
+ * @param rawCodeFragment - The full raw source text
+ * @param startOffset - The zero-based byte offset to compute the position of
+ * @returns An object containing one-based `line` and `column`
+ */
+export function getPosition(rawCodeFragment: string, startOffset: number) {
+	const lines = rawCodeFragment.slice(0, startOffset).split('\n');
+	const line = lines.length;
+	const column = (lines.at(-1) ?? '').length + 1;
+	return { line, column } as const;
+}
+
 export function regexParser(regexpLikeString: string): RegExp | null {
 	if (!regexpLikeString.startsWith('/')) {
 		// Early return if the string does not start with a slash.

--- a/packages/markuplint/src/api/ml-engine.ts
+++ b/packages/markuplint/src/api/ml-engine.ts
@@ -176,7 +176,7 @@ export class MLEngine extends Emitter<MLEngineEventMap> {
 		const debugMap = 'debugMap' in core.document ? core.document.debugMap() : null;
 
 		const resolvedFixedCode = fixedCode ?? sourceCode;
-		this.emit('lint', this.#file.path, sourceCode, violations, resolvedFixedCode, debugMap);
+		this.emit('lint', this.#file.path, sourceCode, violations, resolvedFixedCode, debugMap, fixSummary ?? null);
 		log('exec: end');
 		return {
 			violations: [...violations],

--- a/packages/markuplint/src/api/types.ts
+++ b/packages/markuplint/src/api/types.ts
@@ -1,7 +1,7 @@
 import type { ConfigSet } from '@markuplint/file-resolver';
 import type { LocaleSet } from '@markuplint/i18n';
 import type { Config, SeverityOptions, Violation } from '@markuplint/ml-config';
-import type { AnyMLRule, MLSchema, Ruleset } from '@markuplint/ml-core';
+import type { AnyMLRule, FixSummary, MLSchema, Ruleset } from '@markuplint/ml-core';
 
 /**
  * Options for the markuplint API, controlling configuration, locale, rules, and behavior.
@@ -44,7 +44,7 @@ export type MLEngineEventMap = {
 		violations: readonly Violation[],
 		fixedCode: string,
 		debug: readonly string[] | null,
-		message?: string,
+		fixSummary: FixSummary | null,
 	];
 	'lint-error': [filePath: string, sourceCode: string, error: Readonly<Error>];
 	'config-errors': [filePath: string, errors: readonly Readonly<Error>[]];

--- a/packages/markuplint/src/index.spec.ts
+++ b/packages/markuplint/src/index.spec.ts
@@ -109,6 +109,10 @@ describe('basic test', () => {
 			'Attribute value is must quote on double quotation mark',
 			'Attribute value is must quote on double quotation mark',
 			'Attribute value is must quote on double quotation mark',
+			'Attribute names of HTML elements should be lowercase',
+			'Tag names of HTML elements should be lowercase',
+			'Tag names of HTML elements should be lowercase',
+			'It is the default value',
 		]);
 	});
 
@@ -131,6 +135,7 @@ describe('basic test', () => {
 		expect(violations.map(v => v.ruleId)).toStrictEqual([
 			'invalid-attr',
 			'invalid-attr',
+			'no-default-value',
 			'required-attr',
 			'required-attr',
 			'placeholder-label-option',

--- a/packages/markuplint/src/types.ts
+++ b/packages/markuplint/src/types.ts
@@ -32,3 +32,5 @@ export interface MLResultInfo_v1 {
 		error: string[];
 	};
 }
+
+export { type FixSummary } from '@markuplint/ml-core';

--- a/test/fixture/.markuplintrc
+++ b/test/fixture/.markuplintrc
@@ -2,7 +2,11 @@
 	"extends": ["markuplint:recommended"],
 	"excludeFiles": ["./008.html"],
 	"rules": {
-		"attr-value-quotes": { "reason": "For consistency" }
+		"attr-value-quotes": { "reason": "For consistency" },
+		"case-sensitive-tag-name": true,
+		"case-sensitive-attr-name": true,
+		"no-boolean-attr-value": true,
+		"no-default-value": true
 	},
 	"nodeRules": [
 		{

--- a/test/fixture/027.html
+++ b/test/fixture/027.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>attr-duplication</title>
+</head>
+<body>
+	<!-- Duplicate class attribute -->
+	<div class="foo" class="bar">duplicate class</div>
+
+	<!-- Duplicate id attribute -->
+	<p id="first" id="second">duplicate id</p>
+
+	<!-- Duplicate data attribute -->
+	<span data-value="1" data-value="2">duplicate data attr</span>
+
+	<!-- Duplicate event handler -->
+	<button onclick="doA()" onclick="doB()">duplicate onclick</button>
+
+	<!-- Duplicate aria attribute -->
+	<div role="button" aria-label="one" aria-label="two">duplicate aria-label</div>
+</body>
+</html>

--- a/test/fixture/028.html
+++ b/test/fixture/028.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>case-sensitive-tag-name</title>
+</head>
+<body>
+	<!-- Uppercase tags -->
+	<DIV>uppercase div</DIV>
+	<SPAN>uppercase span</SPAN>
+	<P>uppercase paragraph</P>
+
+	<!-- Mixed case tags -->
+	<Section>
+		<Article>
+			<H1>Mixed case heading</H1>
+			<P>Mixed case paragraph</P>
+		</Article>
+	</Section>
+
+	<!-- Uppercase void elements -->
+	<BR>
+	<HR>
+	<IMG src="test.png" alt="test">
+
+	<!-- Uppercase with attributes -->
+	<A href="/path">uppercase anchor</A>
+	<TABLE>
+		<TR>
+			<TD>cell</TD>
+		</TR>
+	</TABLE>
+</body>
+</html>

--- a/test/fixture/029.html
+++ b/test/fixture/029.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>case-sensitive-attr-name</title>
+</head>
+<body>
+	<!-- Uppercase attribute names -->
+	<div CLASS="foo">uppercase class</div>
+	<div ID="bar">uppercase id</div>
+	<a HREF="/path">uppercase href</a>
+
+	<!-- Mixed case attribute names -->
+	<img SRC="test.png" ALT="test">
+	<input TYPE="checkbox" CHECKED>
+	<div STYLE="color: red" TITLE="tooltip">styled</div>
+
+	<!-- Uppercase data attributes -->
+	<div DATA-VALUE="1" DATA-NAME="test">uppercase data attrs</div>
+
+	<!-- Uppercase aria attributes -->
+	<div ROLE="button" ARIA-LABEL="click me">uppercase aria</div>
+
+	<!-- Multiple uppercase attrs on one element -->
+	<a HREF="/path" TARGET="_blank" REL="noopener" TITLE="link">many uppercase</a>
+</body>
+</html>

--- a/test/fixture/030.html
+++ b/test/fixture/030.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>no-boolean-attr-value</title>
+</head>
+<body>
+	<!-- Boolean attrs with redundant values (same as attr name) -->
+	<input type="text" disabled="disabled">
+	<input type="checkbox" checked="checked">
+	<input type="text" required="required">
+	<input type="text" readonly="readonly">
+	<select multiple="multiple"><option>a</option></select>
+	<textarea autofocus="autofocus"></textarea>
+
+	<!-- Boolean attrs with empty string value -->
+	<input type="text" disabled="">
+	<input type="checkbox" checked="">
+	<input type="text" required="">
+
+	<!-- Boolean attrs with different quoting -->
+	<input type="text" disabled='disabled'>
+	<input type="checkbox" checked='checked'>
+
+	<!-- Boolean attrs on various elements -->
+	<details open="open"><summary>Details</summary>Content</details>
+	<video controls="controls" muted="muted" autoplay="autoplay" loop="loop" src="video.mp4"></video>
+	<audio controls="controls" muted="muted" src="audio.mp3"></audio>
+	<dialog open="open">Dialog</dialog>
+	<ol reversed="reversed"><li>item</li></ol>
+
+	<!-- Boolean attrs on form elements -->
+	<form novalidate="novalidate" action="/submit">
+		<input type="text" required="required" autofocus="autofocus">
+		<fieldset disabled="disabled"><legend>Group</legend></fieldset>
+		<button formnovalidate="formnovalidate" type="submit">Submit</button>
+	</form>
+
+	<!-- Correct usage (no value) - should NOT be flagged -->
+	<input type="text" disabled>
+	<input type="checkbox" checked>
+	<input type="text" required>
+</body>
+</html>

--- a/test/fixture/031.html
+++ b/test/fixture/031.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>no-default-value</title>
+</head>
+<body>
+	<!-- input type="text" is the default -->
+	<input type="text">
+	<input type="text" name="name">
+
+	<!-- col span="1" is the default -->
+	<table>
+		<colgroup>
+			<col span="1">
+		</colgroup>
+		<tr><td>cell</td></tr>
+	</table>
+
+	<!-- Non-default values - should NOT be flagged -->
+	<input type="email">
+	<input type="password">
+	<input type="number">
+</body>
+</html>

--- a/test/fixture/032.html
+++ b/test/fixture/032.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>ineffective-attr</title>
+	<!-- defer on inline script has no effect -->
+	<script defer>const foo = "foo";</script>
+	<!-- defer on module script has no effect (modules are implicitly deferred) -->
+	<script type="module" src="module.js" defer></script>
+</head>
+<body>
+	<!-- Correct usage - should NOT be flagged -->
+	<script defer src="app.js"></script>
+	<script async src="analytics.js"></script>
+</body>
+</html>

--- a/test/fixture/033.html
+++ b/test/fixture/033.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>no-consecutive-br</title>
+</head>
+<body>
+	<!-- Two consecutive br -->
+	<p>First<br><br>Second</p>
+
+	<!-- Three consecutive br -->
+	<p>Alpha<br><br><br>Beta</p>
+
+	<!-- Consecutive br with whitespace between -->
+	<p>Before<br>
+	<br>After</p>
+
+	<!-- Single br - should NOT be flagged -->
+	<p>Line 1<br>Line 2</p>
+	<p>Another<br>paragraph</p>
+</body>
+</html>

--- a/test/fixture/034.html
+++ b/test/fixture/034.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>no-orphaned-end-tag</title>
+</head>
+<body>
+	<!-- Orphaned end tags (no matching open tag) -->
+	<div></span></div>
+	<p>text</p></span>
+
+	<!-- Orphaned br end tag -->
+	</br>
+
+	<!-- Multiple orphaned end tags -->
+	<div></p></em></div>
+
+	<!-- Correct usage - should NOT be flagged -->
+	<div><span>content</span></div>
+	<p><em>emphasized</em></p>
+</body>
+</html>

--- a/test/fixture/035.html
+++ b/test/fixture/035.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>attr-value-quotes</title>
+</head>
+<body>
+	<!-- Unquoted attribute values -->
+	<div class=foo>unquoted class</div>
+	<div data-value=bar>unquoted data attr</div>
+	<input type=text name=field>
+
+	<!-- Single-quoted attribute values -->
+	<div class='bar'>single-quoted class</div>
+	<a href='/path'>single-quoted href</a>
+	<img src='test.png' alt='test image'>
+
+	<!-- Mixed quoting on same element -->
+	<div class=foo id='bar' title="baz">mixed quotes</div>
+
+	<!-- Correct usage (double quotes) - should NOT be flagged -->
+	<div class="correct">double-quoted</div>
+	<a href="/path" title="link">correct</a>
+</body>
+</html>

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -12,6 +12,34 @@
 - `markuplint.hover.accessibility.enable`: Enable the feature that **popup Accessibility Object**
 - `markuplint.hover.accessibility.ariaVersion`: Set `1.1`, `1.2`, or `1.3` WAI-ARIA version. If not set, uses markuplint's default version.
 
+## Auto Fix
+
+Markuplint provides Code Actions for auto-fixable problems.
+
+### Quick Fix
+
+When you hover over a diagnostic with a wavy underline, click the light bulb icon (or press `Ctrl+.` / `Cmd+.`) to see the available Quick Fixes.
+
+### Fix on Save
+
+To automatically fix all auto-fixable Markuplint problems when you save a file, add the following to your VS Code settings:
+
+```json
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll.markuplint": "explicit"
+  }
+}
+```
+
+| Value        | Behavior                                |
+| ------------ | --------------------------------------- |
+| `"explicit"` | Fix on manual save (`Cmd+S` / `Ctrl+S`) |
+| `"always"`   | Fix on manual save and auto-save        |
+| `"never"`    | Disable fix on save (default)           |
+
+> **Note:** Only rules that have auto-fix support will be corrected. Rules without auto-fix will still report diagnostics but require manual changes.
+
 ## Working Directories
 
 In monorepo setups where each sub-package has its own `.markuplintrc`, you may need to configure `markuplint.workingDirectories` so that markuplint resolves configuration files from the correct directory.

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -168,6 +168,15 @@
 				"title": "Restart Language Server",
 				"category": "Markuplint"
 			}
+		],
+		"codeActions": [
+			{
+				"kind": "source.fixAll.markuplint",
+				"title": "Fix all Markuplint auto-fixable problems",
+				"languages": [
+					"html"
+				]
+			}
 		]
 	},
 	"scripts": {
@@ -203,7 +212,7 @@
 		"@markuplint/ml-spec": "5.0.0-alpha.2",
 		"debug": "4.4.3",
 		"glob": "13.0.6",
-		"markuplint": "4.13.0",
+		"markuplint": "5.0.0-alpha.2",
 		"mocha": "11.7.5",
 		"semver": "7.7.4",
 		"vscode-languageclient": "9.0.1",

--- a/vscode/src/server/code-actions.spec.ts
+++ b/vscode/src/server/code-actions.spec.ts
@@ -1,0 +1,227 @@
+import type { FixState } from './v4.js';
+import type { Diagnostic } from 'vscode-languageserver';
+
+import { describe, test, expect } from 'vitest';
+import { DiagnosticSeverity, CodeActionKind } from 'vscode-languageserver';
+
+import {
+	offsetToPosition,
+	createQuickFixActions,
+	createFixAllAction,
+	SOURCE_FIX_ALL_MARKUPLINT,
+} from './code-actions.js';
+
+describe('offsetToPosition', () => {
+	test('offset 0 returns line 0, character 0', () => {
+		expect(offsetToPosition('hello', 0)).toEqual({ line: 0, character: 0 });
+	});
+
+	test('offset after newline returns correct line/character', () => {
+		const src = 'line1\nline2';
+		// offset 6 = start of 'line2'
+		expect(offsetToPosition(src, 6)).toEqual({ line: 1, character: 0 });
+	});
+
+	test('offset in middle of second line', () => {
+		const src = 'abc\ndef';
+		// offset 5 = 'e' in 'def'
+		expect(offsetToPosition(src, 5)).toEqual({ line: 1, character: 1 });
+	});
+
+	test('offset at end of source', () => {
+		const src = 'ab\ncd';
+		expect(offsetToPosition(src, 5)).toEqual({ line: 1, character: 2 });
+	});
+
+	test('empty string returns line 0, character 0', () => {
+		expect(offsetToPosition('', 0)).toEqual({ line: 0, character: 0 });
+	});
+});
+
+function makeDiagnostic(index: number, message = 'test'): Diagnostic {
+	return {
+		severity: DiagnosticSeverity.Error,
+		range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+		message,
+		source: 'markuplint',
+		data: { violationIndex: index },
+	};
+}
+
+describe('createQuickFixActions', () => {
+	test('creates QuickFix for violation with fix', () => {
+		const fixState: FixState = {
+			sourceCode: '<div class="">',
+			violations: [
+				{
+					ruleId: 'class-naming',
+					severity: 'error',
+					message: 'Empty class',
+					line: 1,
+					col: 6,
+					raw: 'class=""',
+					fix: {
+						edits: [{ range: [5, 13], text: '' }],
+					},
+				},
+			],
+			fixedCode: '<div>',
+			fixSummary: null,
+		};
+
+		const diag = makeDiagnostic(0, 'Empty class');
+		const actions = createQuickFixActions('file:///test.html', [diag], fixState);
+
+		expect(actions).toHaveLength(1);
+		const action = actions[0]!;
+		expect(action.kind).toBe(CodeActionKind.QuickFix);
+		expect(action.isPreferred).toBe(true);
+		expect(action.diagnostics).toEqual([diag]);
+		expect(action.edit?.changes?.['file:///test.html']).toHaveLength(1);
+	});
+
+	test('returns empty for violation without fix', () => {
+		const fixState: FixState = {
+			sourceCode: '<div>',
+			violations: [
+				{
+					ruleId: 'some-rule',
+					severity: 'warning',
+					message: 'No fix',
+					line: 1,
+					col: 1,
+					raw: '<div>',
+				},
+			],
+			fixedCode: '<div>',
+			fixSummary: null,
+		};
+
+		const diag = makeDiagnostic(0, 'No fix');
+		const actions = createQuickFixActions('file:///test.html', [diag], fixState);
+
+		expect(actions).toHaveLength(0);
+	});
+
+	test('skips diagnostic without violationIndex', () => {
+		const fixState: FixState = {
+			sourceCode: '<div>',
+			violations: [],
+			fixedCode: '<div>',
+			fixSummary: null,
+		};
+
+		const diag: Diagnostic = {
+			severity: DiagnosticSeverity.Error,
+			range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+			message: 'test',
+			source: 'markuplint',
+		};
+
+		const actions = createQuickFixActions('file:///test.html', [diag], fixState);
+
+		expect(actions).toHaveLength(0);
+	});
+
+	test('converts TextEdit offsets to correct LSP Range', () => {
+		// Source: "ab\ncd" (5 chars)
+		// Edit: replace offset [3,5] ("cd") with "ef"
+		const fixState: FixState = {
+			sourceCode: 'ab\ncd',
+			violations: [
+				{
+					ruleId: 'test',
+					severity: 'error',
+					message: 'msg',
+					line: 2,
+					col: 1,
+					raw: 'cd',
+					fix: {
+						edits: [{ range: [3, 5], text: 'ef' }],
+					},
+				},
+			],
+			fixedCode: 'ab\nef',
+			fixSummary: null,
+		};
+
+		const diag = makeDiagnostic(0);
+		const actions = createQuickFixActions('file:///test.html', [diag], fixState);
+
+		const edit = actions[0]!.edit!.changes!['file:///test.html']![0]!;
+		expect(edit.range.start).toEqual({ line: 1, character: 0 });
+		expect(edit.range.end).toEqual({ line: 1, character: 2 });
+		expect(edit.newText).toBe('ef');
+	});
+});
+
+describe('createFixAllAction', () => {
+	test('returns null when fixedCode equals sourceCode', () => {
+		const fixState: FixState = {
+			sourceCode: '<div>',
+			violations: [],
+			fixedCode: '<div>',
+			fixSummary: null,
+		};
+
+		const result = createFixAllAction('file:///test.html', [], fixState);
+
+		expect(result).toBeNull();
+	});
+
+	test('uses firstPassEdits when available', () => {
+		const fixState: FixState = {
+			sourceCode: 'ab\ncd',
+			violations: [],
+			fixedCode: 'ab\nef',
+			fixSummary: {
+				passCount: 1,
+				totalApplied: 1,
+				totalSkipped: 0,
+				reachedMaxPasses: false,
+				firstPassEdits: [{ range: [3, 5], text: 'ef' }],
+			},
+		};
+
+		const result = createFixAllAction('file:///test.html', [], fixState)!;
+
+		expect(result).not.toBeNull();
+		expect(result.kind).toBe(SOURCE_FIX_ALL_MARKUPLINT);
+		const edits = result.edit!.changes!['file:///test.html']!;
+		expect(edits).toHaveLength(1);
+		expect(edits[0]!.range.start).toEqual({ line: 1, character: 0 });
+		expect(edits[0]!.newText).toBe('ef');
+	});
+
+	test('falls back to full-document replacement when no firstPassEdits', () => {
+		const fixState: FixState = {
+			sourceCode: 'ab\ncd',
+			violations: [],
+			fixedCode: 'ab\nef',
+			fixSummary: null,
+		};
+
+		const result = createFixAllAction('file:///test.html', [], fixState)!;
+
+		expect(result).not.toBeNull();
+		const edits = result.edit!.changes!['file:///test.html']!;
+		expect(edits).toHaveLength(1);
+		expect(edits[0]!.range.start).toEqual({ line: 0, character: 0 });
+		expect(edits[0]!.range.end).toEqual({ line: 1, character: 2 });
+		expect(edits[0]!.newText).toBe('ab\nef');
+	});
+
+	test('includes all diagnostics', () => {
+		const fixState: FixState = {
+			sourceCode: '<div>',
+			violations: [],
+			fixedCode: '<span>',
+			fixSummary: null,
+		};
+
+		const diags = [makeDiagnostic(0, 'a'), makeDiagnostic(1, 'b')];
+		const result = createFixAllAction('file:///test.html', diags, fixState)!;
+
+		expect(result.diagnostics).toHaveLength(2);
+	});
+});

--- a/vscode/src/server/code-actions.ts
+++ b/vscode/src/server/code-actions.ts
@@ -1,0 +1,118 @@
+import type { FixState } from './v4.js';
+import type { TextEdit as MLTextEdit } from '@markuplint/ml-config';
+import type { CodeAction, Diagnostic, Position, Range } from 'vscode-languageserver';
+
+import { CodeActionKind } from 'vscode-languageserver';
+import { getPosition } from '@markuplint/shared';
+
+/**
+ * Code Action kind for "Fix all markuplint issues".
+ * Follows the `source.fixAll.<provider>` convention used by ESLint and others.
+ */
+export const SOURCE_FIX_ALL_MARKUPLINT = `${CodeActionKind.SourceFixAll}.markuplint`;
+
+/**
+ * Converts a 0-based character offset to an LSP Position using the source code.
+ *
+ * @param sourceCode - The full raw source text
+ * @param offset - A zero-based character offset into the source
+ * @returns A 0-based LSP Position (line and character)
+ */
+export function offsetToPosition(sourceCode: string, offset: number): Position {
+	const pos = getPosition(sourceCode, offset);
+	return { line: pos.line - 1, character: pos.column - 1 };
+}
+
+/**
+ * Converts a markuplint TextEdit (offset-based) to an LSP Range.
+ */
+function toRange(sourceCode: string, edit: MLTextEdit): Range {
+	return {
+		start: offsetToPosition(sourceCode, edit.range[0]),
+		end: offsetToPosition(sourceCode, edit.range[1]),
+	};
+}
+
+/**
+ * Creates per-violation QuickFix Code Actions.
+ *
+ * @param uri - The document URI to associate edits with
+ * @param diagnostics - The diagnostics from the Code Action request context
+ * @param fixState - The latest lint result containing violations and fix data
+ * @returns An array of QuickFix Code Actions, one per fixable violation
+ */
+export function createQuickFixActions(
+	uri: string,
+	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+	diagnostics: readonly Diagnostic[],
+	fixState: FixState,
+): CodeAction[] {
+	const actions: CodeAction[] = [];
+	for (const diagnostic of diagnostics) {
+		const index = (diagnostic.data as { violationIndex?: number } | undefined)?.violationIndex;
+		if (index == null) continue;
+		const violation = fixState.violations[index];
+		if (!violation?.fix) continue;
+
+		const edits = violation.fix.edits.map(edit => ({
+			range: toRange(fixState.sourceCode, edit),
+			newText: edit.text,
+		}));
+
+		actions.push({
+			title: `Fix: ${diagnostic.message}`,
+			kind: CodeActionKind.QuickFix,
+			diagnostics: [diagnostic],
+			isPreferred: true,
+			edit: { changes: { [uri]: edits } },
+		});
+	}
+	return actions;
+}
+
+/**
+ * Creates a SourceFixAll Code Action (`source.fixAll.markuplint`).
+ *
+ * Uses firstPassEdits from FixSummary for cursor-safe individual edits.
+ * Falls back to full-document replacement when firstPassEdits is unavailable.
+ *
+ * @param uri - The document URI to associate edits with
+ * @param diagnostics - The diagnostics to attach to the Code Action
+ * @param fixState - The latest lint result containing violations and fix data
+ * @returns A SourceFixAll Code Action, or `null` if nothing to fix
+ */
+export function createFixAllAction(
+	uri: string,
+	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+	diagnostics: readonly Diagnostic[],
+	fixState: FixState,
+): CodeAction | null {
+	if (fixState.fixedCode === fixState.sourceCode) return null;
+
+	let textEdits: { range: Range; newText: string }[];
+
+	if (fixState.fixSummary?.firstPassEdits && fixState.fixSummary.firstPassEdits.length > 0) {
+		textEdits = fixState.fixSummary.firstPassEdits.map(edit => ({
+			range: toRange(fixState.sourceCode, edit),
+			newText: edit.text,
+		}));
+	} else {
+		const lines = fixState.sourceCode.split('\n');
+		textEdits = [
+			{
+				range: {
+					start: { line: 0, character: 0 },
+					end: { line: lines.length - 1, character: lines.at(-1)!.length },
+				},
+				newText: fixState.fixedCode,
+			},
+		];
+	}
+
+	return {
+		title: 'Fix all markuplint issues',
+		kind: SOURCE_FIX_ALL_MARKUPLINT,
+		diagnostics: [...diagnostics],
+		edit: { changes: { [uri]: textEdits } },
+	};
+}

--- a/vscode/src/server/code-actions.ts
+++ b/vscode/src/server/code-actions.ts
@@ -3,7 +3,6 @@ import type { TextEdit as MLTextEdit } from '@markuplint/ml-config';
 import type { CodeAction, Diagnostic, Position, Range } from 'vscode-languageserver';
 
 import { CodeActionKind } from 'vscode-languageserver';
-import { getPosition } from '@markuplint/shared';
 
 /**
  * Code Action kind for "Fix all markuplint issues".
@@ -19,8 +18,8 @@ export const SOURCE_FIX_ALL_MARKUPLINT = `${CodeActionKind.SourceFixAll}.markupl
  * @returns A 0-based LSP Position (line and character)
  */
 export function offsetToPosition(sourceCode: string, offset: number): Position {
-	const pos = getPosition(sourceCode, offset);
-	return { line: pos.line - 1, character: pos.column - 1 };
+	const lines = sourceCode.slice(0, offset).split('\n');
+	return { line: lines.length - 1, character: (lines.at(-1) ?? '').length };
 }
 
 /**

--- a/vscode/src/server/convert-diagnostics.spec.ts
+++ b/vscode/src/server/convert-diagnostics.spec.ts
@@ -1,0 +1,36 @@
+import { describe, test, expect } from 'vitest';
+
+import { convertDiagnostics } from './convert-diagnostics.js';
+
+describe('convertDiagnostics', () => {
+	test('sets data.violationIndex on each diagnostic', () => {
+		const result = {
+			filePath: '/test.html',
+			sourceCode: '<div><span></span></div>',
+			violations: [
+				{ ruleId: 'rule-a', severity: 'error' as const, message: 'Error A', line: 1, col: 1, raw: '<div>' },
+				{
+					ruleId: 'rule-b',
+					severity: 'warning' as const,
+					message: 'Warning B',
+					line: 1,
+					col: 6,
+					raw: '<span>',
+				},
+			],
+			fixedCode: '<div><span></span></div>',
+			status: 'processed' as const,
+		};
+
+		const diagnostics = convertDiagnostics(result);
+
+		expect(diagnostics).toHaveLength(2);
+		expect(diagnostics[0]!.data).toEqual({ violationIndex: 0 });
+		expect(diagnostics[1]!.data).toEqual({ violationIndex: 1 });
+	});
+
+	test('returns empty array for null result', () => {
+		const diagnostics = convertDiagnostics(null);
+		expect(diagnostics).toHaveLength(0);
+	});
+});

--- a/vscode/src/server/convert-diagnostics.ts
+++ b/vscode/src/server/convert-diagnostics.ts
@@ -5,6 +5,15 @@ import { DiagnosticSeverity } from 'vscode-languageserver/node.js';
 
 import { NAME, WEBSITE_URL_RULE_PAGE } from '../const.js';
 
+/**
+ * Converts markuplint violations into LSP diagnostics.
+ *
+ * Each diagnostic includes a `data.violationIndex` property that maps back
+ * to the original violation for use in Code Action resolution.
+ *
+ * @param result - The markuplint lint result, or null if no result is available
+ * @returns An array of LSP diagnostics augmented with line and col numbers
+ */
 export function convertDiagnostics(result: MLResultInfo | null) {
 	const diagnostics: (Diagnostic & { line: number; col: number })[] = [];
 
@@ -12,7 +21,7 @@ export function convertDiagnostics(result: MLResultInfo | null) {
 		return diagnostics;
 	}
 
-	for (const violation of result.violations) {
+	for (const [i, violation] of result.violations.entries()) {
 		diagnostics.push({
 			severity:
 				violation.severity === 'error'
@@ -38,6 +47,7 @@ export function convertDiagnostics(result: MLResultInfo | null) {
 			codeDescription: {
 				href: `${WEBSITE_URL_RULE_PAGE}${violation.ruleId}`,
 			},
+			data: { violationIndex: i },
 		});
 	}
 

--- a/vscode/src/server/document-events.ts
+++ b/vscode/src/server/document-events.ts
@@ -1,10 +1,15 @@
 import type { Module } from './get-module.js';
 import type { LangConfigs, Log } from '../types.js';
 import type { WorkingDirectoryEntry } from '../utils/resolve-working-directory.js';
-import type { PublishDiagnosticsParams, HoverParams } from 'vscode-languageserver/node.js';
+import type {
+	CodeAction,
+	CodeActionParams,
+	PublishDiagnosticsParams,
+	HoverParams,
+} from 'vscode-languageserver/node.js';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 
-import { satisfies, lt } from 'semver';
+import { satisfies, lt, gte } from 'semver';
 import { MarkupKind } from 'vscode-languageserver/node.js';
 
 import { t } from '../i18n.js';
@@ -144,6 +149,19 @@ export function createEventHandlers(
 			}
 
 			v4.onDidChangeContent(document, options.log, notFoundParserError(languageId, options.errorLog));
+		},
+
+		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+		onCodeAction(params: CodeActionParams): CodeAction[] {
+			// Code Actions require v5.0.0+ (Violation.fix data + lint event fixSummary)
+			// Use '5.0.0-0' to include alpha/beta prereleases
+			if (!gte(options.mod.version, '5.0.0-0')) {
+				options.log(`Code Actions skipped: markuplint ${options.mod.version} < 5.0.0`, 'debug');
+				return [];
+			}
+			const actions = v4.onCodeAction(params);
+			options.log(`Code Actions: ${actions.length} for ${params.textDocument.uri}`, 'debug');
+			return actions;
 		},
 
 		async onHover(

--- a/vscode/src/server/server.ts
+++ b/vscode/src/server/server.ts
@@ -1,14 +1,21 @@
 import type { SendDiagnostics } from './document-events.js';
 import type { InitializationOptions, Log } from '../types.js';
-import type { InitializeResult } from 'vscode-languageserver/node.js';
+import type { CodeAction, CodeActionParams, InitializeResult } from 'vscode-languageserver/node.js';
 
-import { createConnection, TextDocuments, TextDocumentSyncKind, ProposedFeatures } from 'vscode-languageserver/node.js';
+import {
+	CodeActionKind,
+	createConnection,
+	TextDocuments,
+	TextDocumentSyncKind,
+	ProposedFeatures,
+} from 'vscode-languageserver/node.js';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 
 import { IMPORT_ASSERTION_COMPAT_WARNING, NO_INSTALL_WARNING } from '../const.js';
 import { t } from '../i18n.js';
 import { errorToPopup, logToDiagnosticsChannel, logToPrimaryChannel, status, warningToPopup } from '../lsp.js';
 
+import { SOURCE_FIX_ALL_MARKUPLINT } from './code-actions.js';
 import { verbosely } from './debug.js';
 import { createEventHandlers } from './document-events.js';
 import { getModule } from './get-module.js';
@@ -45,6 +52,11 @@ export function bootServer() {
 
 	documents.listen(connection);
 
+	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+	let codeActionHandler: (params: CodeActionParams) => CodeAction[] = () => [];
+
+	connection.onCodeAction(params => codeActionHandler(params));
+
 	connection.onInitialize((params): InitializeResult => {
 		log('onInitialize');
 
@@ -68,7 +80,7 @@ export function bootServer() {
 				log(`Working directories: ${JSON.stringify(workingDirectories)}`, 'info');
 			}
 
-			const { onDidOpen, onDidChangeContent, onHover } = createEventHandlers({
+			const { onDidOpen, onDidChangeContent, onHover, onCodeAction } = createEventHandlers({
 				mod,
 				locale,
 				langConfigs,
@@ -105,12 +117,16 @@ export function bootServer() {
 			documents.onDidChangeContent(e => onDidChangeContent(e.document));
 
 			connection.onHover(onHover);
+			codeActionHandler = onCodeAction;
 		});
 
 		return {
 			capabilities: {
 				textDocumentSync: TextDocumentSyncKind.Incremental,
 				hoverProvider: true,
+				codeActionProvider: {
+					codeActionKinds: [CodeActionKind.QuickFix, SOURCE_FIX_ALL_MARKUPLINT],
+				},
 			},
 		};
 	});

--- a/vscode/src/server/v2.ts
+++ b/vscode/src/server/v2.ts
@@ -89,7 +89,7 @@ export async function onDidOpen(
 
 		console.log(`Linted(${date} ${time}): ${document.uri}`);
 
-		const diagnostics = convertDiagnostics({ filePath, sourceCode, violations, fixedCode });
+		const diagnostics = convertDiagnostics({ filePath, sourceCode, violations, fixedCode, status: 'processed' });
 		sendDiagnostics({
 			uri: document.uri,
 			diagnostics,

--- a/vscode/src/server/v3.ts
+++ b/vscode/src/server/v3.ts
@@ -112,7 +112,13 @@ export async function onDidOpen(
 				}
 			}
 
-			const diagnostics = convertDiagnostics({ filePath, sourceCode, violations, fixedCode });
+			const diagnostics = convertDiagnostics({
+				filePath,
+				sourceCode,
+				violations,
+				fixedCode,
+				status: 'processed',
+			});
 			sendDiagnostics({
 				uri: document.uri,
 				diagnostics,

--- a/vscode/src/server/v4.ts
+++ b/vscode/src/server/v4.ts
@@ -2,20 +2,60 @@ import type { SendDiagnostics } from './document-events.js';
 import type { Config, Log } from '../types.js';
 import type { WorkingDirectoryEntry } from '../utils/resolve-working-directory.js';
 import type { ConfigSet } from '@markuplint/file-resolver';
+import type { Violation } from '@markuplint/ml-config';
 import type { ARIAVersion } from '@markuplint/ml-spec';
-import type { MLEngine as _MLEngine } from 'markuplint';
-import type { Position, TextDocumentIdentifier } from 'vscode-languageserver';
+import type { FixSummary, MLEngine as _MLEngine } from 'markuplint';
+import type { CodeActionParams, Position, TextDocumentIdentifier, CodeAction } from 'vscode-languageserver';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 
 import { t } from '../i18n.js';
 import { getFilePath } from '../utils/get-file-path.js';
 import { resolveWorkingDirectory } from '../utils/resolve-working-directory.js';
 
+import { createQuickFixActions, createFixAllAction } from './code-actions.js';
 import { convertDiagnostics } from './convert-diagnostics.js';
 import { getAccessibilityByLocation } from './get-accessibility-by-location.js';
 
-const engines = new Map<string, _MLEngine>();
+/**
+ * Snapshot of the latest lint result for a document, used to produce Code Actions.
+ */
+export type FixState = {
+	readonly sourceCode: string;
+	readonly violations: readonly Violation[];
+	readonly fixedCode: string;
+	readonly fixSummary: FixSummary | null;
+};
 
+const engines = new Map<string, _MLEngine>();
+const fixStates = new Map<string, FixState>();
+let moduleLog: Log | undefined;
+
+/**
+ * Returns the latest fix state for a document.
+ *
+ * @param uri - The document URI
+ * @returns The fix state, or `undefined` if the document has not been linted yet
+ */
+export function getFixState(uri: string): FixState | undefined {
+	return fixStates.get(uri);
+}
+
+/**
+ * Handles the `textDocument/didOpen` event by creating an MLEngine for the document.
+ *
+ * Sets up linting, diagnostics, and fix-state tracking for the opened document.
+ *
+ * @param document - The opened text document
+ * @param MLEngine - The MLEngine constructor
+ * @param config - The extension configuration
+ * @param locale - The locale for diagnostic messages
+ * @param log - Logger for general messages
+ * @param diagnosticsLog - Logger for diagnostic-specific messages
+ * @param sendDiagnostics - Callback to publish diagnostics to the client
+ * @param notFoundParserError - Callback invoked when a parser is not found
+ * @param workingDirectories - Optional list of configured working directories
+ * @param workspaceFolders - Optional list of workspace folder paths
+ */
 export async function onDidOpen(
 	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
 	document: TextDocument,
@@ -31,6 +71,7 @@ export async function onDidOpen(
 	workingDirectories?: readonly WorkingDirectoryEntry[],
 	workspaceFolders?: readonly string[],
 ) {
+	moduleLog = log;
 	const key = document.uri;
 	log(`Opened: ${key}`, 'debug');
 	const currentEngine = engines.get(key);
@@ -61,6 +102,7 @@ export async function onDidOpen(
 		debug: config.debug,
 		defaultConfig: config.defaultConfig,
 		watch: true,
+		fix: true,
 	});
 	log(`Engine created: ${key}`);
 
@@ -87,7 +129,7 @@ export async function onDidOpen(
 		}
 	});
 
-	engine.on('lint', (filePath, sourceCode, violations, fixedCode, debug) => {
+	engine.on('lint', (filePath, sourceCode, violations, fixedCode, debug, fixSummary) => {
 		clearTimeout(debounceTimer);
 		diagnosticsLog('', 'clear');
 
@@ -125,7 +167,15 @@ export async function onDidOpen(
 				}
 			}
 
-			const diagnostics = convertDiagnostics({ filePath, sourceCode, violations, fixedCode });
+			const diagnostics = convertDiagnostics({
+				filePath,
+				sourceCode,
+				violations,
+				fixedCode,
+				status: 'processed',
+			});
+
+			fixStates.set(key, { sourceCode, violations, fixedCode, fixSummary });
 
 			if (diagnostics.length > 0) {
 				diagnosticsLog(`  Violations(${diagnostics.length}):`);
@@ -154,6 +204,16 @@ export async function onDidOpen(
 
 let debounceTimer: ReturnType<typeof setTimeout>;
 
+/**
+ * Handles the `textDocument/didChangeContent` event by re-running the lint engine.
+ *
+ * Debounces execution so that rapid successive changes do not trigger
+ * multiple lint passes.
+ *
+ * @param document - The changed text document
+ * @param log - Logger for messages
+ * @param notFoundParserError - Callback invoked when a parser is not found
+ */
 export function onDidChangeContent(
 	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
 	document: TextDocument,
@@ -185,6 +245,17 @@ export function onDidChangeContent(
 	}, 300);
 }
 
+/**
+ * Retrieves the ARIA accessibility properties of the element at the given position.
+ *
+ * Used by the hover provider to display accessibility information such as
+ * role, exposed state, and ARIA property labels.
+ *
+ * @param textDocument - The text document identifier
+ * @param position - The cursor position within the document
+ * @param ariaVersion - The ARIA specification version to use
+ * @returns The node's accessibility properties, or null if unavailable
+ */
 export async function getNodeWithAccessibilityProps(
 	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
 	textDocument: TextDocumentIdentifier,
@@ -262,4 +333,34 @@ export async function getNodeWithAccessibilityProps(
 		exposed: true,
 		labels,
 	};
+}
+
+/**
+ * Handles `textDocument/codeAction` requests for markuplint v4+.
+ *
+ * Returns per-violation QuickFix actions and a SourceFixAll action
+ * (`source.fixAll.markuplint`) when fixable violations exist.
+ *
+ * @param params - The LSP Code Action request parameters
+ * @returns An array of Code Actions (QuickFix and/or SourceFixAll)
+ */
+// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+export function onCodeAction(params: CodeActionParams): CodeAction[] {
+	const uri = params.textDocument.uri;
+	const fixState = getFixState(uri);
+	if (!fixState) {
+		moduleLog?.(`onCodeAction: no fixState for ${uri}`, 'debug');
+		return [];
+	}
+
+	const fixableCount = fixState.violations.filter(v => v.fix).length;
+	moduleLog?.(
+		`onCodeAction: ${fixState.violations.length} violations (${fixableCount} fixable), ${params.context.diagnostics.length} diagnostics`,
+		'debug',
+	);
+
+	const quickFixes = createQuickFixActions(uri, params.context.diagnostics, fixState);
+	const fixAll = createFixAllAction(uri, params.context.diagnostics, fixState);
+
+	return fixAll ? [...quickFixes, fixAll] : quickFixes;
 }

--- a/vscode/src/utils/resolve-working-directory.ts
+++ b/vscode/src/utils/resolve-working-directory.ts
@@ -103,7 +103,7 @@ export function convertGlobToRegex(pattern: string): RegExp {
 export function resolveWorkingDirectory(
 	filePath: string,
 	workspaceFolders: readonly string[],
-	workingDirectories: readonly WorkingDirectoryEntry[] | undefined,
+	workingDirectories?: readonly WorkingDirectoryEntry[],
 ): ResolvedWorkingDirectory | undefined {
 	if (!workingDirectories || workingDirectories.length === 0) {
 		return undefined;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2530,6 +2530,7 @@ __metadata:
   dependencies:
     "@markuplint/ml-ast": "npm:5.0.0-alpha.2"
     "@markuplint/ml-spec": "npm:5.0.0-alpha.2"
+    "@markuplint/shared": "npm:5.0.0-alpha.2"
     "@markuplint/types": "npm:5.0.0-alpha.2"
     "@typescript-eslint/typescript-estree": "npm:8.56.0"
     debug: "npm:4.4.3"
@@ -18700,7 +18701,7 @@ __metadata:
     debug: "npm:4.4.3"
     esbuild: "npm:0.27.3"
     glob: "npm:13.0.6"
-    markuplint: "npm:4.13.0"
+    markuplint: "npm:5.0.0-alpha.2"
     mocha: "npm:11.7.5"
     semver: "npm:7.7.4"
     typescript: "npm:5.9.3"


### PR DESCRIPTION
## Summary

Phase 4 of the autofix integration (#3294). Adds LSP Code Action support to the VS Code extension:

- **QuickFix**: Per-violation fix actions using `Violation.fix.edits`
- **SourceFixAll**: Applies all fixes using cursor-safe `firstPassEdits` from FixSummary, with full-document replacement fallback
- **fixSummary on lint event**: Extends `MLEngineEventMap.lint` so VS Code receives fix metadata
- **getPosition in shared**: Moves offset→line/column utility to `@markuplint/shared` for reuse

### Changes by package

| Package | Change |
|---------|--------|
| `@markuplint/shared` | Add `getPosition` utility |
| `@markuplint/parser-utils` | Re-export `getPosition` from shared |
| `markuplint` | Add `fixSummary` to lint event, re-export `FixSummary` type |
| `vscode` | Code Action provider (QuickFix + SourceFixAll), fix mode, fix state storage, diagnostic `data.violationIndex`, typecheck fixes |

### Addresses #3287

This PR (together with Phases 1–3 in #3294) covers all four goals in #3287:

| Goal | Status | Details |
|------|--------|---------|
| 1. AST Manipulation API | ✅ | Offset-based TextEdit API supports insert, remove, replace, and reorder (via remove + insert). Multi-pass cycle resolves conflicts. |
| 2. Cursor-safe Fixing | ✅ | `computeCursorOffset` in `FixSummary` + `firstPassEdits` for granular edits |
| 3. `--fix` CLI Improvements | ✅ | Multi-pass fix cycle, overlapping edit conflict resolution, `fix-dry-run` mode |
| 4. VS Code Extension API | ✅ | `CodeActionKind.QuickFix` + `source.fixAll.markuplint` Code Actions |

## Test plan

- [x] `yarn build` — 40 packages pass
- [x] `yarn test` — 2554 tests pass
- [x] `yarn lint-check` — 0 errors, 0 warnings
- [x] `npx vitest run` (vscode) — 33 tests pass (code-actions, convert-diagnostics, resolve-working-directory)
- [x] `vscode:typecheck` — 0 errors
- [x] Fix tests for Pug, JSX, Vue, and Markdown parsers — all pass
- [ ] Manual: Open VS Code with extension, verify QuickFix lightbulb appears on fixable violations
- [ ] Manual: Verify "Fix all markuplint issues" appears in Source Actions
- [ ] Manual: Verify cursor position is preserved after SourceFixAll

Closes #3294
Closes #3287

🤖 Generated with [Claude Code](https://claude.com/claude-code)