### PR TITLE
feat(rules): add head-element-order rule

### DIFF
--- a/packages/@markuplint/rules/schema.json
+++ b/packages/@markuplint/rules/schema.json
@@ -45,6 +45,9 @@
 				"end-tag": {
 					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/end-tag/schema.json"
 				},
+				"head-element-order": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/head-element-order/schema.json"
+				},
 				"heading-levels": {
 					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/heading-levels/schema.json"
 				},

--- a/packages/@markuplint/rules/src/head-element-order/README.ja.md
+++ b/packages/@markuplint/rules/src/head-element-order/README.ja.md
@@ -1,0 +1,97 @@
+---
+description: '`<head>`内の要素が期待される順序でない場合に警告します。'
+---
+
+# `head-element-order`
+
+`<head>`内の要素が期待される順序でない場合に警告します。
+
+順序はCSSセレクタの配列で定義します。要素は最初にマッチしたセレクタの位置順にソートされます。どのセレクタにもマッチしない要素は末尾に配置され、元のソース順が保持されます。
+
+オブジェクト形式のエントリで `"order": "alphabetical"` と `"attr"` キーを指定することで、グループ内のアルファベット順ソートも可能です。
+
+<!-- textlint-disable ja-technical-writing/ja-no-mixed-period -->
+
+❌ 間違ったコード例
+
+<!-- prettier-ignore-start -->
+```html
+<head>
+  <title>Title</title>
+  <meta charset="UTF-8">
+</head>
+```
+<!-- prettier-ignore-end -->
+
+✅ 正しいコード例
+
+<!-- prettier-ignore-start -->
+```html
+<head>
+  <meta charset="UTF-8">
+  <title>Title</title>
+</head>
+```
+<!-- prettier-ignore-end -->
+
+<!-- textlint-enable ja-technical-writing/ja-no-mixed-period -->
+
+## 設定
+
+### デフォルト値
+
+```json
+[
+  "meta[charset]",
+  "meta[http-equiv]",
+  "meta[name=\"viewport\"]",
+  "title",
+  { "selector": "meta", "order": "alphabetical", "attr": "name" },
+  "link",
+  "style",
+  "script"
+]
+```
+
+#### この順序の根拠
+
+- **`meta[charset]`** はHTML仕様でドキュメントの最初の1024バイト以内に配置する必要があります。先頭に置くことでこの制約を確実に満たせます。
+- **`meta[http-equiv]`** はブラウザのドキュメント解釈に影響する可能性があるため（例: `X-UA-Compatible`）、早い位置に配置します。
+- **`meta[name="viewport"]`** はモバイルデバイスでの初期ビューポートレイアウトを制御します。`<title>`より前に配置することで、ページ読み込み時のレイアウトシフトを回避できます。
+- **`title`** はアクセシビリティとSEOに必要で、重要なメタ要素の後に配置するのが一般的です。
+- **`meta`**（残り）は `description`、`author` など。`name` 属性でアルファベット順にソートすることで一貫性を保ちます。
+- **`link`**、**`style`**、**`script`** はメタデータ要素の後に配置します。これはスタイルガイドやフレームワークで広く使われている慣習に沿っています。
+
+### カスタム値
+
+```json
+{
+  "head-element-order": [
+    "meta[charset]",
+    "meta[http-equiv]",
+    "meta[name=\"viewport\"]",
+    "title",
+    { "selector": "meta", "order": "alphabetical", "attr": "name" },
+    "link[rel=\"preconnect\"]",
+    "link[rel=\"stylesheet\"]",
+    "link",
+    "style",
+    "script[src][async]",
+    "script[src][defer]",
+    "script[src]",
+    "script"
+  ]
+}
+```
+
+この高度な例では、[capo.js](https://github.com/rviscomi/capo.js/) のパフォーマンス推奨に従い、`link` と `script` 要素を読み込み挙動ごとに分離しています。`<link rel="preconnect">` はスタイルシートより前に配置し、非同期スクリプトは同期スクリプトと分離しています。
+
+### 順序エントリ
+
+各エントリは文字列（CSSセレクタ）またはオブジェクトです。オブジェクトは以下のプロパティを持ちます:
+
+| プロパティ | 型                                   | デフォルト       | 説明                                       |
+| ---------- | ------------------------------------ | ---------------- | ------------------------------------------ |
+| `selector` | `string`                             | （必須）         | 要素にマッチするCSSセレクタ                |
+| `order`    | `"source-order"` \| `"alphabetical"` | `"source-order"` | グループ内のソート順                       |
+| `attr`     | `string`                             | -                | アルファベット順ソート時のソートキー属性名 |

--- a/packages/@markuplint/rules/src/head-element-order/README.md
+++ b/packages/@markuplint/rules/src/head-element-order/README.md
@@ -1,0 +1,94 @@
+---
+id: head-element-order
+description: Warns if elements within `<head>` are not in the expected order.
+---
+
+# `head-element-order`
+
+Warns if elements within `<head>` are not in the expected order.
+
+The order is defined by an array of CSS selectors. Elements are sorted by the position of their first matching selector. Elements that don't match any selector are placed at the end, preserving their relative source order.
+
+You can also specify alphabetical sorting within a group by using an object entry with `"order": "alphabetical"` and an `"attr"` key.
+
+❌ Examples of **incorrect** code for this rule
+
+<!-- prettier-ignore-start -->
+```html
+<head>
+  <title>Title</title>
+  <meta charset="UTF-8">
+</head>
+```
+<!-- prettier-ignore-end -->
+
+✅ Examples of **correct** code for this rule
+
+<!-- prettier-ignore-start -->
+```html
+<head>
+  <meta charset="UTF-8">
+  <title>Title</title>
+</head>
+```
+<!-- prettier-ignore-end -->
+
+## Configuration
+
+### Default value
+
+```json
+[
+  "meta[charset]",
+  "meta[http-equiv]",
+  "meta[name=\"viewport\"]",
+  "title",
+  { "selector": "meta", "order": "alphabetical", "attr": "name" },
+  "link",
+  "style",
+  "script"
+]
+```
+
+#### Why this order?
+
+- **`meta[charset]`** must appear within the first 1024 bytes of the document per the HTML specification. Placing it first ensures this constraint is met.
+- **`meta[http-equiv]`** may affect how the browser interprets the document (e.g., `X-UA-Compatible`), so it should appear early.
+- **`meta[name="viewport"]`** controls the initial viewport layout on mobile devices. Placing it before `<title>` avoids a potential layout shift during page load.
+- **`title`** is required for accessibility and SEO, and commonly placed after critical meta elements.
+- **`meta`** (remaining) such as `description`, `author`, etc. are sorted alphabetically by the `name` attribute for consistency.
+- **`link`**, **`style`**, **`script`** follow the metadata elements. This matches the widely used convention in style guides and frameworks.
+
+### Custom value
+
+```json
+{
+  "head-element-order": [
+    "meta[charset]",
+    "meta[http-equiv]",
+    "meta[name=\"viewport\"]",
+    "title",
+    { "selector": "meta", "order": "alphabetical", "attr": "name" },
+    "link[rel=\"preconnect\"]",
+    "link[rel=\"stylesheet\"]",
+    "link",
+    "style",
+    "script[src][async]",
+    "script[src][defer]",
+    "script[src]",
+    "script"
+  ]
+}
+```
+
+This advanced example separates `link` and `script` elements by their loading behavior, following [capo.js](https://github.com/rviscomi/capo.js/) performance recommendations. Elements like `<link rel="preconnect">` are placed before stylesheets, and async scripts are separated from synchronous ones.
+
+### Order entry
+
+Each entry can be a string (CSS selector) or an object with the following properties:
+
+| Property   | Type                                 | Default          | Description                                             |
+| ---------- | ------------------------------------ | ---------------- | ------------------------------------------------------- |
+| `selector` | `string`                             | (required)       | CSS selector to match elements                          |
+| `order`    | `"source-order"` \| `"alphabetical"` | `"source-order"` | Sort order within the group                             |
+| `attr`     | `string`                             | -                | Attribute name to use as sort key for alphabetical sort |

--- a/packages/@markuplint/rules/src/head-element-order/index.spec.ts
+++ b/packages/@markuplint/rules/src/head-element-order/index.spec.ts
@@ -1,0 +1,441 @@
+import { mlRuleTest } from 'markuplint';
+import { describe, test, expect } from 'vitest';
+
+import rule from './index.js';
+
+describe('verify', () => {
+	test('correct order: no violations', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<html><head><meta charset="UTF-8"><title>Title</title><link rel="stylesheet" href="style.css"></head><body></body></html>',
+			{
+				rule: {
+					value: ['meta[charset]', 'title', 'link'],
+				},
+			},
+		);
+		expect(violations).toHaveLength(0);
+	});
+
+	test('wrong order: title before meta[charset]', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<html><head><title>Title</title><meta charset="UTF-8"></head><body></body></html>',
+			{
+				rule: {
+					value: ['meta[charset]', 'title', 'link'],
+				},
+			},
+		);
+		expect(violations).toHaveLength(2);
+	});
+
+	test('empty head: no violations', async () => {
+		const { violations } = await mlRuleTest(rule, '<html><head></head><body></body></html>', {
+			rule: {
+				value: ['meta[charset]', 'title'],
+			},
+		});
+		expect(violations).toHaveLength(0);
+	});
+
+	test('no head: no violations', async () => {
+		const { violations } = await mlRuleTest(rule, '<html><body></body></html>', {
+			rule: {
+				value: ['meta[charset]', 'title'],
+			},
+		});
+		expect(violations).toHaveLength(0);
+	});
+
+	test('single child: no violations', async () => {
+		const { violations } = await mlRuleTest(rule, '<html><head><title>Title</title></head><body></body></html>', {
+			rule: {
+				value: ['meta[charset]', 'title'],
+			},
+		});
+		expect(violations).toHaveLength(0);
+	});
+
+	test('unmatched elements go to the end', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<html><head><meta charset="UTF-8"><title>Title</title><base href="/"></head><body></body></html>',
+			{
+				rule: {
+					value: ['meta[charset]', 'title'],
+				},
+			},
+		);
+		expect(violations).toHaveLength(0);
+	});
+
+	test('unmatched element before matched: violation', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<html><head><base href="/"><meta charset="UTF-8"><title>Title</title></head><body></body></html>',
+			{
+				rule: {
+					value: ['meta[charset]', 'title'],
+				},
+			},
+		);
+		expect(violations).toHaveLength(3);
+	});
+
+	test('same group preserves source order', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<html><head><link rel="stylesheet" href="a.css"><link rel="stylesheet" href="b.css"></head><body></body></html>',
+			{
+				rule: {
+					value: ['link'],
+				},
+			},
+		);
+		expect(violations).toHaveLength(0);
+	});
+
+	test('selector conflict: more specific selector wins by position', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width"></head><body></body></html>',
+			{
+				rule: {
+					value: ['meta[charset]', 'meta'],
+				},
+			},
+		);
+		expect(violations).toHaveLength(0);
+	});
+
+	test('selector conflict: meta[charset] matched before meta', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<html><head><meta name="viewport" content="width=device-width"><meta charset="UTF-8"></head><body></body></html>',
+			{
+				rule: {
+					value: ['meta[charset]', 'meta'],
+				},
+			},
+		);
+		expect(violations).toHaveLength(2);
+	});
+
+	test('custom order setting', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<html><head><title>Title</title><meta charset="UTF-8"></head><body></body></html>',
+			{
+				rule: {
+					value: ['title', 'meta[charset]'],
+				},
+			},
+		);
+		expect(violations).toHaveLength(0);
+	});
+
+	test('severity setting', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<html><head><title>Title</title><meta charset="UTF-8"></head><body></body></html>',
+			{
+				rule: {
+					severity: 'error',
+					value: ['meta[charset]', 'title'],
+				},
+			},
+		);
+		expect(violations).toHaveLength(2);
+		expect(violations[0]!.severity).toBe('error');
+		expect(violations[0]!.message).toBe('The "meta" element must be before the "title" element');
+	});
+});
+
+describe('default value', () => {
+	test('correct order with default value', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<html><head><meta charset="UTF-8"><meta http-equiv="X-UA-Compatible" content="IE=edge"><meta name="viewport" content="width=device-width"><title>Title</title><meta name="description" content="Desc"><link rel="stylesheet" href="style.css"></head><body></body></html>',
+		);
+		expect(violations).toHaveLength(0);
+	});
+
+	test('wrong order with default value', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<html><head><title>Title</title><meta charset="UTF-8"></head><body></body></html>',
+		);
+		expect(violations.length).toBeGreaterThan(0);
+	});
+});
+
+describe('selector conflict', () => {
+	test('link[rel="stylesheet"] and link: specific selector wins', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<html><head><link rel="stylesheet" href="a.css"><link rel="icon" href="favicon.ico"></head><body></body></html>',
+			{
+				rule: {
+					value: ['link[rel="stylesheet"]', 'link'],
+				},
+			},
+		);
+		expect(violations).toHaveLength(0);
+	});
+
+	test('link[rel="stylesheet"] and link: wrong order', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<html><head><link rel="icon" href="favicon.ico"><link rel="stylesheet" href="a.css"></head><body></body></html>',
+			{
+				rule: {
+					value: ['link[rel="stylesheet"]', 'link'],
+				},
+			},
+		);
+		expect(violations).toHaveLength(2);
+	});
+
+	test('object entry and string entry coexistence', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<html><head><meta name="author" content="Test"><meta name="description" content="Desc"><meta charset="UTF-8"></head><body></body></html>',
+			{
+				rule: {
+					value: ['meta[charset]', { selector: 'meta', order: 'alphabetical', attr: 'name' }],
+				},
+			},
+		);
+		expect(violations).toHaveLength(3);
+	});
+
+	test('elements matching no selector go to the end', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<html><head><meta charset="UTF-8"><title>Title</title><base href="/"><noscript>No JS</noscript></head><body></body></html>',
+			{
+				rule: {
+					value: ['meta[charset]', 'title'],
+				},
+			},
+		);
+		expect(violations).toHaveLength(0);
+	});
+});
+
+describe('alphabetical sort', () => {
+	test('correct alphabetical order', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<html><head><meta name="author" content="Test"><meta name="description" content="Desc"><meta name="viewport" content="width=device-width"></head><body></body></html>',
+			{
+				rule: {
+					value: [{ selector: 'meta', order: 'alphabetical', attr: 'name' }],
+				},
+			},
+		);
+		expect(violations).toHaveLength(0);
+	});
+
+	test('wrong alphabetical order', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<html><head><meta name="viewport" content="width=device-width"><meta name="author" content="Test"><meta name="description" content="Desc"></head><body></body></html>',
+			{
+				rule: {
+					value: [{ selector: 'meta', order: 'alphabetical', attr: 'name' }],
+				},
+			},
+		);
+		expect(violations).toHaveLength(3);
+	});
+
+	test('elements without attr come first', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<html><head><meta charset="UTF-8"><meta name="author" content="Test"><meta name="description" content="Desc"></head><body></body></html>',
+			{
+				rule: {
+					value: [{ selector: 'meta', order: 'alphabetical', attr: 'name' }],
+				},
+			},
+		);
+		expect(violations).toHaveLength(0);
+	});
+
+	test('stable sort: same attr value preserves source order', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<html><head><meta name="author" content="Alice"><meta name="author" content="Bob"></head><body></body></html>',
+			{
+				rule: {
+					value: [{ selector: 'meta', order: 'alphabetical', attr: 'name' }],
+				},
+			},
+		);
+		expect(violations).toHaveLength(0);
+	});
+
+	test('alphabetical without attr: falls back to source order', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<html><head><meta name="b"><meta name="a"></head><body></body></html>',
+			{
+				rule: {
+					value: [{ selector: 'meta', order: 'alphabetical' }],
+				},
+			},
+		);
+		expect(violations).toHaveLength(0);
+	});
+});
+
+describe('i18n', () => {
+	test('English message', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<html><head><title>Title</title><meta charset="UTF-8"></head><body></body></html>',
+			{
+				rule: {
+					value: ['meta[charset]', 'title'],
+				},
+			},
+		);
+		expect(violations[0]!.message).toBe('The "meta" element should be before the "title" element');
+	});
+
+	test('Japanese message', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<html><head><title>Title</title><meta charset="UTF-8"></head><body></body></html>',
+			{
+				rule: {
+					value: ['meta[charset]', 'title'],
+				},
+			},
+			false,
+			'ja',
+		);
+		expect(violations[0]!.message).toBe('要素「meta」は要素「title」より前にしたほうがよいです');
+	});
+});
+
+describe('fix', () => {
+	test('basic swap: title and meta[charset]', async () => {
+		const { fixedCode } = await mlRuleTest(
+			rule,
+			'<html><head><title>Title</title><meta charset="UTF-8"></head><body></body></html>',
+			{
+				rule: {
+					value: ['meta[charset]', 'title'],
+				},
+			},
+			true,
+		);
+		expect(fixedCode).toBe('<html><head><meta charset="UTF-8"><title>Title</title></head><body></body></html>');
+	});
+
+	test('multiple elements reorder', async () => {
+		const { fixedCode } = await mlRuleTest(
+			rule,
+			'<html><head><script src="app.js"></script><title>Title</title><meta charset="UTF-8"></head><body></body></html>',
+			{
+				rule: {
+					value: ['meta[charset]', 'title', 'script'],
+				},
+			},
+			true,
+		);
+		expect(fixedCode).toBe(
+			'<html><head><meta charset="UTF-8"><title>Title</title><script src="app.js"></script></head><body></body></html>',
+		);
+	});
+
+	test('preserve indentation', async () => {
+		const { fixedCode } = await mlRuleTest(
+			rule,
+			`<html>
+<head>
+	<title>Title</title>
+	<meta charset="UTF-8">
+</head>
+<body></body>
+</html>`,
+			{
+				rule: {
+					value: ['meta[charset]', 'title'],
+				},
+			},
+			true,
+		);
+		expect(fixedCode).toBe(`<html>
+<head>
+	<meta charset="UTF-8">
+	<title>Title</title>
+</head>
+<body></body>
+</html>`);
+	});
+
+	test('alphabetical sort fix', async () => {
+		const { fixedCode } = await mlRuleTest(
+			rule,
+			'<html><head><meta name="viewport" content="width=device-width"><meta name="author" content="Test"><meta name="description" content="Desc"></head><body></body></html>',
+			{
+				rule: {
+					value: [{ selector: 'meta', order: 'alphabetical', attr: 'name' }],
+				},
+			},
+			true,
+		);
+		expect(fixedCode).toBe(
+			'<html><head><meta name="author" content="Test"><meta name="description" content="Desc"><meta name="viewport" content="width=device-width"></head><body></body></html>',
+		);
+	});
+
+	test('already correct order: no change', async () => {
+		const source = '<html><head><meta charset="UTF-8"><title>Title</title></head><body></body></html>';
+		const { fixedCode } = await mlRuleTest(
+			rule,
+			source,
+			{
+				rule: {
+					value: ['meta[charset]', 'title'],
+				},
+			},
+			true,
+		);
+		expect(fixedCode).toBe(source);
+	});
+
+	test('reorder elements with child content (script/style)', async () => {
+		const { fixedCode } = await mlRuleTest(
+			rule,
+			'<html><head><script>console.log("hello")</script><meta charset="UTF-8"></head><body></body></html>',
+			{
+				rule: {
+					value: ['meta[charset]', 'script'],
+				},
+			},
+			true,
+		);
+		expect(fixedCode).toBe(
+			'<html><head><meta charset="UTF-8"><script>console.log("hello")</script></head><body></body></html>',
+		);
+	});
+
+	test('fix: head without explicit close tag', async () => {
+		const { fixedCode } = await mlRuleTest(
+			rule,
+			'<html><head><title>Title</title><meta charset="UTF-8"><body></body></html>',
+			{
+				rule: {
+					value: ['meta[charset]', 'title'],
+				},
+			},
+			true,
+		);
+		expect(fixedCode).toBe('<html><head><meta charset="UTF-8"><title>Title</title><body></body></html>');
+	});
+});

--- a/packages/@markuplint/rules/src/head-element-order/index.ts
+++ b/packages/@markuplint/rules/src/head-element-order/index.ts
@@ -1,0 +1,199 @@
+import { createRule } from '@markuplint/ml-core';
+
+import meta from './meta.js';
+
+type OrderEntry = {
+	readonly selector: string;
+	readonly order?: 'source-order' | 'alphabetical';
+	readonly attr?: string;
+};
+
+export type Value = readonly (string | OrderEntry)[];
+
+type NormalizedEntry = {
+	readonly selector: string;
+	readonly order: 'source-order' | 'alphabetical';
+	readonly attr?: string;
+};
+
+const DEFAULT_VALUE: Value = [
+	'meta[charset]',
+	'meta[http-equiv]',
+	'meta[name="viewport"]',
+	'title',
+	{ selector: 'meta', order: 'alphabetical', attr: 'name' },
+	'link',
+	'style',
+	'script',
+];
+
+function normalizeEntries(value: Value): readonly NormalizedEntry[] {
+	return value.map(entry => {
+		if (typeof entry === 'string') {
+			return { selector: entry, order: 'source-order' as const };
+		}
+		return { selector: entry.selector, order: entry.order ?? 'source-order', attr: entry.attr };
+	});
+}
+
+type ElementInfo = {
+	readonly startOffset: number;
+	readonly groupIndex: number;
+	readonly subKey: string | number;
+	readonly sourceIndex: number;
+	readonly elementText: string;
+	readonly localName: string;
+};
+
+export default createRule<Value>({
+	meta: meta,
+	defaultSeverity: 'warning',
+	defaultValue: DEFAULT_VALUE,
+	verify({ document, report, t }) {
+		const head = document.querySelector('head');
+		if (!head) {
+			return;
+		}
+
+		const children = [...head.children];
+		if (children.length <= 1) {
+			return;
+		}
+
+		const value: Value = head.rule.value ?? DEFAULT_VALUE;
+		const entries = normalizeEntries(value);
+
+		// Use entries.length as the unmatched group index instead of Infinity
+		// to avoid potential Infinity arithmetic issues (e.g. Infinity - Infinity = NaN).
+		const unmatchedGroupIndex = entries.length;
+
+		// Use offset-based text extraction instead of AST traversal because
+		// raw text elements (script, style) have empty childNodes in the AST.
+		const docString = document.toString();
+
+		const blocks: ElementInfo[] = children.map((el, sourceIndex) => {
+			let groupIndex = unmatchedGroupIndex;
+			for (const [i, entry_] of entries.entries()) {
+				if (el.matches(entry_.selector)) {
+					groupIndex = i;
+					break;
+				}
+			}
+			const entry = groupIndex < entries.length ? entries[groupIndex] : undefined;
+			let subKey: string | number;
+			if (entry && entry.order === 'alphabetical' && entry.attr) {
+				subKey = el.getAttribute(entry.attr) ?? '';
+			} else {
+				subKey = sourceIndex;
+			}
+			const endOffset = getElementEndOffset(el);
+			const elementText = docString.slice(el.startOffset, endOffset);
+			return {
+				startOffset: el.startOffset,
+				groupIndex,
+				subKey,
+				sourceIndex,
+				elementText,
+				localName: el.localName,
+			};
+		});
+
+		const sorted = blocks.toSorted((a, b) => {
+			if (a.groupIndex !== b.groupIndex) {
+				return a.groupIndex - b.groupIndex;
+			}
+			if (typeof a.subKey === 'string' && typeof b.subKey === 'string') {
+				// Use simple comparison operators instead of localeCompare to ensure
+				// consistent ordering across different environments and locales.
+				if (a.subKey < b.subKey) {
+					return -1;
+				}
+				if (a.subKey > b.subKey) {
+					return 1;
+				}
+			}
+			return a.sourceIndex - b.sourceIndex;
+		});
+
+		// Only the first violation carries a fix because it replaces
+		// the entire <head> content at once to reorder all elements.
+		const ms = head.rule.severity === 'error' ? 'must' : 'should';
+		let firstViolation = true;
+		for (let i = 0; i < blocks.length; i++) {
+			if (blocks[i]!.sourceIndex !== sorted[i]!.sourceIndex) {
+				const currentEl = children[i]!;
+				const expectedInfo = sorted[i]!;
+				const currentInfo = blocks[i]!;
+				report({
+					scope: currentEl,
+					message: t(
+						`{0} ${ms} be before {1}`,
+						t('the "{0*}" {1}', expectedInfo.localName, 'element'),
+						t('the "{0*}" {1}', currentInfo.localName, 'element'),
+					),
+					fix: firstViolation
+						? fixer => {
+								const headOpenEnd = head.startOffset + head.raw.length;
+								const lastChild = children.at(-1)!;
+								const headCloseStart = head.closeTag
+									? head.closeTag.startOffset
+									: getElementEndOffset(lastChild);
+
+								const originalContent = docString.slice(headOpenEnd, headCloseStart);
+								const newContent = buildFixedContent(originalContent, headOpenEnd, blocks, sorted);
+
+								return fixer.replaceRange([headOpenEnd, headCloseStart], newContent);
+							}
+						: undefined,
+				});
+				firstViolation = false;
+			}
+		}
+	},
+});
+
+function getElementEndOffset(el: {
+	readonly startOffset: number;
+	readonly raw: string;
+	readonly closeTag: { readonly startOffset: number; readonly raw: string } | null;
+}): number {
+	if (el.closeTag) {
+		return el.closeTag.startOffset + el.closeTag.raw.length;
+	}
+	return el.startOffset + el.raw.length;
+}
+
+function buildFixedContent(
+	originalContent: string,
+	headOpenEnd: number,
+	blocks: readonly ElementInfo[],
+	sorted: readonly ElementInfo[],
+): string {
+	const prefixes: string[] = [];
+	for (let i = 0; i < blocks.length; i++) {
+		const block = blocks[i]!;
+		const elStart = block.startOffset - headOpenEnd;
+		let prefixStart: number;
+		if (i === 0) {
+			prefixStart = 0;
+		} else {
+			const prevBlock = blocks[i - 1]!;
+			const prevEnd = prevBlock.startOffset - headOpenEnd + prevBlock.elementText.length;
+			prefixStart = prevEnd;
+		}
+		prefixes.push(originalContent.slice(prefixStart, elStart));
+	}
+
+	const lastBlock = blocks.at(-1)!;
+	const trailStart = lastBlock.startOffset - headOpenEnd + lastBlock.elementText.length;
+	const trailing = originalContent.slice(trailStart);
+
+	let result = '';
+	for (const [i, element] of sorted.entries()) {
+		result += prefixes[i];
+		result += element.elementText;
+	}
+	result += trailing;
+
+	return result;
+}

--- a/packages/@markuplint/rules/src/head-element-order/meta.ts
+++ b/packages/@markuplint/rules/src/head-element-order/meta.ts
@@ -1,0 +1,3 @@
+export default {
+	category: 'style',
+} as const;

--- a/packages/@markuplint/rules/src/head-element-order/schema.json
+++ b/packages/@markuplint/rules/src/head-element-order/schema.json
@@ -1,0 +1,70 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"order-entry": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["selector"],
+			"properties": {
+				"selector": {
+					"type": "string",
+					"minLength": 1,
+					"description": "CSS selector to match elements",
+					"description:ja": "要素にマッチするCSSセレクタ"
+				},
+				"order": {
+					"type": "string",
+					"enum": ["source-order", "alphabetical"],
+					"default": "source-order",
+					"description": "Sort order within the group",
+					"description:ja": "グループ内のソート順"
+				},
+				"attr": {
+					"type": "string",
+					"minLength": 1,
+					"description": "Attribute name to use as sort key when order is 'alphabetical'",
+					"description:ja": "order が 'alphabetical' の場合にソートキーとして使う属性名"
+				}
+			}
+		},
+		"value": {
+			"type": "array",
+			"minItems": 1,
+			"items": {
+				"oneOf": [
+					{
+						"type": "string",
+						"minLength": 1
+					},
+					{
+						"$ref": "#/definitions/order-entry"
+					}
+				]
+			},
+			"description": "An array of CSS selectors or order entries that define the expected order of elements within <head>",
+			"description:ja": "<head>内の要素の期待される順序を定義するCSSセレクタまたは順序エントリの配列"
+		}
+	},
+	"oneOf": [
+		{
+			"type": "boolean"
+		},
+		{
+			"$ref": "#/definitions/value"
+		},
+		{
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"value": { "$ref": "#/definitions/value" },
+				"severity": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/ml-config/schema.json#/definitions/severity",
+					"default": "warning"
+				},
+				"reason": {
+					"type": "string"
+				}
+			}
+		}
+	]
+}

--- a/packages/@markuplint/rules/src/index.ts
+++ b/packages/@markuplint/rules/src/index.ts
@@ -22,6 +22,7 @@ import DeprecatedElement from './deprecated-element/index.js';
 import DisallowedElement from './disallowed-element/index.js';
 import Doctype from './doctype/index.js';
 import EndTag from './end-tag/index.js';
+import HeadElementOrder from './head-element-order/index.js';
 import HeadingLevels from './heading-levels/index.js';
 import IdDuplication from './id-duplication/index.js';
 import IneffectiveAttr from './ineffective-attr/index.js';
@@ -73,6 +74,7 @@ const rules = {
 	'disallowed-element': DisallowedElement,
 	doctype: Doctype,
 	'end-tag': EndTag,
+	'head-element-order': HeadElementOrder,
 	'heading-levels': HeadingLevels,
 	'id-duplication': IdDuplication,
 	'ineffective-attr': IneffectiveAttr,

--- a/packages/markuplint/src/cli/init/get-default-rules.spec.ts
+++ b/packages/markuplint/src/cli/init/get-default-rules.spec.ts
@@ -57,6 +57,10 @@ test('default-rules', () => {
 			category: 'style',
 			defaultValue: false,
 		},
+		'head-element-order': {
+			category: 'style',
+			defaultValue: false,
+		},
 		'heading-levels': {
 			category: 'validation',
 			defaultValue: true,


### PR DESCRIPTION
## Summary

- Add new `head-element-order` rule that warns when elements within `<head>` are not in the expected order
- Order is defined by an array of CSS selectors; elements are sorted by their first matching selector position
- Supports alphabetical sorting within groups via object entries with `"order": "alphabetical"` and `"attr"` key
- Includes autofix support that reorders elements while preserving whitespace/indentation
- Severity-aware messages: "should be before" (warning) / "must be before" (error)

### Default order

```json
["meta[charset]", "meta[http-equiv]", "meta[name=\"viewport\"]", "title", { "selector": "meta", "order": "alphabetical", "attr": "name" }, "link", "style", "script"]
```

### Files added/changed

| File | Description |
|------|-------------|
| `rules/src/head-element-order/index.ts` | Rule implementation (verify + fix) |
| `rules/src/head-element-order/index.spec.ts` | 32 tests (verify, fix, i18n, edge cases) |
| `rules/src/head-element-order/meta.ts` | Category: style |
| `rules/src/head-element-order/schema.json` | JSON Schema for value type |
| `rules/src/head-element-order/README.md` | English documentation |
| `rules/src/head-element-order/README.ja.md` | Japanese documentation |
| `rules/src/index.ts` | Rule registry registration |
| `rules/schema.json` | Schema registry `$ref` |
| `markuplint/.../get-default-rules.spec.ts` | Snapshot update |

## Test plan

- [x] 32 unit tests covering verify, fix, i18n, selector conflicts, alphabetical sorting, edge cases
- [x] Full test suite passes (2636 tests, 169 files)
- [x] `yarn build` passes
- [x] `yarn lint-check` passes (0 errors, 0 warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)