### PR TITLE
refactor: convert legacy patterns to modern ES/Node.js v22+

### DIFF
--- a/packages/@markuplint/create-rule/src/install-scaffold.ts
+++ b/packages/@markuplint/create-rule/src/install-scaffold.ts
@@ -2,13 +2,9 @@ import type { CreateRuleCreatorParams, CreateRuleHelperResult } from './types.js
 
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { fsExists } from './fs-exists.js';
 import { transfer } from './transfer.js';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 
 /**
  * Installs scaffold template files to the destination directory and optionally
@@ -36,7 +32,7 @@ export async function installScaffold(
 		await fs.mkdir(dest);
 	}
 
-	const scaffoldDir = path.resolve(__dirname, '..', 'scaffold', scaffoldType);
+	const scaffoldDir = path.resolve(import.meta.dirname, '..', 'scaffold', scaffoldType);
 
 	const transferred = await transfer(scaffoldType, scaffoldDir, dest, {
 		transpile: params.lang === 'JAVASCRIPT',

--- a/packages/@markuplint/create-rule/src/transfer.spec.ts
+++ b/packages/@markuplint/create-rule/src/transfer.spec.ts
@@ -1,17 +1,13 @@
 import { rm } from 'node:fs/promises';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { test, expect, afterAll, beforeAll } from 'vitest';
 
 import { glob } from './glob.js';
 import { transfer } from './transfer.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const SCAFFOLD = path.resolve(__dirname, '..', 'scaffold');
-const TEST_SANDBOX = path.resolve(__dirname, '..', '__test_sandbox__');
+const SCAFFOLD = path.resolve(import.meta.dirname, '..', 'scaffold');
+const TEST_SANDBOX = path.resolve(import.meta.dirname, '..', '__test_sandbox__');
 
 async function removeTestDir() {
 	await rm(TEST_SANDBOX, { recursive: true, force: true });

--- a/packages/@markuplint/file-resolver/src/config-provider.spec.ts
+++ b/packages/@markuplint/file-resolver/src/config-provider.spec.ts
@@ -1,15 +1,11 @@
 import type { ConfigLoadError } from './config-load-error.js';
 
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { test, expect, vi } from 'vitest';
 
 import { ConfigProvider } from './config-provider.js';
 import { getFile } from './ml-file/index.js';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 
 vi.mock('packaged-config', () => {
 	return {
@@ -22,7 +18,7 @@ vi.mock('packaged-config', () => {
 const configProvider = new ConfigProvider();
 
 test('001 + 002', async () => {
-	const testDir = path.resolve(__dirname, '..', 'test', 'fixtures');
+	const testDir = path.resolve(import.meta.dirname, '..', 'test', 'fixtures');
 	const key = path.resolve(testDir, '002', '.markuplintrc.json');
 	const file = getFile(path.resolve(testDir, '002', 'target.html'));
 	const configSet = await configProvider.resolve(file, [key]);
@@ -93,7 +89,7 @@ test('001 + 002', async () => {
 });
 
 test('001 + 002 + 003', async () => {
-	const testDir = path.resolve(__dirname, '..', 'test', 'fixtures');
+	const testDir = path.resolve(import.meta.dirname, '..', 'test', 'fixtures');
 	const file = getFile(path.resolve(testDir, '003', 'dir', 'target.html'));
 	const key = await configProvider.search(file);
 	const configSet = await configProvider.resolve(file, [key]);
@@ -190,7 +186,7 @@ test('001 + 002 + 003', async () => {
 });
 
 test('Deep target', async () => {
-	const testDir = path.resolve(__dirname, '..', 'test', 'fixtures');
+	const testDir = path.resolve(import.meta.dirname, '..', 'test', 'fixtures');
 	const key = path.resolve(testDir, '004', 'dir', 'dir', 'dir', 'dir', 'dir', '.markuplintrc');
 	const file = getFile(path.resolve(testDir, '004', 'dir', 'dir', 'dir', 'dir', 'dir', 'deep-target.html'));
 	const configSet = await configProvider.resolve(file, [key]);
@@ -208,7 +204,7 @@ test('Deep target', async () => {
 });
 
 test('Import packaged config (Issue: #403)', async () => {
-	const testDir = path.resolve(__dirname, '..', 'test', 'fixtures');
+	const testDir = path.resolve(import.meta.dirname, '..', 'test', 'fixtures');
 	const key = path.resolve(testDir, '005', '.markuplintrc');
 	const file = getFile(path.resolve(testDir, '005', 'target.html'));
 	const configSet = await configProvider.resolve(file, [key]);
@@ -218,7 +214,7 @@ test('Import packaged config (Issue: #403)', async () => {
 });
 
 test('Overrides', async () => {
-	const testDir = path.resolve(__dirname, '..', 'test', 'fixtures');
+	const testDir = path.resolve(import.meta.dirname, '..', 'test', 'fixtures');
 	const key = path.resolve(testDir, '006', '.markuplintrc');
 	const file = getFile(path.resolve(testDir, '006', 'target.html'));
 	const configSet = await configProvider.resolve(file, [key]);
@@ -230,7 +226,7 @@ test('Overrides', async () => {
 });
 
 test('Config Presets', async () => {
-	const testDir = path.resolve(__dirname, '..', 'test', 'fixtures');
+	const testDir = path.resolve(import.meta.dirname, '..', 'test', 'fixtures');
 	const key = path.resolve(testDir, '007', '.markuplintrc');
 	const file = getFile(path.resolve(testDir, '007', 'target.html'));
 	const configSet = await configProvider.resolve(file, [key]);
@@ -241,7 +237,7 @@ test('Config Presets', async () => {
 });
 
 test('TypeScript (.markuplintrc.ts)', async () => {
-	const testDir = path.resolve(__dirname, '..', 'test', 'fixtures');
+	const testDir = path.resolve(import.meta.dirname, '..', 'test', 'fixtures');
 	const key = path.resolve(testDir, '008', '.markuplintrc.ts');
 	const file = getFile(path.resolve(testDir, '008', 'target.html'));
 	const configSet = await configProvider.resolve(file, [key]);
@@ -249,7 +245,7 @@ test('TypeScript (.markuplintrc.ts)', async () => {
 });
 
 test('TypeScript (markuplint.config.ts)', async () => {
-	const testDir = path.resolve(__dirname, '..', 'test', 'fixtures');
+	const testDir = path.resolve(import.meta.dirname, '..', 'test', 'fixtures');
 	const key = path.resolve(testDir, '009', 'markuplint.config.ts');
 	const file = getFile(path.resolve(testDir, '009', 'target.html'));
 	const configSet = await configProvider.resolve(file, [key]);
@@ -258,7 +254,7 @@ test('TypeScript (markuplint.config.ts)', async () => {
 
 test('Link', async () => {
 	const configProvider = new ConfigProvider();
-	const testDir = path.resolve(__dirname, '..', 'test', 'fixtures', '010');
+	const testDir = path.resolve(import.meta.dirname, '..', 'test', 'fixtures', '010');
 	const start = path.resolve(testDir, 'a.json');
 	const files = await configProvider.recursiveLoad(start, false, 'path/to/index.html');
 
@@ -276,7 +272,7 @@ test('Link', async () => {
 });
 
 test('Overrides with OverrideMode', async () => {
-	const testDir = path.resolve(__dirname, '..', 'test', 'fixtures');
+	const testDir = path.resolve(import.meta.dirname, '..', 'test', 'fixtures');
 	const resetKey = path.resolve(testDir, '011', '.markuplintrc.reset.json');
 	const mergeKey = path.resolve(testDir, '011', '.markuplintrc.merge.json');
 	const htmlFile = getFile(path.resolve(testDir, '011', 'target.html'));

--- a/packages/@markuplint/file-resolver/src/config-provider.ts
+++ b/packages/@markuplint/file-resolver/src/config-provider.ts
@@ -69,7 +69,7 @@ export class ConfigProvider {
 		let config = this.#store.get(key);
 
 		if (!config) {
-			config = await this._load(key, cache, referrer);
+			config = await this.#load(key, cache, referrer);
 		}
 
 		if (!config) {
@@ -121,7 +121,7 @@ export class ConfigProvider {
 		if (currentConfig) {
 			return currentConfig;
 		}
-		let configSet = await this._mergeConfigs(keys, cache, targetFile.path);
+		let configSet = await this.#mergeConfigs(keys, cache, targetFile.path);
 
 		const filePath = [...configSet.files].toReversed()[0];
 		if (!filePath) {
@@ -129,7 +129,7 @@ export class ConfigProvider {
 				filePath: targetFile.path,
 			});
 		}
-		const errors = this._validateConfig(configSet.config, filePath);
+		const errors = this.#validateConfig(configSet.config, filePath);
 		configSet.errs.push(...errors);
 
 		const { plugins, errors: pluginErrors } = await resolvePlugins(configSet.config.plugins);
@@ -152,7 +152,7 @@ export class ConfigProvider {
 				}
 			}
 
-			configSet = await this._mergeConfigs([...keys, ...extendHelds], cache, targetFile.path);
+			configSet = await this.#mergeConfigs([...keys, ...extendHelds], cache, targetFile.path);
 
 			this.#held.clear();
 		}
@@ -212,7 +212,7 @@ export class ConfigProvider {
 			return null;
 		}
 		const { filePath, config } = res;
-		const pathResolvedConfig = await this._pathResolve(config, filePath);
+		const pathResolvedConfig = await this.#pathResolve(config, filePath);
 		this.#store.set(filePath, pathResolvedConfig);
 
 		cpLog('Store key: %s', filePath);
@@ -232,7 +232,7 @@ export class ConfigProvider {
 		return key;
 	}
 
-	private async _load(filePath: string, cache: boolean, referrer: string) {
+	async #load(filePath: string, cache: boolean, referrer: string) {
 		const entity = this.#store.get(filePath);
 		if (entity) {
 			return entity;
@@ -241,7 +241,7 @@ export class ConfigProvider {
 		if (isPresetModuleName(filePath)) {
 			const [, name] = filePath.match(/^markuplint:(.+)$/i) ?? [];
 			const config = await getPreset(name ?? filePath);
-			const pathResolvedConfig = await this._pathResolve(config, filePath);
+			const pathResolvedConfig = await this.#pathResolve(config, filePath);
 
 			this.#store.set(filePath, pathResolvedConfig);
 			return pathResolvedConfig;
@@ -262,13 +262,13 @@ export class ConfigProvider {
 			return config;
 		}
 
-		const pathResolvedConfig = await this._pathResolve(config, filePath);
+		const pathResolvedConfig = await this.#pathResolve(config, filePath);
 
 		this.#store.set(filePath, pathResolvedConfig);
 		return pathResolvedConfig;
 	}
 
-	private async _mergeConfigs(keys: readonly string[], cache: boolean, referrer: string) {
+	async #mergeConfigs(keys: readonly string[], cache: boolean, referrer: string) {
 		const resolvedKeys = new Set<string>();
 		const errs: Error[] = [];
 		for (const key of keys) {
@@ -296,7 +296,7 @@ export class ConfigProvider {
 		};
 	}
 
-	private async _pathResolve(config: Config, filePath: string): Promise<OptimizedConfig> {
+	async #pathResolve(config: Config, filePath: string): Promise<OptimizedConfig> {
 		const optimizedConfig = mergeConfig(config);
 		const dir = path.dirname(filePath);
 		return {
@@ -316,7 +316,7 @@ export class ConfigProvider {
 		};
 	}
 
-	private _validateConfig(config: Config, filePath: string) {
+	#validateConfig(config: Config, filePath: string) {
 		const errors: ConfigParserError[] = [];
 		if (config.nodeRules)
 			for (const rule of config.nodeRules) {

--- a/packages/@markuplint/file-resolver/src/ml-file/ml-file.ts
+++ b/packages/@markuplint/file-resolver/src/ml-file/ml-file.ts
@@ -71,7 +71,7 @@ export class MLFile {
 			return this.#code;
 		}
 		if (this.#type === 'file-base' && (await this.isExist())) {
-			return await this._fetch();
+			return await this.#fetch();
 		}
 		return '';
 	}
@@ -89,7 +89,7 @@ export class MLFile {
 		if (this.#type === 'code-base') {
 			return true;
 		}
-		const stat = await this._stat();
+		const stat = await this.#loadStat();
 		return !!stat;
 	}
 
@@ -97,7 +97,7 @@ export class MLFile {
 		if (this.#type === 'code-base') {
 			return true;
 		}
-		const stat = await this._stat();
+		const stat = await this.#loadStat();
 		return !!stat && stat.isFile();
 	}
 
@@ -112,13 +112,13 @@ export class MLFile {
 		this.#code = code;
 	}
 
-	private async _fetch() {
+	async #fetch() {
 		const code = await fs.readFile(this.path, { encoding: 'utf8' });
 		this.#code = code;
 		return code;
 	}
 
-	private async _stat() {
+	async #loadStat() {
 		if (this.#stat) {
 			return this.#stat;
 		}

--- a/packages/@markuplint/file-resolver/src/resolve-plugins.spec.ts
+++ b/packages/@markuplint/file-resolver/src/resolve-plugins.spec.ts
@@ -1,28 +1,24 @@
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { test, expect } from 'vitest';
 
 import { resolvePlugins } from './resolve-plugins.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
 test('resolvePlugins', async () => {
-	const { plugins } = await resolvePlugins([path.resolve(__dirname, '..', 'test', 'plugins', '001.js')]);
+	const { plugins } = await resolvePlugins([path.resolve(import.meta.dirname, '..', 'test', 'plugins', '001.js')]);
 	expect(plugins[0]?.name).toBe('foo');
 	// @ts-ignore
 	expect(await plugins[0].rules?.bar?.verify?.()).toEqual([]);
 });
 
 test('resolve name', async () => {
-	const filePath = path.resolve(__dirname, '..', 'test', 'plugins', '002.js');
+	const filePath = path.resolve(import.meta.dirname, '..', 'test', 'plugins', '002.js');
 	const { plugins } = await resolvePlugins([filePath]);
 	expect(plugins[0]?.name).toBe(filePath.toLowerCase().replaceAll(/\s+|[./\\]/g, '-'));
 });
 
 test('fail loading', async () => {
-	const filePath = path.resolve(__dirname, '..', 'test', 'plugins', 'no-exist.js');
+	const filePath = path.resolve(import.meta.dirname, '..', 'test', 'plugins', 'no-exist.js');
 	// @ts-ignore
 	expect((await resolvePlugins([filePath])).errors[0].message).toBe(`Plugin not found: ${filePath}`);
 });

--- a/packages/@markuplint/file-resolver/src/resolve-pretenders.spec.ts
+++ b/packages/@markuplint/file-resolver/src/resolve-pretenders.spec.ts
@@ -1,16 +1,12 @@
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { test, expect } from 'vitest';
 
 import { resolvePretenders } from './resolve-pretenders.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
 test('files', async () => {
 	const pretenders = await resolvePretenders({
-		files: [path.resolve(__dirname, '..', '..', '..', '@markuplint-test', 'react', 'pretenders.json')],
+		files: [path.resolve(import.meta.dirname, '..', '..', '..', '@markuplint-test', 'react', 'pretenders.json')],
 	});
 	expect(pretenders).toStrictEqual([
 		{

--- a/packages/@markuplint/markdown-parser/src/markdown-aware-parser.ts
+++ b/packages/@markuplint/markdown-parser/src/markdown-aware-parser.ts
@@ -489,10 +489,10 @@ export abstract class MarkdownAwareParser extends Parser<MdastNode> {
 				return this.visitCodeBlock(originNode, token, depth, parentNode);
 			}
 			case 'linkReference': {
-				return this.visitLinkReference(originNode, token, depth, parentNode);
+				return this.#visitLinkReference(originNode, token, depth, parentNode);
 			}
 			case 'imageReference': {
-				return this.visitImageReference(originNode, token, depth, parentNode);
+				return this.#visitImageReference(originNode, token, depth, parentNode);
 			}
 			case 'table': {
 				return this.visitTableElement(originNode, token, depth, parentNode);
@@ -552,7 +552,7 @@ export abstract class MarkdownAwareParser extends Parser<MdastNode> {
 	 * Resolves a linkReference using collected definitions, producing an `<a>` element.
 	 * Falls back to a psblock when the definition is not found.
 	 */
-	private visitLinkReference(
+	#visitLinkReference(
 		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
 		originNode: LinkReference,
 		token: Token,
@@ -582,7 +582,7 @@ export abstract class MarkdownAwareParser extends Parser<MdastNode> {
 	 * Resolves an imageReference using collected definitions, producing an `<img>` element.
 	 * Falls back to a psblock when the definition is not found.
 	 */
-	private visitImageReference(
+	#visitImageReference(
 		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
 		originNode: ImageReference,
 		token: Token,

--- a/packages/@markuplint/ml-config/src/utils.ts
+++ b/packages/@markuplint/ml-config/src/utils.ts
@@ -157,7 +157,7 @@ export function deleteUndefProp(obj: any) {
 	if (!isPlainObject(obj)) {
 		return;
 	}
-	for (const key in obj) {
+	for (const key of Object.keys(obj)) {
 		if (obj[key] === undefined) {
 			delete obj[key];
 		}

--- a/packages/@markuplint/ml-core/src/ml-core.ts
+++ b/packages/@markuplint/ml-core/src/ml-core.ts
@@ -166,8 +166,8 @@ export class MLCore {
 		this.#disabledNamespaces = extractDisabledNamespaces(resolvedRules);
 		this.#configErrors.push(...namedRulesResult.errors, ...nodeRuleResult.errors, ...childNodeRuleResult.errors);
 
-		this._parse();
-		this._createDocument();
+		this.#parse();
+		this.#createDocument();
 	}
 
 	/**
@@ -184,8 +184,8 @@ export class MLCore {
 	 */
 	setCode(sourceCode: string) {
 		this.#sourceCode = sourceCode;
-		this._parse();
-		this._createDocument();
+		this.#parse();
+		this.#createDocument();
 	}
 
 	/**
@@ -237,9 +237,9 @@ export class MLCore {
 			(parserOptions.ignoreFrontMatter !== this.#parserOptions.ignoreFrontMatter ||
 				parserOptions.authoredElementName !== this.#parserOptions.authoredElementName)
 		) {
-			this._parse();
+			this.#parse();
 		}
-		this._createDocument();
+		this.#createDocument();
 	}
 
 	/**
@@ -269,7 +269,7 @@ export class MLCore {
 		log('verify: start');
 		const violations: Violation[] = [];
 		if (this.#document instanceof ParserError) {
-			const parseError = this._createParseError(
+			const parseError = this.#createParseError(
 				this.#document.message,
 				this.#document.line,
 				this.#document.col,
@@ -321,7 +321,7 @@ export class MLCore {
 			});
 		}
 
-		const ruleViolations = await this._runAllRules(fix);
+		const ruleViolations = await this.#runAllRules(fix);
 		violations.push(...ruleViolations);
 
 		if (resultLog.enabled) {
@@ -351,7 +351,7 @@ export class MLCore {
 				const originalDocument = this.#document;
 
 				try {
-					const fixResult = await this._multiPassFix(violations);
+					const fixResult = await this.#multiPassFix(violations);
 					fixedCode = fixResult.code;
 					fixSummary = fixResult.summary;
 				} finally {
@@ -376,7 +376,7 @@ export class MLCore {
 		return { violations, fixedCode, fixSummary };
 	}
 
-	private _createDocument() {
+	#createDocument() {
 		if (!this.#ast) {
 			return;
 		}
@@ -397,7 +397,7 @@ export class MLCore {
 		}
 	}
 
-	private _createParseError(message: string, line: number, col: number, raw: string): Violation | null {
+	#createParseError(message: string, line: number, col: number, raw: string): Violation | null {
 		if (this.#severity.parseError === false || this.#severity.parseError === 'off') {
 			return null;
 		}
@@ -428,9 +428,7 @@ export class MLCore {
 	 * @param initialViolations - Violations from the first verification pass
 	 * @returns The final fixed source code and a summary of the fix process
 	 */
-	private async _multiPassFix(
-		initialViolations: readonly Violation[],
-	): Promise<{ code: string; summary: FixSummary }> {
+	async #multiPassFix(initialViolations: readonly Violation[]): Promise<{ code: string; summary: FixSummary }> {
 		const MAX_FIX_PASSES = 10;
 		let currentCode = this.#sourceCode;
 		let previousCode: string | undefined;
@@ -482,8 +480,8 @@ export class MLCore {
 			const previousGoodCode = currentCode;
 
 			this.#sourceCode = currentCode;
-			this._parse();
-			this._createDocument();
+			this.#parse();
+			this.#createDocument();
 
 			if (this.#document instanceof ParserError) {
 				log('fix pass %d: produced unparsable code, reverting to previous state', pass);
@@ -491,7 +489,7 @@ export class MLCore {
 				break;
 			}
 
-			const newViolations = await this._runAllRules(true);
+			const newViolations = await this.#runAllRules(true);
 			fixes = extractFixes(newViolations);
 			if (fixes.length === 0) {
 				log('fix pass %d: no more fixable violations, stopping', pass);
@@ -523,7 +521,7 @@ export class MLCore {
 	 * @param fix - Whether to execute fix callbacks on violations
 	 * @returns All violations produced by the rule set
 	 */
-	private async _runAllRules(fix: boolean): Promise<Violation[]> {
+	async #runAllRules(fix: boolean): Promise<Violation[]> {
 		const violations: Violation[] = [];
 		if (this.#document instanceof ParserError) {
 			return violations;
@@ -558,7 +556,7 @@ export class MLCore {
 			});
 
 			if (results instanceof ParserError) {
-				const parseError = this._createParseError(results.message, results.line, results.col, results.raw);
+				const parseError = this.#createParseError(results.message, results.line, results.col, results.raw);
 				if (parseError) {
 					log('%s Rule: verify error %o', rule.name, results.message);
 					violations.push(parseError);
@@ -571,7 +569,7 @@ export class MLCore {
 		return violations;
 	}
 
-	private _parse() {
+	#parse() {
 		try {
 			this.#ast = this.#parser.parse(this.#sourceCode, this.#parserOptions);
 		} catch (error) {

--- a/packages/@markuplint/ml-core/src/ml-dom/node/document.ts
+++ b/packages/@markuplint/ml-core/src/ml-dom/node/document.ts
@@ -200,10 +200,10 @@ export class MLDocument<T extends RuleConfigValue, O extends PlainData = undefin
 				.filter((n): n is MLNode<T, O> => !!n),
 		);
 
-		this._pretending(options?.pretenders);
+		this.#pretending(options?.pretenders);
 
 		try {
-			this._ruleMapping(ruleset);
+			this.#ruleMapping(ruleset);
 		} catch (error: unknown) {
 			if (error instanceof InvalidSelectorError) {
 				throw new ConfigParserError(error.message, {
@@ -3346,7 +3346,7 @@ export class MLDocument<T extends RuleConfigValue, O extends PlainData = undefin
 	 *
 	 * @param pretenders - Optional pretender configurations from the document options
 	 */
-	private _pretending(pretenders?: readonly Pretender[]) {
+	#pretending(pretenders?: readonly Pretender[]) {
 		if (docLog.enabled) {
 			docLog('Pretending: %O', pretenders);
 		}
@@ -3364,7 +3364,7 @@ export class MLDocument<T extends RuleConfigValue, O extends PlainData = undefin
 	 *
 	 * @param ruleset - The ruleset containing rules, nodeRules, and childNodeRules
 	 */
-	private _ruleMapping(ruleset: Ruleset) {
+	#ruleMapping(ruleset: Ruleset) {
 		if (docLog.enabled) {
 			docLog('Rule Mapping: %O', Object.keys(ruleset.rules));
 		}

--- a/packages/@markuplint/ml-core/src/ml-dom/node/dom-token-list.ts
+++ b/packages/@markuplint/ml-core/src/ml-dom/node/dom-token-list.ts
@@ -64,7 +64,7 @@ export class MLDomTokenList extends Array<string> implements DOMTokenList {
 			if (!token) {
 				break;
 			}
-			const loc = this._pick(token, offset);
+			const loc = this.#pick(token, offset);
 			if (!loc) {
 				offset = 0;
 				continue;
@@ -97,7 +97,7 @@ export class MLDomTokenList extends Array<string> implements DOMTokenList {
 	 * @implements `@markuplint/ml-core` API: `MLDomTokenList`
 	 */
 	pick(token: string): Scope | null {
-		const r = this._pick(token);
+		const r = this.#pick(token);
 		if (!r) {
 			return null;
 		}
@@ -130,7 +130,7 @@ export class MLDomTokenList extends Array<string> implements DOMTokenList {
 		throw new UnexpectedCallError('Not supported "toggle" method');
 	}
 
-	private _pick(token: string, _offset = 0): (Scope & { _searchedIndex: number }) | null {
+	#pick(token: string, _offset = 0): (Scope & { _searchedIndex: number }) | null {
 		token = token.trim().split(/\s+/)[0] ?? '';
 		if (!token) {
 			return null;

--- a/packages/@markuplint/ml-core/src/ml-rule/ml-rule-context.ts
+++ b/packages/@markuplint/ml-core/src/ml-rule/ml-rule-context.ts
@@ -42,15 +42,15 @@ export class MLRuleContext<T extends RuleConfigValue, O extends PlainData = unde
 		if (typeof report === 'function') {
 			const r = report(this.translate);
 			if (r) {
-				this._push(r);
+				this.#push(r);
 				return true;
 			}
 			return false;
 		}
-		this._push(report);
+		this.#push(report);
 	}
 
-	private _push(report: Report<T, O>) {
+	#push(report: Report<T, O>) {
 		const key = reportKey(report);
 		if (!this.#reportKeys.has(key)) {
 			this.#reportKeys.add(key);

--- a/packages/@markuplint/ml-core/src/ml-rule/ml-rule.ts
+++ b/packages/@markuplint/ml-core/src/ml-rule/ml-rule.ts
@@ -121,12 +121,12 @@ export class MLRule<T extends RuleConfigValue, O extends PlainData = undefined> 
 	 * @returns The global rule info with node and child-node overrides
 	 */
 	getRuleInfo(ruleSet: Ruleset, ruleName: string): GlobalRuleInfo<T, O> {
-		const info = this._optimize(ruleSet.rules, ruleName);
+		const info = this.#optimize(ruleSet.rules, ruleName);
 
 		return {
 			...info,
-			nodeRules: ruleSet.nodeRules.map(r => this._optimize(r.rules, ruleName)).filter(r => !r.disabled),
-			childNodeRules: ruleSet.childNodeRules.map(r => this._optimize(r.rules, ruleName)).filter(r => !r.disabled),
+			nodeRules: ruleSet.nodeRules.map(r => this.#optimize(r.rules, ruleName)).filter(r => !r.disabled),
+			childNodeRules: ruleSet.childNodeRules.map(r => this.#optimize(r.rules, ruleName)).filter(r => !r.disabled),
 		};
 	}
 
@@ -252,7 +252,7 @@ export class MLRule<T extends RuleConfigValue, O extends PlainData = undefined> 
 		return violations;
 	}
 
-	private _optimize(rules: Rules | undefined, ruleName: string) {
+	#optimize(rules: Rules | undefined, ruleName: string) {
 		const rule = (rules?.[ruleName] ?? false) as Rule<T, O>;
 		const info = this.optimizeOption(rule);
 		return info;

--- a/packages/@markuplint/ml-spec/gen/gen.ts
+++ b/packages/@markuplint/ml-spec/gen/gen.ts
@@ -2,12 +2,8 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { globalAttrs } from './global-attribute.data.js';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 
 const defs = {};
 const properties = {};
@@ -72,7 +68,7 @@ for (const key of Object.keys(globalAttrs)) {
 }
 
 fs.writeFileSync(
-	path.resolve(__dirname, '..', 'schemas', 'global-attributes.schema.json'),
+	path.resolve(import.meta.dirname, '..', 'schemas', 'global-attributes.schema.json'),
 	JSON.stringify({
 		definitions: {
 			category: {
@@ -92,7 +88,7 @@ fs.writeFileSync(
 );
 
 fs.writeFileSync(
-	path.resolve(__dirname, '..', 'schemas', 'attributes.schema.json'),
+	path.resolve(import.meta.dirname, '..', 'schemas', 'attributes.schema.json'),
 	JSON.stringify({
 		definitions: {
 			AttributeName: {

--- a/packages/@markuplint/ml-spec/src/utils/get-attr-specs-spec.ts
+++ b/packages/@markuplint/ml-spec/src/utils/get-attr-specs-spec.ts
@@ -40,7 +40,7 @@ export function getAttrSpecs(localName: string, namespace: NamespaceURI | null, 
 	const globalAttrs = schema.def['#globalAttrs'];
 	let attrs: Record<string, Partial<Attribute>> = {};
 
-	for (const catName in elSpec.globalAttrs) {
+	for (const catName of Object.keys(elSpec.globalAttrs)) {
 		// @ts-ignore
 		const catAttrs: boolean | string[] = elSpec.globalAttrs[catName];
 		if (catAttrs === false) {
@@ -70,7 +70,7 @@ export function getAttrSpecs(localName: string, namespace: NamespaceURI | null, 
 		}
 	}
 
-	for (const attrName in elSpec.attributes) {
+	for (const attrName of Object.keys(elSpec.attributes)) {
 		const attr = elSpec.attributes[attrName];
 		if (!attr) {
 			continue;

--- a/packages/@markuplint/pretenders/src/jsx/index.spec.ts
+++ b/packages/@markuplint/pretenders/src/jsx/index.spec.ts
@@ -1,13 +1,11 @@
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { describe, test, expect } from 'vitest';
 
 import { jsxScanner } from './index.js';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const _ = (filePath: string) => filePath.split('/').join(path.sep);
-const testDir = path.resolve(__dirname, '..', '..', 'test', 'fixtures');
+const testDir = path.resolve(import.meta.dirname, '..', '..', 'test', 'fixtures');
 
 describe('jsxScanner', () => {
 	test('001.tsx', async () => {

--- a/packages/@markuplint/selector/src/match-selector.ts
+++ b/packages/@markuplint/selector/src/match-selector.ts
@@ -101,7 +101,7 @@ class SelectorTarget {
 	}
 
 	match(el: SelectorNode): SelectorMatches {
-		const unitCheck = this._matchWithoutCombineChecking(el);
+		const unitCheck = this.#matchWithoutCombineChecking(el);
 		if (!unitCheck.matched) {
 			return unitCheck;
 		}
@@ -191,7 +191,7 @@ class SelectorTarget {
 		}
 	}
 
-	private _matchWithoutCombineChecking(el: SelectorNode) {
+	#matchWithoutCombineChecking(el: SelectorNode) {
 		return uncombinedRegexSelect(el, this.#selector);
 	}
 }

--- a/packages/@markuplint/selector/src/selector.ts
+++ b/packages/@markuplint/selector/src/selector.ts
@@ -478,7 +478,6 @@ class SelectorTarget {
 	 *
 	 * @param el
 	 * @param scope
-	 * @private
 	 */
 	#matchWithoutCombineChecking(el: SelectorNode, scope: SelectorNode | null): SelectorResult {
 		const specificity: Writable<Specificity> = [0, 0, 0];

--- a/packages/@markuplint/selector/src/selector.ts
+++ b/packages/@markuplint/selector/src/selector.ts
@@ -238,7 +238,7 @@ class SelectorTarget {
 	}
 
 	match(el: SelectorNode, scope: SelectorNode | null, count: number): SelectorResult {
-		const result = this._match(el, scope, count);
+		const result = this.#match(el, scope, count);
 		if (selLog.enabled) {
 			const nodeName = el.nodeName;
 			const selector = this.#combinedFrom?.target.toString() ?? this.toString();
@@ -262,12 +262,8 @@ class SelectorTarget {
 		].join('');
 	}
 
-	private _match(
-		el: SelectorNode,
-		scope: SelectorNode | null,
-		count: number,
-	): SelectorResult & { combinator?: string } {
-		const unitCheck = this._matchWithoutCombineChecking(el, scope);
+	#match(el: SelectorNode, scope: SelectorNode | null, count: number): SelectorResult & { combinator?: string } {
+		const unitCheck = this.#matchWithoutCombineChecking(el, scope);
 		if (!unitCheck.matched) {
 			return unitCheck;
 		}
@@ -484,7 +480,7 @@ class SelectorTarget {
 	 * @param scope
 	 * @private
 	 */
-	private _matchWithoutCombineChecking(el: SelectorNode, scope: SelectorNode | null): SelectorResult {
+	#matchWithoutCombineChecking(el: SelectorNode, scope: SelectorNode | null): SelectorResult {
 		const specificity: Writable<Specificity> = [0, 0, 0];
 
 		if (!isElement(el)) {

--- a/packages/@markuplint/types/src/token/token-collection.ts
+++ b/packages/@markuplint/types/src/token/token-collection.ts
@@ -91,11 +91,21 @@ export class TokenCollection extends Array<Token> {
 			addToken(strings);
 		}
 
-		return TokenCollection._new(tokens, new TokenCollection('', typeOptions));
+		return TokenCollection.#new(tokens, new TokenCollection('', typeOptions));
 	}
 
 	static get [Symbol.species]() {
 		return Array;
+	}
+
+	static #new(
+		tokens: readonly Readonly<Token>[],
+		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+		old?: TokenCollection,
+	) {
+		const newCollection = new TokenCollection('', old);
+		newCollection.push(...tokens);
+		return newCollection;
 	}
 
 	readonly allowEmpty: NonNullable<List['allowEmpty']>;
@@ -294,7 +304,7 @@ export class TokenCollection extends Array<Token> {
 		const tokens = this.slice();
 		while (tokens.length > 0) {
 			const chunkTokens = tokens.splice(0, split);
-			const chunk = TokenCollection._new(chunkTokens, this);
+			const chunk = TokenCollection.#new(chunkTokens, this);
 			chunks.push(chunk);
 		}
 		return chunks;
@@ -332,8 +342,8 @@ export class TokenCollection extends Array<Token> {
 	divide(position: number) {
 		const _a = this.slice(0, position);
 		const _b = this.slice(position);
-		const a = TokenCollection._new(_a, this);
-		const b = TokenCollection._new(_b, this);
+		const a = TokenCollection.#new(_a, this);
+		const b = TokenCollection.#new(_b, this);
 		return [a, b] as const;
 	}
 
@@ -420,7 +430,7 @@ export class TokenCollection extends Array<Token> {
 	 * @returns A new TokenCollection with the filtered tokens
 	 */
 	filter(callback: Parameters<Array<Token>['filter']>[0]): TokenCollection {
-		return TokenCollection._new(super.filter(callback), this);
+		return TokenCollection.#new(super.filter(callback), this);
 	}
 
 	/**
@@ -495,9 +505,9 @@ export class TokenCollection extends Array<Token> {
 		const copy = this.slice();
 		const head = copy.shift();
 		if (!head) {
-			return { head: head ?? null, tail: TokenCollection._new([], this) };
+			return { head: head ?? null, tail: TokenCollection.#new([], this) };
 		}
-		const tail = TokenCollection._new(copy, this);
+		const tail = TokenCollection.#new(copy, this);
 		return { head, tail };
 	}
 
@@ -556,15 +566,5 @@ export class TokenCollection extends Array<Token> {
 	 */
 	toJSON() {
 		return this.map(t => t.toJSON());
-	}
-
-	private static _new(
-		tokens: readonly Readonly<Token>[],
-		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-		old?: TokenCollection,
-	) {
-		const newCollection = new TokenCollection('', old);
-		newCollection.push(...tokens);
-		return newCollection;
 	}
 }

--- a/packages/markuplint/src/api/ml-engine.spec.ts
+++ b/packages/markuplint/src/api/ml-engine.spec.ts
@@ -3,14 +3,10 @@ import type { Violation } from '@markuplint/ml-config';
 
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { describe, it, expect } from 'vitest';
 
 import { MLEngine } from './ml-engine.js';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 
 describe('Event notification', () => {
 	it('config', async () => {
@@ -89,7 +85,7 @@ describe('Resolving the plugin', () => {
 			config: {
 				plugins: [
 					{
-						name: path.resolve(__dirname, '..', '..', 'test', 'plugin001.js'),
+						name: path.resolve(import.meta.dirname, '..', '..', 'test', 'plugin001.js'),
 						settings: {
 							foo: 'IT IS SUCCESS',
 						},
@@ -220,8 +216,8 @@ describe('Config Priority', () => {
 
 describe('#1862 configFile skips default config search', () => {
 	it('configFile only — default config file is not loaded', async () => {
-		const filePath = path.resolve(__dirname, '../../test/issue1862/index.html');
-		const configFilePath = path.resolve(__dirname, '../../test/issue1862/config.json');
+		const filePath = path.resolve(import.meta.dirname, '../../test/issue1862/index.html');
+		const configFilePath = path.resolve(import.meta.dirname, '../../test/issue1862/config.json');
 		const file = await MLEngine.toMLFile(filePath);
 		const engine = new MLEngine(file!, {
 			configFile: configFilePath,
@@ -242,8 +238,8 @@ describe('#1862 configFile skips default config search', () => {
 	});
 
 	it('configFile + noSearchConfig — consistent behavior', async () => {
-		const filePath = path.resolve(__dirname, '../../test/issue1862/index.html');
-		const configFilePath = path.resolve(__dirname, '../../test/issue1862/config.json');
+		const filePath = path.resolve(import.meta.dirname, '../../test/issue1862/index.html');
+		const configFilePath = path.resolve(import.meta.dirname, '../../test/issue1862/config.json');
 		const file = await MLEngine.toMLFile(filePath);
 		const engine = new MLEngine(file!, {
 			configFile: configFilePath,

--- a/packages/markuplint/src/api/ml-engine.ts
+++ b/packages/markuplint/src/api/ml-engine.ts
@@ -134,7 +134,7 @@ export class MLEngine extends Emitter<MLEngineEventMap> {
 	 */
 	async exec(): Promise<MLResultInfo | null> {
 		log('exec: start');
-		const core = await this.setup();
+		const core = await this.#setup();
 
 		if (!core) {
 			log('exec: cancel (unsetuped yet)');
@@ -194,7 +194,7 @@ export class MLEngine extends Emitter<MLEngineEventMap> {
 	 * @param code - The new markup source code
 	 */
 	async setCode(code: string) {
-		const core = await this.setup();
+		const core = await this.#setup();
 
 		if (!core) {
 			return;
@@ -217,13 +217,13 @@ export class MLEngine extends Emitter<MLEngineEventMap> {
 		};
 
 		if (enable) {
-			this.#watcher.on('change', this.onChange.bind(this));
+			this.#watcher.on('change', this.#onChange.bind(this));
 		} else {
 			this.#watcher.removeAllListeners();
 		}
 	}
 
-	private async createCore(fabric: MLFabric) {
+	async #createCore(fabric: MLFabric) {
 		fileLog('Get source code');
 		const sourceCode = await this.#file.getCode();
 		fileLog('Source code path: %s', this.#file.path);
@@ -242,20 +242,14 @@ export class MLEngine extends Emitter<MLEngineEventMap> {
 		return core;
 	}
 
-	private i18n() {
-		const i18nSettings = i18n(this.#options?.locale);
-		this.emit('i18n', this.#file.path, i18nSettings);
-		return i18nSettings;
-	}
-
-	private async onChange(filePath: string) {
+	async #onChange(filePath: string) {
 		if (!this.#options?.watch) {
 			return;
 		}
 
 		this.emit('log', 'watch:onChange', filePath);
 
-		const fabric = await this.provide(false);
+		const fabric = await this.#provide(false);
 
 		if (!fabric) {
 			return;
@@ -270,7 +264,7 @@ export class MLEngine extends Emitter<MLEngineEventMap> {
 		await this.exec();
 	}
 
-	private async provide(cache = true): Promise<MLFabric | null> {
+	async #provide(cache = true): Promise<MLFabric | null> {
 		let configSet: ConfigSet;
 
 		try {
@@ -306,7 +300,7 @@ export class MLEngine extends Emitter<MLEngineEventMap> {
 			return null;
 		}
 
-		const { parser, parserOptions, matched } = await this.resolveParser(configSet);
+		const { parser, parserOptions, matched } = await this.#resolveParser(configSet);
 		const checkingExt = !this.#options?.ignoreExt;
 
 		if (checkingExt && !matched) {
@@ -324,13 +318,13 @@ export class MLEngine extends Emitter<MLEngineEventMap> {
 			...this.#options?.severity,
 		};
 
-		const pretenders = await this.resolvePretenders(configSet);
+		const pretenders = await this.#resolvePretenders(configSet);
 		fileLog('Resolved pretenders: %O', pretenders);
 
-		const ruleset = this.resolveRuleset(configSet);
+		const ruleset = this.#resolveRuleset(configSet);
 		fileLog('Resolved ruleset: %O', ruleset);
 
-		const schemas = await this.resolveSchemas(configSet);
+		const schemas = await this.#resolveSchemas(configSet);
 		if (fileLog.enabled) {
 			if (schemas[0].cites.length > 0) {
 				const [, ...additionalSpecs] = schemas;
@@ -343,7 +337,7 @@ export class MLEngine extends Emitter<MLEngineEventMap> {
 			}
 		}
 
-		const rules = await this.resolveRules(configSet.plugins, ruleset);
+		const rules = await this.#resolveRules(configSet.plugins, ruleset);
 		fileLog('Resolved rules: %O', rules);
 
 		const locale = i18n(this.#options?.locale);
@@ -419,7 +413,7 @@ export class MLEngine extends Emitter<MLEngineEventMap> {
 		return configSet;
 	}
 
-	private async resolveParser(
+	async #resolveParser(
 		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
 		configSet: ConfigSet,
 	) {
@@ -429,7 +423,7 @@ export class MLEngine extends Emitter<MLEngineEventMap> {
 		return parser;
 	}
 
-	private async resolvePretenders(
+	async #resolvePretenders(
 		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
 		configSet: ConfigSet,
 	) {
@@ -438,7 +432,7 @@ export class MLEngine extends Emitter<MLEngineEventMap> {
 		return pretenders;
 	}
 
-	private async resolveRules(plugins: readonly Plugin[], ruleset: Ruleset) {
+	async #resolveRules(plugins: readonly Plugin[], ruleset: Ruleset) {
 		const rules = await resolveRules(
 			plugins,
 			ruleset,
@@ -453,7 +447,7 @@ export class MLEngine extends Emitter<MLEngineEventMap> {
 		return rules;
 	}
 
-	private resolveRuleset(
+	#resolveRuleset(
 		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
 		configSet: ConfigSet,
 	) {
@@ -462,7 +456,7 @@ export class MLEngine extends Emitter<MLEngineEventMap> {
 		return ruleset;
 	}
 
-	private async resolveSchemas(
+	async #resolveSchemas(
 		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
 		configSet: ConfigSet,
 	) {
@@ -471,11 +465,11 @@ export class MLEngine extends Emitter<MLEngineEventMap> {
 		return schemas;
 	}
 
-	private async setup() {
+	async #setup() {
 		if (this.#core) {
 			return this.#core;
 		}
-		const fabric = await this.provide();
+		const fabric = await this.#provide();
 
 		if (!fabric) {
 			return null;
@@ -485,6 +479,6 @@ export class MLEngine extends Emitter<MLEngineEventMap> {
 			this.emit('config-errors', this.#file.path, fabric.configErrors);
 		}
 
-		return this.createCore(fabric);
+		return this.#createCore(fabric);
 	}
 }

--- a/packages/markuplint/src/cli/index.spec.ts
+++ b/packages/markuplint/src/cli/index.spec.ts
@@ -1,15 +1,12 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { execa } from '@markuplint/test-tools';
 import { describe, test, expect, beforeAll } from 'vitest';
 
 import { cli } from './bootstrap.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const entryFilePath = path.resolve(__dirname, '../../bin/markuplint.mjs');
+const entryFilePath = path.resolve(import.meta.dirname, '../../bin/markuplint.mjs');
 
 const escape = (path: string) => path.replaceAll('\\', '\\\\'); // For Windows
 
@@ -18,8 +15,8 @@ async function delay(ms: number) {
 }
 
 beforeAll(async () => {
-	const originFilePath = path.resolve(__dirname, '../../test/fix/origin.html');
-	const fixedFilePath = path.resolve(__dirname, '../../test/fix/fixed.html');
+	const originFilePath = path.resolve(import.meta.dirname, '../../test/fix/origin.html');
+	const fixedFilePath = path.resolve(import.meta.dirname, '../../test/fix/fixed.html');
 	const originContent = await readFile(originFilePath, { encoding: 'utf8' });
 	await writeFile(fixedFilePath, originContent, { encoding: 'utf8' });
 	await delay(500);
@@ -49,20 +46,20 @@ describe('STDOUT Test', () => {
 	});
 
 	test('verify', async () => {
-		const targetFilePath = path.resolve(__dirname, '../../../../test/fixture/001.html');
+		const targetFilePath = path.resolve(import.meta.dirname, '../../../../test/fixture/001.html');
 		const { stdout, exitCode } = await execa(entryFilePath, ['--no-color', escape(targetFilePath)]);
 		expect(stdout).toBe(`<markuplint> passed ${targetFilePath}`);
 		expect(exitCode).toBe(0);
 	});
 
 	test('verify --problem-only', async () => {
-		const targetFilePath = path.resolve(__dirname, '../../../../test/fixture/001.html');
+		const targetFilePath = path.resolve(import.meta.dirname, '../../../../test/fixture/001.html');
 		const { stdout } = await execa(entryFilePath, ['--problem-only', escape(targetFilePath)]);
 		expect(stdout).toBe('');
 	});
 
 	test('verify and failure', async () => {
-		const targetFilePath = path.resolve(__dirname, '../../../../test/fixture/002.html');
+		const targetFilePath = path.resolve(import.meta.dirname, '../../../../test/fixture/002.html');
 		const { stdout, stderr, exitCode } = await execa(entryFilePath, ['--no-color', escape(targetFilePath)], {
 			reject: false,
 		});
@@ -72,7 +69,7 @@ describe('STDOUT Test', () => {
 	});
 
 	test('allow warnings', async () => {
-		const targetFilePath = path.resolve(__dirname, '../../../../test/fixture/002.html');
+		const targetFilePath = path.resolve(import.meta.dirname, '../../../../test/fixture/002.html');
 		const { stdout, stderr, exitCode } = await execa(
 			entryFilePath,
 			['--no-allow-warnings', '--no-color', escape(targetFilePath)],
@@ -118,20 +115,20 @@ describe('STDOUT Test', () => {
 	});
 
 	test('format', async () => {
-		const targetFilePath = path.resolve(__dirname, '../../../../test/fixture/001.html');
+		const targetFilePath = path.resolve(import.meta.dirname, '../../../../test/fixture/001.html');
 		const { stdout } = await execa(entryFilePath, ['--format', 'JSON', escape(targetFilePath)]);
 		expect(stdout).toBe('[]');
 	});
 
 	test('no files', async () => {
-		const targetFilePath = path.resolve(__dirname, '../../../../test/xxx/*');
+		const targetFilePath = path.resolve(import.meta.dirname, '../../../../test/xxx/*');
 		const { stdout, exitCode } = await execa(entryFilePath, ['--format', 'JSON', escape(targetFilePath)]);
 		expect(stdout).toBe('[]');
 		expect(exitCode).toBe(0);
 	});
 
 	test('no files --allow-empty-input="true"', async () => {
-		const targetFilePath = path.resolve(__dirname, '../../../../test/xxx/*');
+		const targetFilePath = path.resolve(import.meta.dirname, '../../../../test/xxx/*');
 		const { exitCode } = await execa(entryFilePath, ['--allow-empty-input="true"', escape(targetFilePath)], {
 			reject: false,
 		});
@@ -139,7 +136,7 @@ describe('STDOUT Test', () => {
 	});
 
 	test('no files --allow-empty-input="false"', async () => {
-		const targetFilePath = path.resolve(__dirname, '../../../../test/xxx/*');
+		const targetFilePath = path.resolve(import.meta.dirname, '../../../../test/xxx/*');
 		const { exitCode } = await execa(entryFilePath, ['--allow-empty-input="false"', escape(targetFilePath)], {
 			reject: false,
 		});
@@ -147,7 +144,7 @@ describe('STDOUT Test', () => {
 	});
 
 	test('no files --no-allow-empty-input', async () => {
-		const targetFilePath = path.resolve(__dirname, '../../../../test/xxx/*');
+		const targetFilePath = path.resolve(import.meta.dirname, '../../../../test/xxx/*');
 		const { exitCode } = await execa(entryFilePath, ['--no-allow-empty-input', escape(targetFilePath)], {
 			reject: false,
 		});
@@ -155,7 +152,7 @@ describe('STDOUT Test', () => {
 	});
 
 	test('--severity-parse-error (no specified)', async () => {
-		const targetFilePath = path.resolve(__dirname, '../../../../test/fixture/pug/004.pug');
+		const targetFilePath = path.resolve(import.meta.dirname, '../../../../test/fixture/pug/004.pug');
 		const { exitCode } = await execa(entryFilePath, [escape(targetFilePath)], {
 			reject: false,
 		});
@@ -163,7 +160,7 @@ describe('STDOUT Test', () => {
 	});
 
 	test('--severity-parse-error error', async () => {
-		const targetFilePath = path.resolve(__dirname, '../../../../test/fixture/pug/004.pug');
+		const targetFilePath = path.resolve(import.meta.dirname, '../../../../test/fixture/pug/004.pug');
 		const { exitCode } = await execa(entryFilePath, ['--severity-parse-error', 'error', escape(targetFilePath)], {
 			reject: false,
 		});
@@ -171,7 +168,7 @@ describe('STDOUT Test', () => {
 	});
 
 	test('--severity-parse-error warning', async () => {
-		const targetFilePath = path.resolve(__dirname, '../../../../test/fixture/pug/004.pug');
+		const targetFilePath = path.resolve(import.meta.dirname, '../../../../test/fixture/pug/004.pug');
 		const { exitCode } = await execa(entryFilePath, ['--severity-parse-error', 'warning', escape(targetFilePath)], {
 			reject: false,
 		});
@@ -179,7 +176,7 @@ describe('STDOUT Test', () => {
 	});
 
 	test('--severity-parse-error off', async () => {
-		const targetFilePath = path.resolve(__dirname, '../../../../test/fixture/pug/004.pug');
+		const targetFilePath = path.resolve(import.meta.dirname, '../../../../test/fixture/pug/004.pug');
 		const { exitCode } = await execa(entryFilePath, ['--severity-parse-error', 'off', escape(targetFilePath)], {
 			reject: false,
 		});
@@ -187,7 +184,7 @@ describe('STDOUT Test', () => {
 	});
 
 	test('--max-count with 002.html', async () => {
-		const targetFilePath = path.resolve(__dirname, '../../../../test/fixture/002.html');
+		const targetFilePath = path.resolve(import.meta.dirname, '../../../../test/fixture/002.html');
 
 		// First, get the full number of violations
 		const { stderr: fullStderr } = await execa(entryFilePath, ['--no-color', escape(targetFilePath)], {
@@ -212,7 +209,7 @@ describe('STDOUT Test', () => {
 	});
 
 	test('--max-count=1', async () => {
-		const targetFilePath = path.resolve(__dirname, '../../../../test/fixture/002.html');
+		const targetFilePath = path.resolve(import.meta.dirname, '../../../../test/fixture/002.html');
 		const { stderr, exitCode } = await execa(
 			entryFilePath,
 			['--no-color', '--max-count=1', escape(targetFilePath)],
@@ -228,7 +225,7 @@ describe('STDOUT Test', () => {
 	});
 
 	test('--max-count=0 (no limit)', async () => {
-		const targetFilePath = path.resolve(__dirname, '../../../../test/fixture/002.html');
+		const targetFilePath = path.resolve(import.meta.dirname, '../../../../test/fixture/002.html');
 
 		// Get violations without limit
 		const { stderr: noLimitStderr } = await execa(entryFilePath, ['--no-color', escape(targetFilePath)], {
@@ -256,7 +253,7 @@ describe('STDOUT Test', () => {
 	});
 
 	test('--max-count with JSON format', async () => {
-		const targetFilePath = path.resolve(__dirname, '../../../../test/fixture/002.html');
+		const targetFilePath = path.resolve(import.meta.dirname, '../../../../test/fixture/002.html');
 
 		// Test with JSON format and limit
 		const { stdout } = await execa(entryFilePath, ['--format=json', '--max-count=2', escape(targetFilePath)], {
@@ -270,9 +267,9 @@ describe('STDOUT Test', () => {
 
 	test('--max-count with multiple files shows skipped status', async () => {
 		const targetFiles = [
-			path.resolve(__dirname, '../../../../test/fixture/001.html'), // No violations
-			path.resolve(__dirname, '../../../../test/fixture/002.html'), // Has violations
-			path.resolve(__dirname, '../../../../test/fixture/003.html'), // Should be skipped
+			path.resolve(import.meta.dirname, '../../../../test/fixture/001.html'), // No violations
+			path.resolve(import.meta.dirname, '../../../../test/fixture/002.html'), // Has violations
+			path.resolve(import.meta.dirname, '../../../../test/fixture/003.html'), // Should be skipped
 		];
 
 		const { stdout } = await execa(
@@ -291,11 +288,11 @@ describe('STDOUT Test', () => {
 
 describe('Issues', () => {
 	test('#1042', async () => {
-		const originFilePath = path.resolve(__dirname, '../../test/fix/origin.html');
-		const fixedFilePath = path.resolve(__dirname, '../../test/fix/fixed.html');
+		const originFilePath = path.resolve(import.meta.dirname, '../../test/fix/origin.html');
+		const fixedFilePath = path.resolve(import.meta.dirname, '../../test/fix/fixed.html');
 		const originContent = await readFile(originFilePath, { encoding: 'utf8' });
 
-		const configFilePath = path.resolve(__dirname, '../../test/fix/fix-test.markuplintrc');
+		const configFilePath = path.resolve(import.meta.dirname, '../../test/fix/fix-test.markuplintrc');
 		await execa(
 			entryFilePath,
 			['--fix', escape(fixedFilePath), '--config', escape(configFilePath), '--no-search-config'],
@@ -309,8 +306,8 @@ describe('Issues', () => {
 	});
 
 	test('#1824-1', async () => {
-		const filePath = path.resolve(__dirname, '../../test/issue1824/index.html');
-		const config1 = path.resolve(__dirname, '../../test/issue1824/config1.json');
+		const filePath = path.resolve(import.meta.dirname, '../../test/issue1824/index.html');
+		const config1 = path.resolve(import.meta.dirname, '../../test/issue1824/config1.json');
 
 		const { stdout, stderr } = await execa(
 			entryFilePath,
@@ -327,7 +324,7 @@ describe('Issues', () => {
 				severity: 'warning',
 				line: 1,
 				col: 1,
-				message: `Plugin not found: ${path.resolve(__dirname, '../../test/issue1824/no-exist-plugin.js')}`,
+				message: `Plugin not found: ${path.resolve(import.meta.dirname, '../../test/issue1824/no-exist-plugin.js')}`,
 				raw: '',
 			},
 		]);
@@ -335,8 +332,8 @@ describe('Issues', () => {
 	});
 
 	test('#1824-2', async () => {
-		const filePath = path.resolve(__dirname, '../../test/issue1824/index.html');
-		const config2 = path.resolve(__dirname, '../../test/issue1824/config2.json');
+		const filePath = path.resolve(import.meta.dirname, '../../test/issue1824/index.html');
+		const config2 = path.resolve(import.meta.dirname, '../../test/issue1824/config2.json');
 
 		const { stdout, stderr } = await execa(
 			entryFilePath,
@@ -363,7 +360,7 @@ describe('Issues', () => {
 
 describe('--max-warnings option', () => {
 	test('--max-warnings=-1 (default) does not limit warnings', async () => {
-		const targetFilePath = path.resolve(__dirname, '../../../../test/fixture/002.html');
+		const targetFilePath = path.resolve(import.meta.dirname, '../../../../test/fixture/002.html');
 
 		const { exitCode } = await execa(entryFilePath, [escape(targetFilePath)], {
 			reject: false,
@@ -374,7 +371,7 @@ describe('--max-warnings option', () => {
 	});
 
 	test('--max-warnings=0 exits with code 1 when warnings exist', async () => {
-		const targetFilePath = path.resolve(__dirname, '../../../../test/fixture/002.html');
+		const targetFilePath = path.resolve(import.meta.dirname, '../../../../test/fixture/002.html');
 
 		const { exitCode, stderr } = await execa(entryFilePath, ['--max-warnings=0', escape(targetFilePath)], {
 			reject: false,
@@ -386,7 +383,7 @@ describe('--max-warnings option', () => {
 
 	test('--max-warnings=5 allows warnings up to limit', async () => {
 		// Use existing fixture file that has 6 warnings
-		const targetFilePath = path.resolve(__dirname, '../../../../test/fixture/002.html');
+		const targetFilePath = path.resolve(import.meta.dirname, '../../../../test/fixture/002.html');
 
 		// With limit 10, should exit with code 0 (6 warnings < 10)
 		const { exitCode: exitCode10 } = await execa(
@@ -409,8 +406,8 @@ describe('--max-warnings option', () => {
 		// Use files with only warnings:
 		// 001.html: 0 warnings, 002.html: 6 warnings = 6 total
 		const targetFiles = [
-			path.resolve(__dirname, '../../../../test/fixture/001.html'),
-			path.resolve(__dirname, '../../../../test/fixture/002.html'),
+			path.resolve(import.meta.dirname, '../../../../test/fixture/001.html'),
+			path.resolve(import.meta.dirname, '../../../../test/fixture/002.html'),
 		];
 
 		// With limit 10, should exit with code 0 (6 warnings < 10)
@@ -432,7 +429,7 @@ describe('--max-warnings option', () => {
 
 	test('--max-warnings with warnings-only file still returns exit code 0', async () => {
 		// Use a file that has warnings only (allowWarnings defaults to true)
-		const targetFilePath = path.resolve(__dirname, '../../../../test/fixture/002.html');
+		const targetFilePath = path.resolve(import.meta.dirname, '../../../../test/fixture/002.html');
 
 		const { exitCode } = await execa(entryFilePath, ['--max-warnings=100', escape(targetFilePath)], {
 			reject: false,
@@ -445,8 +442,8 @@ describe('--max-warnings option', () => {
 
 describe('--fix-dry-run', () => {
 	test('produces diff output for fixable file without modifying it', async () => {
-		const targetFilePath = path.resolve(__dirname, '../../test/fix/dry-run-target.html');
-		const configFilePath = path.resolve(__dirname, '../../test/fix/dry-run-config.json');
+		const targetFilePath = path.resolve(import.meta.dirname, '../../test/fix/dry-run-target.html');
+		const configFilePath = path.resolve(import.meta.dirname, '../../test/fix/dry-run-config.json');
 
 		const originalContent = await readFile(targetFilePath, { encoding: 'utf8' });
 
@@ -474,7 +471,7 @@ describe('--fix-dry-run', () => {
 	});
 
 	test('produces no diff output for file without fixable issues', async () => {
-		const targetFilePath = path.resolve(__dirname, '../../../../test/fixture/001.html');
+		const targetFilePath = path.resolve(import.meta.dirname, '../../../../test/fixture/001.html');
 
 		const { stdout } = await execa(entryFilePath, ['--fix-dry-run', '--no-color', escape(targetFilePath)], {
 			reject: false,
@@ -486,8 +483,8 @@ describe('--fix-dry-run', () => {
 	});
 
 	test('--fix and --fix-dry-run combined: dry-run takes precedence', async () => {
-		const targetFilePath = path.resolve(__dirname, '../../test/fix/dry-run-target.html');
-		const configFilePath = path.resolve(__dirname, '../../test/fix/dry-run-config.json');
+		const targetFilePath = path.resolve(import.meta.dirname, '../../test/fix/dry-run-target.html');
+		const configFilePath = path.resolve(import.meta.dirname, '../../test/fix/dry-run-config.json');
 
 		const originalContent = await readFile(targetFilePath, { encoding: 'utf8' });
 


### PR DESCRIPTION
## Summary

- Convert 32 TypeScript `private` methods across 12 files to ES private fields (`#`) — aligning with the 100+ existing `#` fields in the codebase
- Replace `fileURLToPath(import.meta.url)` workarounds with `import.meta.dirname` / `import.meta.filename` direct references across 9 files
- Replace 3 `for...in` loops with `Object.keys()` to avoid inherited property iteration

## Details

### ES Private Fields (`#`)
Packages converted (dependency order): `@markuplint/types`, `@markuplint/selector`, `@markuplint/ml-core`, `@markuplint/file-resolver`, `@markuplint/markdown-parser`, `markuplint`

Notable adjustments:
- `MLFile._stat()` → `#loadStat()` (renamed to avoid collision with existing `#stat` field)
- `MLEngine.i18n()` removed (dead code exposed by `no-unused-private-class-members` ESLint rule after `private` → `#` conversion)

### `import.meta.dirname`
Eliminated all `__dirname` / `__filename` intermediate variables. All 9 files now use `import.meta.dirname` directly at call sites. Removed unused `fileURLToPath` imports.

### `for...in` → `Object.keys()`
- `@markuplint/ml-config`: `deleteUndefProp()`
- `@markuplint/ml-spec`: `getAttrSpecs()` (2 loops)

## Test plan

- [x] `yarn build` — 40 projects successful
- [x] `yarn test` — 169 test files, 2636 tests passed
- [x] `yarn lint` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)