### PR TITLE
feat(rules): support event name array for no-use-event-handler-attr

### DIFF
--- a/packages/@markuplint/rules/src/no-use-event-handler-attr/README.ja.md
+++ b/packages/@markuplint/rules/src/no-use-event-handler-attr/README.ja.md
@@ -24,4 +24,68 @@ description: イベントハンドラ属性を指定すると警告します。
 </script>
 ```
 
+## 詳細
+
+### 設定値
+
+型: `boolean` | `string[]`
+
+- `true`（デフォルト）: すべてのイベントハンドラ属性を禁止します。
+- `string[]`: 指定したイベントのみ禁止します。リストにないイベントハンドラは許可されます。イベント名は `on` プレフィックスなしの小文字で指定します（例: `"onclick"` ではなく `"click"`）。正規表現パターン（例: `/^mouse/`）も使用できます。
+
+```json class=config
+{
+  "rules": {
+    "no-use-event-handler-attr": true
+  }
+}
+```
+
+特定のイベントのみ禁止する場合:
+
+```json class=config
+{
+  "rules": {
+    "no-use-event-handler-attr": ["click"]
+  }
+}
+```
+
+```json class=config
+{
+  "rules": {
+    "no-use-event-handler-attr": ["click", "mousedown"]
+  }
+}
+```
+
+正規表現パターンを使用する場合:
+
+```json class=config
+{
+  "rules": {
+    "no-use-event-handler-attr": ["/^mouse/"]
+  }
+}
+```
+
+### `ignore` オプション
+
+`ignore` オプションは**属性名**（`on` プレフィックス付き、例: `"onclick"`）で特定の属性を除外します。`value` より先に評価されます。文字列および正規表現パターンを受け付けます。
+
+```json class=config
+{
+  "rules": {
+    "no-use-event-handler-attr": {
+      "value": ["click", "mousedown"],
+      "options": {
+        "ignore": "onclick"
+      }
+    }
+  }
+}
+```
+
+上記の例では `onclick` が `ignore` で除外されるため、`onmousedown` のみ報告されます。
+
 <!-- textlint-enable ja-technical-writing/ja-no-mixed-period -->

--- a/packages/@markuplint/rules/src/no-use-event-handler-attr/README.md
+++ b/packages/@markuplint/rules/src/no-use-event-handler-attr/README.md
@@ -22,3 +22,67 @@ Warn when specifying the event handler attribute.
   document.getElementById('foo').addEventListener('click', () => doSomething());
 </script>
 ```
+
+## Details
+
+### Setting value
+
+Type: `boolean` | `string[]`
+
+- `true` (default): Disallow all event handler attributes.
+- `string[]`: Disallow only the specified events. Event handlers not listed will be allowed. Event names should be lowercase without the `on` prefix (e.g. `"click"`, not `"onclick"`). A regex pattern (e.g. `/^mouse/`) is also accepted.
+
+```json class=config
+{
+  "rules": {
+    "no-use-event-handler-attr": true
+  }
+}
+```
+
+To disallow only specific events:
+
+```json class=config
+{
+  "rules": {
+    "no-use-event-handler-attr": ["click"]
+  }
+}
+```
+
+```json class=config
+{
+  "rules": {
+    "no-use-event-handler-attr": ["click", "mousedown"]
+  }
+}
+```
+
+Using a regex pattern:
+
+```json class=config
+{
+  "rules": {
+    "no-use-event-handler-attr": ["/^mouse/"]
+  }
+}
+```
+
+### `ignore` option
+
+The `ignore` option excludes specific attributes by their **full attribute name** (with the `on` prefix, e.g. `"onclick"`). It is evaluated before the `value` filter. Both a plain string and a regex pattern are accepted.
+
+```json class=config
+{
+  "rules": {
+    "no-use-event-handler-attr": {
+      "value": ["click", "mousedown"],
+      "options": {
+        "ignore": "onclick"
+      }
+    }
+  }
+}
+```
+
+In the example above, `onclick` is excluded by `ignore`, so only `onmousedown` is reported.

--- a/packages/@markuplint/rules/src/no-use-event-handler-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/no-use-event-handler-attr/index.spec.ts
@@ -56,3 +56,161 @@ test('ignore by regex', async () => {
 	});
 	expect(violations).toStrictEqual([]);
 });
+
+test('value: ["click"] reports only click', async () => {
+	const { violations } = await mlRuleTest(rule, '<div onclick="fn()" onmouseover="fn()"></div>', {
+		rule: { value: ['click'] },
+	});
+	expect(violations).toStrictEqual([
+		{
+			severity: 'warning',
+			line: 1,
+			col: 6,
+			raw: 'onclick="fn()"',
+			message: 'The "onclick" attribute is disallowed',
+		},
+	]);
+});
+
+test('value: ["click", "keydown"] reports matching events', async () => {
+	const { violations } = await mlRuleTest(rule, '<div onclick="fn()" onkeydown="fn()" onmouseover="fn()"></div>', {
+		rule: { value: ['click', 'keydown'] },
+	});
+	expect(violations).toStrictEqual([
+		{
+			severity: 'warning',
+			line: 1,
+			col: 6,
+			raw: 'onclick="fn()"',
+			message: 'The "onclick" attribute is disallowed',
+		},
+		{
+			severity: 'warning',
+			line: 1,
+			col: 21,
+			raw: 'onkeydown="fn()"',
+			message: 'The "onkeydown" attribute is disallowed',
+		},
+	]);
+});
+
+test('value: ["Click"] is case-insensitive', async () => {
+	const { violations } = await mlRuleTest(rule, '<div onclick="fn()"></div>', { rule: { value: ['Click'] } });
+	expect(violations).toStrictEqual([
+		{
+			severity: 'warning',
+			line: 1,
+			col: 6,
+			raw: 'onclick="fn()"',
+			message: 'The "onclick" attribute is disallowed',
+		},
+	]);
+});
+
+test('value: ["/^mouse/"] regex pattern', async () => {
+	const { violations } = await mlRuleTest(rule, '<div onclick="fn()" onmousedown="fn()" onmouseover="fn()"></div>', {
+		rule: { value: ['/^mouse/'] },
+	});
+	expect(violations).toStrictEqual([
+		{
+			severity: 'warning',
+			line: 1,
+			col: 21,
+			raw: 'onmousedown="fn()"',
+			message: 'The "onmousedown" attribute is disallowed',
+		},
+		{
+			severity: 'warning',
+			line: 1,
+			col: 40,
+			raw: 'onmouseover="fn()"',
+			message: 'The "onmouseover" attribute is disallowed',
+		},
+	]);
+});
+
+test('value: ["click"] with ignore: "onclick" — ignore takes priority', async () => {
+	const { violations } = await mlRuleTest(rule, '<div onclick="fn()" onmousedown="fn()"></div>', {
+		rule: { value: ['click', 'mousedown'], options: { ignore: 'onclick' } },
+	});
+	expect(violations).toStrictEqual([
+		{
+			severity: 'warning',
+			line: 1,
+			col: 21,
+			raw: 'onmousedown="fn()"',
+			message: 'The "onmousedown" attribute is disallowed',
+		},
+	]);
+});
+
+test('value: ["click"] with JSX onClick', async () => {
+	const { violations } = await mlRuleTest(rule, '<div onClick={fn}></div>', {
+		rule: { value: ['click'] },
+		parser: { '.*': '@markuplint/jsx-parser' },
+	});
+	expect(violations).toStrictEqual([
+		{
+			severity: 'warning',
+			line: 1,
+			col: 6,
+			raw: 'onClick={fn}',
+			message: 'The "onClick" attribute is disallowed',
+		},
+	]);
+});
+
+test('value: ["mousedown"] does not report JSX onClick', async () => {
+	const { violations } = await mlRuleTest(rule, '<div onClick={fn}></div>', {
+		rule: { value: ['mousedown'] },
+		parser: { '.*': '@markuplint/jsx-parser' },
+	});
+	expect(violations).toStrictEqual([]);
+});
+
+test('non-event attributes are not affected', async () => {
+	const { violations } = await mlRuleTest(rule, '<div class="foo" id="bar"></div>', { rule: { value: ['click'] } });
+	expect(violations).toStrictEqual([]);
+});
+
+test('value: false disables the rule', async () => {
+	const { violations } = await mlRuleTest(rule, '<div onclick="fn()"></div>', { rule: { value: false } });
+	expect(violations).toStrictEqual([]);
+});
+
+test('"on" attribute alone is not treated as an event handler', async () => {
+	const { violations } = await mlRuleTest(rule, '<div on="handler"></div>');
+	expect(violations).toStrictEqual([]);
+});
+
+test('value: ["click"] with Vue @click', async () => {
+	const { violations } = await mlRuleTest(rule, '<template><div @click="fn()"></div></template>', {
+		rule: { value: ['click'] },
+		parser: { '.*': '@markuplint/vue-parser' },
+		specs: { '.*': '@markuplint/vue-spec' },
+	});
+	expect(violations).toStrictEqual([
+		{
+			severity: 'warning',
+			line: 1,
+			col: 16,
+			raw: '@click="fn()"',
+			message: 'The "onclick" attribute is disallowed',
+		},
+	]);
+});
+
+test('value: ["click"] with regex ignore — ignore takes priority', async () => {
+	const { violations } = await mlRuleTest(rule, '<div onclick="fn()" onmousedown="fn()"></div>', {
+		rule: { value: ['click', 'mousedown'], options: { ignore: '/^onclick$/' } },
+	});
+	expect(violations).toStrictEqual([
+		{
+			severity: 'warning',
+			line: 1,
+			col: 21,
+			raw: 'onmousedown="fn()"',
+			message: 'The "onmousedown" attribute is disallowed',
+		},
+	]);
+});

--- a/packages/@markuplint/rules/src/no-use-event-handler-attr/index.ts
+++ b/packages/@markuplint/rules/src/no-use-event-handler-attr/index.ts
@@ -11,14 +11,38 @@ type Options = {
 };
 
 /**
+ * Extracts the event name from an attribute name by stripping the `on` prefix
+ * and lowercasing. Returns `null` if the attribute is not an event handler.
+ */
+function extractEventName(attrName: string): string | null {
+	const m = /^on(.+)/i.exec(attrName);
+	return m?.[1] ? m[1].toLowerCase() : null;
+}
+
+/**
+ * Tests whether an event name matches a pattern. The pattern is either a plain
+ * string (compared case-insensitively) or a regex literal (`/pattern/flags`).
+ */
+function matchEventName(eventName: string, pattern: string): boolean {
+	const regexMatch = /^\/(.*)\/([gim])*$/.exec(pattern);
+	if (regexMatch?.[1]) {
+		return new RegExp(regexMatch[1], regexMatch[2]).test(eventName);
+	}
+	return eventName === pattern.toLowerCase();
+}
+
+/**
  * Rule that disallows inline event handler attributes (e.g., `onclick`,
  * `onchange`).
  *
  * Reports any attribute on an HTML element whose name starts with `on`,
  * indicating an inline event handler. An `ignore` option allows specific
  * attribute names or patterns to be excluded from the check.
+ *
+ * The value can be `true` (disallow all event handlers) or a `string[]`
+ * of event names (without the `on` prefix) to selectively disallow.
  */
-export default createRule<boolean, Options>({
+export default createRule<boolean | readonly string[], Options>({
 	meta: meta,
 	defaultSeverity: 'warning',
 	defaultOptions: {},
@@ -42,7 +66,14 @@ export default createRule<boolean, Options>({
 				}
 			}
 
-			if (/^on/i.test(name)) {
+			const eventName = extractEventName(name);
+			if (eventName == null) {
+				return;
+			}
+
+			const { value } = attr.rule;
+
+			if (value === true) {
 				report({
 					scope: attr,
 					raw: attr.raw,
@@ -50,6 +81,22 @@ export default createRule<boolean, Options>({
 					col: attr.startCol,
 					message: t('{0} is disallowed', t('the "{0*}" {1}', name, 'attribute')),
 				});
+				return;
+			}
+
+			if (Array.isArray(value)) {
+				for (const pattern of value) {
+					if (matchEventName(eventName, pattern)) {
+						report({
+							scope: attr,
+							raw: attr.raw,
+							line: attr.startLine,
+							col: attr.startCol,
+							message: t('{0} is disallowed', t('the "{0*}" {1}', name, 'attribute')),
+						});
+						return;
+					}
+				}
 			}
 		});
 	},

--- a/packages/@markuplint/rules/src/no-use-event-handler-attr/schema.json
+++ b/packages/@markuplint/rules/src/no-use-event-handler-attr/schema.json
@@ -2,7 +2,22 @@
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"definitions": {
 		"value": {
-			"type": "boolean"
+			"oneOf": [
+				{
+					"type": "boolean"
+				},
+				{
+					"type": "array",
+					"uniqueItems": true,
+					"minItems": 1,
+					"items": {
+						"type": "string",
+						"minLength": 1
+					}
+				}
+			],
+			"description": "Set to true to disallow all event handler attributes, or specify an array of event names (without the 'on' prefix) to selectively disallow.",
+			"description:ja": "trueですべてのイベントハンドラ属性を禁止、またはイベント名の配列（onプレフィックスなし）で選択的に禁止します。"
 		},
 		"options": {
 			"type": "object",


### PR DESCRIPTION
## Summary

- Extend `no-use-event-handler-attr` rule's `value` from `boolean` to `boolean | string[]`
- When `string[]` is specified, only the listed events are disallowed (e.g. `["click", "mousedown"]`)
- Event names are specified without the `on` prefix, in lowercase; regex patterns (e.g. `/^mouse/`) are also supported
- The `ignore` option (full attribute name) is evaluated before the `value` filter

Closes #394

## Changes

- `schema.json`: value definition expanded to `oneOf: [boolean, string[]]` with description
- `index.ts`: added `extractEventName()` / `matchEventName()` helpers; verify flow updated for selective disallow
- `index.spec.ts`: 12 new tests added (4 → 16 total), covering string array, case-insensitivity, regex, ignore interaction, JSX, Vue, edge cases
- `README.md` / `README.ja.md`: Setting value section + ignore option documentation

## Test plan

- [x] `yarn lint-check` — 0 errors, 0 warnings
- [x] `yarn build` — all 40 packages pass
- [x] `yarn test` — all 2648 tests pass (169 files)
- [x] `npx vitest run packages/@markuplint/rules/src/no-use-event-handler-attr/` — 16/16 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)