### PR TITLE
feat: display specConformance and unify reason separator

### DIFF
--- a/packages/@markuplint/cli-utils/src/message-to-string.spec.ts
+++ b/packages/@markuplint/cli-utils/src/message-to-string.spec.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+
+import { messageToString } from './message-to-string.js';
+
+describe('messageToString', () => {
+	it('returns message only', () => {
+		expect(messageToString('error')).toBe('error');
+	});
+
+	it('includes specConformance tag', () => {
+		expect(messageToString('error', 'normative')).toBe('error [normative]');
+	});
+
+	it('includes reason', () => {
+		expect(messageToString('error', undefined, 'detail')).toBe('error / detail');
+	});
+
+	it('includes both specConformance and reason', () => {
+		expect(messageToString('error', 'non-normative', 'detail')).toBe('error [non-normative] / detail');
+	});
+});

--- a/packages/@markuplint/cli-utils/src/message-to-string.ts
+++ b/packages/@markuplint/cli-utils/src/message-to-string.ts
@@ -1,14 +1,19 @@
 /**
- * Combines a lint violation message with an optional reason string.
- * When a reason is provided, it is appended after a " / " separator.
+ * Combines a lint violation message with an optional specConformance tag
+ * and reason string.
  *
  * @param message - The primary violation message
+ * @param specConformance - An optional conformance level (e.g. "normative")
  * @param reason - An optional supplementary reason or detail to append
  * @returns The combined message string
  */
-export function messageToString(message: string, reason?: string) {
-	if (!reason) {
-		return message;
+export function messageToString(message: string, specConformance?: string, reason?: string) {
+	let result = message;
+	if (specConformance) {
+		result += ` [${specConformance}]`;
 	}
-	return `${message} / ${reason}`;
+	if (reason) {
+		result += ` / ${reason}`;
+	}
+	return result;
 }

--- a/packages/markuplint/src/reporter/github-reporter.spec.ts
+++ b/packages/markuplint/src/reporter/github-reporter.spec.ts
@@ -88,6 +88,49 @@ describe('githubReporter', () => {
 		]);
 	});
 
+	it('includes specConformance tag when present', () => {
+		const result = githubReporter({
+			filePath: '/path/to/file.html',
+			fixedCode: '',
+			sourceCode: '',
+			violations: [
+				{
+					severity: 'error',
+					message: 'Not allowed here',
+					reason: 'content model violation',
+					specConformance: 'normative',
+					line: 1,
+					col: 1,
+					raw: '<div>',
+					ruleId: 'permitted-contents',
+					name: 'html-standard/permitted-contents',
+				},
+			],
+		});
+		expect(result).toEqual([
+			'::error file=/path/to/file.html,line=1,col=1::Not allowed here [normative] / content model violation (html-standard/permitted-contents)',
+		]);
+	});
+
+	it('omits specConformance tag when absent', () => {
+		const result = githubReporter({
+			filePath: '/path/to/file.html',
+			fixedCode: '',
+			sourceCode: '',
+			violations: [
+				{
+					severity: 'warning',
+					message: 'Some issue',
+					line: 1,
+					col: 1,
+					raw: '<div>',
+					ruleId: 'some-rule',
+				},
+			],
+		});
+		expect(result).toEqual(['::warning file=/path/to/file.html,line=1,col=1::Some issue (some-rule)']);
+	});
+
 	it('falls back to ruleId when violation.name is undefined', () => {
 		const result = githubReporter({
 			filePath: '/path/to/file.html',

--- a/packages/markuplint/src/reporter/github-reporter.ts
+++ b/packages/markuplint/src/reporter/github-reporter.ts
@@ -17,7 +17,7 @@ export function githubReporter(results: MLResultInfo) {
 
 	for (const violation of results.violations) {
 		const command = severityToCommand(violation.severity);
-		const meg = messageToString(violation.message, violation.reason);
+		const meg = messageToString(violation.message, violation.specConformance, violation.reason);
 		out.push(
 			`::${command} file=${results.filePath},line=${violation.line},col=${violation.col}::${meg} (${violation.name ?? violation.ruleId})`,
 		);

--- a/packages/markuplint/src/reporter/simple-reporter.ts
+++ b/packages/markuplint/src/reporter/simple-reporter.ts
@@ -28,7 +28,7 @@ export function simpleReporter(results: MLResultInfo, options: CLIOptions) {
 	for (const violation of results.violations) {
 		sizes.line = Math.max(sizes.line, violation.line.toString(10).length);
 		sizes.col = Math.max(sizes.col, violation.col.toString(10).length);
-		const meg = messageToString(violation.message, violation.reason);
+		const meg = messageToString(violation.message, violation.specConformance, violation.reason);
 		sizes.meg = Math.max(sizes.meg, getWidth(meg));
 	}
 
@@ -38,7 +38,7 @@ export function simpleReporter(results: MLResultInfo, options: CLIOptions) {
 		out.push(`<${commandName}> ${font.underline(results.filePath)}: ${loggerError('✗')}`);
 		for (const violation of results.violations) {
 			const s = violation.severity === 'error' ? loggerError('✖') : loggerWarning('⚠️');
-			const meg = messageToString(violation.message, violation.reason);
+			const meg = messageToString(violation.message, violation.specConformance, violation.reason);
 			out.push(
 				`  ${font.cyan(
 					`${pad(violation.line, sizes.line, true)}:${pad(violation.col, sizes.col)}`,

--- a/packages/markuplint/src/reporter/standard-reporter.ts
+++ b/packages/markuplint/src/reporter/standard-reporter.ts
@@ -29,7 +29,7 @@ export function standardReporter(results: MLResultInfo, options: CLIOptions) {
 	for (const violation of results.violations) {
 		sizes.line = Math.max(sizes.line, violation.line.toString(10).length);
 		sizes.col = Math.max(sizes.col, violation.col.toString(10).length);
-		const meg = messageToString(violation.message, violation.reason);
+		const meg = messageToString(violation.message, violation.specConformance, violation.reason);
 		sizes.meg = Math.max(sizes.meg, getWidth(meg));
 	}
 
@@ -39,7 +39,7 @@ export function standardReporter(results: MLResultInfo, options: CLIOptions) {
 		const lines = results.sourceCode.split(/\r?\n/);
 		for (const violation of results.violations) {
 			const logger = violation.severity === 'error' ? loggerError : loggerWarning;
-			const meg = messageToString(violation.message, violation.reason);
+			const meg = messageToString(violation.message, violation.specConformance, violation.reason);
 			const startLine = violation.line - 1;
 
 			// Main message

--- a/vscode/src/server/convert-diagnostics.spec.ts
+++ b/vscode/src/server/convert-diagnostics.spec.ts
@@ -29,6 +29,82 @@ describe('convertDiagnostics', () => {
 		expect(diagnostics[1]!.data).toEqual({ violationIndex: 1 });
 	});
 
+	test('formats message with specConformance and unified separator', () => {
+		const result = {
+			filePath: '/test.html',
+			sourceCode: '<div></div>',
+			violations: [
+				{
+					ruleId: 'permitted-contents',
+					severity: 'error' as const,
+					message: 'Not allowed here',
+					reason: 'content model violation',
+					specConformance: 'normative' as const,
+					line: 1,
+					col: 1,
+					raw: '<div>',
+				},
+			],
+			fixedCode: '<div></div>',
+			status: 'processed' as const,
+		};
+
+		const diagnostics = convertDiagnostics(result);
+		expect(diagnostics[0]!.message).toBe('Not allowed here [normative] / content model violation');
+		expect(diagnostics[0]!.code).toBe('permitted-contents');
+	});
+
+	test('uses name as code and appends ruleId to message when name is present', () => {
+		const result = {
+			filePath: '/test.html',
+			sourceCode: '<div></div>',
+			violations: [
+				{
+					ruleId: 'permitted-contents',
+					name: 'html-standard/permitted-contents',
+					severity: 'error' as const,
+					message: 'Not allowed here',
+					reason: 'content model violation',
+					specConformance: 'normative' as const,
+					line: 1,
+					col: 1,
+					raw: '<div>',
+				},
+			],
+			fixedCode: '<div></div>',
+			status: 'processed' as const,
+		};
+
+		const diagnostics = convertDiagnostics(result);
+		expect(diagnostics[0]!.message).toBe(
+			'Not allowed here [normative] / content model violation (permitted-contents)',
+		);
+		expect(diagnostics[0]!.code).toBe('html-standard/permitted-contents');
+	});
+
+	test('omits specConformance from message when absent', () => {
+		const result = {
+			filePath: '/test.html',
+			sourceCode: '<div></div>',
+			violations: [
+				{
+					ruleId: 'some-rule',
+					severity: 'warning' as const,
+					message: 'Some issue',
+					line: 1,
+					col: 1,
+					raw: '<div>',
+				},
+			],
+			fixedCode: '<div></div>',
+			status: 'processed' as const,
+		};
+
+		const diagnostics = convertDiagnostics(result);
+		expect(diagnostics[0]!.message).toBe('Some issue');
+		expect(diagnostics[0]!.code).toBe('some-rule');
+	});
+
 	test('returns empty array for null result', () => {
 		const diagnostics = convertDiagnostics(null);
 		expect(diagnostics).toHaveLength(0);

--- a/vscode/src/server/convert-diagnostics.ts
+++ b/vscode/src/server/convert-diagnostics.ts
@@ -41,9 +41,13 @@ export function convertDiagnostics(result: MLResultInfo | null) {
 					character: Math.max(violation.col + violation.raw.length - 1, 0),
 				},
 			},
-			message: violation.message + (violation.reason ? ' - ' + violation.reason : ''),
+			message:
+				violation.message +
+				(violation.specConformance ? ` [${violation.specConformance}]` : '') +
+				(violation.reason ? ' / ' + violation.reason : '') +
+				(violation.name ? ` (${violation.ruleId})` : ''),
 			source: NAME,
-			code: violation.ruleId,
+			code: violation.name ?? violation.ruleId,
 			codeDescription: {
 				href: `${WEBSITE_URL_RULE_PAGE}${violation.ruleId}`,
 			},


### PR DESCRIPTION
## Summary

- Update `messageToString` in `@markuplint/cli-utils` to accept an optional `specConformance` parameter, rendering it as a bracketed tag (e.g. `[normative]`) between the message and reason
- Pass `violation.specConformance` to `messageToString` in all three CLI reporters (standard, simple, github)
- Unify VS Code diagnostic message separator from ` - ` to ` / ` to match CLI format, display `[specConformance]` tag, use `violation.name` as the `code` field when available, and append `(ruleId)` to the message when a named group is present

## Test plan

- [x] `messageToString` unit tests (4 cases: message only, specConformance, reason, both)
- [x] `githubReporter` tests (specConformance present/absent)
- [x] `convertDiagnostics` tests (specConformance + unified separator, name/code field, absent case)
- [x] Full test suite passed (170 files, 2642 tests)
- [x] Lint passed (0 errors, 0 warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)