### PR TITLE
fix(rules): use forLegacyNode import for BCD to fix ERR_IMPORT_ATTRIBUTE_MISSING

### DIFF
--- a/packages/@markuplint/rules/src/no-unsupported-features/compat-data.spec.ts
+++ b/packages/@markuplint/rules/src/no-unsupported-features/compat-data.spec.ts
@@ -4,7 +4,14 @@ import { describe, test, expect } from 'vitest';
 
 import type { TargetBrowser } from './compat-data.js';
 
-import { checkSupport, isVersionSatisfied, parseVersion, toBcdBrowserId } from './compat-data.js';
+import {
+	checkAttributeSupport,
+	checkElementSupport,
+	checkSupport,
+	isVersionSatisfied,
+	parseVersion,
+	toBcdBrowserId,
+} from './compat-data.js';
 
 describe('parseVersion', () => {
 	test('normal version', () => {
@@ -159,5 +166,60 @@ describe('checkSupport', () => {
 			{ version_added: '40', prefix: 'webkit' },
 		];
 		expect(checkSupport(support, target)).toBeNull();
+	});
+});
+
+// These async tests load BCD data via `loadBcd()` internally.
+// NOTE: vitest intercepts dynamic imports, so these tests do NOT reproduce
+// the `ERR_IMPORT_ATTRIBUTE_MISSING` error that occurs with Node.js native
+// ESM loader on Node.js >= 22. The import path fix (`forLegacyNode`) is
+// validated by Node.js-level execution, not by vitest. These tests serve
+// as functional coverage for `checkElementSupport` / `checkAttributeSupport`.
+//
+// The `bcdPromise` cache (module-level `let`) is intentionally shared across
+// tests because BCD data is immutable — reloading ~70MB per test is wasteful.
+// Test execution order does not affect correctness.
+//
+// Assertion values depend on BCD data; if BCD updates change support versions,
+// these tests may need updating.
+describe('checkElementSupport', () => {
+	test('known element with old browser returns unsupported', async () => {
+		const targets: readonly TargetBrowser[] = [{ browser: 'chrome', version: '30', displayName: 'Chrome' }];
+		const results = await checkElementSupport('dialog', targets);
+		expect(results.length).toBe(1);
+		expect(results[0]?.browser).toBe('chrome');
+	});
+
+	test('common element returns empty array', async () => {
+		const targets: readonly TargetBrowser[] = [{ browser: 'chrome', version: '100', displayName: 'Chrome' }];
+		const results = await checkElementSupport('div', targets);
+		expect(results).toEqual([]);
+	});
+
+	test('unknown element returns empty array without crashing', async () => {
+		const targets: readonly TargetBrowser[] = [{ browser: 'chrome', version: '100', displayName: 'Chrome' }];
+		const results = await checkElementSupport('nonexistentelement', targets);
+		expect(results).toEqual([]);
+	});
+});
+
+describe('checkAttributeSupport', () => {
+	test('known attribute with old browser returns unsupported', async () => {
+		const targets: readonly TargetBrowser[] = [{ browser: 'chrome', version: '30', displayName: 'Chrome' }];
+		const results = await checkAttributeSupport('video', 'controlslist', targets);
+		expect(results.length).toBe(1);
+		expect(results[0]?.browser).toBe('chrome');
+	});
+
+	test('common attribute returns empty array', async () => {
+		const targets: readonly TargetBrowser[] = [{ browser: 'chrome', version: '100', displayName: 'Chrome' }];
+		const results = await checkAttributeSupport('input', 'type', targets);
+		expect(results).toEqual([]);
+	});
+
+	test('unknown attribute returns empty array without crashing', async () => {
+		const targets: readonly TargetBrowser[] = [{ browser: 'chrome', version: '100', displayName: 'Chrome' }];
+		const results = await checkAttributeSupport('div', 'data-unknown', targets);
+		expect(results).toEqual([]);
 	});
 });

--- a/packages/@markuplint/rules/src/no-unsupported-features/compat-data.ts
+++ b/packages/@markuplint/rules/src/no-unsupported-features/compat-data.ts
@@ -54,13 +54,25 @@ let bcdPromise: Promise<CompatData> | undefined;
  * at startup, even when this rule is disabled. Dynamic import defers the
  * cost until the rule actually runs.
  *
+ * Uses `forLegacyNode` to avoid `ERR_IMPORT_ATTRIBUTE_MISSING` on Node.js >= 22.
+ * The main entry (`@mdn/browser-compat-data`) points directly to `data.json`,
+ * which requires `import ... with { type: "json" }` on Node.js >= 22.
+ * The `forLegacyNode` wrapper uses `fs.readFileSync` instead, compatible
+ * with all Node.js versions.
+ *
+ * NOTE: If `forLegacyNode` is removed in a future BCD version, migrate to:
+ *   `import('...', { with: { type: 'json' } })`
+ * once the minimum supported Node.js version supports import attributes.
+ *
  * Uses a Promise-based cache to prevent race conditions when multiple
  * concurrent calls trigger the import simultaneously.
  */
 
 function loadBcd(): Promise<CompatData> {
 	if (!bcdPromise) {
-		bcdPromise = import('@mdn/browser-compat-data').then(mod => mod.default ?? mod);
+		// `?? mod` is a defensive fallback for CJS interop environments
+		// where `default` may not be set on the module namespace object.
+		bcdPromise = import('@mdn/browser-compat-data/forLegacyNode').then(mod => mod.default ?? mod);
 	}
 	return bcdPromise;
 }

--- a/packages/@markuplint/rules/src/no-unsupported-features/index.spec.ts
+++ b/packages/@markuplint/rules/src/no-unsupported-features/index.spec.ts
@@ -31,8 +31,7 @@ describe('browser support (BCD-based)', () => {
 	});
 
 	test('attribute not supported in old browsers', async () => {
-		// Use <dialog> + closedby which was added more recently in browsers
-		// The dialog element itself may also be unsupported, so we check attribute-specific violations
+		// <dialog> element and its "open" attribute are both unsupported in IE
 		const { violations } = await mlRuleTest(rule, '<dialog open></dialog>', {
 			rule: {
 				options: {
@@ -40,9 +39,12 @@ describe('browser support (BCD-based)', () => {
 				},
 			},
 		});
-		// At minimum, the dialog element is unsupported in IE
-		expect(violations.length).toBeGreaterThanOrEqual(1);
+		// 2 violations: one for the element, one for the attribute
+		expect(violations.length).toBe(2);
 		expect(violations[0]?.message).toContain('"dialog"');
+		expect(violations[0]?.message).toContain('element');
+		expect(violations[1]?.message).toContain('"open"');
+		expect(violations[1]?.message).toContain('attribute');
 	});
 
 	test('common attribute supported everywhere', async () => {
@@ -156,10 +158,9 @@ describe('checkExperimental', () => {
 				},
 			},
 		});
-		expect(violations.length).toBeGreaterThanOrEqual(1);
-		const experimentalViolation = violations.find(v => v.message.includes('experimental'));
-		expect(experimentalViolation).toBeDefined();
-		expect(experimentalViolation?.message).toContain('"credentialless"');
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.message).toContain('experimental');
+		expect(violations[0]?.message).toContain('"credentialless"');
 	});
 
 	test('works without browserslist config', async () => {
@@ -171,8 +172,8 @@ describe('checkExperimental', () => {
 				},
 			},
 		});
-		expect(violations.length).toBeGreaterThanOrEqual(1);
-		expect(violations.some(v => v.message.includes('experimental'))).toBe(true);
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.message).toContain('experimental');
 	});
 });
 


### PR DESCRIPTION
## Summary

- Fix `no-unsupported-features` rule crashing with `ERR_IMPORT_ATTRIBUTE_MISSING` on Node.js >= 22
- Switch BCD dynamic import from `@mdn/browser-compat-data` to `@mdn/browser-compat-data/forLegacyNode` (uses `fs.readFileSync` instead of JSON import attributes)
- Add unit tests for `checkElementSupport` and `checkAttributeSupport`
- Harden existing test assertions from loose (`toBeGreaterThanOrEqual`) to exact values

## Background

Node.js v22+ requires `{ with: { type: "json" } }` for JSON module imports. The main entry of `@mdn/browser-compat-data` v7 points directly to `data.json`, causing `ERR_IMPORT_ATTRIBUTE_MISSING` when the rule dynamically imports BCD data. The `forLegacyNode` wrapper uses `fs.readFileSync` and works on all Node.js versions.

Closes #3328

## Test plan

- [x] `npx vitest run packages/@markuplint/rules/src/no-unsupported-features/` — 59 tests passed
- [x] `yarn test` — 2660 tests passed
- [x] `yarn lint-check` — 0 errors, 0 warnings
- [x] `yarn build` — 40 projects built successfully
- [x] Verified `import('@mdn/browser-compat-data')` fails with `ERR_IMPORT_ATTRIBUTE_MISSING` on Node.js v24
- [x] Verified `import('@mdn/browser-compat-data/forLegacyNode')` works on Node.js v24

🤖 Generated with [Claude Code](https://claude.com/claude-code)