### PR TITLE
docs: migrate worktree instructions to git-wt

### DIFF
--- a/.claude/commands/git.md
+++ b/.claude/commands/git.md
@@ -12,7 +12,7 @@ git rev-parse --show-toplevel
 
 - If the result is the main repository path (e.g., ends with `/markuplint`), **STOP immediately**
 - Warn the user: "You are in the main working directory. Commits must be made in a worktree."
-- Do NOT proceed with any git operations — create or switch to a worktree first
+- Do NOT proceed with any git operations — use `git wt <branch-name> dev` to create a worktree first
 - Only continue if you are confirmed to be inside a worktree
 
 # Commit creation

--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -30,15 +30,15 @@ Follow these steps in order:
 1. Generate a branch name:
    - With Issue URL: `issue/<number>-<slug>` (slug from title, lowercase, hyphens, max 50 chars)
    - Without Issue URL: `fix/<short-description>` or `feat/<short-description>` as appropriate
-2. Check for existing worktrees: `git worktree list`
+2. Check for existing worktrees: `git wt`
    - If a worktree for this branch already exists, use it
-3. Worktree path: `../markuplint-worktree-<short-name>` (under the parent directory of the current repository)
+3. Worktree path: `../markuplint-wt/<branch-name>` (automatically determined by `wt.basedir`)
 4. Execute:
    ```bash
-   git worktree add ../markuplint-worktree-<short-name> -b <branch-name> dev
-   cd ../markuplint-worktree-<short-name>
-   yarn install && yarn build
+   git wt <branch-name> dev
+   cd ../markuplint-wt/<branch-name>
    ```
+   `wt.hook` により `yarn install` → `yarn build` が自動実行される
 5. **All subsequent work (analysis, edits, commits) MUST happen in the worktree**
 
 ## Step 3: Analyze the Problem

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,29 +80,40 @@ Each package has a `SKILL.md` with package-specific maintenance guidance.
 ## Worktree Usage (MANDATORY)
 
 **CRITICAL: Direct commits to `dev` are BLOCKED. All work requires a feature branch.**
-**CRITICAL: NEVER create a feature branch in the main working directory. ALWAYS use `git worktree`.**
+**CRITICAL: NEVER create a feature branch in the main working directory. ALWAYS use `git wt`.**
 
 The main working directory MUST stay on `dev` at all times. Any feature branch work — no matter how small (even a single-file docs change) — MUST be done in a worktree.
 
+Worktree operations use [`git-wt`](https://github.com/k1LoW/git-wt) (`git wt`). Worktrees are created under `../markuplint-wt/<branch-name>` (`wt.basedir` setting).
+
+### Setup
+
+If `git wt` is not available, install and configure it:
+
+```bash
+brew install k1LoW/tap/git-wt
+git config wt.basedir "../{gitroot}-wt"
+git config --add wt.hook "yarn install"
+git config --add wt.hook "yarn build"
+```
+
 ### Procedure
 
-1. **Check for existing worktrees first**: `git worktree list`
+1. **Check for existing worktrees first**: `git wt`
    - If the target branch already has a worktree, work there
 2. **Create a new worktree** for new branches:
    ```bash
-   git worktree add ../markuplint-worktree-<short-name> -b <branch-name> dev
+   git wt <branch-name> dev
    ```
-3. **Install and build** in the worktree before any work:
+   `wt.hook` により `yarn install` → `yarn build` が自動実行される
+3. **Move into the worktree**:
    ```bash
-   cd ../markuplint-worktree-<short-name>
-   yarn install
-   yarn build
+   cd ../markuplint-wt/<branch-name>
    ```
 4. **Do all edits, commits, and pushes** from within the worktree
 5. **Clean up** when done:
    ```bash
-   git worktree remove ../markuplint-worktree-<short-name>
-   git branch -D <branch-name>   # only if branch was merged
+   git wt -d <branch-name>   # worktree remove + branch delete in one step
    ```
 
 ### Important Notes


### PR DESCRIPTION
## Summary

- Migrate worktree operations from `git worktree` to [`git-wt`](https://github.com/k1LoW/git-wt) (`git wt`)
- Change path convention from `../markuplint-worktree-<short-name>` to `../markuplint-wt/<branch-name>`
- Add `wt.hook` config for automatic `yarn install` / `yarn build` on worktree creation
- Simplify cleanup to a single `git wt -d` command (replaces `git worktree remove` + `git branch -D`)

## Changed files

- `CLAUDE.md` — Rewrite Worktree Usage section for `git wt`, add Setup section
- `.claude/commands/issue.md` — Update Step 2 worktree creation instructions
- `.claude/commands/git.md` — Update Worktree Guard to reference `git wt`

## Test plan

- [x] `git wt` lists worktrees correctly
- [x] `git wt <branch> dev` creates worktree and runs hooks automatically
- [x] `git wt -d <branch>` deletes worktree and branch in one step
- [x] `yarn lint-check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)