### PR TITLE
chore: update sponsors and add /sponsors command

### DIFF
--- a/.claude/commands/sponsors.md
+++ b/.claude/commands/sponsors.md
@@ -1,0 +1,24 @@
+Check and update GitHub Sponsors listings.
+
+## Steps
+
+1. Fetch active sponsors and their tiers via GitHub GraphQL API:
+
+```bash
+gh api graphql -f query='{ organization(login: "markuplint") { sponsorshipsAsMaintainer(first: 100, activeOnly: true) { nodes { sponsorEntity { ... on User { login name avatarUrl } ... on Organization { login name avatarUrl } } tier { monthlyPriceInDollars name } } } } }'
+```
+
+2. Read current listings from these 4 files:
+   - `README.md` (root)
+   - `packages/markuplint/README.md`
+   - `website/community/index.mdx`
+   - `website/i18n/ja/docusaurus-plugin-content-docs-community/current/index.mdx`
+
+3. Show a diff report:
+   - New sponsors (not yet listed)
+   - Ended sponsors (to be moved to Past sponsors)
+   - Tier changes
+
+4. After user confirmation, update all 4 files in sync.
+
+See `.claude/skills/sponsors/SKILL.md` for listing formats and tier details.

--- a/.claude/skills/sponsors/SKILL.md
+++ b/.claude/skills/sponsors/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: sponsors
+description: >
+  Check current active GitHub Sponsors and sync README/website listings.
+  Used for periodic checks and listing updates.
+metadata:
+  internal: true
+---
+
+# Sponsors Management Skill
+
+Manage GitHub Sponsors listings across the project.
+
+## Listing Files (4 locations)
+
+| # | File | Format |
+|---|---|---|
+| 1 | `README.md` (root) | `<img>` tag |
+| 2 | `packages/markuplint/README.md` | `<img>` tag |
+| 3 | `website/community/index.mdx` | `<Profile>` component |
+| 4 | `website/i18n/ja/docusaurus-plugin-content-docs-community/current/index.mdx` | `<Profile>` component |
+
+## Tiers and Incentives
+
+| Tier | Monthly | Incentive |
+|---|---|---|
+| Corporate | $100/mo | Company logo on README + website |
+| Personal | $10/mo | Personal avatar on README + website |
+| Badge | $5/mo | GitHub badge only (no README/website listing) |
+
+## Fetching Active Sponsors (GitHub GraphQL API)
+
+```bash
+gh api graphql -f query='
+{
+  organization(login: "markuplint") {
+    sponsorshipsAsMaintainer(first: 100, activeOnly: true) {
+      nodes {
+        sponsorEntity {
+          ... on User {
+            login
+            name
+            avatarUrl
+          }
+          ... on Organization {
+            login
+            name
+            avatarUrl
+          }
+        }
+        tier {
+          monthlyPriceInDollars
+          name
+        }
+      }
+    }
+  }
+}
+'
+```
+
+## Listing Formats
+
+### README (root & packages/markuplint)
+
+**Corporate (`<img width="140">`):**
+```markdown
+[<img width="140" src="https://avatars.githubusercontent.com/u/{USER_ID}" alt="{NAME}" />]({URL})
+```
+
+**Personal (`<img width="36">`):**
+```markdown
+[<img width="36" src="https://avatars.githubusercontent.com/u/{USER_ID}" alt="{NAME}" />](https://github.com/{LOGIN})
+```
+
+### Website (MDX)
+
+**Corporate:**
+```mdx
+<Profile
+  avatar="https://avatars.githubusercontent.com/u/{USER_ID}"
+  name="{NAME}"
+  website="{URL}"
+  github="https://github.com/{LOGIN}"
+  twitter="{TWITTER}"
+/>
+```
+
+**Personal:**
+```mdx
+<Profile
+  mini
+  avatar="https://avatars.githubusercontent.com/u/{USER_ID}"
+  name="{NAME}"
+  github="https://github.com/{LOGIN}"
+/>
+```
+
+## Update Procedure
+
+1. **Fetch active sponsors via GraphQL API**
+2. **Read current listings from all 4 files**
+3. **Identify differences:**
+   - New sponsors (in API but not listed) -> Add
+   - Ended sponsors (listed but not in API) -> Move to Past sponsors
+   - Tier changes ($10 -> $5, etc.) -> Add or remove from listings
+4. **Update all 4 files in sync** (never update just one and forget the others)
+5. **Moving to Past sponsors:**
+   - README: Remove the line only (no Past sponsors section)
+   - Website: Remove `<Profile>`, add `- [login](URL)` to Past sponsors list
+
+## Notes
+
+- The Japanese website version has no Corporate sponsors section (English only)
+- $5/mo Badge tier sponsors are NOT listed on README/website
+- Add new entries to the top of the Past sponsors list

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,13 +4,14 @@ Use the following skills and commands for common tasks. **Always invoke the appr
 
 ## Commands (slash commands)
 
-| Command    | Description                                            | File                                      |
-| ---------- | ------------------------------------------------------ | ----------------------------------------- |
-| `/git`     | Commit rules, message format, and package commit order | [git.md](.claude/commands/git.md)         |
-| `/pr`      | Create and push a pull request via `gh pr create`      | [pr.md](.claude/commands/pr.md)           |
-| `/doc`     | Update documentation (README, ARCHITECTURE, JSDoc)     | [doc.md](.claude/commands/doc.md)         |
-| `/release` | Create GitHub Release notes                            | [release.md](.claude/commands/release.md) |
-| `/issue`   | Analyze a GitHub Issue and create a resolution plan    | [issue.md](.claude/commands/issue.md)     |
+| Command     | Description                                            | File                                        |
+| ----------- | ------------------------------------------------------ | ------------------------------------------- |
+| `/git`      | Commit rules, message format, and package commit order | [git.md](.claude/commands/git.md)           |
+| `/pr`       | Create and push a pull request via `gh pr create`      | [pr.md](.claude/commands/pr.md)             |
+| `/doc`      | Update documentation (README, ARCHITECTURE, JSDoc)     | [doc.md](.claude/commands/doc.md)           |
+| `/release`  | Create GitHub Release notes                            | [release.md](.claude/commands/release.md)   |
+| `/issue`    | Analyze a GitHub Issue and create a resolution plan    | [issue.md](.claude/commands/issue.md)       |
+| `/sponsors` | Check and update GitHub Sponsors listings              | [sponsors.md](.claude/commands/sponsors.md) |
 
 ## Skills
 
@@ -21,6 +22,7 @@ Use the following skills and commands for common tasks. **Always invoke the appr
 | framework-parsers | Create and maintain framework parser and spec packages | [SKILL.md](.claude/skills/framework-parsers/SKILL.md) |
 | product-manager   | Analyze, review, and generate documentation for repos  | [SKILL.md](.claude/skills/product-manager/SKILL.md)   |
 | qa-engineer       | Code reviews and test quality checks as a QA engineer  | [SKILL.md](.claude/skills/qa-engineer/SKILL.md)       |
+| sponsors          | Check and update GitHub Sponsors listings              | [SKILL.md](.claude/skills/sponsors/SKILL.md)          |
 
 ### Package Skills
 

--- a/README.md
+++ b/README.md
@@ -55,11 +55,8 @@
 ### Personal Supporters
 
 [<img width="36" src="https://avatars.githubusercontent.com/u/91733847" alt="Tokitake" />](https://github.com/Tokitake)
-[<img width="36" src="https://avatars.githubusercontent.com/u/1996642" alt="Okuto Oyama" />](https://github.com/yamanoku)
-[<img width="36" src="https://avatars.githubusercontent.com/u/6581173" alt="miita" />](https://github.com/mikimhk)
 [<img width="36" src="https://avatars.githubusercontent.com/u/111797" alt="Yasuo Fukuda" />](https://github.com/sigwyg)
 [<img width="36" src="https://avatars.githubusercontent.com/u/91047157" alt="shamokit" />](https://github.com/shamokit)
-[<img width="36" src="https://avatars.githubusercontent.com/u/18516475" alt="takanorip" />](https://github.com/takanorip)
 
 Need [Sponsors❤️‍🔥](https://github.com/sponsors/markuplint)
 

--- a/packages/markuplint/README.md
+++ b/packages/markuplint/README.md
@@ -130,11 +130,8 @@ Examples
 ### Personal Supporters
 
 [<img width="36" src="https://avatars.githubusercontent.com/u/91733847" alt="Tokitake" />](https://github.com/Tokitake)
-[<img width="36" src="https://avatars.githubusercontent.com/u/1996642" alt="Okuto Oyama" />](https://github.com/yamanoku)
-[<img width="36" src="https://avatars.githubusercontent.com/u/6581173" alt="miita" />](https://github.com/mikimhk)
 [<img width="36" src="https://avatars.githubusercontent.com/u/111797" alt="Yasuo Fukuda" />](https://github.com/sigwyg)
 [<img width="36" src="https://avatars.githubusercontent.com/u/91047157" alt="shamokit" />](https://github.com/shamokit)
-[<img width="36" src="https://avatars.githubusercontent.com/u/18516475" alt="takanorip" />](https://github.com/takanorip)
 
 Need [Sponsors❤️‍🔥](https://github.com/sponsors/markuplint)
 

--- a/website/community/index.mdx
+++ b/website/community/index.mdx
@@ -73,18 +73,6 @@ import Profile from '@site/src/components/Profile';
   />
   <Profile
     mini
-    avatar="https://avatars.githubusercontent.com/u/1996642"
-    name="yamanoku"
-    github="https://github.com/yamanoku"
-  />
-  <Profile
-    mini
-    avatar="https://avatars.githubusercontent.com/u/6581173"
-    name="miita"
-    github="https://github.com/mikimhk"
-  />
-  <Profile
-    mini
     avatar="https://avatars.githubusercontent.com/u/111797"
     name="Yasuo Fukuda"
     github="https://github.com/sigwyg"
@@ -95,15 +83,12 @@ import Profile from '@site/src/components/Profile';
     name="shamokit"
     github="https://github.com/shamokit"
   />
-  <Profile
-    mini
-    avatar="https://avatars.githubusercontent.com/u/18516475"
-    name="takanorip"
-    github="https://github.com/takanorip"
-  />
 </Grid>
 
 ### Past sponsors
 
+- [yamanoku](https://github.com/yamanoku)
+- [mikimhk](https://github.com/mikimhk)
+- [takanorip](https://github.com/takanorip)
 - [tamshow](https://github.com/tamshow)
 - [hideyukisaito](https://github.com/hideyukisaito)

--- a/website/i18n/ja/docusaurus-plugin-content-docs-community/current/index.mdx
+++ b/website/i18n/ja/docusaurus-plugin-content-docs-community/current/index.mdx
@@ -61,18 +61,6 @@ import Profile from '@site/src/components/Profile';
   />
   <Profile
     mini
-    avatar="https://avatars.githubusercontent.com/u/1996642"
-    name="Okuto Oyama"
-    github="https://github.com/yamanoku"
-  />
-  <Profile
-    mini
-    avatar="https://avatars.githubusercontent.com/u/6581173"
-    name="miita"
-    github="https://github.com/mikimhk"
-  />
-  <Profile
-    mini
     avatar="https://avatars.githubusercontent.com/u/111797"
     name="Yasuo Fukuda"
     github="https://github.com/sigwyg"
@@ -83,15 +71,12 @@ import Profile from '@site/src/components/Profile';
     name="shamokit"
     github="https://github.com/shamokit"
   />
-  <Profile
-    mini
-    avatar="https://avatars.githubusercontent.com/u/18516475"
-    name="takanorip"
-    github="https://github.com/takanorip"
-  />
 </Grid>
 
 ### 過去にスポンサードいただいた方
 
+- [yamanoku](https://github.com/yamanoku)
+- [mikimhk](https://github.com/mikimhk)
+- [takanorip](https://github.com/takanorip)
 - [tamshow](https://github.com/tamshow)
 - [hideyukisaito](https://github.com/hideyukisaito)


### PR DESCRIPTION
## Summary

- Move inactive sponsors (yamanoku, mikimhk, takanorip) from active Personal sponsors to Past sponsors across all 4 listing files
- Add `/sponsors` command and skill for periodic sponsor checks via GitHub GraphQL API
- Update CLAUDE.md tables with new command and skill entries

## Test plan

- [x] `yarn lint-check` passes (0 errors, 0 warnings, 0 CSpell issues)
- [ ] Verify sponsor listings render correctly on README
- [ ] Verify `/sponsors` command works with `gh api graphql`

🤖 Generated with [Claude Code](https://claude.com/claude-code)