### PR TITLE
Fix recursive dependency detection in dependency mapper

### DIFF
--- a/packages/@markuplint/pretenders/src/dependency-mapper.spec.ts
+++ b/packages/@markuplint/pretenders/src/dependency-mapper.spec.ts
@@ -105,6 +105,35 @@ describe('dependencyMapper', () => {
 		]);
 	});
 
+	test('Intermediate Recursive: A -> B -> C -> B', () => {
+		expect(
+			dependencyMapper(
+				new Map([
+					//
+					['A', ['B']],
+					['B', ['C']],
+					['C', ['B']],
+				]),
+			),
+		).toStrictEqual([
+			{
+				selector: 'A',
+				as: 'C',
+				_via: ['B', 'C', '...[Recursive]'],
+			},
+			{
+				selector: 'B',
+				as: 'C',
+				_via: ['C', '...[Recursive]'],
+			},
+			{
+				selector: 'C',
+				as: 'B',
+				_via: ['B', '...[Recursive]'],
+			},
+		]);
+	});
+
 	test('Recursive', () => {
 		expect(
 			dependencyMapper(

--- a/packages/@markuplint/pretenders/src/dependency-mapper.ts
+++ b/packages/@markuplint/pretenders/src/dependency-mapper.ts
@@ -61,6 +61,7 @@ export function dependencyMapper(map: Readonly<PretenderDirectorMap>): Pretender
 		let filePath = _filePath;
 		let elName = getElName(identity);
 		const via: string[] = [];
+		const visited = new Set<string>([identifier]);
 
 		while (true) {
 			const mappedPretender = map.get(elName);
@@ -71,11 +72,12 @@ export function dependencyMapper(map: Readonly<PretenderDirectorMap>): Pretender
 			identity = mappedPretender[0];
 			filePath = mappedPretender[1];
 
-			if (elName === identifier) {
+			if (visited.has(elName)) {
 				via.push('...[Recursive]');
 				break;
 			}
 
+			visited.add(elName);
 			via.push(elName);
 			elName = getElName(identity);
 		}


### PR DESCRIPTION
Fixes #3336 

## What is the purpose of this PR?

- [x] Fix bug
- [ ] Fix typo
- [ ] Update specs
- [ ] Add new rule
- [ ] Add new parser
- [ ] Improve or refactor rules
- [ ] Add a new core feature
- [ ] Improve or refactor core features
- [ ] Update documents
- [ ] Others

### Description

This PR fixes a bug in the `dependencyMapper` function where intermediate recursive dependencies were not being detected correctly. The previous implementation only checked if the current element name matched the original identifier, which failed to catch cycles that occurred deeper in the dependency chain (e.g., A → B → C → B).

**Changes:**
- Introduced a `visited` Set to track all elements encountered during dependency resolution, not just the starting identifier
- Changed the recursion detection logic from checking `elName === identifier` to checking `visited.has(elName)`
- This ensures that any cycle in the dependency chain is properly detected and marked with `...[Recursive]`

**Test Coverage:**
Added a new test case "Intermediate Recursive: A -> B -> C -> B" that verifies the fix handles cycles that don't immediately loop back to the starting element.

## Checklist

- [x] Fix bug
  - [x] Add the test that can check whether resolved the issue.

https://claude.ai/code/session_01RrFDcFDuW4FrheHHFnj2za