### PR TITLE
Support import-path-based resolution in dependency mapper

### DIFF
--- a/packages/@markuplint/pretenders/src/dependency-mapper.spec.ts
+++ b/packages/@markuplint/pretenders/src/dependency-mapper.spec.ts
@@ -8,8 +8,8 @@ describe('dependencyMapper', () => {
 			dependencyMapper(
 				new Map([
 					//
-					['A', ['div']],
-					['B', ['A']],
+					['A', ['A', 'div']],
+					['B', ['B', 'A']],
 				]),
 			),
 		).toStrictEqual([
@@ -30,11 +30,11 @@ describe('dependencyMapper', () => {
 			dependencyMapper(
 				new Map([
 					//
-					['A', ['div']],
-					['B', ['A']],
-					['C', ['B']],
-					['D', ['C']],
-					['E', ['D']],
+					['A', ['A', 'div']],
+					['B', ['B', 'A']],
+					['C', ['C', 'B']],
+					['D', ['D', 'C']],
+					['E', ['E', 'D']],
 				]),
 			),
 		).toStrictEqual([
@@ -70,11 +70,11 @@ describe('dependencyMapper', () => {
 			dependencyMapper(
 				new Map([
 					//
-					['E', ['D']],
-					['D', ['C']],
-					['C', ['B']],
-					['B', ['A']],
-					['A', ['div']],
+					['E', ['E', 'D']],
+					['D', ['D', 'C']],
+					['C', ['C', 'B']],
+					['B', ['B', 'A']],
+					['A', ['A', 'div']],
 				]),
 			),
 		).toStrictEqual([
@@ -110,9 +110,9 @@ describe('dependencyMapper', () => {
 			dependencyMapper(
 				new Map([
 					//
-					['A', ['B']],
-					['B', ['C']],
-					['C', ['B']],
+					['A', ['A', 'B']],
+					['B', ['B', 'C']],
+					['C', ['C', 'B']],
 				]),
 			),
 		).toStrictEqual([
@@ -139,10 +139,10 @@ describe('dependencyMapper', () => {
 			dependencyMapper(
 				new Map([
 					//
-					['A', ['B']],
-					['B', ['C']],
-					['C', ['D']],
-					['D', ['A']],
+					['A', ['A', 'B']],
+					['B', ['B', 'C']],
+					['C', ['C', 'D']],
+					['D', ['D', 'A']],
 				]),
 			),
 		).toStrictEqual([
@@ -165,6 +165,59 @@ describe('dependencyMapper', () => {
 				selector: 'D',
 				as: 'A',
 				_via: ['A', 'B', 'C', '...[Recursive]'],
+			},
+		]);
+	});
+
+	test('Import-path-based resolution with nameIndex', () => {
+		const map = new Map([
+			['./components/A/Button', ['Button', 'button']],
+			['./components/B/Button', ['Button', 'div']],
+			['./components/MyButton', ['MyButton', 'Button']],
+		]) as Parameters<typeof dependencyMapper>[0];
+
+		const nameIndex = new Map([
+			['Button', './components/A/Button'],
+			['MyButton', './components/MyButton'],
+		]);
+
+		expect(dependencyMapper(map, nameIndex)).toStrictEqual([
+			{
+				selector: 'Button',
+				as: 'button',
+			},
+			{
+				selector: 'Button',
+				as: 'div',
+			},
+			{
+				selector: 'MyButton',
+				_via: ['Button'],
+				as: 'button',
+			},
+		]);
+	});
+
+	test('Import-path-based resolution avoids name collision', () => {
+		const map = new Map([
+			['./lib/Button', ['Button', 'button']],
+			['./app/MyButton', ['MyButton', { element: 'Button', slots: true, inheritAttrs: true }]],
+		]) as Parameters<typeof dependencyMapper>[0];
+
+		const nameIndex = new Map([
+			['Button', './lib/Button'],
+			['MyButton', './app/MyButton'],
+		]);
+
+		expect(dependencyMapper(map, nameIndex)).toStrictEqual([
+			{
+				selector: 'Button',
+				as: 'button',
+			},
+			{
+				selector: 'MyButton',
+				_via: ['Button'],
+				as: 'button',
 			},
 		]);
 	});

--- a/packages/@markuplint/pretenders/src/dependency-mapper.spec.ts
+++ b/packages/@markuplint/pretenders/src/dependency-mapper.spec.ts
@@ -1,3 +1,5 @@
+import type { PretenderDirectorMap } from './pretender-director.js';
+
 import { describe, test, expect } from 'vitest';
 
 import { dependencyMapper } from './dependency-mapper.js';
@@ -170,11 +172,11 @@ describe('dependencyMapper', () => {
 	});
 
 	test('Import-path-based resolution with nameIndex', () => {
-		const map = new Map([
+		const map: PretenderDirectorMap = new Map([
 			['./components/A/Button', ['Button', 'button']],
 			['./components/B/Button', ['Button', 'div']],
 			['./components/MyButton', ['MyButton', 'Button']],
-		]) as Parameters<typeof dependencyMapper>[0];
+		]);
 
 		const nameIndex = new Map([
 			['Button', './components/A/Button'],
@@ -199,10 +201,10 @@ describe('dependencyMapper', () => {
 	});
 
 	test('Import-path-based resolution avoids name collision', () => {
-		const map = new Map([
+		const map: PretenderDirectorMap = new Map([
 			['./lib/Button', ['Button', 'button']],
 			['./app/MyButton', ['MyButton', { element: 'Button', slots: true, inheritAttrs: true }]],
-		]) as Parameters<typeof dependencyMapper>[0];
+		]);
 
 		const nameIndex = new Map([
 			['Button', './lib/Button'],
@@ -216,6 +218,75 @@ describe('dependencyMapper', () => {
 			},
 			{
 				selector: 'MyButton',
+				_via: ['Button'],
+				as: 'button',
+			},
+		]);
+	});
+
+	test('buildNameIndex fallback: import-path keys without explicit nameIndex', () => {
+		const map: PretenderDirectorMap = new Map([
+			['./lib/Button', ['Button', 'button']],
+			['./app/MyButton', ['MyButton', 'Button']],
+		]);
+
+		// No nameIndex provided → buildNameIndex derives it from the map
+		expect(dependencyMapper(map)).toStrictEqual([
+			{
+				selector: 'Button',
+				as: 'button',
+			},
+			{
+				selector: 'MyButton',
+				_via: ['Button'],
+				as: 'button',
+			},
+		]);
+	});
+
+	test('cycle detection with import-path keys', () => {
+		const map: PretenderDirectorMap = new Map([
+			['./a', ['A', 'B']],
+			['./b', ['B', 'A']],
+		]);
+
+		const nameIndex = new Map([
+			['A', './a'],
+			['B', './b'],
+		]);
+
+		// identity is updated before cycle check, so 'as' reflects the cyclic entry's identity
+		expect(dependencyMapper(map, nameIndex)).toStrictEqual([
+			{
+				selector: 'A',
+				as: 'B',
+				_via: ['B', '...[Recursive]'],
+			},
+			{
+				selector: 'B',
+				as: 'A',
+				_via: ['A', '...[Recursive]'],
+			},
+		]);
+	});
+
+	test('nameIndex miss falls through to direct key lookup', () => {
+		const map: PretenderDirectorMap = new Map([
+			['./Button', ['Button', 'button']],
+			['Card', ['Card', 'Button']],
+		]);
+
+		// nameIndex only has Button, not Card
+		const nameIndex = new Map([['Button', './Button']]);
+
+		// Card's identity is 'Button' → nameIndex resolves to './Button' → 'button'
+		expect(dependencyMapper(map, nameIndex)).toStrictEqual([
+			{
+				selector: 'Button',
+				as: 'button',
+			},
+			{
+				selector: 'Card',
 				_via: ['Button'],
 				as: 'button',
 			},

--- a/packages/@markuplint/pretenders/src/dependency-mapper.ts
+++ b/packages/@markuplint/pretenders/src/dependency-mapper.ts
@@ -1,83 +1,48 @@
+import type { PretenderDirectorMap } from './pretender-director.js';
 import type { Identifier, Identity } from './types.js';
 import type { Pretender } from '@markuplint/ml-config';
 
 /**
- * Internal map structure storing component identifiers to their identity and source location.
- */
-type PretenderDirectorMap = Map<Identifier, [identity: Identity, filePath?: string]>;
-
-/**
- * Collects and manages pretender mappings discovered during source file scanning.
- * Acts as a registry where component-to-element relationships are added during
- * traversal, then resolved into a flat list of pretenders with dependency linking.
- */
-export class PretenderDirector {
-	#map: PretenderDirectorMap = new Map();
-
-	/**
-	 * Registers a component as a pretender mapping. If the identifier is already
-	 * registered, the call is silently ignored (first definition wins).
-	 *
-	 * @param identifier - The component selector (e.g., component name)
-	 * @param identity - The native HTML element the component renders as
-	 * @param filePath - The relative file path where the component is defined
-	 * @param line - The line number of the component declaration
-	 * @param col - The column number of the component declaration
-	 */
-	add(identifier: Identifier, identity: Identity, filePath: string, line: number, col: number) {
-		if (this.#map.has(identifier)) {
-			return;
-		}
-
-		this.#map.set(identifier, [identity, `${filePath}:${line}:${col}`]);
-	}
-
-	/**
-	 * Resolves all registered mappings into a sorted array of Pretender objects.
-	 * Follows component-to-component chains to determine the final native element identity.
-	 *
-	 * @returns A sorted array of resolved Pretender objects
-	 */
-	getPretenders() {
-		return dependencyMapper(this.#map);
-	}
-}
-
-/**
  * Resolves a map of component-to-identity mappings into a flat array of Pretender objects.
  * Follows chains where one component wraps another (e.g., MyButton -> Button -> button)
- * until a native element is reached or a recursive loop is detected.
+ * until a native element is reached or a cycle is detected.
  *
- * @param map - The map of component identifiers to their identity and file path
+ * Uses import-path-based resolution when a name index is provided, falling back to
+ * name-based lookup for backward compatibility.
+ *
+ * @param map - The map of component keys to their [identifier, identity, filePath] tuples
+ * @param nameIndex - Optional mapping from component names to map keys for resolving references
  * @returns A sorted array of fully resolved Pretender objects
  */
-export function dependencyMapper(map: Readonly<PretenderDirectorMap>): Pretender[] {
+export function dependencyMapper(
+	map: Readonly<PretenderDirectorMap>,
+	nameIndex?: Readonly<Map<Identifier, string>>,
+): Pretender[] {
+	const resolvedNameIndex = nameIndex ?? buildNameIndex(map);
 	const linkedPretenders: Pretender[] = [];
 
-	const collection = [...map.entries()];
-
-	for (const [identifier, [_identity, _filePath]] of collection) {
+	for (const [key, [identifier, _identity, _filePath]] of map) {
 		let identity = _identity;
 		let filePath = _filePath;
 		let elName = getElName(identity);
 		const via: string[] = [];
-		const visited = new Set<string>([identifier]);
+		const visited = new Set<string>([key]);
 
 		while (true) {
-			const mappedPretender = map.get(elName);
+			const lookupKey = resolvedNameIndex.get(elName) ?? elName;
+			const mappedPretender = map.get(lookupKey);
 			if (!mappedPretender) {
 				break;
 			}
 
-			identity = mappedPretender[0];
-			filePath = mappedPretender[1];
+			identity = mappedPretender[1];
+			filePath = mappedPretender[2];
 
-			if (visited.has(elName)) {
+			if (visited.has(lookupKey)) {
 				via.push('...[Recursive]');
 				break;
 			}
-
-			visited.add(elName);
+			visited.add(lookupKey);
 			via.push(elName);
 			elName = getElName(identity);
 		}
@@ -99,6 +64,20 @@ export function dependencyMapper(map: Readonly<PretenderDirectorMap>): Pretender
 	}
 
 	return linkedPretenders.toSorted(propSort('selector'));
+}
+
+/**
+ * Builds a name-to-key index from the map for backward-compatible name-based lookup.
+ * First definition wins when multiple entries share the same identifier.
+ */
+function buildNameIndex(map: Readonly<PretenderDirectorMap>): Map<Identifier, string> {
+	const index = new Map<Identifier, string>();
+	for (const [key, [identifier]] of map) {
+		if (!index.has(identifier)) {
+			index.set(identifier, key);
+		}
+	}
+	return index;
 }
 
 function getElName(identity: Identity) {

--- a/packages/@markuplint/pretenders/src/pretender-director.spec.ts
+++ b/packages/@markuplint/pretenders/src/pretender-director.spec.ts
@@ -1,0 +1,161 @@
+import { describe, test, expect } from 'vitest';
+
+import { PretenderDirector } from './pretender-director.js';
+
+describe('PretenderDirector', () => {
+	test('add without importPath uses identifier as key (backward compat)', () => {
+		const director = new PretenderDirector();
+		director.add('Button', 'button', 'components/Button.tsx', 2, 6);
+		director.add('Card', 'div', 'components/Card.tsx', 3, 0);
+		const result = director.getPretenders();
+		expect(result).toStrictEqual([
+			{
+				selector: 'Button',
+				as: 'button',
+				filePath: 'components/Button.tsx:2:6',
+			},
+			{
+				selector: 'Card',
+				as: 'div',
+				filePath: 'components/Card.tsx:3:0',
+			},
+		]);
+	});
+
+	test('duplicate identifier without importPath is ignored (first wins)', () => {
+		const director = new PretenderDirector();
+		director.add('Button', 'button', 'a.tsx', 1, 0);
+		director.add('Button', 'div', 'b.tsx', 2, 0);
+		const result = director.getPretenders();
+		expect(result).toStrictEqual([
+			{
+				selector: 'Button',
+				as: 'button',
+				filePath: 'a.tsx:1:0',
+			},
+		]);
+	});
+
+	test('add with importPath allows same-name components from different files', () => {
+		const director = new PretenderDirector();
+		director.add('Button', 'button', 'A/Button.vue', 1, 0, './A/Button');
+		director.add('Button', 'div', 'B/Button.vue', 1, 0, './B/Button');
+		const result = director.getPretenders();
+		expect(result).toHaveLength(2);
+		expect(result).toStrictEqual([
+			{
+				selector: 'Button',
+				as: 'button',
+				filePath: 'A/Button.vue:1:0',
+			},
+			{
+				selector: 'Button',
+				as: 'div',
+				filePath: 'B/Button.vue:1:0',
+			},
+		]);
+	});
+
+	test('duplicate importPath is ignored (first wins)', () => {
+		const director = new PretenderDirector();
+		director.add('Button', 'button', 'a.tsx', 1, 0, './components/Button');
+		director.add('Button', 'div', 'b.tsx', 2, 0, './components/Button');
+		const result = director.getPretenders();
+		expect(result).toStrictEqual([
+			{
+				selector: 'Button',
+				as: 'button',
+				filePath: 'a.tsx:1:0',
+			},
+		]);
+	});
+
+	test('chain resolution through nameIndex with import paths', () => {
+		const director = new PretenderDirector();
+		director.add('Button', 'button', 'lib/Button.vue', 1, 0, './lib/Button');
+		director.add('MyButton', 'Button', 'app/MyButton.vue', 1, 0, './app/MyButton');
+		const result = director.getPretenders();
+		expect(result).toStrictEqual([
+			{
+				selector: 'Button',
+				as: 'button',
+				filePath: 'lib/Button.vue:1:0',
+			},
+			{
+				selector: 'MyButton',
+				as: 'button',
+				filePath: 'lib/Button.vue:1:0',
+				_via: ['Button'],
+			},
+		]);
+	});
+
+	test('nameIndex resolves to first-registered component (first wins)', () => {
+		const director = new PretenderDirector();
+		// First Button registered → nameIndex maps 'Button' → './A/Button'
+		director.add('Button', 'button', 'A/Button.vue', 1, 0, './A/Button');
+		// Second Button registered → nameIndex still maps 'Button' → './A/Button'
+		director.add('Button', 'div', 'B/Button.vue', 1, 0, './B/Button');
+		// MyButton wraps 'Button' → resolves through nameIndex to ./A/Button → 'button'
+		director.add('MyButton', 'Button', 'MyButton.vue', 1, 0, './MyButton');
+		const result = director.getPretenders();
+		const myButton = result.find(p => p.selector === 'MyButton');
+		expect(myButton).toStrictEqual({
+			selector: 'MyButton',
+			as: 'button',
+			filePath: 'A/Button.vue:1:0',
+			_via: ['Button'],
+		});
+	});
+
+	test('cycle detection with import paths', () => {
+		const director = new PretenderDirector();
+		director.add('A', 'B', 'a.vue', 1, 0, './a');
+		director.add('B', 'A', 'b.vue', 1, 0, './b');
+		const result = director.getPretenders();
+		// identity is updated before cycle check, so 'as' reflects the cyclic entry's identity
+		expect(result).toStrictEqual([
+			{
+				selector: 'A',
+				as: 'B',
+				filePath: 'a.vue:1:0',
+				_via: ['B', '...[Recursive]'],
+			},
+			{
+				selector: 'B',
+				as: 'A',
+				filePath: 'b.vue:1:0',
+				_via: ['A', '...[Recursive]'],
+			},
+		]);
+	});
+
+	test('mixed: some components with importPath, some without', () => {
+		const director = new PretenderDirector();
+		// JSX scanner style (no importPath)
+		director.add('Card', 'div', 'Card.tsx', 5, 0);
+		// Vue scanner style (with importPath)
+		director.add('Button', 'button', 'Button.vue', 1, 0, './Button');
+		// Chain from Card to Button (cross-scanner resolution)
+		director.add('CardButton', 'Button', 'CardButton.tsx', 1, 0);
+		const result = director.getPretenders();
+		expect(result).toStrictEqual([
+			{
+				selector: 'Button',
+				as: 'button',
+				filePath: 'Button.vue:1:0',
+			},
+			{
+				selector: 'Card',
+				as: 'div',
+				filePath: 'Card.tsx:5:0',
+			},
+			{
+				selector: 'CardButton',
+				as: 'button',
+				filePath: 'Button.vue:1:0',
+				_via: ['Button'],
+			},
+		]);
+	});
+});

--- a/packages/@markuplint/pretenders/src/pretender-director.ts
+++ b/packages/@markuplint/pretenders/src/pretender-director.ts
@@ -1,36 +1,55 @@
-import type { Identifier, Identity } from './types.js';
+import type { Identifier, Identity, ImportPath } from './types.js';
 
 import { dependencyMapper } from './dependency-mapper.js';
 
 /**
- * Internal map structure storing component identifiers to their identity and source location.
+ * Internal map structure storing component mappings keyed by import path (or identifier as fallback).
+ * The value tuple includes the component identifier (name), its identity, and an optional source location.
  */
-type PretenderDirectorMap = Map<Identifier, [identity: Identity, filePath?: string]>;
+export type PretenderDirectorMap = Map<string, [identifier: Identifier, identity: Identity, filePath?: string]>;
 
 /**
  * Collects and manages pretender mappings discovered during source file scanning.
  * Acts as a registry where component-to-element relationships are added during
  * traversal, then resolved into a flat list of pretenders with dependency linking.
+ *
+ * The internal map uses import paths as keys when available, falling back to
+ * component identifiers (names) for backward compatibility with name-based scanners.
  */
 export class PretenderDirector {
 	#map: PretenderDirectorMap = new Map();
+	#nameIndex: Map<Identifier, string> = new Map();
 
 	/**
-	 * Registers a component as a pretender mapping. If the identifier is already
-	 * registered, the call is silently ignored (first definition wins).
+	 * Registers a component as a pretender mapping. If the key (import path or identifier)
+	 * is already registered, the call is silently ignored (first definition wins).
 	 *
 	 * @param identifier - The component selector (e.g., component name)
 	 * @param identity - The native HTML element the component renders as
 	 * @param filePath - The relative file path where the component is defined
 	 * @param line - The line number of the component declaration
 	 * @param col - The column number of the component declaration
+	 * @param importPath - Optional import path for uniquely identifying the component across files
 	 */
-	add(identifier: Identifier, identity: Identity, filePath: string, line: number, col: number) {
-		if (this.#map.has(identifier)) {
+	add(
+		identifier: Identifier,
+		identity: Identity,
+		filePath: string,
+		line: number,
+		col: number,
+		importPath?: ImportPath,
+	) {
+		const key = importPath ?? identifier;
+
+		if (this.#map.has(key)) {
 			return;
 		}
 
-		this.#map.set(identifier, [identity, `${filePath}:${line}:${col}`]);
+		this.#map.set(key, [identifier, identity, `${filePath}:${line}:${col}`]);
+
+		if (!this.#nameIndex.has(identifier)) {
+			this.#nameIndex.set(identifier, key);
+		}
 	}
 
 	/**
@@ -40,6 +59,6 @@ export class PretenderDirector {
 	 * @returns A sorted array of resolved Pretender objects
 	 */
 	getPretenders() {
-		return dependencyMapper(this.#map);
+		return dependencyMapper(this.#map, this.#nameIndex);
 	}
 }

--- a/packages/@markuplint/pretenders/src/types.ts
+++ b/packages/@markuplint/pretenders/src/types.ts
@@ -28,6 +28,14 @@ export type Identifier = Pretender['selector'];
 export type Identity = Pretender['as'];
 
 /**
+ * An import path string used to uniquely identify a component across files.
+ * When provided, this is used as the map key instead of the component name,
+ * enabling disambiguation of identically named components from different locations
+ * (e.g., `../A/Button.vue` vs `../B/Button.vue`).
+ */
+export type ImportPath = string;
+
+/**
  * Represents an attribute found on a JSX element during scanning.
  */
 export type Attr = {


### PR DESCRIPTION
Fixes #3337

## What is the purpose of this PR?

- [ ] Fix bug
- [x] Improve or refactor core features
- [ ] Update specs
- [ ] Others

### Description

This PR enhances the `dependencyMapper` and `PretenderDirector` to support import-path-based resolution of component dependencies, enabling disambiguation of identically named components from different file locations.

**Key Changes:**

1. **Updated `PretenderDirectorMap` structure**: Changed from `Map<Identifier, [identity, filePath]>` to `Map<string, [identifier, identity, filePath]>`, where the key is now an import path (or identifier as fallback) rather than just the component name.

2. **Enhanced `dependencyMapper` function**: 
   - Now accepts an optional `nameIndex` parameter for import-path-based lookup
   - Falls back to name-based lookup via `buildNameIndex()` for backward compatibility
   - Properly resolves component references using the name index when available

3. **Improved `PretenderDirector` class**:
   - Added `importPath` parameter to the `add()` method
   - Maintains an internal `#nameIndex` map for efficient name-to-key resolution
   - Passes the name index to `dependencyMapper` for accurate dependency resolution

4. **Added `ImportPath` type**: New type definition in `types.ts` for import path strings used to uniquely identify components across files.

5. **Updated test cases**: All existing tests now include self-references in dependency mappings (e.g., `['A', ['A', 'div']]`) and two new test cases demonstrate import-path-based resolution with name collision avoidance.

This change enables the pretender system to correctly handle scenarios where multiple components with the same name exist in different files, such as `./components/A/Button` and `./components/B/Button`.

## Checklist

- [x] Improve or refactor core features
  - [x] Added comprehensive test coverage including edge cases for import-path-based resolution
  - [x] Maintained backward compatibility with name-based lookup
  - [x] All existing tests pass with updated test data

https://claude.ai/code/session_01VzyPW4hPfityqjF7yW3Dqo