### PR TITLE
feat(pretenders): add MLAST-based templateScanner for Vue/Svelte/Astro

### DIFF
--- a/packages/@markuplint/pretenders/package.json
+++ b/packages/@markuplint/pretenders/package.json
@@ -28,10 +28,16 @@
 		"clean": "tsc --build --clean tsconfig.build.json"
 	},
 	"dependencies": {
+		"@markuplint/ml-ast": "5.0.0-alpha.3",
 		"@markuplint/ml-config": "5.0.0-alpha.3",
 		"@markuplint/parser-utils": "5.0.0-alpha.3",
 		"glob": "13.0.6",
 		"meow": "14.1.0",
 		"typescript": "5.9.3"
+	},
+	"optionalDependencies": {
+		"@markuplint/astro-parser": "5.0.0-alpha.3",
+		"@markuplint/svelte-parser": "5.0.0-alpha.3",
+		"@markuplint/vue-parser": "5.0.0-alpha.3"
 	}
 }

--- a/packages/@markuplint/pretenders/src/index.ts
+++ b/packages/@markuplint/pretenders/src/index.ts
@@ -2,8 +2,11 @@
  * @module @markuplint/pretenders
  *
  * Provides scanning utilities for detecting component-to-element mappings (pretenders)
- * in JSX/TSX source files. Pretenders allow markuplint to understand which native HTML
+ * in source files. Pretenders allow markuplint to understand which native HTML
  * elements a component renders, enabling accurate linting of component-based code.
+ *
+ * - {@link jsxScanner} — Scans JSX/TSX files using the TypeScript compiler API
+ * - {@link templateScanner} — Scans Vue, Svelte, and Astro SFC files using markuplint's parsers
  */
 
 export { jsxScanner } from './jsx/index.js';

--- a/packages/@markuplint/pretenders/src/index.ts
+++ b/packages/@markuplint/pretenders/src/index.ts
@@ -7,4 +7,5 @@
  */
 
 export { jsxScanner } from './jsx/index.js';
+export { templateScanner } from './template/index.js';
 export type * from './types.js';

--- a/packages/@markuplint/pretenders/src/template/derive-name.spec.ts
+++ b/packages/@markuplint/pretenders/src/template/derive-name.spec.ts
@@ -1,0 +1,61 @@
+import { describe, test, expect } from 'vitest';
+
+import { deriveName } from './derive-name.js';
+
+describe('deriveName', () => {
+	test('removes .vue extension and keeps PascalCase', () => {
+		expect(deriveName('BaseButton.vue')).toBe('BaseButton');
+	});
+
+	test('removes .svelte extension and keeps PascalCase', () => {
+		expect(deriveName('Dialog.svelte')).toBe('Dialog');
+	});
+
+	test('removes .astro extension and keeps PascalCase', () => {
+		expect(deriveName('Card.astro')).toBe('Card');
+	});
+
+	test('converts kebab-case filename to PascalCase', () => {
+		expect(deriveName('base-button.vue')).toBe('BaseButton');
+	});
+
+	test('converts kebab-case with multiple segments to PascalCase', () => {
+		expect(deriveName('my-fancy-dialog.svelte')).toBe('MyFancyDialog');
+	});
+
+	test('uses parent directory name for index files', () => {
+		expect(deriveName('Card/index.vue')).toBe('Card');
+	});
+
+	test('uses parent directory name for index.svelte', () => {
+		expect(deriveName('components/Dialog/index.svelte')).toBe('Dialog');
+	});
+
+	test('uses parent directory name for index.astro', () => {
+		expect(deriveName('layouts/Main/index.astro')).toBe('Main');
+	});
+
+	test('handles absolute path with index file', () => {
+		expect(deriveName('/home/user/project/src/components/Card/index.vue')).toBe('Card');
+	});
+
+	test('handles absolute path with named file', () => {
+		expect(deriveName('/home/user/project/src/components/BaseButton.vue')).toBe('BaseButton');
+	});
+
+	test('converts kebab-case directory name to PascalCase for index files', () => {
+		expect(deriveName('my-card/index.vue')).toBe('MyCard');
+	});
+
+	test('handles single character segments in kebab-case', () => {
+		expect(deriveName('x-button.vue')).toBe('XButton');
+	});
+
+	test('preserves already PascalCase names', () => {
+		expect(deriveName('MyComponent.vue')).toBe('MyComponent');
+	});
+
+	test('handles camelCase filenames by uppercasing first letter', () => {
+		expect(deriveName('myComponent.vue')).toBe('MyComponent');
+	});
+});

--- a/packages/@markuplint/pretenders/src/template/derive-name.ts
+++ b/packages/@markuplint/pretenders/src/template/derive-name.ts
@@ -1,0 +1,28 @@
+import path from 'node:path';
+
+/**
+ * Derives a PascalCase component name from a file path.
+ *
+ * Rules:
+ * - `BaseButton.vue` → `BaseButton` (remove extension)
+ * - `base-button.vue` → `BaseButton` (kebab-case → PascalCase)
+ * - `Card/index.vue` → `Card` (parent directory name for index files)
+ */
+export function deriveName(filePath: string): string {
+	const parsed = path.parse(filePath);
+	const baseName = parsed.name;
+
+	const nameToConvert = baseName === 'index' ? path.basename(parsed.dir) : baseName;
+
+	return toPascalCase(nameToConvert);
+}
+
+function toPascalCase(str: string): string {
+	if (str.includes('-')) {
+		return str
+			.split('-')
+			.map(segment => segment.charAt(0).toUpperCase() + segment.slice(1))
+			.join('');
+	}
+	return str.charAt(0).toUpperCase() + str.slice(1);
+}

--- a/packages/@markuplint/pretenders/src/template/detect-slots.spec.ts
+++ b/packages/@markuplint/pretenders/src/template/detect-slots.spec.ts
@@ -1,0 +1,56 @@
+import path from 'node:path';
+
+import { describe, test, expect } from 'vitest';
+
+import { detectSlots } from './detect-slots.js';
+import { parseComponent } from './parse-component.js';
+
+const fixtureDir = path.resolve(import.meta.dirname, '..', '..', 'test', 'fixtures', 'template');
+
+describe('detectSlots', () => {
+	describe('Vue', () => {
+		test('returns true when <slot> element exists in nodeList', async () => {
+			const doc = await parseComponent(path.resolve(fixtureDir, 'WithSlot.vue'));
+			expect(detectSlots(doc!)).toBe(true);
+		});
+
+		test('returns false when no <slot> element exists', async () => {
+			const doc = await parseComponent(path.resolve(fixtureDir, 'SimpleButton.vue'));
+			expect(detectSlots(doc!)).toBe(false);
+		});
+
+		test('returns false for text-only templates', async () => {
+			const doc = await parseComponent(path.resolve(fixtureDir, 'FragmentOnly.vue'));
+			expect(detectSlots(doc!)).toBe(false);
+		});
+	});
+
+	describe('Svelte', () => {
+		test('returns true when <slot> element exists (Svelte 4 syntax)', async () => {
+			const doc = await parseComponent(path.resolve(fixtureDir, 'WithSlot.svelte'));
+			expect(detectSlots(doc!)).toBe(true);
+		});
+
+		test('returns true when {@render children()} exists (Svelte 5 syntax)', async () => {
+			const doc = await parseComponent(path.resolve(fixtureDir, 'WithSnippet.svelte'));
+			expect(detectSlots(doc!)).toBe(true);
+		});
+
+		test('returns false when no slot syntax exists', async () => {
+			const doc = await parseComponent(path.resolve(fixtureDir, 'SimpleButton.svelte'));
+			expect(detectSlots(doc!)).toBe(false);
+		});
+	});
+
+	describe('Astro', () => {
+		test('returns true when <slot /> element exists', async () => {
+			const doc = await parseComponent(path.resolve(fixtureDir, 'WithSlot.astro'));
+			expect(detectSlots(doc!)).toBe(true);
+		});
+
+		test('returns false when no slot exists', async () => {
+			const doc = await parseComponent(path.resolve(fixtureDir, 'SimpleButton.astro'));
+			expect(detectSlots(doc!)).toBe(false);
+		});
+	});
+});

--- a/packages/@markuplint/pretenders/src/template/detect-slots.ts
+++ b/packages/@markuplint/pretenders/src/template/detect-slots.ts
@@ -1,0 +1,23 @@
+import type { MLASTDocument } from '@markuplint/ml-ast';
+
+/**
+ * Detects whether a parsed component template contains slot usage.
+ *
+ * Supports:
+ * - Vue: `<slot>` element (`nodeName === 'slot'`)
+ * - Svelte 4: `<slot>` element (parsed as psblock `#ps:SlotElement`)
+ * - Svelte 5: `{@render children()}` (parsed as psblock `#ps:RenderTag`)
+ * - Astro: `<slot />` element (`nodeName === 'slot'`)
+ */
+export function detectSlots(doc: MLASTDocument): boolean {
+	for (const node of doc.nodeList) {
+		if (node.type === 'starttag' && node.nodeName === 'slot') {
+			return true;
+		}
+
+		if (node.type === 'psblock' && (node.nodeName === '#ps:SlotElement' || node.nodeName === '#ps:RenderTag')) {
+			return true;
+		}
+	}
+	return false;
+}

--- a/packages/@markuplint/pretenders/src/template/extract-attrs.spec.ts
+++ b/packages/@markuplint/pretenders/src/template/extract-attrs.spec.ts
@@ -1,0 +1,48 @@
+import path from 'node:path';
+
+import { describe, test, expect } from 'vitest';
+
+import { extractAttrs } from './extract-attrs.js';
+import { extractRoot } from './extract-root.js';
+import { parseComponent } from './parse-component.js';
+
+const fixtureDir = path.resolve(import.meta.dirname, '..', '..', 'test', 'fixtures', 'template');
+
+describe('extractAttrs', () => {
+	test('extracts static attributes from Vue <button>', async () => {
+		const doc = await parseComponent(path.resolve(fixtureDir, 'SimpleButton.vue'));
+		const root = extractRoot(doc!);
+		const attrs = extractAttrs(root!);
+		expect(attrs).toStrictEqual([
+			{ name: 'type', value: 'button' },
+			{ name: 'class', value: 'btn' },
+		]);
+	});
+
+	test('extracts static attributes from Svelte <button>', async () => {
+		const doc = await parseComponent(path.resolve(fixtureDir, 'SimpleButton.svelte'));
+		const root = extractRoot(doc!);
+		const attrs = extractAttrs(root!);
+		expect(attrs).toStrictEqual([
+			{ name: 'type', value: 'button' },
+			{ name: 'class', value: 'btn' },
+		]);
+	});
+
+	test('extracts static attributes from Astro <button>', async () => {
+		const doc = await parseComponent(path.resolve(fixtureDir, 'SimpleButton.astro'));
+		const root = extractRoot(doc!);
+		const attrs = extractAttrs(root!);
+		expect(attrs).toStrictEqual([
+			{ name: 'type', value: 'button' },
+			{ name: 'class', value: 'btn' },
+		]);
+	});
+
+	test('extracts class attribute from wrapper div', async () => {
+		const doc = await parseComponent(path.resolve(fixtureDir, 'WithSlot.vue'));
+		const root = extractRoot(doc!);
+		const attrs = extractAttrs(root!);
+		expect(attrs).toStrictEqual([{ name: 'class', value: 'wrapper' }]);
+	});
+});

--- a/packages/@markuplint/pretenders/src/template/extract-attrs.spec.ts
+++ b/packages/@markuplint/pretenders/src/template/extract-attrs.spec.ts
@@ -45,4 +45,11 @@ describe('extractAttrs', () => {
 		const attrs = extractAttrs(root!);
 		expect(attrs).toStrictEqual([{ name: 'class', value: 'wrapper' }]);
 	});
+
+	test('extracts boolean attribute without value property', async () => {
+		const doc = await parseComponent(path.resolve(fixtureDir, 'DisabledButton.vue'));
+		const root = extractRoot(doc!);
+		const attrs = extractAttrs(root!);
+		expect(attrs).toStrictEqual([{ name: 'disabled' }]);
+	});
 });

--- a/packages/@markuplint/pretenders/src/template/extract-attrs.ts
+++ b/packages/@markuplint/pretenders/src/template/extract-attrs.ts
@@ -1,0 +1,28 @@
+import type { MLASTElement } from '@markuplint/ml-ast';
+import type { PretenderAttr } from '@markuplint/ml-config';
+
+/**
+ * Extracts static attributes from an MLAST element node as PretenderAttr entries.
+ *
+ * Only includes attributes with type `'attr'` (regular HTML attributes).
+ * Spread attributes are skipped. Boolean attributes (no value) are included
+ * without a `value` property.
+ */
+export function extractAttrs(element: MLASTElement): readonly PretenderAttr[] {
+	const result: PretenderAttr[] = [];
+
+	for (const attr of element.attributes) {
+		if (attr.type !== 'attr') {
+			continue;
+		}
+
+		const value = attr.value.raw;
+		if (value === '') {
+			result.push({ name: attr.nodeName });
+		} else {
+			result.push({ name: attr.nodeName, value });
+		}
+	}
+
+	return result;
+}

--- a/packages/@markuplint/pretenders/src/template/extract-root.spec.ts
+++ b/packages/@markuplint/pretenders/src/template/extract-root.spec.ts
@@ -1,0 +1,71 @@
+import path from 'node:path';
+
+import { describe, test, expect } from 'vitest';
+
+import { parseComponent } from './parse-component.js';
+import { extractRoot } from './extract-root.js';
+
+const fixtureDir = path.resolve(import.meta.dirname, '..', '..', 'test', 'fixtures', 'template');
+
+describe('extractRoot', () => {
+	describe('Vue', () => {
+		test('finds root <button> element at depth=0', async () => {
+			const doc = await parseComponent(path.resolve(fixtureDir, 'SimpleButton.vue'));
+			const root = extractRoot(doc!);
+			expect(root).not.toBeNull();
+			expect(root!.nodeName).toBe('button');
+		});
+
+		test('finds authored component <BaseButton> at depth=0', async () => {
+			const doc = await parseComponent(path.resolve(fixtureDir, 'WrappedComponent.vue'));
+			const root = extractRoot(doc!);
+			expect(root).not.toBeNull();
+			expect(root!.nodeName).toBe('BaseButton');
+		});
+
+		test('returns null when only text content exists (Fragment-like)', async () => {
+			const doc = await parseComponent(path.resolve(fixtureDir, 'FragmentOnly.vue'));
+			const root = extractRoot(doc!);
+			expect(root).toBeNull();
+		});
+
+		test('finds root <div> even when component has slots', async () => {
+			const doc = await parseComponent(path.resolve(fixtureDir, 'WithSlot.vue'));
+			const root = extractRoot(doc!);
+			expect(root).not.toBeNull();
+			expect(root!.nodeName).toBe('div');
+		});
+	});
+
+	describe('Svelte', () => {
+		test('finds root <button> element at depth=0', async () => {
+			const doc = await parseComponent(path.resolve(fixtureDir, 'SimpleButton.svelte'));
+			const root = extractRoot(doc!);
+			expect(root).not.toBeNull();
+			expect(root!.nodeName).toBe('button');
+		});
+
+		test('finds root <div> with slot child', async () => {
+			const doc = await parseComponent(path.resolve(fixtureDir, 'WithSlot.svelte'));
+			const root = extractRoot(doc!);
+			expect(root).not.toBeNull();
+			expect(root!.nodeName).toBe('div');
+		});
+	});
+
+	describe('Astro', () => {
+		test('finds root <button> element skipping frontmatter', async () => {
+			const doc = await parseComponent(path.resolve(fixtureDir, 'SimpleButton.astro'));
+			const root = extractRoot(doc!);
+			expect(root).not.toBeNull();
+			expect(root!.nodeName).toBe('button');
+		});
+
+		test('finds root <div> with slot child', async () => {
+			const doc = await parseComponent(path.resolve(fixtureDir, 'WithSlot.astro'));
+			const root = extractRoot(doc!);
+			expect(root).not.toBeNull();
+			expect(root!.nodeName).toBe('div');
+		});
+	});
+});

--- a/packages/@markuplint/pretenders/src/template/extract-root.ts
+++ b/packages/@markuplint/pretenders/src/template/extract-root.ts
@@ -1,0 +1,18 @@
+import type { MLASTDocument, MLASTElement } from '@markuplint/ml-ast';
+
+/**
+ * Extracts the first substantive element at depth=0 from a parsed document.
+ *
+ * Skips text nodes, comments, preprocessor-specific blocks (frontmatter, etc.),
+ * and end tags. Returns the first `starttag` node found at depth 0.
+ *
+ * @returns The root element, or `null` if only text/comments exist (Fragment-like).
+ */
+export function extractRoot(doc: MLASTDocument): MLASTElement | null {
+	for (const node of doc.nodeList) {
+		if (node.type === 'starttag' && node.depth === 0 && !node.isFragment) {
+			return node;
+		}
+	}
+	return null;
+}

--- a/packages/@markuplint/pretenders/src/template/index.spec.ts
+++ b/packages/@markuplint/pretenders/src/template/index.spec.ts
@@ -1,0 +1,178 @@
+import path from 'node:path';
+
+import { describe, test, expect } from 'vitest';
+
+import { templateScanner } from './index.js';
+
+const _ = (filePath: string) => filePath.split('/').join(path.sep);
+const fixtureDir = path.resolve(import.meta.dirname, '..', '..', 'test', 'fixtures', 'template');
+const resolve = (name: string) => path.resolve(fixtureDir, name);
+
+describe('templateScanner', () => {
+	describe('Vue', () => {
+		test('scans SimpleButton.vue — root <button> with static attrs', async () => {
+			const result = await templateScanner([resolve('SimpleButton.vue')]);
+			expect(result).toStrictEqual([
+				{
+					selector: 'SimpleButton',
+					as: {
+						element: 'button',
+						attrs: [
+							{ name: 'type', value: 'button' },
+							{ name: 'class', value: 'btn' },
+						],
+						slots: null,
+					},
+					filePath: _('packages/@markuplint/pretenders/test/fixtures/template/SimpleButton.vue:2:2'),
+				},
+			]);
+		});
+
+		test('scans WrappedComponent.vue — root is authored <BaseButton>', async () => {
+			const result = await templateScanner([resolve('WrappedComponent.vue')]);
+			expect(result).toStrictEqual([
+				{
+					selector: 'WrappedComponent',
+					as: {
+						element: 'BaseButton',
+						attrs: [{ name: 'variant', value: 'primary' }],
+						slots: null,
+					},
+					filePath: _('packages/@markuplint/pretenders/test/fixtures/template/WrappedComponent.vue:2:2'),
+				},
+			]);
+		});
+
+		test('scans FragmentOnly.vue — returns empty (no root element)', async () => {
+			const result = await templateScanner([resolve('FragmentOnly.vue')]);
+			expect(result).toStrictEqual([]);
+		});
+
+		test('scans WithSlot.vue — root <div> with slots detected', async () => {
+			const result = await templateScanner([resolve('WithSlot.vue')]);
+			expect(result).toStrictEqual([
+				{
+					selector: 'WithSlot',
+					as: {
+						element: 'div',
+						attrs: [{ name: 'class', value: 'wrapper' }],
+						slots: true,
+					},
+					filePath: _('packages/@markuplint/pretenders/test/fixtures/template/WithSlot.vue:2:2'),
+				},
+			]);
+		});
+	});
+
+	describe('Svelte', () => {
+		test('scans SimpleButton.svelte — root <button> with static attrs', async () => {
+			const result = await templateScanner([resolve('SimpleButton.svelte')]);
+			expect(result).toStrictEqual([
+				{
+					selector: 'SimpleButton',
+					as: {
+						element: 'button',
+						attrs: [
+							{ name: 'type', value: 'button' },
+							{ name: 'class', value: 'btn' },
+						],
+						slots: null,
+					},
+					filePath: _('packages/@markuplint/pretenders/test/fixtures/template/SimpleButton.svelte:1:1'),
+				},
+			]);
+		});
+
+		test('scans WithSlot.svelte — Svelte 4 <slot> detected', async () => {
+			const result = await templateScanner([resolve('WithSlot.svelte')]);
+			expect(result).toStrictEqual([
+				{
+					selector: 'WithSlot',
+					as: {
+						element: 'div',
+						attrs: [{ name: 'class', value: 'wrapper' }],
+						slots: true,
+					},
+					filePath: _('packages/@markuplint/pretenders/test/fixtures/template/WithSlot.svelte:1:1'),
+				},
+			]);
+		});
+
+		test('scans WithSnippet.svelte — Svelte 5 {@render children()} detected', async () => {
+			const result = await templateScanner([resolve('WithSnippet.svelte')]);
+			expect(result).toStrictEqual([
+				{
+					selector: 'WithSnippet',
+					as: {
+						element: 'div',
+						attrs: [{ name: 'class', value: 'wrapper' }],
+						slots: true,
+					},
+					filePath: _('packages/@markuplint/pretenders/test/fixtures/template/WithSnippet.svelte:1:1'),
+				},
+			]);
+		});
+	});
+
+	describe('Astro', () => {
+		test('scans SimpleButton.astro — root <button> skipping frontmatter', async () => {
+			const result = await templateScanner([resolve('SimpleButton.astro')]);
+			expect(result).toStrictEqual([
+				{
+					selector: 'SimpleButton',
+					as: {
+						element: 'button',
+						attrs: [
+							{ name: 'type', value: 'button' },
+							{ name: 'class', value: 'btn' },
+						],
+						slots: null,
+					},
+					filePath: _('packages/@markuplint/pretenders/test/fixtures/template/SimpleButton.astro:3:1'),
+				},
+			]);
+		});
+
+		test('scans WithSlot.astro — <slot /> detected', async () => {
+			const result = await templateScanner([resolve('WithSlot.astro')]);
+			expect(result).toStrictEqual([
+				{
+					selector: 'WithSlot',
+					as: {
+						element: 'div',
+						attrs: [{ name: 'class', value: 'wrapper' }],
+						slots: true,
+					},
+					filePath: _('packages/@markuplint/pretenders/test/fixtures/template/WithSlot.astro:3:1'),
+				},
+			]);
+		});
+	});
+
+	describe('Options', () => {
+		test('ignoreComponentNames filters out specified components', async () => {
+			const result = await templateScanner([resolve('SimpleButton.vue')], {
+				ignoreComponentNames: ['SimpleButton'],
+			});
+			expect(result).toStrictEqual([]);
+		});
+
+		test('multiple files scanned together and sorted by selector', async () => {
+			const result = await templateScanner([resolve('SimpleButton.vue'), resolve('WithSlot.vue')]);
+			expect(result).toHaveLength(2);
+			expect(result[0]!.selector).toBe('SimpleButton');
+			expect(result[1]!.selector).toBe('WithSlot');
+		});
+	});
+
+	describe('Edge cases', () => {
+		test('rejects relative file paths', () => {
+			expect(() => templateScanner(['relative/path.vue'])).toThrow(ReferenceError);
+		});
+
+		test('unsupported file extension returns empty result', async () => {
+			const result = await templateScanner([resolve('SimpleButton.vue').replace('.vue', '.html')]);
+			expect(result).toStrictEqual([]);
+		});
+	});
+});

--- a/packages/@markuplint/pretenders/src/template/index.ts
+++ b/packages/@markuplint/pretenders/src/template/index.ts
@@ -1,0 +1,62 @@
+import type { PretenderScanTemplateOptions } from './types.js';
+import type { OriginalNode } from '@markuplint/ml-config';
+
+import path from 'node:path';
+
+import { createScanner } from '../create-scanner.js';
+import { PretenderDirector } from '../pretender-director.js';
+
+import { deriveName } from './derive-name.js';
+import { detectSlots } from './detect-slots.js';
+import { extractAttrs } from './extract-attrs.js';
+import { extractRoot } from './extract-root.js';
+import { parseComponent } from './parse-component.js';
+
+/**
+ * Template scanner for Vue, Svelte, and Astro component files.
+ *
+ * Parses component files using markuplint's existing framework parsers,
+ * extracts root elements at depth=0, detects static attributes and slot usage,
+ * and registers component-to-element mappings via PretenderDirector.
+ */
+export const templateScanner = createScanner<PretenderScanTemplateOptions>(async (files, options) => {
+	const cwd = options?.cwd ?? process.cwd();
+	const ignoreComponentNames = options?.ignoreComponentNames ?? [];
+	const director = new PretenderDirector();
+
+	for (const filePath of files) {
+		const componentName = deriveName(filePath);
+
+		if (ignoreComponentNames.includes(componentName)) {
+			continue;
+		}
+
+		const doc = await parseComponent(filePath);
+		if (!doc) {
+			continue;
+		}
+
+		const root = extractRoot(doc);
+		if (!root) {
+			continue;
+		}
+
+		const tagName = root.nodeName;
+		const attrs = extractAttrs(root);
+		const hasSlots = detectSlots(doc);
+		const relFilePath = path.relative(cwd, filePath);
+
+		const identity: string | OriginalNode =
+			attrs.length > 0 || hasSlots
+				? {
+						element: tagName,
+						...(attrs.length > 0 ? { attrs } : {}),
+						slots: hasSlots ? true : null,
+					}
+				: tagName;
+
+		director.add(componentName, identity, relFilePath, root.line, root.col);
+	}
+
+	return director.getPretenders();
+});

--- a/packages/@markuplint/pretenders/src/template/parse-component.spec.ts
+++ b/packages/@markuplint/pretenders/src/template/parse-component.spec.ts
@@ -1,0 +1,62 @@
+import path from 'node:path';
+
+import { describe, test, expect } from 'vitest';
+
+import { getFrameworkType, parseComponent } from './parse-component.js';
+
+const fixtureDir = path.resolve(import.meta.dirname, '..', '..', 'test', 'fixtures', 'template');
+
+describe('getFrameworkType', () => {
+	test('returns "vue" for .vue files', () => {
+		expect(getFrameworkType('Component.vue')).toBe('vue');
+	});
+
+	test('returns "svelte" for .svelte files', () => {
+		expect(getFrameworkType('Component.svelte')).toBe('svelte');
+	});
+
+	test('returns "astro" for .astro files', () => {
+		expect(getFrameworkType('Component.astro')).toBe('astro');
+	});
+
+	test('returns null for unsupported extensions', () => {
+		expect(getFrameworkType('Component.html')).toBeNull();
+	});
+
+	test('returns null for files without extensions', () => {
+		expect(getFrameworkType('Makefile')).toBeNull();
+	});
+
+	test('is case-insensitive for extensions', () => {
+		expect(getFrameworkType('Component.VUE')).toBe('vue');
+	});
+});
+
+describe('parseComponent', () => {
+	test('returns MLASTDocument for a valid .vue file', async () => {
+		const doc = await parseComponent(path.resolve(fixtureDir, 'SimpleButton.vue'));
+		expect(doc).not.toBeNull();
+		expect(doc!.nodeList.length).toBeGreaterThan(0);
+	});
+
+	test('returns MLASTDocument for a valid .svelte file', async () => {
+		const doc = await parseComponent(path.resolve(fixtureDir, 'SimpleButton.svelte'));
+		expect(doc).not.toBeNull();
+		expect(doc!.nodeList.length).toBeGreaterThan(0);
+	});
+
+	test('returns MLASTDocument for a valid .astro file', async () => {
+		const doc = await parseComponent(path.resolve(fixtureDir, 'SimpleButton.astro'));
+		expect(doc).not.toBeNull();
+		expect(doc!.nodeList.length).toBeGreaterThan(0);
+	});
+
+	test('returns null for unsupported file extension', async () => {
+		const doc = await parseComponent('/absolute/path/to/Component.html');
+		expect(doc).toBeNull();
+	});
+
+	test('returns null when file does not exist (fs.readFileSync throws)', async () => {
+		await expect(parseComponent('/nonexistent/path/Component.vue')).rejects.toThrow();
+	});
+});

--- a/packages/@markuplint/pretenders/src/template/parse-component.ts
+++ b/packages/@markuplint/pretenders/src/template/parse-component.ts
@@ -1,0 +1,56 @@
+import type { MLASTDocument, MLParser } from '@markuplint/ml-ast';
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+type FrameworkType = 'vue' | 'svelte' | 'astro';
+
+const EXTENSION_MAP: Record<string, FrameworkType> = {
+	'.vue': 'vue',
+	'.svelte': 'svelte',
+	'.astro': 'astro',
+};
+
+/**
+ * Determines the framework type from the file extension.
+ */
+export function getFrameworkType(filePath: string): FrameworkType | null {
+	const ext = path.extname(filePath).toLowerCase();
+	return EXTENSION_MAP[ext] ?? null;
+}
+
+/**
+ * Dynamically imports the appropriate parser for the given framework.
+ */
+async function getParser(framework: FrameworkType): Promise<MLParser> {
+	switch (framework) {
+		case 'vue': {
+			const { parser } = await import('@markuplint/vue-parser');
+			return parser;
+		}
+		case 'svelte': {
+			const { parser } = await import('@markuplint/svelte-parser');
+			return parser;
+		}
+		case 'astro': {
+			const { parser } = await import('@markuplint/astro-parser');
+			return parser;
+		}
+	}
+}
+
+/**
+ * Parses a component file into an MLASTDocument using the appropriate framework parser.
+ *
+ * @returns The parsed document, or `null` if the file extension is not supported.
+ */
+export async function parseComponent(filePath: string): Promise<MLASTDocument | null> {
+	const framework = getFrameworkType(filePath);
+	if (!framework) {
+		return null;
+	}
+
+	const sourceCode = fs.readFileSync(filePath, 'utf8');
+	const parser = await getParser(framework);
+	return parser.parse(sourceCode);
+}

--- a/packages/@markuplint/pretenders/src/template/parse-component.ts
+++ b/packages/@markuplint/pretenders/src/template/parse-component.ts
@@ -19,30 +19,32 @@ export function getFrameworkType(filePath: string): FrameworkType | null {
 	return EXTENSION_MAP[ext] ?? null;
 }
 
+const PARSER_PACKAGES: Record<FrameworkType, string> = {
+	vue: '@markuplint/vue-parser',
+	svelte: '@markuplint/svelte-parser',
+	astro: '@markuplint/astro-parser',
+};
+
 /**
  * Dynamically imports the appropriate parser for the given framework.
+ *
+ * @returns The parser, or `null` if the parser package is not installed.
  */
-async function getParser(framework: FrameworkType): Promise<MLParser> {
-	switch (framework) {
-		case 'vue': {
-			const { parser } = await import('@markuplint/vue-parser');
-			return parser;
-		}
-		case 'svelte': {
-			const { parser } = await import('@markuplint/svelte-parser');
-			return parser;
-		}
-		case 'astro': {
-			const { parser } = await import('@markuplint/astro-parser');
-			return parser;
-		}
+async function getParser(framework: FrameworkType): Promise<MLParser | null> {
+	const pkg = PARSER_PACKAGES[framework];
+	try {
+		const mod: { parser: MLParser } = await import(pkg);
+		return mod.parser;
+	} catch {
+		return null;
 	}
 }
 
 /**
  * Parses a component file into an MLASTDocument using the appropriate framework parser.
  *
- * @returns The parsed document, or `null` if the file extension is not supported.
+ * @returns The parsed document, or `null` if the file extension is not supported
+ *          or the required parser package is not installed.
  */
 export async function parseComponent(filePath: string): Promise<MLASTDocument | null> {
 	const framework = getFrameworkType(filePath);
@@ -50,7 +52,11 @@ export async function parseComponent(filePath: string): Promise<MLASTDocument | 
 		return null;
 	}
 
-	const sourceCode = fs.readFileSync(filePath, 'utf8');
 	const parser = await getParser(framework);
+	if (!parser) {
+		return null;
+	}
+
+	const sourceCode = fs.readFileSync(filePath, 'utf8');
 	return parser.parse(sourceCode);
 }

--- a/packages/@markuplint/pretenders/src/template/types.ts
+++ b/packages/@markuplint/pretenders/src/template/types.ts
@@ -1,0 +1,6 @@
+import type { PretenderScanOptions } from '@markuplint/ml-config';
+
+/**
+ * Options for the template scanner.
+ */
+export interface PretenderScanTemplateOptions extends PretenderScanOptions {}

--- a/packages/@markuplint/pretenders/test/fixtures/template/DisabledButton.vue
+++ b/packages/@markuplint/pretenders/test/fixtures/template/DisabledButton.vue
@@ -1,0 +1,3 @@
+<template>
+	<button disabled>Submit</button>
+</template>

--- a/packages/@markuplint/pretenders/test/fixtures/template/FragmentOnly.vue
+++ b/packages/@markuplint/pretenders/test/fixtures/template/FragmentOnly.vue
@@ -1,0 +1,3 @@
+<template>
+	some text only
+</template>

--- a/packages/@markuplint/pretenders/test/fixtures/template/SimpleButton.astro
+++ b/packages/@markuplint/pretenders/test/fixtures/template/SimpleButton.astro
@@ -1,0 +1,3 @@
+---
+---
+<button type="button" class="btn">Click me</button>

--- a/packages/@markuplint/pretenders/test/fixtures/template/SimpleButton.svelte
+++ b/packages/@markuplint/pretenders/test/fixtures/template/SimpleButton.svelte
@@ -1,0 +1,1 @@
+<button type="button" class="btn">Click me</button>

--- a/packages/@markuplint/pretenders/test/fixtures/template/SimpleButton.vue
+++ b/packages/@markuplint/pretenders/test/fixtures/template/SimpleButton.vue
@@ -1,0 +1,3 @@
+<template>
+	<button type="button" class="btn">Click me</button>
+</template>

--- a/packages/@markuplint/pretenders/test/fixtures/template/WithSlot.astro
+++ b/packages/@markuplint/pretenders/test/fixtures/template/WithSlot.astro
@@ -1,0 +1,5 @@
+---
+---
+<div class="wrapper">
+	<slot />
+</div>

--- a/packages/@markuplint/pretenders/test/fixtures/template/WithSlot.svelte
+++ b/packages/@markuplint/pretenders/test/fixtures/template/WithSlot.svelte
@@ -1,0 +1,3 @@
+<div class="wrapper">
+	<slot></slot>
+</div>

--- a/packages/@markuplint/pretenders/test/fixtures/template/WithSlot.vue
+++ b/packages/@markuplint/pretenders/test/fixtures/template/WithSlot.vue
@@ -1,0 +1,5 @@
+<template>
+	<div class="wrapper">
+		<slot></slot>
+	</div>
+</template>

--- a/packages/@markuplint/pretenders/test/fixtures/template/WithSnippet.svelte
+++ b/packages/@markuplint/pretenders/test/fixtures/template/WithSnippet.svelte
@@ -1,0 +1,3 @@
+<div class="wrapper">
+	{@render children()}
+</div>

--- a/packages/@markuplint/pretenders/test/fixtures/template/WrappedComponent.vue
+++ b/packages/@markuplint/pretenders/test/fixtures/template/WrappedComponent.vue
@@ -1,0 +1,3 @@
+<template>
+	<BaseButton variant="primary">Submit</BaseButton>
+</template>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2271,7 +2271,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@markuplint/astro-parser@workspace:packages/@markuplint/astro-parser":
+"@markuplint/astro-parser@npm:5.0.0-alpha.3, @markuplint/astro-parser@workspace:packages/@markuplint/astro-parser":
   version: 0.0.0-use.local
   resolution: "@markuplint/astro-parser@workspace:packages/@markuplint/astro-parser"
   dependencies:
@@ -2552,11 +2552,22 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@markuplint/pretenders@workspace:packages/@markuplint/pretenders"
   dependencies:
+    "@markuplint/astro-parser": "npm:5.0.0-alpha.3"
+    "@markuplint/ml-ast": "npm:5.0.0-alpha.3"
     "@markuplint/ml-config": "npm:5.0.0-alpha.3"
     "@markuplint/parser-utils": "npm:5.0.0-alpha.3"
+    "@markuplint/svelte-parser": "npm:5.0.0-alpha.3"
+    "@markuplint/vue-parser": "npm:5.0.0-alpha.3"
     glob: "npm:13.0.6"
     meow: "npm:14.1.0"
     typescript: "npm:5.9.3"
+  dependenciesMeta:
+    "@markuplint/astro-parser":
+      optional: true
+    "@markuplint/svelte-parser":
+      optional: true
+    "@markuplint/vue-parser":
+      optional: true
   bin:
     pretenders: ./bin/pretenders.mjs
   languageName: unknown
@@ -2652,7 +2663,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@markuplint/svelte-parser@workspace:packages/@markuplint/svelte-parser":
+"@markuplint/svelte-parser@npm:5.0.0-alpha.3, @markuplint/svelte-parser@workspace:packages/@markuplint/svelte-parser":
   version: 0.0.0-use.local
   resolution: "@markuplint/svelte-parser@workspace:packages/@markuplint/svelte-parser"
   dependencies:
@@ -2725,7 +2736,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@markuplint/vue-parser@workspace:packages/@markuplint/vue-parser":
+"@markuplint/vue-parser@npm:5.0.0-alpha.3, @markuplint/vue-parser@workspace:packages/@markuplint/vue-parser":
   version: 0.0.0-use.local
   resolution: "@markuplint/vue-parser@workspace:packages/@markuplint/vue-parser"
   dependencies:


### PR DESCRIPTION
Implement a new templateScanner module that reuses markuplint's existing
framework parsers to extract root elements from component files and
generate Pretender mappings (#3338).

- derive-name: converts file paths to PascalCase component names
- extract-root: finds first depth=0 element from MLAST nodeList
- extract-attrs: extracts static attributes from root elements
- detect-slots: detects slot usage across Vue, Svelte 4/5, and Astro
- parse-component: dynamically imports the appropriate framework parser
- templateScanner: orchestrates the pipeline via PretenderDirector

47 tests covering unit modules and full integration pipeline.

https://claude.ai/code/session_012LcNN5rE7PihHjJfDNEct6