### PR TITLE
Add unified scan function for JSX and template components

### DIFF
--- a/packages/@markuplint/pretenders/src/cli.ts
+++ b/packages/@markuplint/pretenders/src/cli.ts
@@ -14,9 +14,8 @@ import path from 'node:path';
 import meow from 'meow';
 
 import { getFileList } from './input.js';
-import { jsxScanner } from './jsx/index.js';
 import { out } from './out.js';
-import { templateScanner } from './template/index.js';
+import { scan } from './scan.js';
 
 const commands = meow({
 	importMeta: import.meta,
@@ -39,22 +38,8 @@ if (commands.input.length === 0) {
 async function main() {
 	const files = await getFileList(commands.input);
 
-	const jsxFiles = files.filter(filePath => /\.[jt]sx?$/.test(filePath));
-	const templateFiles = files.filter(filePath => /\.(?:vue|svelte|astro)$/.test(filePath));
-
-	const ignoreComponentNames = commands.flags.ignore?.split(',').map(s => s.trim());
-
-	const [jsxPretenders, templatePretenders] = await Promise.all([
-		jsxFiles.length > 0 ? jsxScanner(jsxFiles, { ignoreComponentNames }) : Promise.resolve([]),
-		templateFiles.length > 0 ? templateScanner(templateFiles, { ignoreComponentNames }) : Promise.resolve([]),
-	]);
-
-	const pretenders = [...jsxPretenders, ...templatePretenders].toSorted((a, b) => {
-		const nameA = a.selector.toLowerCase();
-		const nameB = b.selector.toLowerCase();
-		if (nameA < nameB) return -1;
-		if (nameA > nameB) return 1;
-		return 0;
+	const pretenders = await scan(files, {
+		ignoreComponentNames: commands.flags.ignore?.split(',').map(s => s.trim()),
 	});
 
 	const outFilePath = path.resolve(process.cwd(), commands.flags.out);

--- a/packages/@markuplint/pretenders/src/cli.ts
+++ b/packages/@markuplint/pretenders/src/cli.ts
@@ -16,6 +16,7 @@ import meow from 'meow';
 import { getFileList } from './input.js';
 import { jsxScanner } from './jsx/index.js';
 import { out } from './out.js';
+import { templateScanner } from './template/index.js';
 
 const commands = meow({
 	importMeta: import.meta,
@@ -39,9 +40,21 @@ async function main() {
 	const files = await getFileList(commands.input);
 
 	const jsxFiles = files.filter(filePath => /\.[jt]sx?$/.test(filePath));
+	const templateFiles = files.filter(filePath => /\.(?:vue|svelte|astro)$/.test(filePath));
 
-	const pretenders = await jsxScanner(jsxFiles, {
-		ignoreComponentNames: commands.flags.ignore?.split(',').map(s => s.trim()),
+	const ignoreComponentNames = commands.flags.ignore?.split(',').map(s => s.trim());
+
+	const [jsxPretenders, templatePretenders] = await Promise.all([
+		jsxFiles.length > 0 ? jsxScanner(jsxFiles, { ignoreComponentNames }) : Promise.resolve([]),
+		templateFiles.length > 0 ? templateScanner(templateFiles, { ignoreComponentNames }) : Promise.resolve([]),
+	]);
+
+	const pretenders = [...jsxPretenders, ...templatePretenders].toSorted((a, b) => {
+		const nameA = a.selector.toLowerCase();
+		const nameB = b.selector.toLowerCase();
+		if (nameA < nameB) return -1;
+		if (nameA > nameB) return 1;
+		return 0;
 	});
 
 	const outFilePath = path.resolve(process.cwd(), commands.flags.out);

--- a/packages/@markuplint/pretenders/src/dependency-mapper.ts
+++ b/packages/@markuplint/pretenders/src/dependency-mapper.ts
@@ -87,7 +87,7 @@ function getElName(identity: Identity) {
 	return identity.element;
 }
 
-function propSort<T, P extends keyof T>(propName: P) {
+export function propSort<T, P extends keyof T>(propName: P) {
 	return (a: T, b: T) => {
 		const nameA = toLowerCase(a[propName]);
 		const nameB = toLowerCase(b[propName]);

--- a/packages/@markuplint/pretenders/src/index.ts
+++ b/packages/@markuplint/pretenders/src/index.ts
@@ -13,6 +13,8 @@
 
 export { jsxScanner } from './jsx/index.js';
 export { templateScanner } from './template/index.js';
+export { scan } from './scan.js';
+export type { ScanOptions } from './scan.js';
 export { analyzeImports, resolveComponentImport } from './import-resolver/index.js';
 export type { ImportBinding, ImportAnalysisResult } from './import-resolver/types.js';
 export type * from './types.js';

--- a/packages/@markuplint/pretenders/src/scan.spec.ts
+++ b/packages/@markuplint/pretenders/src/scan.spec.ts
@@ -1,0 +1,90 @@
+import path from 'node:path';
+
+import { describe, test, expect } from 'vitest';
+
+import { scan } from './scan.js';
+
+const _ = (filePath: string) => filePath.split('/').join(path.sep);
+const fixtureDir = path.resolve(import.meta.dirname, '..', 'test', 'fixtures');
+const jsxFixture = (name: string) => path.resolve(fixtureDir, name);
+const templateFixture = (name: string) => path.resolve(fixtureDir, 'template', name);
+
+describe('scan', () => {
+	describe('dispatch by extension', () => {
+		test('JSX-only input produces JSX pretenders', async () => {
+			const result = await scan([jsxFixture('002.tsx')]);
+			expect(result).toStrictEqual([
+				{
+					selector: 'FooBar',
+					as: 'div',
+					filePath: _('packages/@markuplint/pretenders/test/fixtures/002.tsx:1:6'),
+				},
+			]);
+		});
+
+		test('template-only input produces template pretenders', async () => {
+			const result = await scan([templateFixture('SimpleButton.vue')]);
+			expect(result).toStrictEqual([expect.objectContaining({ selector: 'SimpleButton' })]);
+		});
+
+		test('mixed JSX + template input merges and sorts results', async () => {
+			const result = await scan([
+				jsxFixture('002.tsx'),
+				templateFixture('SimpleButton.vue'),
+				templateFixture('WithSlot.svelte'),
+			]);
+			const selectors = result.map(p => p.selector);
+			expect(selectors).toStrictEqual(['FooBar', 'SimpleButton', 'WithSlot']);
+		});
+	});
+
+	describe('sort order', () => {
+		test('results are sorted case-insensitively by selector', async () => {
+			const result = await scan([templateFixture('WithSlot.vue'), templateFixture('SimpleButton.vue')]);
+			const selectors = result.map(p => p.selector);
+			expect(selectors).toStrictEqual(['SimpleButton', 'WithSlot']);
+		});
+	});
+
+	describe('ignoreComponentNames', () => {
+		test('filters out JSX components', async () => {
+			const result = await scan([jsxFixture('002.tsx')], {
+				ignoreComponentNames: ['FooBar'],
+			});
+			expect(result).toStrictEqual([]);
+		});
+
+		test('filters out template components', async () => {
+			const result = await scan([templateFixture('SimpleButton.vue')], {
+				ignoreComponentNames: ['SimpleButton'],
+			});
+			expect(result).toStrictEqual([]);
+		});
+
+		test('filters across both scanners in mixed input', async () => {
+			const result = await scan([jsxFixture('002.tsx'), templateFixture('SimpleButton.vue')], {
+				ignoreComponentNames: ['FooBar', 'SimpleButton'],
+			});
+			expect(result).toStrictEqual([]);
+		});
+	});
+
+	describe('edge cases', () => {
+		test('empty file list returns empty result', async () => {
+			const result = await scan([]);
+			expect(result).toStrictEqual([]);
+		});
+
+		test('unsupported extensions are silently ignored', async () => {
+			const result = await scan([
+				path.resolve(fixtureDir, 'nonexistent.html'),
+				templateFixture('SimpleButton.vue'),
+			]);
+			expect(result).toStrictEqual([expect.objectContaining({ selector: 'SimpleButton' })]);
+		});
+
+		test('rejects relative file paths via underlying scanners', async () => {
+			await expect(scan(['relative/path.tsx'])).rejects.toThrow(ReferenceError);
+		});
+	});
+});

--- a/packages/@markuplint/pretenders/src/scan.ts
+++ b/packages/@markuplint/pretenders/src/scan.ts
@@ -1,0 +1,30 @@
+import type { Pretender } from '@markuplint/ml-config';
+
+import { propSort } from './dependency-mapper.js';
+import { jsxScanner } from './jsx/index.js';
+import { templateScanner } from './template/index.js';
+
+export interface ScanOptions {
+	readonly ignoreComponentNames?: readonly string[];
+}
+
+/**
+ * Dispatches files to the appropriate scanner based on file extension,
+ * runs both scanners in parallel, and merges + sorts the results.
+ *
+ * - `.js`, `.jsx`, `.ts`, `.tsx` → {@link jsxScanner}
+ * - `.vue`, `.svelte`, `.astro` → {@link templateScanner}
+ */
+export async function scan(files: readonly string[], options?: ScanOptions): Promise<Pretender[]> {
+	const jsxFiles = files.filter(filePath => /\.[jt]sx?$/.test(filePath));
+	const templateFiles = files.filter(filePath => /\.(?:vue|svelte|astro)$/.test(filePath));
+
+	const ignoreComponentNames = options?.ignoreComponentNames ? [...options.ignoreComponentNames] : undefined;
+
+	const [jsxPretenders, templatePretenders] = await Promise.all([
+		jsxFiles.length > 0 ? jsxScanner(jsxFiles, { ignoreComponentNames }) : Promise.resolve([]),
+		templateFiles.length > 0 ? templateScanner(templateFiles, { ignoreComponentNames }) : Promise.resolve([]),
+	]);
+
+	return [...jsxPretenders, ...templatePretenders].toSorted(propSort('selector'));
+}


### PR DESCRIPTION
Fixes #3340 

## What is the purpose of this PR?

- [x] Add a new core feature
- [x] Improve or refactor core features

### Description

This PR introduces a new `scan()` function that provides a unified interface for scanning both JSX and template-based components. Previously, callers had to manually dispatch files to the appropriate scanner (`jsxScanner` or `templateScanner`). The new function:

- **Automatically dispatches files** based on extension:
  - `.js`, `.jsx`, `.ts`, `.tsx` → `jsxScanner`
  - `.vue`, `.svelte`, `.astro` → `templateScanner`
- **Runs both scanners in parallel** for better performance
- **Merges and sorts results** case-insensitively by component selector
- **Supports filtering** via the `ignoreComponentNames` option across both scanners
- **Exports the utility** from the main package index for public use

The CLI has been updated to use this new unified function, simplifying the code and enabling future support for template components without additional changes.

#### Changes:
- Added `scan.ts` with the new unified scanning function
- Added comprehensive test suite (`scan.spec.ts`) covering dispatch logic, sorting, filtering, and edge cases
- Updated `cli.ts` to use the new `scan()` function
- Exported `propSort` utility from `dependency-mapper.ts` for reuse
- Exported `scan` and `ScanOptions` from the main package index

## Checklist

- [x] Add a new core feature
  - [x] Add comprehensive test coverage (90 lines of test cases)
  - [x] Export from main package index for public API

https://claude.ai/code/session_01DUrBdgGFD3bXan8xvYbUnL