### PR TITLE
Implement JSX children slot detection for pretenders

### DIFF
--- a/packages/@markuplint/ml-core/src/index.spec.ts
+++ b/packages/@markuplint/ml-core/src/index.spec.ts
@@ -289,6 +289,42 @@ div#hoge.foo.bar
 			}).matches('Custom'),
 		).toBeTruthy();
 	});
+
+	test('pretenders: slots: null treats component as void-like (no children shared)', async () => {
+		const jsxParser = await import('@markuplint/jsx-parser');
+
+		// slots: null — virtual element should have no children
+		const voidEl = createTestElement('<VoidComp>child text</VoidComp>', {
+			parser: jsxParser,
+			pretenders: [
+				{
+					selector: 'VoidComp',
+					as: { element: 'img', slots: null },
+				},
+			],
+		});
+		const voidPretender = voidEl.pretenderContext;
+		expect(voidPretender?.type).toBe('pretender');
+		if (voidPretender?.type === 'pretender') {
+			expect([...voidPretender.as.childNodes]).toHaveLength(0);
+		}
+
+		// slots: true — virtual element should share children
+		const slotEl = createTestElement('<SlotComp>child text</SlotComp>', {
+			parser: jsxParser,
+			pretenders: [
+				{
+					selector: 'SlotComp',
+					as: { element: 'div', slots: true },
+				},
+			],
+		});
+		const slotPretender = slotEl.pretenderContext;
+		expect(slotPretender?.type).toBe('pretender');
+		if (slotPretender?.type === 'pretender') {
+			expect([...slotPretender.as.childNodes].length).toBeGreaterThan(0);
+		}
+	});
 });
 
 describe('Rule', () => {

--- a/packages/@markuplint/ml-core/src/index.spec.ts
+++ b/packages/@markuplint/ml-core/src/index.spec.ts
@@ -303,11 +303,8 @@ div#hoge.foo.bar
 				},
 			],
 		});
-		const voidPretender = voidEl.pretenderContext;
-		expect(voidPretender?.type).toBe('pretender');
-		if (voidPretender?.type === 'pretender') {
-			expect([...voidPretender.as.childNodes]).toHaveLength(0);
-		}
+		expect(voidEl.pretenderContext?.type).toBe('pretender');
+		expect([...(voidEl.pretenderContext as any).as.childNodes]).toHaveLength(0);
 
 		// slots: true — virtual element should share children
 		const slotEl = createTestElement('<SlotComp>child text</SlotComp>', {
@@ -319,11 +316,24 @@ div#hoge.foo.bar
 				},
 			],
 		});
-		const slotPretender = slotEl.pretenderContext;
-		expect(slotPretender?.type).toBe('pretender');
-		if (slotPretender?.type === 'pretender') {
-			expect([...slotPretender.as.childNodes].length).toBeGreaterThan(0);
-		}
+		expect(slotEl.pretenderContext?.type).toBe('pretender');
+		expect([...(slotEl.pretenderContext as any).as.childNodes].length).toBeGreaterThan(0);
+	});
+
+	test('pretenders: bare string identity (slots undefined) shares children for backward compat', async () => {
+		const jsxParser = await import('@markuplint/jsx-parser');
+
+		const el = createTestElement('<Comp>child text</Comp>', {
+			parser: jsxParser,
+			pretenders: [
+				{
+					selector: 'Comp',
+					as: 'div',
+				},
+			],
+		});
+		expect(el.pretenderContext?.type).toBe('pretender');
+		expect([...(el.pretenderContext as any).as.childNodes].length).toBeGreaterThan(0);
 	});
 });
 

--- a/packages/@markuplint/ml-core/src/ml-dom/node/element.ts
+++ b/packages/@markuplint/ml-core/src/ml-dom/node/element.ts
@@ -33,7 +33,7 @@ import { MLAttr } from './attr.js';
 import { MLDomTokenList } from './dom-token-list.js';
 import { MLElementCloseTag } from './element-close-tag.js';
 import { toNamedNodeMap } from './named-node-map.js';
-import { toHTMLCollection } from './node-list.js';
+import { toHTMLCollection, toNodeList } from './node-list.js';
 import { MLParentNode } from './parent-node.js';
 import { UnexpectedCallError } from './unexpected-call-error.js';
 
@@ -3968,6 +3968,8 @@ export class MLElement<T extends RuleConfigValue, O extends PlainData = undefine
 			aria = pretenderElement.aria;
 		}
 
+		const slots = typeof pretenderElement === 'string' ? undefined : pretenderElement.slots;
+
 		const as = new MLElement<T, O>(
 			{
 				...this._astToken,
@@ -3981,7 +3983,13 @@ export class MLElement<T extends RuleConfigValue, O extends PlainData = undefine
 			this.ownerMLDocument,
 		);
 
-		as.resetChildren(this.childNodes);
+		// When slots is null, the component does not accept children (void-like).
+		// Explicitly set empty children to prevent inheriting from the AST token.
+		if (slots === null) {
+			as.resetChildren(toNodeList([]));
+		} else {
+			as.resetChildren(this.childNodes);
+		}
 		as.pretenderContext = {
 			type: 'origin',
 			origin: this,

--- a/packages/@markuplint/ml-core/src/test/index.ts
+++ b/packages/@markuplint/ml-core/src/test/index.ts
@@ -44,9 +44,13 @@ export function createTestDocument<T extends RuleConfigValue = any, O extends Pl
 			: options.parser.parse(sourceCode, options.config?.parserOptions)
 		: parser.parse(sourceCode, options?.config?.parserOptions);
 	const ruleset = convertRuleset(options?.config);
-	const document = new MLDocument<T, O>(ast, ruleset, [options?.specs ?? ({} as any), {}], {
-		ariaVersion: ARIA_RECOMMENDED_VERSION,
-	});
+	const document = new MLDocument<T, O>(
+		ast,
+		ruleset,
+		[options?.specs ?? ({} as any), {}],
+		{ ariaVersion: ARIA_RECOMMENDED_VERSION },
+		options?.pretenders ? { pretenders: options.pretenders } : undefined,
+	);
 	return document;
 }
 

--- a/packages/@markuplint/pretenders/src/jsx/create-identify.ts
+++ b/packages/@markuplint/pretenders/src/jsx/create-identify.ts
@@ -1,19 +1,19 @@
 import type { Attr, Identity } from '../types.js';
-import type { PretenderAttr, Slot } from '@markuplint/ml-config';
+import type { PretenderAttr } from '@markuplint/ml-config';
 
 /**
  * Creates a pretender identity from a JSX element's tag name, attributes, and slots.
- * If the element has no attributes, returns just the tag name string.
+ * If the element has no attributes and no slots, returns just the tag name string.
  * Otherwise, returns a detailed identity object including attributes, slots,
  * and whether the element inherits spread attributes.
  *
  * @param tagName - The HTML element or component tag name
  * @param attrs - The attributes discovered on the JSX element
- * @param slots - The child slots discovered within the JSX element
+ * @param slots - Whether the component accepts children (`true`) or not (`null`)
  * @returns A simple tag name string or a detailed Identity object
  */
-export function createIndentity(tagName: string, attrs: readonly Attr[], slots: readonly Slot[]) {
-	if (attrs.length === 0) {
+export function createIndentity(tagName: string, attrs: readonly Attr[], slots: null | true) {
+	if (attrs.length === 0 && slots !== true) {
 		return tagName;
 	}
 

--- a/packages/@markuplint/pretenders/src/jsx/get-children.ts
+++ b/packages/@markuplint/pretenders/src/jsx/get-children.ts
@@ -5,18 +5,21 @@ import ts from 'typescript';
 const {
 	forEachChild,
 	isIdentifier,
+	isJsxAttributes,
 	isJsxElement,
-	isJsxExpression,
 	isJsxSelfClosingElement,
 	isPropertyAccessExpression,
 } = ts;
 
 /**
  * Detects whether a JSX element accepts children by searching for
- * `{children}` or `{props.children}` expressions in its subtree.
+ * `{children}` or `{props.children}` expressions in its content subtree.
+ *
+ * Only searches content children (text, expressions, nested elements),
+ * NOT attribute values on the element or nested elements.
  *
  * - Self-closing elements (`<Foo />`) cannot have children → returns `null`
- * - Opening elements with `{children}` or `{props.children}` → returns `true`
+ * - Opening elements with `{children}` or `{props.children}` in content → returns `true`
  * - Opening elements without children expressions → returns `null`
  *
  * @param el - The JSX opening or self-closing element to inspect
@@ -38,42 +41,53 @@ export function getChildren(
 		return null;
 	}
 
-	return hasChildrenExpression(parent, sourceFile) ? true : null;
+	// Search only through content children (JsxChild[]),
+	// which excludes opening/closing tags and their attributes.
+	for (const child of parent.children) {
+		if (hasChildrenIdentifier(child, sourceFile)) {
+			return true;
+		}
+	}
+	return null;
 }
 
 /**
  * Recursively checks whether a node or its descendants contain a
- * `{children}` or `{props.children}` JSX expression.
+ * `children` identifier or `props.children` property access.
+ *
+ * Skips JsxAttributes nodes to avoid false positives from
+ * `{children}` used as attribute values on nested elements.
  */
-function hasChildrenExpression(
+function hasChildrenIdentifier(
 	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
 	node: Node,
 	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
 	sourceFile: SourceFile,
 ): boolean {
-	if (isJsxExpression(node) && node.expression) {
-		const expr = node.expression;
+	// Skip attribute containers — {children} in attrs is not a slot indicator
+	if (isJsxAttributes(node)) {
+		return false;
+	}
 
-		// {children}
-		if (isIdentifier(expr) && expr.getText(sourceFile) === 'children') {
-			return true;
-		}
+	// {children}
+	if (isIdentifier(node) && node.getText(sourceFile) === 'children') {
+		return true;
+	}
 
-		// {props.children}
-		if (
-			isPropertyAccessExpression(expr) &&
-			isIdentifier(expr.name) &&
-			expr.name.getText(sourceFile) === 'children' &&
-			isIdentifier(expr.expression) &&
-			expr.expression.getText(sourceFile) === 'props'
-		) {
-			return true;
-		}
+	// {props.children}
+	if (
+		isPropertyAccessExpression(node) &&
+		isIdentifier(node.name) &&
+		node.name.getText(sourceFile) === 'children' &&
+		isIdentifier(node.expression) &&
+		node.expression.getText(sourceFile) === 'props'
+	) {
+		return true;
 	}
 
 	let found = false;
 	forEachChild(node, child => {
-		if (!found && hasChildrenExpression(child, sourceFile)) {
+		if (!found && hasChildrenIdentifier(child, sourceFile)) {
 			found = true;
 		}
 	});

--- a/packages/@markuplint/pretenders/src/jsx/get-children.ts
+++ b/packages/@markuplint/pretenders/src/jsx/get-children.ts
@@ -1,24 +1,81 @@
-import type { Slot } from '@markuplint/ml-config';
-import type { JsxOpeningElement, JsxSelfClosingElement, SourceFile } from 'typescript';
+import type { JsxOpeningElement, JsxSelfClosingElement, Node, SourceFile } from 'typescript';
 
-// import { finder } from './finder.js';
+import ts from 'typescript';
+
+const {
+	forEachChild,
+	isIdentifier,
+	isJsxElement,
+	isJsxExpression,
+	isJsxSelfClosingElement,
+	isPropertyAccessExpression,
+} = ts;
 
 /**
- * Extracts child slot information from a JSX element.
- * Currently returns an empty array as child slot extraction is not yet implemented.
+ * Detects whether a JSX element accepts children by searching for
+ * `{children}` or `{props.children}` expressions in its subtree.
  *
- * @param el - The JSX opening or self-closing element to extract children from
+ * - Self-closing elements (`<Foo />`) cannot have children → returns `null`
+ * - Opening elements with `{children}` or `{props.children}` → returns `true`
+ * - Opening elements without children expressions → returns `null`
+ *
+ * @param el - The JSX opening or self-closing element to inspect
  * @param sourceFile - The TypeScript source file containing the element
- * @returns An array of Slot objects representing discovered child slots
+ * @returns `true` if children are accepted, `null` otherwise
  */
 export function getChildren(
 	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
 	el: JsxOpeningElement | JsxSelfClosingElement,
 	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
 	sourceFile: SourceFile,
-): Slot[] {
-	const children: Slot[] = [];
-	// const find = finder(sourceFile);
+): null | true {
+	if (isJsxSelfClosingElement(el)) {
+		return null;
+	}
 
-	return children;
+	const parent = el.parent;
+	if (!isJsxElement(parent)) {
+		return null;
+	}
+
+	return hasChildrenExpression(parent, sourceFile) ? true : null;
+}
+
+/**
+ * Recursively checks whether a node or its descendants contain a
+ * `{children}` or `{props.children}` JSX expression.
+ */
+function hasChildrenExpression(
+	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+	node: Node,
+	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+	sourceFile: SourceFile,
+): boolean {
+	if (isJsxExpression(node) && node.expression) {
+		const expr = node.expression;
+
+		// {children}
+		if (isIdentifier(expr) && expr.getText(sourceFile) === 'children') {
+			return true;
+		}
+
+		// {props.children}
+		if (
+			isPropertyAccessExpression(expr) &&
+			isIdentifier(expr.name) &&
+			expr.name.getText(sourceFile) === 'children' &&
+			isIdentifier(expr.expression) &&
+			expr.expression.getText(sourceFile) === 'props'
+		) {
+			return true;
+		}
+	}
+
+	let found = false;
+	forEachChild(node, child => {
+		if (!found && hasChildrenExpression(child, sourceFile)) {
+			found = true;
+		}
+	});
+	return found;
 }

--- a/packages/@markuplint/pretenders/src/jsx/index.spec.ts
+++ b/packages/@markuplint/pretenders/src/jsx/index.spec.ts
@@ -161,6 +161,15 @@ describe('jsxScanner', () => {
 	test('005 — children slot detection', async () => {
 		expect(await jsxScanner([path.resolve(testDir, '005.tsx')])).toStrictEqual([
 			{
+				selector: 'AttrOnlyChildren',
+				as: {
+					element: 'div',
+					attrs: [{ name: 'data-ref' }],
+					slots: null,
+				},
+				filePath: _('packages/@markuplint/pretenders/test/fixtures/005.tsx:32:6'),
+			},
+			{
 				selector: 'NestedChildren',
 				as: {
 					element: 'div',
@@ -172,6 +181,14 @@ describe('jsxScanner', () => {
 				selector: 'StaticContent',
 				as: 'p',
 				filePath: _('packages/@markuplint/pretenders/test/fixtures/005.tsx:17:6'),
+			},
+			{
+				selector: 'TernaryChildren',
+				as: {
+					element: 'div',
+					slots: true,
+				},
+				filePath: _('packages/@markuplint/pretenders/test/fixtures/005.tsx:37:6'),
 			},
 			{
 				selector: 'VoidComponent',

--- a/packages/@markuplint/pretenders/src/jsx/index.spec.ts
+++ b/packages/@markuplint/pretenders/src/jsx/index.spec.ts
@@ -26,7 +26,7 @@ describe('jsxScanner', () => {
 							name: 'aria-yyy',
 						},
 					],
-					slots: [],
+					slots: null,
 				},
 				filePath: _('packages/@markuplint/pretenders/test/fixtures/001.tsx:1:6'),
 			},
@@ -35,7 +35,7 @@ describe('jsxScanner', () => {
 				as: {
 					element: 'BReturns',
 					inheritAttrs: true,
-					slots: [],
+					slots: null,
 				},
 				filePath: _('packages/@markuplint/pretenders/test/fixtures/001.tsx:11:6'),
 			},
@@ -154,6 +154,50 @@ describe('jsxScanner', () => {
 					inheritAttrs: true,
 				},
 				filePath: _('packages/@markuplint/pretenders/test/fixtures/004.tsx:1:6'),
+			},
+		]);
+	});
+
+	test('005 — children slot detection', async () => {
+		expect(await jsxScanner([path.resolve(testDir, '005.tsx')])).toStrictEqual([
+			{
+				selector: 'NestedChildren',
+				as: {
+					element: 'div',
+					slots: true,
+				},
+				filePath: _('packages/@markuplint/pretenders/test/fixtures/005.tsx:22:6'),
+			},
+			{
+				selector: 'StaticContent',
+				as: 'p',
+				filePath: _('packages/@markuplint/pretenders/test/fixtures/005.tsx:17:6'),
+			},
+			{
+				selector: 'VoidComponent',
+				as: {
+					element: 'img',
+					attrs: [{ name: 'src' }],
+					slots: null,
+				},
+				filePath: _('packages/@markuplint/pretenders/test/fixtures/005.tsx:12:6'),
+			},
+			{
+				selector: 'WithChildren',
+				as: {
+					element: 'div',
+					attrs: [{ name: 'className', value: 'wrapper' }],
+					slots: true,
+				},
+				filePath: _('packages/@markuplint/pretenders/test/fixtures/005.tsx:2:6'),
+			},
+			{
+				selector: 'WithPropsChildren',
+				as: {
+					element: 'section',
+					slots: true,
+				},
+				filePath: _('packages/@markuplint/pretenders/test/fixtures/005.tsx:7:6'),
 			},
 		]);
 	});

--- a/packages/@markuplint/pretenders/src/jsx/index.ts
+++ b/packages/@markuplint/pretenders/src/jsx/index.ts
@@ -94,6 +94,11 @@ export const jsxScanner = createScanner<PretenderScanJSXOptions>(
 			allowJs: true,
 		});
 
+		// Trigger the binder so that parent pointers are set on AST nodes.
+		// getChildren() relies on node.parent to navigate from JsxOpeningElement
+		// to its containing JsxElement for children slot detection.
+		program.getTypeChecker();
+
 		for (const sourceFile of program.getSourceFiles()) {
 			if (!sourceFile.isDeclarationFile) {
 				forEachChild(sourceFile, node => visit(node, sourceFile));

--- a/packages/@markuplint/pretenders/src/scan.spec.ts
+++ b/packages/@markuplint/pretenders/src/scan.spec.ts
@@ -69,6 +69,42 @@ describe('scan', () => {
 		});
 	});
 
+	describe('slots flow', () => {
+		test('JSX scanner produces correct slots values', async () => {
+			const result = await scan([jsxFixture('005.tsx')]);
+			const withChildren = result.find(p => p.selector === 'WithChildren');
+			const voidComp = result.find(p => p.selector === 'VoidComponent');
+			const staticComp = result.find(p => p.selector === 'StaticContent');
+
+			expect(typeof withChildren!.as).toBe('object');
+			expect((withChildren!.as as any).slots).toBe(true);
+
+			expect(typeof voidComp!.as).toBe('object');
+			expect((voidComp!.as as any).slots).toBe(null);
+
+			// Static content with no attrs returns bare string — slots info implicit
+			expect(typeof staticComp!.as).toBe('string');
+		});
+
+		test('template scanner produces correct slots values', async () => {
+			const result = await scan([templateFixture('SimpleButton.vue'), templateFixture('WithSlot.vue')]);
+			const noSlot = result.find(p => p.selector === 'SimpleButton');
+			const withSlot = result.find(p => p.selector === 'WithSlot');
+
+			expect((noSlot!.as as any).slots).toBe(null);
+			expect((withSlot!.as as any).slots).toBe(true);
+		});
+
+		test('mixed input preserves slots from both scanners', async () => {
+			const result = await scan([jsxFixture('005.tsx'), templateFixture('WithSlot.vue')]);
+			const jsxSlot = result.find(p => p.selector === 'WithChildren');
+			const templateSlot = result.find(p => p.selector === 'WithSlot');
+
+			expect((jsxSlot!.as as any).slots).toBe(true);
+			expect((templateSlot!.as as any).slots).toBe(true);
+		});
+	});
+
 	describe('edge cases', () => {
 		test('empty file list returns empty result', async () => {
 			const result = await scan([]);

--- a/packages/@markuplint/pretenders/test/fixtures/005.tsx
+++ b/packages/@markuplint/pretenders/test/fixtures/005.tsx
@@ -27,3 +27,13 @@ const NestedChildren = ({ children }) => {
 		</div>
 	);
 };
+
+// Edge case: {children} appears only in an attribute value, not as element content
+const AttrOnlyChildren = ({ children }) => {
+	return <div data-ref={children}>static text</div>;
+};
+
+// Edge case: ternary with props.children
+const TernaryChildren = props => {
+	return <div>{props.children ? props.children : 'fallback'}</div>;
+};

--- a/packages/@markuplint/pretenders/test/fixtures/005.tsx
+++ b/packages/@markuplint/pretenders/test/fixtures/005.tsx
@@ -1,0 +1,29 @@
+// Component that accepts children via destructured {children}
+const WithChildren = ({ children }) => {
+	return <div className="wrapper">{children}</div>;
+};
+
+// Component that accepts children via props.children
+const WithPropsChildren = props => {
+	return <section>{props.children}</section>;
+};
+
+// Self-closing (void) component — no children slot
+const VoidComponent = props => {
+	return <img src={props.src} />;
+};
+
+// Component with static content only — no children slot
+const StaticContent = () => {
+	return <p>Hello World</p>;
+};
+
+// Component with nested {children} (not at root level)
+const NestedChildren = ({ children }) => {
+	return (
+		<div>
+			<header>Title</header>
+			<main>{children}</main>
+		</div>
+	);
+};


### PR DESCRIPTION
Fixes #3341 

## What is the purpose of this PR?

- [x] Add a new core feature
- [x] Improve or refactor core features

### Description

This PR implements automatic detection of whether JSX components accept children, enabling proper handling of void-like components in the pretenders system.

#### Key Changes

1. **JSX Children Detection (`getChildren` function)**
   - Replaced stub implementation with actual logic to detect `{children}` and `{props.children}` expressions in JSX component content
   - Returns `true` if children are accepted, `null` if not (void-like)
   - Self-closing elements automatically return `null`
   - Skips attribute values to avoid false positives from nested elements

2. **Pretender Identity Creation**
   - Updated `createIndentity` to handle the new `slots` field (boolean or null)
   - Returns bare string identity only when there are no attributes AND no children slot
   - Properly represents components with slots in the identity object

3. **Child Node Handling in Virtual Elements**
   - Modified `MLElement` to respect the `slots` field from pretender definitions
   - When `slots: null`, virtual elements have no children (void-like behavior)
   - When `slots: true` or undefined, children are inherited from the original element
   - Maintains backward compatibility: bare string identities (undefined slots) share children

4. **Test Infrastructure**
   - Added comprehensive test fixture (`005.tsx`) covering:
     - Components with destructured `{children}`
     - Components using `props.children`
     - Self-closing void components
     - Static content components
     - Nested children expressions
     - Edge cases (attribute-only children, ternary expressions)
   - Added unit tests validating slots detection across JSX and template scanners
   - Added integration tests verifying void-like component behavior

5. **TypeScript AST Binding**
   - Ensured type checker is invoked to set up parent pointers on AST nodes
   - Required for `getChildren` to navigate from opening elements to their containing elements

#### Type Changes

- `getChildren` return type: `Slot[]` → `null | true`
- `createIndentity` slots parameter: `readonly Slot[]` → `null | true`

## Checklist

- [x] Add a new core feature
  - [x] Add comprehensive tests covering detection logic and integration
  - [x] Verify backward compatibility with existing pretender configurations
- [x] Improve or refactor core features
  - [x] Refactor child node handling to respect slots configuration
  - [x] Update test expectations to reflect new slots values

https://claude.ai/code/session_01StoPtxTHHz1xzTPMnLp1jP