### PR TITLE
Add dynamic component scanning to pretenders configuration

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -405,6 +405,35 @@
 				"$ref": "#/definitions/pretender"
 			}
 		},
+		"pretenderScanConfig": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["files"],
+			"properties": {
+				"files": {
+					"description": "Glob pattern(s) for component files to scan. File extensions determine the scanner: .js/.jsx/.ts/.tsx use the JSX scanner, .vue/.svelte/.astro use the template scanner.",
+					"oneOf": [
+						{
+							"type": "string"
+						},
+						{
+							"type": "array",
+							"minItems": 1,
+							"items": {
+								"type": "string"
+							}
+						}
+					]
+				},
+				"ignoreComponentNames": {
+					"description": "Component names to exclude from scanning results.",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				}
+			}
+		},
 		"pretenderDetails": {
 			"type": "object",
 			"additionalProperties": false,
@@ -427,6 +456,14 @@
 				},
 				"data": {
 					"$ref": "#/definitions/pretenders"
+				},
+				"scan": {
+					"description": "@experimental Dynamic component scanning configuration. Each entry specifies glob pattern(s) for component files.",
+					"type": "array",
+					"minItems": 1,
+					"items": {
+						"$ref": "#/definitions/pretenderScanConfig"
+					}
 				}
 			}
 		}

--- a/packages/@markuplint/file-resolver/package.json
+++ b/packages/@markuplint/file-resolver/package.json
@@ -36,6 +36,7 @@
 		"@markuplint/ml-core": "5.0.0-alpha.3",
 		"@markuplint/ml-spec": "5.0.0-alpha.3",
 		"@markuplint/parser-utils": "5.0.0-alpha.3",
+		"@markuplint/pretenders": "5.0.0-alpha.3",
 		"@markuplint/selector": "5.0.0-alpha.3",
 		"@markuplint/shared": "5.0.0-alpha.3",
 		"cosmiconfig": "9.0.0",

--- a/packages/@markuplint/file-resolver/src/config-provider.ts
+++ b/packages/@markuplint/file-resolver/src/config-provider.ts
@@ -310,6 +310,13 @@ export class ConfigProvider {
 				? {
 						...optimizedConfig.pretenders,
 						files: await relPathToNameOrAbsPath(dir, optimizedConfig.pretenders?.files),
+						scan: optimizedConfig.pretenders?.scan?.map(entry => ({
+							...entry,
+							files:
+								typeof entry.files === 'string'
+									? path.resolve(dir, entry.files)
+									: entry.files.map(f => path.resolve(dir, f)),
+						})),
 					}
 				: undefined,
 			overrides: await relPathToNameOrAbsPath(dir, optimizedConfig.overrides, undefined, true),

--- a/packages/@markuplint/file-resolver/src/resolve-pretenders.spec.ts
+++ b/packages/@markuplint/file-resolver/src/resolve-pretenders.spec.ts
@@ -29,3 +29,81 @@ test('imports', async () => {
 		},
 	]);
 });
+
+test('scan with file path', async () => {
+	const fixtureDir = path.resolve(
+		import.meta.dirname,
+		'..',
+		'..',
+		'..',
+		'@markuplint',
+		'pretenders',
+		'test',
+		'fixtures',
+	);
+	const pretenders = await resolvePretenders({
+		scan: [
+			{
+				files: path.resolve(fixtureDir, 'template', 'SimpleButton.vue'),
+			},
+		],
+	});
+	expect(pretenders).toStrictEqual([expect.objectContaining({ selector: 'SimpleButton' })]);
+});
+
+test('scan with ignoreComponentNames', async () => {
+	const fixtureDir = path.resolve(
+		import.meta.dirname,
+		'..',
+		'..',
+		'..',
+		'@markuplint',
+		'pretenders',
+		'test',
+		'fixtures',
+	);
+	const pretenders = await resolvePretenders({
+		scan: [
+			{
+				files: path.resolve(fixtureDir, 'template', 'SimpleButton.vue'),
+				ignoreComponentNames: ['SimpleButton'],
+			},
+		],
+	});
+	expect(pretenders).toStrictEqual([]);
+});
+
+test('scan combined with inline data', async () => {
+	const fixtureDir = path.resolve(
+		import.meta.dirname,
+		'..',
+		'..',
+		'..',
+		'@markuplint',
+		'pretenders',
+		'test',
+		'fixtures',
+	);
+	const pretenders = await resolvePretenders({
+		data: [{ selector: 'InlineComp', as: 'span' }],
+		scan: [
+			{
+				files: path.resolve(fixtureDir, 'template', 'SimpleButton.vue'),
+			},
+		],
+	});
+	const selectors = pretenders.map(p => p.selector);
+	expect(selectors).toContain('InlineComp');
+	expect(selectors).toContain('SimpleButton');
+});
+
+test('scan with empty glob match', async () => {
+	const pretenders = await resolvePretenders({
+		scan: [
+			{
+				files: '/nonexistent-path/**/*.vue',
+			},
+		],
+	});
+	expect(pretenders).toStrictEqual([]);
+});

--- a/packages/@markuplint/file-resolver/src/resolve-pretenders.ts
+++ b/packages/@markuplint/file-resolver/src/resolve-pretenders.ts
@@ -1,12 +1,14 @@
 import type { OptimizedConfig, Pretender, PretenderFileData } from '@markuplint/ml-config';
 
+import { glob } from 'glob';
+
 import { generalImport } from './general-import.js';
 
 type PretendersConfig = OptimizedConfig['pretenders'];
 
 /**
- * Resolves pretender definitions from files, imported modules, and inline data
- * in the configuration.
+ * Resolves pretender definitions from files, imported modules, inline data,
+ * and dynamic component scanning in the configuration.
  *
  * @param config - The pretenders configuration section from the optimized config
  * @returns An array of all resolved pretender definitions
@@ -43,6 +45,21 @@ export async function resolvePretenders(config: PretendersConfig): Promise<Prete
 
 	if (config.data) {
 		data.push(...config.data);
+	}
+
+	if (config.scan) {
+		const { scan } = await import('@markuplint/pretenders');
+		for (const entry of config.scan) {
+			const patterns = typeof entry.files === 'string' ? [entry.files] : [...entry.files];
+			const globResults = await Promise.all(patterns.map(p => glob(p)));
+			const resolved = globResults.flat();
+			if (resolved.length > 0) {
+				const scanned = await scan(resolved, {
+					ignoreComponentNames: entry.ignoreComponentNames ? [...entry.ignoreComponentNames] : undefined,
+				});
+				data.push(...scanned);
+			}
+		}
 	}
 
 	return data;

--- a/packages/@markuplint/file-resolver/src/resolve-pretenders.ts
+++ b/packages/@markuplint/file-resolver/src/resolve-pretenders.ts
@@ -1,5 +1,7 @@
 import type { OptimizedConfig, Pretender, PretenderFileData } from '@markuplint/ml-config';
 
+import path from 'node:path';
+
 import { glob } from 'glob';
 
 import { generalImport } from './general-import.js';
@@ -52,7 +54,7 @@ export async function resolvePretenders(config: PretendersConfig): Promise<Prete
 		for (const entry of config.scan) {
 			const patterns = typeof entry.files === 'string' ? [entry.files] : [...entry.files];
 			const globResults = await Promise.all(patterns.map(p => glob(p)));
-			const resolved = globResults.flat();
+			const resolved = globResults.flat().map(f => path.resolve(f));
 			if (resolved.length > 0) {
 				const scanned = await scan(resolved, {
 					ignoreComponentNames: entry.ignoreComponentNames ? [...entry.ignoreComponentNames] : undefined,

--- a/packages/@markuplint/file-resolver/tsconfig.json
+++ b/packages/@markuplint/file-resolver/tsconfig.json
@@ -20,6 +20,9 @@
 			"path": "../parser-utils"
 		},
 		{
+			"path": "../pretenders"
+		},
+		{
 			"path": "../selector"
 		},
 		{

--- a/packages/@markuplint/ml-config/ARCHITECTURE.ja.md
+++ b/packages/@markuplint/ml-config/ARCHITECTURE.ja.md
@@ -94,7 +94,8 @@ type RuleConfig<T, O> = {
 
 - `Pretender` -- CSS セレクタを使用してカスタム要素を標準要素に見せかける。`as` フィールドで要素名または詳細な `OriginalNode` を指定
 - `OriginalNode` -- 要素名、スロット、名前空間、属性、継承属性、ARIA プロパティを定義
-- `PretenderDetails` -- マージ後に使用される正規化形式 `{data?, files?, imports?}`
+- `PretenderDetails` -- マージ後に使用される正規化形式 `{data?, files?, imports?, scan?}`
+- `PretenderScanConfig` -- 動的スキャン設定 `{files, ignoreComponentNames?}`。拡張子によりスキャナーを自動判定（`.js/.jsx/.ts/.tsx` → JSX スキャナー、`.vue/.svelte/.astro` → テンプレートスキャナー）
 
 ### 自動修正型
 
@@ -139,7 +140,7 @@ flowchart TD
 | `specs`          | オブジェクト shallow merge | `mergeObject()`                                      | 同上                                          |
 | `excludeFiles`   | 結合+重複排除              | `concatArray(uniquely=true)`                         | 単純な値の重複排除                            |
 | `severity`       | オブジェクト shallow merge | `mergeObject()`                                      | parser と同様                                 |
-| `pretenders`     | セマンティックマージ       | `mergePretenders()`                                  | files/imports: 上書き、data: 追加             |
+| `pretenders`     | セマンティックマージ       | `mergePretenders()`                                  | files/imports: 上書き、data/scan: 追加        |
 | `rules`          | ルール別マージ             | `mergeRules()` → `mergeRule()`                       | **最も複雑 -- 次節で詳述**                    |
 | `nodeRules`      | 結合+名前で重複排除        | `concatArray(uniquely=true, comparePropName='name')` | 名前付きエントリは重複排除、無名は追加        |
 | `childNodeRules` | 結合+名前で重複排除        | `concatArray(uniquely=true, comparePropName='name')` | nodeRules と同様                              |
@@ -198,7 +199,7 @@ flowchart TD
 
 #### mergePretenders(a, b)
 
-配列形式の pretenders を正規化形式 `PretenderDetails`（`{data: [...]}`）に変換してからセマンティックマージ: `files`/`imports` は上書き（右辺優先）、`data` は追加（連結）。
+配列形式の pretenders を正規化形式 `PretenderDetails`（`{data: [...]}`）に変換してからセマンティックマージ: `files`/`imports` は上書き（右辺優先）、`data` と `scan` は追加（連結）。
 
 ## テンプレートレンダリングシステム
 

--- a/packages/@markuplint/ml-config/ARCHITECTURE.md
+++ b/packages/@markuplint/ml-config/ARCHITECTURE.md
@@ -94,7 +94,8 @@ type RuleConfig<T, O> = {
 
 - `Pretender` -- Uses a CSS selector to make custom elements appear as standard elements for linting purposes; the `as` field specifies the element name or a detailed `OriginalNode`
 - `OriginalNode` -- Defines an element's name, slots, namespace, attributes, inherited attributes, and ARIA properties
-- `PretenderDetails` -- Normalized form `{data?, files?, imports?}` used after merging
+- `PretenderDetails` -- Normalized form `{data?, files?, imports?, scan?}` used after merging
+- `PretenderScanConfig` -- Dynamic scanning configuration `{files, ignoreComponentNames?}` for automatic component detection; file extensions determine the scanner (`.js/.jsx/.ts/.tsx` → JSX scanner, `.vue/.svelte/.astro` → template scanner)
 
 ### Autofix Types
 
@@ -139,7 +140,7 @@ flowchart TD
 | `specs`          | Object shallow merge             | `mergeObject()`                                      | Same as above                                        |
 | `excludeFiles`   | Concat + deduplicate             | `concatArray(uniquely=true)`                         | Simple value deduplication                           |
 | `severity`       | Object shallow merge             | `mergeObject()`                                      | Same as parser                                       |
-| `pretenders`     | Semantic merge                   | `mergePretenders()`                                  | files/imports: override, data: append                |
+| `pretenders`     | Semantic merge                   | `mergePretenders()`                                  | files/imports: override, data/scan: append           |
 | `rules`          | Per-rule merge                   | `mergeRules()` then `mergeRule()`                    | **Most complex -- see next section**                 |
 | `nodeRules`      | Concat + deduplicate by name     | `concatArray(uniquely=true, comparePropName='name')` | Named entries deduplicated; unnamed entries appended |
 | `childNodeRules` | Concat + deduplicate by name     | `concatArray(uniquely=true, comparePropName='name')` | Same as nodeRules                                    |
@@ -198,7 +199,7 @@ Collects the union of all keys from both override records. For each key, calls `
 
 #### mergePretenders(a, b)
 
-Converts array-form pretenders to the normalized `PretenderDetails` form (`{data: [...]}`) then applies semantic merge: `files`/`imports` are overridden (right-side wins), `data` is appended (concatenated).
+Converts array-form pretenders to the normalized `PretenderDetails` form (`{data: [...]}`) then applies semantic merge: `files`/`imports` are overridden (right-side wins), `data` and `scan` are appended (concatenated).
 
 ## Template Rendering System
 

--- a/packages/@markuplint/ml-config/src/merge-config.spec.ts
+++ b/packages/@markuplint/ml-config/src/merge-config.spec.ts
@@ -740,6 +740,71 @@ describe('Pretenders', () => {
 			},
 		});
 	});
+
+	test('scan configs are concatenated', () => {
+		expect(
+			mergeConfig(
+				{
+					pretenders: {
+						scan: [{ files: './src/**/*.vue' }],
+					},
+				},
+				{
+					pretenders: {
+						scan: [{ files: './src/**/*.tsx', ignoreComponentNames: ['Internal'] }],
+					},
+				},
+			),
+		).toStrictEqual({
+			pretenders: {
+				scan: [{ files: './src/**/*.vue' }, { files: './src/**/*.tsx', ignoreComponentNames: ['Internal'] }],
+			},
+		});
+	});
+
+	test('scan from one side only', () => {
+		expect(
+			mergeConfig(
+				{
+					pretenders: {
+						data: [{ selector: 'Comp', as: 'div' }],
+					},
+				},
+				{
+					pretenders: {
+						scan: [{ files: './src/**/*.vue' }],
+					},
+				},
+			),
+		).toStrictEqual({
+			pretenders: {
+				data: [{ selector: 'Comp', as: 'div' }],
+				scan: [{ files: './src/**/*.vue' }],
+			},
+		});
+	});
+
+	test('scan preserved when b has no scan', () => {
+		expect(
+			mergeConfig(
+				{
+					pretenders: {
+						scan: [{ files: './src/**/*.vue' }],
+					},
+				},
+				{
+					pretenders: {
+						data: [{ selector: 'Comp', as: 'div' }],
+					},
+				},
+			),
+		).toStrictEqual({
+			pretenders: {
+				data: [{ selector: 'Comp', as: 'div' }],
+				scan: [{ files: './src/**/*.vue' }],
+			},
+		});
+	});
 });
 
 describe('Named rule group merging', () => {

--- a/packages/@markuplint/ml-config/src/merge-config.ts
+++ b/packages/@markuplint/ml-config/src/merge-config.ts
@@ -141,11 +141,12 @@ function mergePretenders(
 	}
 
 	// files/imports: override (right-side wins)
-	// data: append (concatenate)
+	// data/scan: append (concatenate)
 	const details: PretenderDetails = {
 		files: bDetails.files ?? aDetails.files,
 		imports: bDetails.imports ?? aDetails.imports,
 		data: concatArray(aDetails.data, bDetails.data),
+		scan: concatArray(aDetails.scan, bDetails.scan),
 	};
 	deleteUndefProp(details);
 	return details;

--- a/packages/@markuplint/ml-config/src/types.ts
+++ b/packages/@markuplint/ml-config/src/types.ts
@@ -116,7 +116,8 @@ export type SeverityOptions = {
 
 /**
  * Normalized form of pretender configuration used after merging.
- * Contains optional file references, import paths, and inline pretender data.
+ * Contains optional file references, import paths, inline pretender data,
+ * and dynamic scanning configuration.
  */
 export type PretenderDetails = {
 	/**
@@ -129,6 +130,16 @@ export type PretenderDetails = {
 	 */
 	readonly imports?: readonly string[];
 	readonly data?: readonly Pretender[];
+
+	/**
+	 * Dynamic scanning configuration. Each entry specifies a glob pattern
+	 * for component files to scan. File extensions determine the scanner:
+	 * `.js/.jsx/.ts/.tsx` use the JSX scanner, `.vue/.svelte/.astro` use
+	 * the template scanner.
+	 *
+	 * @experimental
+	 */
+	readonly scan?: readonly PretenderScanConfig[];
 };
 
 /**
@@ -168,13 +179,6 @@ export type Pretender = {
 	 * @experimental
 	 */
 	readonly filePath?: string;
-
-	/**
-	 * Dynamic scaning
-	 *
-	 * @experimental
-	 */
-	readonly scan?: readonly PretenderScanConfig[];
 };
 
 export type OriginalNode = {
@@ -301,18 +305,27 @@ export type PretenderARIA = {
 };
 
 /**
+ * Configuration for dynamic component scanning.
+ * File extensions determine the scanner automatically:
+ * `.js/.jsx/.ts/.tsx` → JSX scanner, `.vue/.svelte/.astro` → template scanner.
+ *
  * @experimental
  */
 export type PretenderScanConfig = {
 	/**
-	 * Supporting for Glob format
+	 * Glob pattern(s) for component files to scan.
 	 */
-	readonly files: string;
-	readonly type: string;
-	readonly options: PretenderScanOptions;
+	readonly files: string | readonly string[];
+
+	/**
+	 * Component names to exclude from scanning results.
+	 */
+	readonly ignoreComponentNames?: readonly string[];
 };
 
 /**
+ * Base options for pretender scanners.
+ *
  * @experimental
  */
 export interface PretenderScanOptions {

--- a/packages/@markuplint/pretenders/README.md
+++ b/packages/@markuplint/pretenders/README.md
@@ -1,18 +1,54 @@
 # @markuplint/pretenders
 
 [![npm version](https://badge.fury.io/js/%40markuplint%2Fpretenders.svg)](https://www.npmjs.com/package/@markuplint/pretenders)
-[![Build Status](https://travis-ci.org/markuplint/markuplint.svg?branch=main)](https://travis-ci.org/markuplint/markuplint)
-[![Coverage Status](https://coveralls.io/repos/github/markuplint/markuplint/badge.svg?branch=main)](https://coveralls.io/github/markuplint/markuplint?branch=main)
 
-This module features both an API and a CLI that generate **[Pretenders](https://markuplint.dev/docs/guides/besides-html#pretenders) data** from the loaded components
+This module features both an API and a CLI that generate **[Pretenders](https://markuplint.dev/docs/guides/besides-html#pretenders) data** from the loaded components.
 
-## Usage
+## Supported Frameworks
+
+| Framework   | Extensions                   | Scanner           | Approach                              |
+| ----------- | ---------------------------- | ----------------- | ------------------------------------- |
+| React / JSX | `.js`, `.jsx`, `.ts`, `.tsx` | `jsxScanner`      | TypeScript compiler API               |
+| Vue         | `.vue`                       | `templateScanner` | MLAST via `@markuplint/vue-parser`    |
+| Svelte      | `.svelte`                    | `templateScanner` | MLAST via `@markuplint/svelte-parser` |
+| Astro       | `.astro`                     | `templateScanner` | MLAST via `@markuplint/astro-parser`  |
+
+## CLI Usage
 
 ```sh
-$ npx @markuplint/pretenders "./src/**/*.jsx" --out "./pretenders.json"
+$ npx @markuplint/pretenders "./src/**/*.{jsx,tsx,vue,svelte,astro}" --out "./pretenders.json"
 ```
 
-The module analyzes components defined in files using a parser, currently supporting JSX (both `*.jsx` and `*.tsx` formats). It searches for functions or function objects that return elements and maps their function names or the variable names holding these function objects. For example, if a function object named `Foo` returns a `<div>`, the component `Foo` is considered as pretending to be a `div`. In the CLI, it exports the mapped data as a JSON file. By loading this JSON file into the Pretenders feature, the module evaluates the `Foo` component as equivalent to a `div`.
+The CLI accepts glob patterns covering any combination of the supported frameworks. It dispatches files to the appropriate scanner based on file extension, runs them in parallel, and writes the merged results as JSON.
+
+| Flag          | Description                                        |
+| ------------- | -------------------------------------------------- |
+| `-O`, `--out` | Output file path (required)                        |
+| `--ignore`    | Comma-separated list of component names to exclude |
+
+### Configuration-based Scanning
+
+Instead of the CLI, you can configure dynamic scanning directly in your markuplint config file. The `scan` field in `pretenders` accepts glob patterns and automatically dispatches to the appropriate scanner:
+
+```jsonc
+// .markuplintrc
+{
+  "pretenders": {
+    "scan": [
+      {
+        "files": "./src/components/**/*.{vue,tsx,svelte,astro}",
+        "ignoreComponentNames": ["InternalHelper"],
+      },
+    ],
+  },
+}
+```
+
+## How It Works
+
+### JSX Scanner
+
+The JSX scanner analyzes components defined in files using the TypeScript compiler API. It searches for functions or function objects that return elements and maps their function names or the variable names holding these function objects. For example, if a function object named `Foo` returns a `<div>`, the component `Foo` is considered as pretending to be a `div`.
 
 ```jsx
 const Foo = () => <div />;
@@ -24,20 +60,12 @@ function Bar() {
 
 ```json
 [
-  {
-    "selector": "Foo",
-    "as": "div"
-  },
-  {
-    "selector": "Bar",
-    "as": "span"
-  }
+  { "selector": "Foo", "as": "div" },
+  { "selector": "Bar", "as": "span" }
 ]
 ```
 
-The module is **experimental**. It uses the TypeScript compiler to identify functions or function objects in JSX files where the return values are components or HTML elements. Currently, it only performs a simplistic mapping based on function and variable names without considering dependencies between files. **Consequently, it does not handle name duplications across files or variable scopes;** components with duplicate names overwrite existing data during processing.
-
-In addition to definitions based on function and variable names, the module also infers HTML elements from properties, as exemplified by `styled-components`, and infers dependencies from arguments.
+The JSX scanner also infers HTML elements from styled-components patterns and infers dependencies from wrapper function arguments:
 
 ```jsx
 const Foo = styled.div`
@@ -51,88 +79,143 @@ const Bar = styled(Foo)`
 
 ```json
 [
+  { "selector": "Foo", "as": "div" },
+  { "selector": "Bar", "as": "div" }
+]
+```
+
+The JSX scanner detects **slots** (children). If a component accepts `children` props, the resulting pretender includes `slots: true` in its `as` field.
+
+### Template Scanner
+
+The template scanner uses markuplint's own framework parsers (Vue, Svelte, Astro) to extract the root element from component templates at depth=0. It also detects static attributes and slot/children usage.
+
+```vue
+<template>
+  <button type="submit"><slot /></button>
+</template>
+```
+
+```json
+[
   {
-    "selector": "Foo",
-    "as": "div"
-  },
-  {
-    "selector": "Bar",
-    "as": "div"
+    "selector": "SubmitButton",
+    "as": {
+      "element": "button",
+      "attrs": [{ "name": "type", "value": "submit" }],
+      "slots": true
+    }
   }
 ]
 ```
 
+Slot detection covers:
+
+- `<slot>` elements in Vue, Svelte, and Astro
+- `{@render children()}` snippets in Svelte 5
+
+### Import Resolver
+
+The import resolver analyzes `<script>` / frontmatter / ESM blocks in component files and extracts static import bindings. This links template component usage to source file locations, enabling cross-file dependency resolution.
+
+Supported script block types:
+
+- Vue `<script setup>`
+- Svelte `<script>`
+- Astro frontmatter (`---...---`)
+- MDX top-level ESM
+
 ## API
 
+### `scan(files, options)`
+
+The unified entry point. Dispatches files to the appropriate scanner based on file extension, runs both scanners in parallel, and returns the merged, sorted results.
+
+```ts
+import { scan } from '@markuplint/pretenders';
+
+const pretenders = await scan([
+  './src/components/Button.tsx',
+  './src/components/Card.vue',
+  './src/components/Alert.svelte',
+]);
+```
+
+#### Parameters
+
+| Parameter                      | Type                | Description                             |
+| ------------------------------ | ------------------- | --------------------------------------- |
+| `files`                        | `readonly string[]` | Absolute file paths to scan             |
+| `options.ignoreComponentNames` | `readonly string[]` | Component names to exclude from results |
+
 ### `jsxScanner(files, options)`
+
+Scans JSX/TSX files using the TypeScript compiler API.
 
 ```ts
 import { jsxScanner } from '@markuplint/pretenders';
 
-const pretenders = jsxScanner(['./src/**/*.jsx'], {
+const pretenders = await jsxScanner(['./src/**/*.jsx'], {
   cwd: process.cwd(),
   asFragment: [/(?:^|\.)provider$/i],
   ignoreComponentNames: [],
-  taggedStylingComponent: [
-    // PropertyAccessExpression: styled.button`css-prop: value;`
-    /^styled\.(?<tagName>[a-z][\da-z]*)$/i,
-    // CallExpression: styled(Button)`css-prop: value;`
-    /^styled\s*\(\s*(?<tagName>[a-z][\da-z]*)\s*\)$/i,
-  ],
+  taggedStylingComponent: [/^styled\.(?<tagName>[a-z][\da-z]*)$/i, /^styled\s*\(\s*(?<tagName>[a-z][\da-z]*)\s*\)$/i],
   extendingWrapper: [],
 });
 ```
 
-#### `files`
+#### Parameters
 
-Type: `string[]`
+| Parameter                        | Type                   | Description                                  |
+| -------------------------------- | ---------------------- | -------------------------------------------- |
+| `files`                          | `string[]`             | File paths to scan                           |
+| `options.cwd`                    | `string`               | Current working directory                    |
+| `options.asFragment`             | `RegExp[]`             | Patterns for components treated as fragments |
+| `options.ignoreComponentNames`   | `string[]`             | Component names to ignore                    |
+| `options.taggedStylingComponent` | `RegExp[]`             | Patterns for styled-components               |
+| `options.extendingWrapper`       | `RegExp[] \| object[]` | Patterns for HOC/wrapper components          |
 
-An array of file paths to scan.
+### `templateScanner(files, options)`
 
-##### `options.cwd`
+Scans Vue, Svelte, and Astro component files using markuplint's own parsers (MLAST-based).
 
-Type: `string`
+```ts
+import { templateScanner } from '@markuplint/pretenders';
 
-The current working directory.
-
-##### `options.asFragment`
-
-Type: `RegExp[]`
-
-A list of regular expressions to match components that should be treated as fragments.
-
-##### `options.ignoreComponentNames`
-
-Type: `string[]`
-
-A list of component names to ignore.
-
-##### `options.taggedStylingComponent`
-
-Type: `RegExp[]`
-
-A list of regular expressions to match components that are styled.
-
-##### `options.extendingWrapper`
-
-Type: `RegExp[]` | `{ identifier: RegExp, numberOfArgument: number }[]`
-
-```js
-jsxScanner(['./src/**/*.jsx'], {
-  extendingWrapper: [
-    {
-      identifier: /^namespace\.primary$/i,
-      numberOfArgument: 1,
-    },
-  ],
-});
+const pretenders = await templateScanner(
+  ['./src/components/Button.vue', './src/components/Alert.svelte', './src/components/Card.astro'],
+  {
+    ignoreComponentNames: ['InternalHelper'],
+  },
+);
 ```
 
-```jsx
-const Foo = <div />;
-const Bar = namespace.primary(true, Foo);
+#### Parameters
+
+| Parameter                      | Type                | Description                                    |
+| ------------------------------ | ------------------- | ---------------------------------------------- |
+| `files`                        | `readonly string[]` | Absolute file paths to scan                    |
+| `options.cwd`                  | `string`            | Current working directory (for relative paths) |
+| `options.ignoreComponentNames` | `readonly string[]` | Component names to exclude from results        |
+
+### `analyzeImports(filePath, source)`
+
+Extracts import bindings from a component file's script block.
+
+```ts
+import { analyzeImports } from '@markuplint/pretenders';
+
+const result = await analyzeImports('App.vue', source);
+// result.bindings: [{ localName: 'MyButton', source: './components/MyButton.vue' }, ...]
 ```
 
-A list of regular expressions to match components that are extended.
-`identifier` is a regular expression to match the component name.
-`numberOfArgument` is the number of arguments to pass to the component.
+### `resolveComponentImport(componentName, bindings)`
+
+Resolves a component name used in a template to its import source path. Handles Vue's kebab-case to PascalCase normalization (e.g., `<my-button>` resolves to `MyButton`).
+
+```ts
+import { resolveComponentImport } from '@markuplint/pretenders';
+
+const binding = resolveComponentImport('my-button', bindings);
+// binding: { localName: 'MyButton', source: './components/MyButton.vue' }
+```

--- a/packages/@markuplint/pretenders/src/dependency-mapper.ts
+++ b/packages/@markuplint/pretenders/src/dependency-mapper.ts
@@ -87,6 +87,14 @@ function getElName(identity: Identity) {
 	return identity.element;
 }
 
+/**
+ * Creates a comparator function that sorts objects by a specified property.
+ *
+ * @template T - The object type
+ * @template P - The property key type
+ * @param propName - The property to sort by (case-insensitive for strings)
+ * @returns A comparator function for use with `Array.prototype.sort()`
+ */
 export function propSort<T, P extends keyof T>(propName: P) {
 	return (a: T, b: T) => {
 		const nameA = toLowerCase(a[propName]);

--- a/packages/@markuplint/pretenders/src/index.ts
+++ b/packages/@markuplint/pretenders/src/index.ts
@@ -5,6 +5,7 @@
  * in source files. Pretenders allow markuplint to understand which native HTML
  * elements a component renders, enabling accurate linting of component-based code.
  *
+ * - {@link scan} — Unified entry point that dispatches to the appropriate scanner by file extension
  * - {@link jsxScanner} — Scans JSX/TSX files using the TypeScript compiler API
  * - {@link templateScanner} — Scans Vue, Svelte, and Astro SFC files using markuplint's parsers
  * - {@link analyzeImports} — Extracts import bindings from component script blocks

--- a/packages/@markuplint/pretenders/src/scan.ts
+++ b/packages/@markuplint/pretenders/src/scan.ts
@@ -4,7 +4,11 @@ import { propSort } from './dependency-mapper.js';
 import { jsxScanner } from './jsx/index.js';
 import { templateScanner } from './template/index.js';
 
+/**
+ * Options for the unified {@link scan} function.
+ */
 export interface ScanOptions {
+	/** Component names to exclude from scanning results */
 	readonly ignoreComponentNames?: readonly string[];
 }
 
@@ -14,6 +18,10 @@ export interface ScanOptions {
  *
  * - `.js`, `.jsx`, `.ts`, `.tsx` → {@link jsxScanner}
  * - `.vue`, `.svelte`, `.astro` → {@link templateScanner}
+ *
+ * @param files - Absolute file paths to scan
+ * @param options - Optional scan configuration
+ * @returns All discovered pretender mappings, sorted by selector
  */
 export async function scan(files: readonly string[], options?: ScanOptions): Promise<Pretender[]> {
 	const jsxFiles = files.filter(filePath => /\.[jt]sx?$/.test(filePath));

--- a/packages/@markuplint/pretenders/src/template/derive-name.ts
+++ b/packages/@markuplint/pretenders/src/template/derive-name.ts
@@ -7,6 +7,9 @@ import path from 'node:path';
  * - `BaseButton.vue` → `BaseButton` (remove extension)
  * - `base-button.vue` → `BaseButton` (kebab-case → PascalCase)
  * - `Card/index.vue` → `Card` (parent directory name for index files)
+ *
+ * @param filePath - The component file path to derive a name from
+ * @returns The PascalCase component name
  */
 export function deriveName(filePath: string): string {
 	const parsed = path.parse(filePath);

--- a/packages/@markuplint/pretenders/src/template/detect-slots.ts
+++ b/packages/@markuplint/pretenders/src/template/detect-slots.ts
@@ -8,6 +8,9 @@ import type { MLASTDocument } from '@markuplint/ml-ast';
  * - Svelte 4: `<slot>` element (parsed as psblock `#ps:SlotElement`)
  * - Svelte 5: `{@render children()}` (parsed as psblock `#ps:RenderTag`)
  * - Astro: `<slot />` element (`nodeName === 'slot'`)
+ *
+ * @param doc - The parsed MLAST document to search
+ * @returns `true` if the template contains any slot or children render usage
  */
 export function detectSlots(doc: MLASTDocument): boolean {
 	for (const node of doc.nodeList) {

--- a/packages/@markuplint/pretenders/src/template/extract-attrs.ts
+++ b/packages/@markuplint/pretenders/src/template/extract-attrs.ts
@@ -7,6 +7,9 @@ import type { PretenderAttr } from '@markuplint/ml-config';
  * Only includes attributes with type `'attr'` (regular HTML attributes).
  * Spread attributes are skipped. Boolean attributes (no value) are included
  * without a `value` property.
+ *
+ * @param element - The MLAST element node to extract attributes from
+ * @returns Static attributes suitable for pretender definitions
  */
 export function extractAttrs(element: MLASTElement): readonly PretenderAttr[] {
 	const result: PretenderAttr[] = [];

--- a/packages/@markuplint/pretenders/src/template/extract-root.ts
+++ b/packages/@markuplint/pretenders/src/template/extract-root.ts
@@ -6,6 +6,7 @@ import type { MLASTDocument, MLASTElement } from '@markuplint/ml-ast';
  * Skips text nodes, comments, preprocessor-specific blocks (frontmatter, etc.),
  * and end tags. Returns the first `starttag` node found at depth 0.
  *
+ * @param doc - The parsed MLAST document to search
  * @returns The root element, or `null` if only text/comments exist (Fragment-like).
  */
 export function extractRoot(doc: MLASTDocument): MLASTElement | null {

--- a/packages/@markuplint/pretenders/src/template/parse-component.spec.ts
+++ b/packages/@markuplint/pretenders/src/template/parse-component.spec.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 
 import { describe, test, expect } from 'vitest';
 
-import { getFrameworkType, parseComponent } from './parse-component.js';
+import { getFrameworkType, isModuleNotFoundError, parseComponent } from './parse-component.js';
 
 const fixtureDir = path.resolve(import.meta.dirname, '..', '..', 'test', 'fixtures', 'template');
 
@@ -29,6 +29,35 @@ describe('getFrameworkType', () => {
 
 	test('is case-insensitive for extensions', () => {
 		expect(getFrameworkType('Component.VUE')).toBe('vue');
+	});
+});
+
+describe('isModuleNotFoundError', () => {
+	test('returns true for ERR_MODULE_NOT_FOUND error', () => {
+		const err = new Error("Cannot find module '@markuplint/vue-parser'");
+		(err as NodeJS.ErrnoException).code = 'ERR_MODULE_NOT_FOUND';
+		expect(isModuleNotFoundError(err)).toBe(true);
+	});
+
+	test('returns false for TypeError', () => {
+		expect(isModuleNotFoundError(new TypeError('Parser initialization failed'))).toBe(false);
+	});
+
+	test('returns false for Error without code property', () => {
+		expect(isModuleNotFoundError(new Error('Something went wrong'))).toBe(false);
+	});
+
+	test('returns false for Error with different code', () => {
+		const err = new Error('Permission denied');
+		(err as NodeJS.ErrnoException).code = 'EACCES';
+		expect(isModuleNotFoundError(err)).toBe(false);
+	});
+
+	test('returns false for non-Error values', () => {
+		expect(isModuleNotFoundError(null)).toBe(false);
+		expect(isModuleNotFoundError()).toBe(false);
+		expect(isModuleNotFoundError('ERR_MODULE_NOT_FOUND')).toBe(false);
+		expect(isModuleNotFoundError({ code: 'ERR_MODULE_NOT_FOUND' })).toBe(false);
 	});
 });
 

--- a/packages/@markuplint/pretenders/src/template/parse-component.ts
+++ b/packages/@markuplint/pretenders/src/template/parse-component.ts
@@ -13,6 +13,9 @@ const EXTENSION_MAP: Record<string, FrameworkType> = {
 
 /**
  * Determines the framework type from the file extension.
+ *
+ * @param filePath - The file path to check
+ * @returns The framework type, or `null` if the extension is not recognized
  */
 export function getFrameworkType(filePath: string): FrameworkType | null {
 	const ext = path.extname(filePath).toLowerCase();
@@ -43,6 +46,7 @@ async function getParser(framework: FrameworkType): Promise<MLParser | null> {
 /**
  * Parses a component file into an MLASTDocument using the appropriate framework parser.
  *
+ * @param filePath - The absolute path to the component file
  * @returns The parsed document, or `null` if the file extension is not supported
  *          or the required parser package is not installed.
  */

--- a/packages/@markuplint/pretenders/src/template/parse-component.ts
+++ b/packages/@markuplint/pretenders/src/template/parse-component.ts
@@ -38,8 +38,15 @@ async function getParser(framework: FrameworkType): Promise<MLParser | null> {
 	try {
 		const mod: { parser: MLParser } = await import(pkg);
 		return mod.parser;
-	} catch {
-		return null;
+	} catch (error: unknown) {
+		if (
+			error instanceof Error &&
+			'code' in error &&
+			(error as NodeJS.ErrnoException).code === 'ERR_MODULE_NOT_FOUND'
+		) {
+			return null;
+		}
+		throw error;
 	}
 }
 

--- a/packages/@markuplint/pretenders/src/template/parse-component.ts
+++ b/packages/@markuplint/pretenders/src/template/parse-component.ts
@@ -29,6 +29,15 @@ const PARSER_PACKAGES: Record<FrameworkType, string> = {
 };
 
 /**
+ * Checks if an error is a Node.js ERR_MODULE_NOT_FOUND error.
+ */
+export function isModuleNotFoundError(error: unknown): boolean {
+	return (
+		error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === 'ERR_MODULE_NOT_FOUND'
+	);
+}
+
+/**
  * Dynamically imports the appropriate parser for the given framework.
  *
  * @returns The parser, or `null` if the parser package is not installed.
@@ -39,11 +48,7 @@ async function getParser(framework: FrameworkType): Promise<MLParser | null> {
 		const mod: { parser: MLParser } = await import(pkg);
 		return mod.parser;
 	} catch (error: unknown) {
-		if (
-			error instanceof Error &&
-			'code' in error &&
-			(error as NodeJS.ErrnoException).code === 'ERR_MODULE_NOT_FOUND'
-		) {
+		if (isModuleNotFoundError(error)) {
 			return null;
 		}
 		throw error;

--- a/packages/markuplint/ARCHITECTURE.ja.md
+++ b/packages/markuplint/ARCHITECTURE.ja.md
@@ -146,7 +146,7 @@ flowchart TD
     ExcludeCheck -->|No| ResolveParser["resolveParser()\n パーサーモジュール選択"]
     ResolveParser --> ExtCheck{"拡張子が一致?\n(--ignore-ext でなければ)"}
     ExtCheck -->|No| ReturnNull3["null を返却"]
-    ExtCheck -->|Yes| ResolvePretenders["resolvePretenders()"]
+    ExtCheck -->|Yes| ResolvePretenders["resolvePretenders()\n files + imports + data + scan"]
     ResolvePretenders --> ResolveRuleset["resolveRuleset()\n convertRuleset()"]
     ResolveRuleset --> ResolveSchemas["resolveSchemas()"]
     ResolveSchemas --> ResolveRules["resolveRules()\n プラグイン + カスタムルール"]

--- a/packages/markuplint/ARCHITECTURE.md
+++ b/packages/markuplint/ARCHITECTURE.md
@@ -146,7 +146,7 @@ flowchart TD
     ExcludeCheck -->|No| ResolveParser["resolveParser()\n parser module selection"]
     ResolveParser --> ExtCheck{"extension matched?\n(unless --ignore-ext)"}
     ExtCheck -->|No| ReturnNull3["Return null"]
-    ExtCheck -->|Yes| ResolvePretenders["resolvePretenders()"]
+    ExtCheck -->|Yes| ResolvePretenders["resolvePretenders()\n files + imports + data + scan"]
     ResolvePretenders --> ResolveRuleset["resolveRuleset()\n convertRuleset()"]
     ResolveRuleset --> ResolveSchemas["resolveSchemas()"]
     ResolveSchemas --> ResolveRules["resolveRules()\n plugins + custom rules"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2350,6 +2350,7 @@ __metadata:
     "@markuplint/ml-core": "npm:5.0.0-alpha.3"
     "@markuplint/ml-spec": "npm:5.0.0-alpha.3"
     "@markuplint/parser-utils": "npm:5.0.0-alpha.3"
+    "@markuplint/pretenders": "npm:5.0.0-alpha.3"
     "@markuplint/selector": "npm:5.0.0-alpha.3"
     "@markuplint/shared": "npm:5.0.0-alpha.3"
     "@types/node": "npm:24.5.1"


### PR DESCRIPTION
Fixes #3335 

## What is the purpose of this PR?

- [x] Add a new core feature
- [x] Improve or refactor core features
- [x] Update documents

### Description

This PR adds support for **dynamic component scanning** to the pretenders feature, allowing developers to automatically extract component metadata from source files during linting rather than manually maintaining static pretender definitions.

#### Key Changes

1. **New `scan` Configuration Field**
   - Added `scan` field to `PretenderDetails` type that accepts an array of `PretenderScanConfig` objects
   - Each scan config specifies glob patterns for component files and optional component names to ignore
   - File extensions automatically determine which scanner to use (`.js/.jsx/.ts/.tsx` → JSX scanner, `.vue/.svelte/.astro` → template scanner)

2. **Unified `scan()` API**
   - New top-level `scan(files, options)` function that dispatches files to appropriate scanners based on extension
   - Runs JSX and template scanners in parallel for efficiency
   - Returns merged and sorted results

3. **Enhanced Template Scanner**
   - Added `isModuleNotFoundError()` utility to gracefully handle missing parser packages
   - Improved error handling to distinguish between missing optional dependencies and actual errors
   - Added JSDoc documentation for all public functions

4. **Configuration Resolution**
   - Updated `resolvePretenders()` to process `scan` entries using glob patterns
   - Integrated glob resolution with the new `scan()` API
   - Supports combining inline `data` with dynamically scanned components

5. **Config Merging**
   - Updated `mergePretenders()` to concatenate `scan` arrays (similar to `data`)
   - Properly handles cases where only one config has `scan` entries

6. **Path Resolution**
   - Updated `ConfigProvider` to resolve relative paths in `scan` entries to absolute paths
   - Supports both string and array formats for the `files` field

7. **Comprehensive Documentation**
   - Completely rewrote README with sections for each supported framework
   - Added CLI usage examples with glob patterns
   - Documented configuration-based scanning approach
   - Added detailed API documentation for all scanner functions
   - Included examples of JSX, Vue, Svelte, and Astro component scanning

#### Supported Frameworks

| Framework   | Extensions                   | Scanner           |
| ----------- | ---------------------------- | ----------------- |
| React / JSX | `.js`, `.jsx`, `.ts`, `.tsx` | `jsxScanner`      |
| Vue         | `.vue`                       | `templateScanner` |
| Svelte      | `.svelte`                    | `templateScanner` |
| Astro       | `.astro`                     | `templateScanner` |

#### Example Usage

**CLI:**
```sh
npx @markuplint/pretenders "./src/**/*.{jsx,tsx,vue,svelte,astro}" --out "./pretenders.json"
```

**Configuration:**
```jsonc
{
  "pretenders": {
    "scan": [
      {
        "files": "./src/components/**/*.{vue,tsx,svelte,astro}",
        "ignoreComponentNames": ["InternalHelper"],
      },
    ],
  },
}
```

## Checklist

- [x] Add a new core feature
  - [x] Add tests for scan configuration resolution
  - [x] Add tests for config merging with scan entries
  - [x] Add tests for module not found error handling
  - [x] Add tests for empty glob matches
- [x] Update documents
  - [x] Comprehensive README rewrite with framework support table
  - [x] API documentation for all scanner functions
  - [x] Configuration examples
  - [x] Architecture documentation updates

https://claude.ai/code/session_01UDvPKAxcLEFbXwUKv4hZVm