### PR TITLE
docs: enhance `/issue` command to support creating GitHub Issues

### DIFF
--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -12,6 +12,7 @@ Follow these steps in order:
 
 1. Extract owner/repo/number from the Issue URL
 2. Run `gh issue view <URL> --json number,title,body,labels,comments,assignees,state` to retrieve all Issue details
+3. Proceed to **Step 2**
 
 **If NO URL is provided (or input is empty/a keyword):**
 
@@ -22,14 +23,45 @@ Follow these steps in order:
    - Which packages or rules are affected? (if known)
 2. Gather enough context to form a clear problem statement before proceeding
 3. Do NOT skip this step — do NOT guess or assume the problem
+4. Proceed to **Step 1b**
+
+## Step 1b: Register as a GitHub Issue (URL なしの場合のみ)
+
+> This step runs ONLY when no Issue URL was provided in Step 1.
+
+Based on the information gathered from the user, create a GitHub Issue:
+
+1. **Draft the Issue content**:
+   - Title: concise summary (e.g., `Bug: <description>` or `Feature: <description>`)
+   - Body: structured with the following sections:
+     ```
+     ## Summary
+     <problem statement>
+
+     ## Reproduction (if bug)
+     <steps to reproduce>
+
+     ## Expected Behavior
+     <what should happen>
+
+     ## Affected Packages
+     <list of packages/rules if known>
+     ```
+   - Labels: assign appropriate labels (`bug`, `enhancement`, etc.) if known
+2. **Show the draft to the user** and ask for confirmation before creating
+3. **Create the Issue**:
+   ```bash
+   gh issue create --title "<title>" --body "<body>" [--label "<label>"]
+   ```
+4. **Capture the Issue number and URL** from the output for use in subsequent steps
+5. From this point forward, treat the newly created Issue the same as if it had been provided via URL
 
 ## Step 2: Create a Worktree
 
 **CRITICAL: ALWAYS create a worktree. NEVER work in the main directory.**
 
-1. Generate a branch name:
-   - With Issue URL: `issue/<number>-<slug>` (slug from title, lowercase, hyphens, max 50 chars)
-   - Without Issue URL: `fix/<short-description>` or `feat/<short-description>` as appropriate
+1. Generate a branch name: `issue/<number>-<slug>` (slug from title, lowercase, hyphens, max 50 chars)
+   - The Issue number is always available at this point (either from the URL or from Step 1b)
 2. Check for existing worktrees: `git wt`
    - If a worktree for this branch already exists, use it
 3. Worktree path: `../markuplint-wt/<branch-name>` (automatically determined by `wt.basedir`)
@@ -43,7 +75,7 @@ Follow these steps in order:
 
 ## Step 3: Analyze the Problem
 
-Read through the Issue body and comments (or user description) carefully, then organize the following:
+Read through the Issue body and comments carefully, then organize the following:
 
 1. **Summary**: What is happening / what is being requested
 2. **Reproduction**: For bugs, reproduction steps and environment

--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -1,5 +1,5 @@
 ---
-description: Analyze a GitHub Issue and create a resolution plan
+description: Analyze or create a GitHub Issue and build a resolution plan
 ---
 
 Input: $ARGUMENTS
@@ -29,29 +29,50 @@ Follow these steps in order:
 
 > This step runs ONLY when no Issue URL was provided in Step 1.
 
-Based on the information gathered from the user, create a GitHub Issue:
+Based on the information gathered from the user, create a GitHub Issue.
+Use the repository's existing Issue templates (`.github/ISSUE_TEMPLATE/`) as the format reference:
 
-1. **Draft the Issue content**:
-   - Title: concise summary (e.g., `Bug: <description>` or `Feature: <description>`)
-   - Body: structured with the following sections:
+1. **Determine the Issue type** and match to an existing template:
+   - Bug → `bug_report.md` format (label: `Bug`)
+   - Feature request → `feature.md` format (label: `Features: Proposal`)
+   - Spec update → `update_specs.md` format (label: `Specs`)
+2. **Fetch available labels** to avoid typos:
+   ```bash
+   gh label list --limit 50
+   ```
+3. **Draft the Issue content** following the matched template format:
+   - **Bug** (based on `bug_report.md`):
      ```
-     ## Summary
+     - Markuplint version: `<version>`
+     - Parser lang: <parser>
+     - Node.js version: `<version>`
+     - OS: <os>
+
+     ## Describe the bug
      <problem statement>
 
-     ## Reproduction (if bug)
-     <steps to reproduce>
+     ## Code Example or Playground URL
+     <code snippet or URL>
 
-     ## Expected Behavior
+     ## Steps To Reproduce
+     1. ...
+
+     ## The current behavior
+     <what happens now>
+
+     ## The expected behavior
      <what should happen>
-
-     ## Affected Packages
-     <list of packages/rules if known>
      ```
-   - Labels: assign appropriate labels (`bug`, `enhancement`, etc.) if known
-2. **Show the draft to the user** and ask for confirmation before creating
-3. **Create the Issue**:
+   - **Feature** (based on `feature.md`): free-form description of the proposal
+   - **Spec update** (based on `update_specs.md`):
+     ```
+     ## Document or Issue Link
+     <link to spec or merged PR>
+     ```
+4. **Show the draft to the user** and ask for confirmation before creating
+5. **Create the Issue**:
    ```bash
-   gh issue create --title "<title>" --body "<body>" [--label "<label>"]
+   gh issue create --title "<title>" --body "<body>" --label "<label>"
    ```
 4. **Capture the Issue number and URL** from the output for use in subsequent steps
 5. From this point forward, treat the newly created Issue the same as if it had been provided via URL

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Use the following skills and commands for common tasks. **Always invoke the appr
 | `/pr`       | Create and push a pull request via `gh pr create`      | [pr.md](.claude/commands/pr.md)             |
 | `/doc`      | Update documentation (README, ARCHITECTURE, JSDoc)     | [doc.md](.claude/commands/doc.md)           |
 | `/release`  | Create GitHub Release notes                            | [release.md](.claude/commands/release.md)   |
-| `/issue`    | Analyze a GitHub Issue and create a resolution plan    | [issue.md](.claude/commands/issue.md)       |
+| `/issue`    | Analyze or create a GitHub Issue and build a resolution plan | [issue.md](.claude/commands/issue.md)       |
 | `/sponsors` | Check and update GitHub Sponsors listings              | [sponsors.md](.claude/commands/sponsors.md) |
 
 ## Skills


### PR DESCRIPTION
Fixes #???

## What is the purpose of this PR?

- [x] Update documents
- [ ] Others

### Description

This PR enhances the `/issue` command documentation to support both analyzing existing GitHub Issues and creating new ones when no Issue URL is provided.

**Key changes:**

1. **Updated command description** in both `issue.md` and `CLAUDE.md` to reflect the dual capability: "Analyze or create a GitHub Issue and build a resolution plan"

2. **Added Step 1b: Register as a GitHub Issue** - A new comprehensive workflow for creating GitHub Issues when no URL is provided:
   - Determines Issue type (Bug, Feature, Spec update) and matches to existing templates
   - Fetches available labels to prevent typos
   - Provides template-specific formatting for each Issue type
   - Shows draft to user for confirmation before creation
   - Captures Issue number and URL for subsequent steps

3. **Simplified Step 2 branch naming** - Removed the conditional logic for branch naming since an Issue number is now always available (either from the provided URL or from Step 1b creation)

4. **Clarified Step 3** - Removed the parenthetical about "or user description" since the Issue is now always registered before analysis

These changes make the `/issue` command more versatile by enabling users to create Issues directly through the command workflow, ensuring consistent formatting and proper GitHub integration.

## Checklist

- [x] Update documents
  - [x] Enhanced `/issue` command documentation with Issue creation workflow
  - [x] Updated command description in CLAUDE.md reference

https://claude.ai/code/session_01CkoV9rNU8qbhtippp2Yk5Y