### PR TITLE
Add Vue Options API component resolution and barrel file support

### DIFF
--- a/packages/@markuplint/pretenders/README.md
+++ b/packages/@markuplint/pretenders/README.md
@@ -116,14 +116,19 @@ Slot detection covers:
 
 ### Import Resolver
 
-The import resolver analyzes `<script>` / frontmatter / ESM blocks in component files and extracts static import bindings. This links template component usage to source file locations, enabling cross-file dependency resolution.
+The import resolver analyzes `<script>` / frontmatter / ESM blocks in component files and extracts import bindings. This links template component usage to source file locations, enabling cross-file dependency resolution.
 
 Supported script block types:
 
-- Vue `<script setup>`
-- Svelte `<script>`
+- Vue `<script setup>` (all static imports are exposed as bindings)
+- Vue Options API `<script>` (fallback when no `<script setup>`; only imports registered in `components: { ... }` are returned)
+- Svelte `<script>` (prefers instance script over module script)
 - Astro frontmatter (`---...---`)
 - MDX top-level ESM
+
+Dynamic imports with string literal specifiers (`import('./path')`) are included in bindings with `type: 'dynamic'`. Template literal and variable specifiers are excluded.
+
+Barrel file re-exports can be resolved with `resolveBarrelExport`, which maps a named import from a directory with an index file back to its original source module (single-level only).
 
 ## API
 
@@ -135,9 +140,9 @@ The unified entry point. Dispatches files to the appropriate scanner based on fi
 import { scan } from '@markuplint/pretenders';
 
 const pretenders = await scan([
-  './src/components/Button.tsx',
-  './src/components/Card.vue',
-  './src/components/Alert.svelte',
+  '/absolute/path/to/Button.tsx',
+  '/absolute/path/to/Card.vue',
+  '/absolute/path/to/Alert.svelte',
 ]);
 ```
 
@@ -155,7 +160,7 @@ Scans JSX/TSX files using the TypeScript compiler API.
 ```ts
 import { jsxScanner } from '@markuplint/pretenders';
 
-const pretenders = await jsxScanner(['./src/**/*.jsx'], {
+const pretenders = await jsxScanner(['/absolute/path/to/Component.jsx'], {
   cwd: process.cwd(),
   asFragment: [/(?:^|\.)provider$/i],
   ignoreComponentNames: [],
@@ -166,14 +171,14 @@ const pretenders = await jsxScanner(['./src/**/*.jsx'], {
 
 #### Parameters
 
-| Parameter                        | Type                   | Description                                  |
-| -------------------------------- | ---------------------- | -------------------------------------------- |
-| `files`                          | `string[]`             | File paths to scan                           |
-| `options.cwd`                    | `string`               | Current working directory                    |
-| `options.asFragment`             | `RegExp[]`             | Patterns for components treated as fragments |
-| `options.ignoreComponentNames`   | `string[]`             | Component names to ignore                    |
-| `options.taggedStylingComponent` | `RegExp[]`             | Patterns for styled-components               |
-| `options.extendingWrapper`       | `RegExp[] \| object[]` | Patterns for HOC/wrapper components          |
+| Parameter                        | Type                                                             | Description                                                |
+| -------------------------------- | ---------------------------------------------------------------- | ---------------------------------------------------------- |
+| `files`                          | `readonly string[]`                                              | Absolute file paths to scan                                |
+| `options.cwd`                    | `string`                                                         | Current working directory                                  |
+| `options.asFragment`             | `readonly (RegExp \| string)[]`                                  | Patterns for components treated as transparent fragments   |
+| `options.ignoreComponentNames`   | `readonly string[]`                                              | Component names to ignore                                  |
+| `options.taggedStylingComponent` | `readonly (RegExp \| string)[]`                                  | Patterns for styled-components tagged template expressions |
+| `options.extendingWrapper`       | `readonly (string \| RegExp \| ExtendingWrapperCallerOptions)[]` | Patterns for HOC/wrapper components                        |
 
 ### `templateScanner(files, options)`
 
@@ -183,7 +188,7 @@ Scans Vue, Svelte, and Astro component files using markuplint's own parsers (MLA
 import { templateScanner } from '@markuplint/pretenders';
 
 const pretenders = await templateScanner(
-  ['./src/components/Button.vue', './src/components/Alert.svelte', './src/components/Card.astro'],
+  ['/absolute/path/to/Button.vue', '/absolute/path/to/Alert.svelte', '/absolute/path/to/Card.astro'],
   {
     ignoreComponentNames: ['InternalHelper'],
   },
@@ -200,22 +205,74 @@ const pretenders = await templateScanner(
 
 ### `analyzeImports(filePath, source)`
 
-Extracts import bindings from a component file's script block.
+Extracts import bindings from a component file's script block. Detects the framework from the file extension and extracts the appropriate source block automatically.
+
+Returns `null` if the file extension is not a supported framework (`.vue`, `.svelte`, `.astro`, `.mdx`).
 
 ```ts
 import { analyzeImports } from '@markuplint/pretenders';
 
 const result = await analyzeImports('App.vue', source);
-// result.bindings: [{ localName: 'MyButton', source: './components/MyButton.vue' }, ...]
+// result.bindings: [{ localName: 'MyButton', importedName: 'default', source: './components/MyButton.vue', type: 'default' }, ...]
 ```
+
+#### Parameters
+
+| Parameter  | Type     | Description                                           |
+| ---------- | -------- | ----------------------------------------------------- |
+| `filePath` | `string` | File path (used for framework detection by extension) |
+| `source`   | `string` | Full source text of the component file                |
+
+#### Returns
+
+`Promise<ImportAnalysisResult | null>` — The analysis result with all import bindings, or `null` if the framework is not supported.
 
 ### `resolveComponentImport(componentName, bindings)`
 
-Resolves a component name used in a template to its import source path. Handles Vue's kebab-case to PascalCase normalization (e.g., `<my-button>` resolves to `MyButton`).
+Resolves a component name used in a template to its import binding. Handles Vue's kebab-case to PascalCase normalization (e.g., `<my-button>` resolves to `MyButton`).
 
 ```ts
 import { resolveComponentImport } from '@markuplint/pretenders';
 
 const binding = resolveComponentImport('my-button', bindings);
-// binding: { localName: 'MyButton', source: './components/MyButton.vue' }
+// binding: { localName: 'MyButton', importedName: 'default', source: './components/MyButton.vue', type: 'default' }
 ```
+
+#### Parameters
+
+| Parameter       | Type                       | Description                            |
+| --------------- | -------------------------- | -------------------------------------- |
+| `componentName` | `string`                   | Component name as used in the template |
+| `bindings`      | `readonly ImportBinding[]` | Import bindings from `analyzeImports`  |
+
+#### Returns
+
+`ImportBinding | undefined` — The matching binding, or `undefined` if no match.
+
+### `resolveBarrelExport(specifier, importedName, importerPath)`
+
+Resolves a barrel file (`index.ts`/`index.js`) re-export to the original source module path. Only handles relative specifiers and single-level barrel resolution.
+
+```ts
+import { analyzeImports, resolveComponentImport, resolveBarrelExport } from '@markuplint/pretenders';
+
+const result = await analyzeImports('App.vue', source);
+const binding = resolveComponentImport('Button', result.bindings);
+
+if (binding) {
+  const originalSource = resolveBarrelExport(binding.source, binding.importedName, '/absolute/path/to/App.vue');
+  // originalSource: './Button.vue' (resolved from './components' barrel)
+}
+```
+
+#### Parameters
+
+| Parameter      | Type     | Description                                     |
+| -------------- | -------- | ----------------------------------------------- |
+| `specifier`    | `string` | The import specifier (e.g., `'./components'`)   |
+| `importedName` | `string` | The name being imported (e.g., `'Button'`)      |
+| `importerPath` | `string` | Absolute path of the file containing the import |
+
+#### Returns
+
+`string | null` — The relative source path from the barrel file, or `null` if not a barrel or name not found.

--- a/packages/@markuplint/pretenders/src/import-resolver/extract-script-source.spec.ts
+++ b/packages/@markuplint/pretenders/src/import-resolver/extract-script-source.spec.ts
@@ -121,6 +121,14 @@ import { ref } from 'vue'
 		expect(result).toBeNull();
 	});
 
+	test('offset points to content start (after opening tag)', () => {
+		const source = "<script>\nimport X from './X'\n</script>";
+		const result = extractVueScript(source);
+		expect(result).not.toBeNull();
+		// offset is right after '<script>' (8 chars)
+		expect(result!.offset).toBe('<script>'.length);
+	});
+
 	test('picks regular <script> when both setup and regular exist', () => {
 		const source = `<script setup>
 import { ref } from 'vue'
@@ -190,6 +198,33 @@ export default {
 	test('returns empty array for empty source', () => {
 		const result = extractVueOptionsApiComponents('');
 		expect(result).toStrictEqual([]);
+	});
+
+	test('works inside defineComponent wrapper', () => {
+		const source = `
+import { defineComponent } from 'vue'
+import Button from './Button.vue'
+export default defineComponent({
+  components: { Button }
+})`;
+		const result = extractVueOptionsApiComponents(source);
+		expect(result).toStrictEqual(['Button']);
+	});
+
+	test('works with defineComponent and multiple components', () => {
+		const source = `
+import { defineComponent } from 'vue'
+import Button from './Button.vue'
+import Card from './Card.vue'
+export default defineComponent({
+  components: {
+    Button,
+    MyCard: Card,
+  },
+  setup() { return {} }
+})`;
+		const result = extractVueOptionsApiComponents(source);
+		expect(result).toStrictEqual(['Button', 'Card']);
 	});
 });
 

--- a/packages/@markuplint/pretenders/src/import-resolver/extract-script-source.spec.ts
+++ b/packages/@markuplint/pretenders/src/import-resolver/extract-script-source.spec.ts
@@ -2,6 +2,8 @@ import { describe, test, expect } from 'vitest';
 
 import {
 	extractVueScriptSetup,
+	extractVueScript,
+	extractVueOptionsApiComponents,
 	extractSvelteScript,
 	extractAstroFrontmatter,
 	extractMdxEsm,
@@ -72,6 +74,122 @@ export default {
 		expect(result).not.toBeNull();
 		// offset is right after '<script setup>' (14 chars)
 		expect(result!.offset).toBe('<script setup>'.length);
+	});
+});
+
+describe('extractVueScript', () => {
+	test('extracts regular <script> content', () => {
+		const source = `<template><div /></template>
+
+<script>
+import Button from './Button.vue'
+export default {
+  components: { Button }
+}
+</script>`;
+		const result = extractVueScript(source);
+		expect(result).not.toBeNull();
+		expect(result!.content).toContain("import Button from './Button.vue'");
+		expect(result!.content).toContain('components: { Button }');
+	});
+
+	test('extracts <script lang="ts"> content', () => {
+		const source = `<script lang="ts">
+import Button from './Button.vue'
+export default { components: { Button } }
+</script>
+
+<template><Button /></template>`;
+		const result = extractVueScript(source);
+		expect(result).not.toBeNull();
+		expect(result!.content).toContain("import Button from './Button.vue'");
+	});
+
+	test('ignores <script setup> blocks', () => {
+		const source = `<script setup>
+import { ref } from 'vue'
+</script>
+
+<template><div /></template>`;
+		const result = extractVueScript(source);
+		expect(result).toBeNull();
+	});
+
+	test('returns null when no script tag exists', () => {
+		const source = '<template><div>hello</div></template>';
+		const result = extractVueScript(source);
+		expect(result).toBeNull();
+	});
+
+	test('picks regular <script> when both setup and regular exist', () => {
+		const source = `<script setup>
+import { ref } from 'vue'
+</script>
+
+<script>
+import Button from './Button.vue'
+export default { components: { Button } }
+</script>
+
+<template><Button /></template>`;
+		const result = extractVueScript(source);
+		expect(result).not.toBeNull();
+		expect(result!.content).toContain("import Button from './Button.vue'");
+		expect(result!.content).not.toContain('ref');
+	});
+});
+
+describe('extractVueOptionsApiComponents', () => {
+	test('extracts shorthand component names', () => {
+		const source = `
+import Button from './Button.vue'
+import Card from './Card.vue'
+export default {
+  components: { Button, Card }
+}`;
+		const result = extractVueOptionsApiComponents(source);
+		expect(result).toStrictEqual(['Button', 'Card']);
+	});
+
+	test('extracts aliased component names (value is the import)', () => {
+		const source = `
+import MyBtn from './Button.vue'
+export default {
+  components: { Btn: MyBtn, Card }
+}`;
+		const result = extractVueOptionsApiComponents(source);
+		expect(result).toStrictEqual(['MyBtn', 'Card']);
+	});
+
+	test('handles multiline component registration', () => {
+		const source = `
+import Button from './Button.vue'
+import Card from './Card.vue'
+import Input from './Input.vue'
+export default {
+  components: {
+    Button,
+    Card,
+    Input,
+  },
+  data() { return {} }
+}`;
+		const result = extractVueOptionsApiComponents(source);
+		expect(result).toStrictEqual(['Button', 'Card', 'Input']);
+	});
+
+	test('returns empty array when no components property', () => {
+		const source = `
+export default {
+  data() { return {} }
+}`;
+		const result = extractVueOptionsApiComponents(source);
+		expect(result).toStrictEqual([]);
+	});
+
+	test('returns empty array for empty source', () => {
+		const result = extractVueOptionsApiComponents('');
+		expect(result).toStrictEqual([]);
 	});
 });
 

--- a/packages/@markuplint/pretenders/src/import-resolver/extract-script-source.ts
+++ b/packages/@markuplint/pretenders/src/import-resolver/extract-script-source.ts
@@ -55,6 +55,81 @@ export function extractVueScriptSetup(source: string): ScriptSourceBlock | null 
 }
 
 /**
+ * Extracts the content of a regular `<script>` block (NOT `<script setup>`) from a Vue SFC source.
+ * Only matches `<script>` without the `setup` attribute.
+ *
+ * @param source - The full Vue SFC source text
+ * @returns The extracted script block, or `null` if no regular `<script>` is found
+ */
+export function extractVueScript(source: string): ScriptSourceBlock | null {
+	const re = /<script(?:\s[^>]*)?>/gi;
+	let match: RegExpExecArray | null;
+
+	while ((match = re.exec(source)) !== null) {
+		const startTag = match[0];
+
+		// Skip <script setup> blocks
+		if (/\bsetup\b/i.test(startTag)) {
+			continue;
+		}
+
+		const contentStart = match.index + startTag.length;
+		const remaining = source.slice(contentStart);
+		const endMatch = /<\/script\s*>/i.exec(remaining);
+		if (!endMatch) {
+			continue;
+		}
+
+		return {
+			content: remaining.slice(0, endMatch.index),
+			offset: contentStart,
+		};
+	}
+
+	return null;
+}
+
+/**
+ * Extracts component names registered in the Vue Options API `components` property.
+ * Handles both shorthand (`{ Button }`) and aliased (`{ Btn: MyButton }`) forms.
+ * For aliased forms, returns the value (the import name), not the key (the template name).
+ *
+ * @param scriptContent - The content of the `<script>` block (without tags)
+ * @returns An array of component local names referenced in the `components` registration
+ */
+export function extractVueOptionsApiComponents(scriptContent: string): string[] {
+	if (!scriptContent) {
+		return [];
+	}
+
+	// Match `components: { ... }` allowing for multiline
+	const re = /\bcomponents\s*:\s*\{([^}]*)\}/;
+	const match = re.exec(scriptContent);
+	if (!match?.[1]) {
+		return [];
+	}
+
+	const names: string[] = [];
+	for (const entry of match[1].split(',')) {
+		const trimmed = entry.trim();
+		if (!trimmed) {
+			continue;
+		}
+
+		// Aliased form: `Btn: MyButton` → use value `MyButton`
+		const colonParts = trimmed.split(':');
+		if (colonParts.length === 2 && colonParts[1]) {
+			names.push(colonParts[1].trim());
+		} else {
+			// Shorthand: `Button` → use as-is
+			names.push(trimmed);
+		}
+	}
+
+	return names;
+}
+
+/**
  * Extracts the content of the `<script>` block from a Svelte component source.
  * Prefers the instance `<script>` over `<script context="module">`.
  * Falls back to the module script if no instance script is found.

--- a/packages/@markuplint/pretenders/src/import-resolver/extract-script-source.ts
+++ b/packages/@markuplint/pretenders/src/import-resolver/extract-script-source.ts
@@ -116,13 +116,17 @@ export function extractVueOptionsApiComponents(scriptContent: string): string[] 
 			continue;
 		}
 
-		// Aliased form: `Btn: MyButton` → use value `MyButton`
-		const colonParts = trimmed.split(':');
-		if (colonParts.length === 2 && colonParts[1]) {
-			names.push(colonParts[1].trim());
-		} else {
+		// Split on first colon only to handle values containing colons
+		const colonIdx = trimmed.indexOf(':');
+		if (colonIdx === -1) {
 			// Shorthand: `Button` → use as-is
 			names.push(trimmed);
+		} else {
+			// Aliased form: `Btn: MyButton` → use value `MyButton`
+			const value = trimmed.slice(colonIdx + 1).trim();
+			if (value) {
+				names.push(value);
+			}
 		}
 	}
 

--- a/packages/@markuplint/pretenders/src/import-resolver/index.spec.ts
+++ b/packages/@markuplint/pretenders/src/import-resolver/index.spec.ts
@@ -87,6 +87,46 @@ export default {
 			});
 		});
 
+		test('Options API with defineComponent wrapper', async () => {
+			const source = `<template><Button /></template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+import Button from './Button.vue'
+export default defineComponent({
+  components: { Button }
+})
+</script>`;
+			const result = await analyzeImports('App.vue', source);
+			expect(result).not.toBeNull();
+			expect(result!.bindings).toHaveLength(1);
+			expect(result!.bindings[0]).toMatchObject({
+				localName: 'Button',
+				source: './Button.vue',
+				type: 'default',
+			});
+		});
+
+		test('Options API with named imports', async () => {
+			const source = `<template><Card /></template>
+
+<script>
+import { Card } from './ui'
+export default {
+  components: { Card }
+}
+</script>`;
+			const result = await analyzeImports('App.vue', source);
+			expect(result).not.toBeNull();
+			expect(result!.bindings).toHaveLength(1);
+			expect(result!.bindings[0]).toMatchObject({
+				localName: 'Card',
+				importedName: 'Card',
+				source: './ui',
+				type: 'named',
+			});
+		});
+
 		test('prefers <script setup> over Options API when both exist', async () => {
 			const source = `<script setup>
 import Button from './Button.vue'
@@ -119,6 +159,20 @@ import { Card as MyCard } from './ui'
 			expect(result!.bindings).toHaveLength(2);
 			expect(result!.bindings[0]).toMatchObject({ localName: 'Button', source: './Button.vue' });
 			expect(result!.bindings[1]).toMatchObject({ localName: 'MyCard', importedName: 'Card' });
+		});
+
+		test('extracts dynamic import from <script setup>', async () => {
+			const source = `<script setup>
+import Button from './Button.vue'
+const Dialog = import('./Dialog.vue')
+</script>
+
+<template><Button /></template>`;
+			const result = await analyzeImports('App.vue', source);
+			expect(result).not.toBeNull();
+			expect(result!.bindings).toHaveLength(2);
+			expect(result!.bindings[0]).toMatchObject({ localName: 'Button', type: 'default' });
+			expect(result!.bindings[1]).toMatchObject({ source: './Dialog.vue', type: 'dynamic' });
 		});
 
 		test('excludes import type from bindings', async () => {
@@ -260,5 +314,16 @@ describe('resolveComponentImport', () => {
 
 	test('single-word name without hyphen is not transformed', () => {
 		expect(resolveComponentImport('card', bindings)).toBeUndefined();
+	});
+
+	test('does not match dynamic import bindings (localName is sentinel *)', () => {
+		const bindingsWithDynamic: ImportBinding[] = [
+			{ localName: '*', importedName: '*', source: './Dialog.vue', type: 'dynamic' },
+			{ localName: 'Button', importedName: 'default', source: './Button.vue', type: 'default' },
+		];
+		// Dynamic binding should not match any component name
+		expect(resolveComponentImport('Dialog', bindingsWithDynamic)).toBeUndefined();
+		// Static binding still resolves
+		expect(resolveComponentImport('Button', bindingsWithDynamic)).toStrictEqual(bindingsWithDynamic[1]);
 	});
 });

--- a/packages/@markuplint/pretenders/src/import-resolver/index.spec.ts
+++ b/packages/@markuplint/pretenders/src/import-resolver/index.spec.ts
@@ -31,7 +31,7 @@ import { ref } from 'vue'
 			});
 		});
 
-		test('returns empty bindings for Vue without <script setup>', async () => {
+		test('returns empty bindings for Vue without <script setup> and no components', async () => {
 			const source = `<template><div /></template>
 <script>
 export default { name: 'MyComp' }
@@ -39,6 +39,70 @@ export default { name: 'MyComp' }
 			const result = await analyzeImports('App.vue', source);
 			expect(result).not.toBeNull();
 			expect(result!.bindings).toStrictEqual([]);
+		});
+
+		test('extracts imports from Options API components registration', async () => {
+			const source = `<template>
+  <Button /><Card />
+</template>
+
+<script>
+import Button from './Button.vue'
+import Card from './Card.vue'
+import { someHelper } from './utils'
+export default {
+  components: { Button, Card }
+}
+</script>`;
+			const result = await analyzeImports('App.vue', source);
+			expect(result).not.toBeNull();
+			expect(result!.bindings).toHaveLength(2);
+			expect(result!.bindings[0]).toMatchObject({
+				localName: 'Button',
+				source: './Button.vue',
+				type: 'default',
+			});
+			expect(result!.bindings[1]).toMatchObject({
+				localName: 'Card',
+				source: './Card.vue',
+				type: 'default',
+			});
+		});
+
+		test('Options API with aliased component registration', async () => {
+			const source = `<template><Btn /></template>
+
+<script>
+import MyButton from './Button.vue'
+export default {
+  components: { Btn: MyButton }
+}
+</script>`;
+			const result = await analyzeImports('App.vue', source);
+			expect(result).not.toBeNull();
+			expect(result!.bindings).toHaveLength(1);
+			expect(result!.bindings[0]).toMatchObject({
+				localName: 'MyButton',
+				source: './Button.vue',
+			});
+		});
+
+		test('prefers <script setup> over Options API when both exist', async () => {
+			const source = `<script setup>
+import Button from './Button.vue'
+</script>
+
+<script>
+import Card from './Card.vue'
+export default { components: { Card } }
+</script>
+
+<template><Button /><Card /></template>`;
+			const result = await analyzeImports('App.vue', source);
+			expect(result).not.toBeNull();
+			// Should use <script setup> bindings, not Options API
+			expect(result!.bindings).toHaveLength(1);
+			expect(result!.bindings[0]).toMatchObject({ localName: 'Button' });
 		});
 
 		test('extracts from <script setup lang="ts">', async () => {

--- a/packages/@markuplint/pretenders/src/import-resolver/index.ts
+++ b/packages/@markuplint/pretenders/src/import-resolver/index.ts
@@ -8,17 +8,19 @@
  * Uses es-module-lexer (WASM-based) to identify import specifiers, then
  * supplements with regex parsing on statement slices to extract local names.
  *
- * Phase 1 supports:
- * - Vue `<script setup>` (direct static imports only)
+ * Supports:
+ * - Vue `<script setup>` (static imports)
+ * - Vue Options API `components` property registration (fallback when no `<script setup>`)
  * - Svelte `<script>` tags
  * - Astro frontmatter (`---...---`)
  * - MDX top-level ESM
+ * - Dynamic imports with string literal specifiers (`import('./path')`)
+ * - Barrel file re-export resolution (single-level, via `resolveBarrelExport`)
  *
- * Phase 1 excludes:
- * - Vue Options API `components` property registration
- * - Dynamic imports (`import()`)
+ * Excludes:
  * - `import.meta` references
- * - Barrel file re-export resolution (planned for Phase 2)
+ * - Dynamic imports with template literals or variable specifiers
+ * - Multi-level barrel chains (only single-level re-exports are resolved)
  *
  * Note: The current implementation uses regex-based source extraction.
  * When the CLI multi-framework dispatch (#3340) creates a unified parsing
@@ -33,11 +35,14 @@ import path from 'node:path';
 
 import {
 	extractVueScriptSetup,
+	extractVueScript,
+	extractVueOptionsApiComponents,
 	extractSvelteScript,
 	extractAstroFrontmatter,
 	extractMdxEsm,
 } from './extract-script-source.js';
 import { parseImports } from './parse-imports.js';
+export { resolveBarrelExport } from './resolve-barrel.js';
 
 export type { ImportBinding, ImportAnalysisResult } from './types.js';
 
@@ -86,6 +91,11 @@ export async function analyzeImports(filePath: string, source: string): Promise<
 	switch (framework) {
 		case 'vue': {
 			scriptSource = extractVueScriptSetup(source);
+			if (!scriptSource) {
+				// Fallback to Vue Options API: extract regular <script>, parse imports,
+				// then filter to only those registered in the `components` property.
+				return analyzeVueOptionsApi(source);
+			}
 			break;
 		}
 		case 'svelte': {
@@ -107,6 +117,32 @@ export async function analyzeImports(filePath: string, source: string): Promise<
 	}
 
 	const bindings = await parseImports(scriptSource.content);
+	return { bindings };
+}
+
+/**
+ * Analyzes a Vue SFC's regular `<script>` block for Options API component registration.
+ * Parses all imports from the script block, then filters to only those whose
+ * local name appears in the `components: { ... }` property.
+ *
+ * @param source - The full Vue SFC source text
+ * @returns The analysis result with filtered bindings, or empty bindings if not applicable
+ */
+async function analyzeVueOptionsApi(source: string): Promise<ImportAnalysisResult> {
+	const scriptBlock = extractVueScript(source);
+	if (!scriptBlock) {
+		return { bindings: [] };
+	}
+
+	const allBindings = await parseImports(scriptBlock.content);
+	const componentNames = extractVueOptionsApiComponents(scriptBlock.content);
+
+	if (componentNames.length === 0) {
+		return { bindings: [] };
+	}
+
+	const componentNameSet = new Set(componentNames);
+	const bindings = allBindings.filter(b => componentNameSet.has(b.localName));
 	return { bindings };
 }
 

--- a/packages/@markuplint/pretenders/src/import-resolver/index.ts
+++ b/packages/@markuplint/pretenders/src/import-resolver/index.ts
@@ -8,21 +8,52 @@
  * Uses es-module-lexer (WASM-based) to identify import specifiers, then
  * supplements with regex parsing on statement slices to extract local names.
  *
- * Supports:
- * - Vue `<script setup>` (static imports)
- * - Vue Options API `components` property registration (fallback when no `<script setup>`)
- * - Svelte `<script>` tags
+ * ## Supported frameworks
+ *
+ * - Vue `<script setup>` (all static imports are exposed as bindings)
+ * - Vue Options API `components` property (fallback when no `<script setup>`;
+ *   only imports registered in `components: { ... }` are returned)
+ * - Svelte `<script>` tags (prefers instance script over module script)
  * - Astro frontmatter (`---...---`)
  * - MDX top-level ESM
- * - Dynamic imports with string literal specifiers (`import('./path')`)
- * - Barrel file re-export resolution (single-level, via `resolveBarrelExport`)
  *
- * Excludes:
+ * ## Dynamic imports
+ *
+ * Dynamic imports with string literal specifiers (`import('./path')`) are
+ * included in the bindings with `type: 'dynamic'`. These bindings use
+ * `localName: '*'` as a sentinel since dynamic imports have no local binding.
+ * Template literal and variable specifiers are excluded.
+ *
+ * ## Barrel file resolution
+ *
+ * `resolveBarrelExport` is a standalone utility (not called by `analyzeImports`)
+ * that resolves a named import from a barrel directory (e.g., `'./components'`)
+ * to its original source module. Only single-level re-exports are resolved.
+ *
+ * ### Usage example: resolving barrel imports
+ *
+ * ```ts
+ * import { analyzeImports, resolveComponentImport, resolveBarrelExport } from '@markuplint/pretenders';
+ *
+ * const result = await analyzeImports('App.vue', source);
+ * const binding = resolveComponentImport('Button', result.bindings);
+ *
+ * if (binding) {
+ *   // Check if the import source is a barrel directory
+ *   const originalSource = resolveBarrelExport(binding.source, binding.importedName, filePath);
+ *   // originalSource: './Button.vue' (resolved from './components' barrel)
+ * }
+ * ```
+ *
+ * ## Excludes
+ *
  * - `import.meta` references
  * - Dynamic imports with template literals or variable specifiers
  * - Multi-level barrel chains (only single-level re-exports are resolved)
  *
- * Note: The current implementation uses regex-based source extraction.
+ * ## Future integration
+ *
+ * The current implementation uses regex-based source extraction.
  * When the CLI multi-framework dispatch (#3340) creates a unified parsing
  * pipeline, MLAST psblock-based extraction can be integrated by parsing
  * the file once and passing the document to both templateScanner and

--- a/packages/@markuplint/pretenders/src/import-resolver/parse-imports.spec.ts
+++ b/packages/@markuplint/pretenders/src/import-resolver/parse-imports.spec.ts
@@ -168,19 +168,51 @@ describe('parseImports', () => {
 		});
 	});
 
-	describe('dynamic imports are excluded', () => {
-		test('dynamic import is ignored', async () => {
+	describe('dynamic imports', () => {
+		test('dynamic import with string literal is resolved', async () => {
 			const source = ["import Button from './Button.vue'", "const Lazy = import('./Lazy.vue')"].join('\n');
+			const result = await parseImports(source);
+			expect(result).toHaveLength(2);
+			expect(result[0]).toMatchObject({ localName: 'Button' });
+			expect(result[1]).toStrictEqual({
+				localName: '*',
+				importedName: '*',
+				source: './Lazy.vue',
+				type: 'dynamic',
+			});
+		});
+
+		test('dynamic import with double-quoted string literal', async () => {
+			const source = 'const Lazy = import("./Lazy.vue")';
+			const result = await parseImports(source);
+			expect(result).toHaveLength(1);
+			expect(result[0]).toStrictEqual({
+				localName: '*',
+				importedName: '*',
+				source: './Lazy.vue',
+				type: 'dynamic',
+			});
+		});
+
+		test('import.meta is still ignored', async () => {
+			const source = ["import Button from './B.vue'", 'const url = import.meta.env.BASE_URL'].join('\n');
 			const result = await parseImports(source);
 			expect(result).toHaveLength(1);
 			expect(result[0]).toMatchObject({ localName: 'Button' });
 		});
 
-		test('import.meta is ignored', async () => {
-			const source = ["import Button from './B.vue'", 'const url = import.meta.env.BASE_URL'].join('\n');
+		test('dynamic import with template literal is excluded', async () => {
+			const source = 'const Lazy = import(`./components/${name}.vue`)';
 			const result = await parseImports(source);
-			expect(result).toHaveLength(1);
-			expect(result[0]).toMatchObject({ localName: 'Button' });
+			expect(result).toStrictEqual([]);
+		});
+
+		test('multiple dynamic imports', async () => {
+			const source = ["const A = import('./A.vue')", "const B = import('./B.vue')"].join('\n');
+			const result = await parseImports(source);
+			expect(result).toHaveLength(2);
+			expect(result[0]).toMatchObject({ source: './A.vue', type: 'dynamic' });
+			expect(result[1]).toMatchObject({ source: './B.vue', type: 'dynamic' });
 		});
 	});
 

--- a/packages/@markuplint/pretenders/src/import-resolver/parse-imports.ts
+++ b/packages/@markuplint/pretenders/src/import-resolver/parse-imports.ts
@@ -168,10 +168,11 @@ function extractBindingsFromStatement(statementText: string, source: string): Im
 }
 
 /**
- * Analyzes source text and extracts all static import bindings using es-module-lexer.
+ * Analyzes source text and extracts import bindings using es-module-lexer.
  *
- * Only processes static imports (type === 1). Dynamic imports and `import.meta`
- * references are ignored as specified in Phase 1 constraints.
+ * Processes static imports and dynamic imports with string literal specifiers.
+ * `import.meta` references and dynamic imports with non-literal specifiers
+ * (template literals, variables) are excluded.
  *
  * @param source - The source text to analyze (e.g., content of a `<script setup>` block)
  * @returns An array of all import bindings found in the source
@@ -203,7 +204,8 @@ export async function parseImports(source: string): Promise<readonly ImportBindi
 
 		if (imp.d >= 0) {
 			// Dynamic import with a string literal specifier (e.g., `import('./Foo.vue')`)
-			// We record a wildcard binding since the consumer decides how to use it.
+			// Dynamic imports have no local binding name, so we use '*' as a sentinel.
+			// Consumers should check `type === 'dynamic'` to distinguish from namespace imports.
 			bindings.push({
 				localName: '*',
 				importedName: '*',

--- a/packages/@markuplint/pretenders/src/import-resolver/parse-imports.ts
+++ b/packages/@markuplint/pretenders/src/import-resolver/parse-imports.ts
@@ -191,17 +191,29 @@ export async function parseImports(source: string): Promise<readonly ImportBindi
 	const bindings: ImportBinding[] = [];
 
 	for (const imp of imports) {
-		// Skip dynamic imports (d >= 0) and import.meta (d === -2)
-		// Static imports have d === -1
-		if (imp.d !== -1) {
+		// import.meta (d === -2) — always skip
+		if (imp.d === -2) {
 			continue;
 		}
 
-		// n = normalized module specifier
+		// n = normalized module specifier (absent for template-literal dynamic imports)
 		if (!imp.n) {
 			continue;
 		}
 
+		if (imp.d >= 0) {
+			// Dynamic import with a string literal specifier (e.g., `import('./Foo.vue')`)
+			// We record a wildcard binding since the consumer decides how to use it.
+			bindings.push({
+				localName: '*',
+				importedName: '*',
+				source: imp.n,
+				type: 'dynamic',
+			});
+			continue;
+		}
+
+		// Static imports (d === -1)
 		// ss/se = statement start/end positions
 		const statementText = source.slice(imp.ss, imp.se);
 		bindings.push(...extractBindingsFromStatement(statementText, imp.n));

--- a/packages/@markuplint/pretenders/src/import-resolver/resolve-barrel.spec.ts
+++ b/packages/@markuplint/pretenders/src/import-resolver/resolve-barrel.spec.ts
@@ -49,6 +49,15 @@ beforeAll(() => {
 	fs.mkdirSync(formsDir);
 	fs.writeFileSync(path.join(formsDir, 'TextInput.vue'), '<template><input type="text" /></template>');
 	fs.writeFileSync(path.join(formsDir, 'index.ts'), "export { TextInput } from './TextInput.vue'\n");
+
+	// Create barrel with type-only re-exports mixed in
+	const typedDir = path.join(tmpDir, 'typed');
+	fs.mkdirSync(typedDir);
+	fs.writeFileSync(path.join(typedDir, 'Modal.vue'), '<template><dialog /></template>');
+	fs.writeFileSync(
+		path.join(typedDir, 'index.ts'),
+		["export type { ModalProps } from './types'", "export { default as Modal } from './Modal.vue'"].join('\n'),
+	);
 });
 
 afterAll(() => {
@@ -56,51 +65,64 @@ afterAll(() => {
 });
 
 describe('resolveBarrelExport', () => {
-	test('resolves named re-export from barrel index.ts', async () => {
+	test('resolves named re-export from barrel index.ts', () => {
 		const basePath = path.join(tmpDir, 'App.vue');
-		const result = await resolveBarrelExport('./components', 'Button', basePath);
+		const result = resolveBarrelExport('./components', 'Button', basePath);
 		expect(result).toBe('./Button.vue');
 	});
 
-	test('resolves second named re-export from barrel', async () => {
+	test('resolves second named re-export from barrel', () => {
 		const basePath = path.join(tmpDir, 'App.vue');
-		const result = await resolveBarrelExport('./components', 'Card', basePath);
+		const result = resolveBarrelExport('./components', 'Card', basePath);
 		expect(result).toBe('./Card.vue');
 	});
 
-	test('returns null for non-existent export name', async () => {
+	test('returns null for non-existent export name', () => {
 		const basePath = path.join(tmpDir, 'App.vue');
-		const result = await resolveBarrelExport('./components', 'NonExistent', basePath);
+		const result = resolveBarrelExport('./components', 'NonExistent', basePath);
 		expect(result).toBeNull();
 	});
 
-	test('returns null for non-barrel file (no index)', async () => {
+	test('returns null for non-barrel file (no index)', () => {
 		const basePath = path.join(tmpDir, 'App.vue');
-		const result = await resolveBarrelExport('./utils', 'helper', basePath);
+		const result = resolveBarrelExport('./utils', 'helper', basePath);
 		expect(result).toBeNull();
 	});
 
-	test('resolves from barrel with index.js', async () => {
+	test('resolves from barrel with index.js', () => {
 		const basePath = path.join(tmpDir, 'App.vue');
-		const result = await resolveBarrelExport('./widgets', 'Toggle', basePath);
+		const result = resolveBarrelExport('./widgets', 'Toggle', basePath);
 		expect(result).toBe('./Toggle.vue');
 	});
 
-	test('resolves named (non-default) re-export', async () => {
+	test('resolves named (non-default) re-export', () => {
 		const basePath = path.join(tmpDir, 'App.vue');
-		const result = await resolveBarrelExport('./forms', 'TextInput', basePath);
+		const result = resolveBarrelExport('./forms', 'TextInput', basePath);
 		expect(result).toBe('./TextInput.vue');
 	});
 
-	test('returns null for specifier that is already a file', async () => {
+	test('returns null for specifier that is already a file', () => {
 		const basePath = path.join(tmpDir, 'App.vue');
-		const result = await resolveBarrelExport('./components/Button.vue', 'default', basePath);
+		const result = resolveBarrelExport('./components/Button.vue', 'default', basePath);
 		expect(result).toBeNull();
 	});
 
-	test('returns null for non-relative specifier (npm package)', async () => {
+	test('returns null for non-relative specifier (npm package)', () => {
 		const basePath = path.join(tmpDir, 'App.vue');
-		const result = await resolveBarrelExport('vue', 'ref', basePath);
+		const result = resolveBarrelExport('vue', 'ref', basePath);
+		expect(result).toBeNull();
+	});
+
+	test('skips export type and resolves value re-export', () => {
+		const basePath = path.join(tmpDir, 'App.vue');
+		const result = resolveBarrelExport('./typed', 'Modal', basePath);
+		expect(result).toBe('./Modal.vue');
+	});
+
+	test('does not resolve type-only export name', () => {
+		const basePath = path.join(tmpDir, 'App.vue');
+		// `export type { ModalProps }` does not match the value re-export regex
+		const result = resolveBarrelExport('./typed', 'ModalProps', basePath);
 		expect(result).toBeNull();
 	});
 });

--- a/packages/@markuplint/pretenders/src/import-resolver/resolve-barrel.spec.ts
+++ b/packages/@markuplint/pretenders/src/import-resolver/resolve-barrel.spec.ts
@@ -1,0 +1,106 @@
+import { describe, test, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { resolveBarrelExport } from './resolve-barrel.js';
+
+/**
+ * Creates a temporary directory structure for barrel file tests.
+ */
+let tmpDir: string;
+
+beforeAll(() => {
+	tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'barrel-test-'));
+
+	// Create components directory with barrel index
+	const componentsDir = path.join(tmpDir, 'components');
+	fs.mkdirSync(componentsDir);
+
+	// components/Button.vue
+	fs.writeFileSync(path.join(componentsDir, 'Button.vue'), '<template><button /></template>');
+
+	// components/Card.vue
+	fs.writeFileSync(path.join(componentsDir, 'Card.vue'), '<template><div class="card" /></template>');
+
+	// components/index.ts — barrel re-exports
+	fs.writeFileSync(
+		path.join(componentsDir, 'index.ts'),
+		["export { default as Button } from './Button.vue'", "export { default as Card } from './Card.vue'"].join('\n'),
+	);
+
+	// Create a namespace barrel
+	const iconsDir = path.join(tmpDir, 'icons');
+	fs.mkdirSync(iconsDir);
+	fs.writeFileSync(path.join(iconsDir, 'Star.vue'), '<template><svg /></template>');
+	fs.writeFileSync(path.join(iconsDir, 'index.ts'), "export * from './Star.vue'\n");
+
+	// Create a non-barrel file
+	fs.writeFileSync(path.join(tmpDir, 'utils.ts'), 'export function helper() {}');
+
+	// Create barrel with .js index
+	const widgetsDir = path.join(tmpDir, 'widgets');
+	fs.mkdirSync(widgetsDir);
+	fs.writeFileSync(path.join(widgetsDir, 'Toggle.vue'), '<template><input type="checkbox" /></template>');
+	fs.writeFileSync(path.join(widgetsDir, 'index.js'), "export { default as Toggle } from './Toggle.vue'\n");
+
+	// Create named re-export barrel
+	const formsDir = path.join(tmpDir, 'forms');
+	fs.mkdirSync(formsDir);
+	fs.writeFileSync(path.join(formsDir, 'TextInput.vue'), '<template><input type="text" /></template>');
+	fs.writeFileSync(path.join(formsDir, 'index.ts'), "export { TextInput } from './TextInput.vue'\n");
+});
+
+afterAll(() => {
+	fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('resolveBarrelExport', () => {
+	test('resolves named re-export from barrel index.ts', async () => {
+		const basePath = path.join(tmpDir, 'App.vue');
+		const result = await resolveBarrelExport('./components', 'Button', basePath);
+		expect(result).toBe('./Button.vue');
+	});
+
+	test('resolves second named re-export from barrel', async () => {
+		const basePath = path.join(tmpDir, 'App.vue');
+		const result = await resolveBarrelExport('./components', 'Card', basePath);
+		expect(result).toBe('./Card.vue');
+	});
+
+	test('returns null for non-existent export name', async () => {
+		const basePath = path.join(tmpDir, 'App.vue');
+		const result = await resolveBarrelExport('./components', 'NonExistent', basePath);
+		expect(result).toBeNull();
+	});
+
+	test('returns null for non-barrel file (no index)', async () => {
+		const basePath = path.join(tmpDir, 'App.vue');
+		const result = await resolveBarrelExport('./utils', 'helper', basePath);
+		expect(result).toBeNull();
+	});
+
+	test('resolves from barrel with index.js', async () => {
+		const basePath = path.join(tmpDir, 'App.vue');
+		const result = await resolveBarrelExport('./widgets', 'Toggle', basePath);
+		expect(result).toBe('./Toggle.vue');
+	});
+
+	test('resolves named (non-default) re-export', async () => {
+		const basePath = path.join(tmpDir, 'App.vue');
+		const result = await resolveBarrelExport('./forms', 'TextInput', basePath);
+		expect(result).toBe('./TextInput.vue');
+	});
+
+	test('returns null for specifier that is already a file', async () => {
+		const basePath = path.join(tmpDir, 'App.vue');
+		const result = await resolveBarrelExport('./components/Button.vue', 'default', basePath);
+		expect(result).toBeNull();
+	});
+
+	test('returns null for non-relative specifier (npm package)', async () => {
+		const basePath = path.join(tmpDir, 'App.vue');
+		const result = await resolveBarrelExport('vue', 'ref', basePath);
+		expect(result).toBeNull();
+	});
+});

--- a/packages/@markuplint/pretenders/src/import-resolver/resolve-barrel.ts
+++ b/packages/@markuplint/pretenders/src/import-resolver/resolve-barrel.ts
@@ -12,8 +12,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-/** Regex to match `export { Name } from './source'` or `export { default as Name } from './source'` */
-const RE_NAMED_REEXPORT = /export\s*\{([^}]+)\}\s*from\s*['"]([^'"]+)['"]/g;
+/** Pattern to match `export { Name } from './source'` or `export { default as Name } from './source'` */
+const RE_NAMED_REEXPORT = /export\s*\{([^}]+)\}\s*from\s*['"]([^'"]+)['"]/;
 
 /** Index file names to check, in priority order */
 const INDEX_FILES = ['index.ts', 'index.js', 'index.mts', 'index.mjs'];

--- a/packages/@markuplint/pretenders/src/import-resolver/resolve-barrel.ts
+++ b/packages/@markuplint/pretenders/src/import-resolver/resolve-barrel.ts
@@ -1,0 +1,122 @@
+/**
+ * @module resolve-barrel
+ *
+ * Resolves barrel file (index.ts/index.js) re-exports to their original source.
+ * Only handles single-level barrel resolution — nested barrel chains are not followed.
+ *
+ * Given a specifier like `'./components'`, checks if it is a directory with an
+ * index file, parses that index file's export statements, and maps the requested
+ * binding name back to the original module.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+/** Regex to match `export { Name } from './source'` or `export { default as Name } from './source'` */
+const RE_NAMED_REEXPORT = /export\s*\{([^}]+)\}\s*from\s*['"]([^'"]+)['"]/g;
+
+/** Index file names to check, in priority order */
+const INDEX_FILES = ['index.ts', 'index.js', 'index.mts', 'index.mjs'];
+
+/**
+ * Resolves a barrel file re-export to the original source module path.
+ *
+ * @param specifier - The import specifier (e.g., `'./components'`)
+ * @param importedName - The name being imported (e.g., `'Button'`)
+ * @param importerPath - The absolute path of the file containing the import
+ * @returns The relative source path from the barrel file, or `null` if not a barrel or name not found
+ */
+export function resolveBarrelExport(specifier: string, importedName: string, importerPath: string): string | null {
+	// Only handle relative specifiers
+	if (!specifier.startsWith('.')) {
+		return null;
+	}
+
+	const importerDir = path.dirname(importerPath);
+	const resolved = path.resolve(importerDir, specifier);
+
+	// If the specifier points to an existing file, it's not a barrel
+	if (isFile(resolved)) {
+		return null;
+	}
+
+	// Check if the resolved path is a directory with an index file
+	const indexPath = findIndexFile(resolved);
+	if (!indexPath) {
+		return null;
+	}
+
+	const indexSource = fs.readFileSync(indexPath, 'utf8');
+	return matchExportedName(indexSource, importedName);
+}
+
+/**
+ * Finds the first matching index file in the given directory.
+ */
+function findIndexFile(dirPath: string): string | null {
+	if (!isDirectory(dirPath)) {
+		return null;
+	}
+
+	for (const name of INDEX_FILES) {
+		const candidate = path.join(dirPath, name);
+		if (isFile(candidate)) {
+			return candidate;
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Parses export statements in a barrel file and returns the source path
+ * for the given exported name.
+ */
+function matchExportedName(indexSource: string, targetName: string): string | null {
+	// Parse named re-exports: `export { X } from '...'` and `export { default as X } from '...'`
+	let match: RegExpExecArray | null;
+	const namedRe = new RegExp(RE_NAMED_REEXPORT.source, 'g');
+
+	while ((match = namedRe.exec(indexSource)) !== null) {
+		const entriesRaw = match[1]!;
+		const source = match[2]!;
+
+		for (const entry of entriesRaw.split(',')) {
+			const trimmed = entry.trim();
+			if (!trimmed) {
+				continue;
+			}
+
+			const asParts = trimmed.split(/\s+as\s+/);
+			// `default as Button` → exported name is `Button`
+			// `Button` → exported name is `Button`
+			// `Button as Btn` → exported name is `Btn`
+			const exportedName = asParts.length === 2 ? asParts[1]!.trim() : trimmed;
+
+			if (exportedName === targetName) {
+				return source;
+			}
+		}
+	}
+
+	// Star re-exports: `export * from '...'` — we can't statically verify the name,
+	// but for single-level resolution we do not traverse further.
+	// Return null since we can't confirm the name exists in the star export.
+	return null;
+}
+
+function isFile(p: string): boolean {
+	try {
+		return fs.statSync(p).isFile();
+	} catch {
+		return false;
+	}
+}
+
+function isDirectory(p: string): boolean {
+	try {
+		return fs.statSync(p).isDirectory();
+	} catch {
+		return false;
+	}
+}

--- a/packages/@markuplint/pretenders/src/import-resolver/types.ts
+++ b/packages/@markuplint/pretenders/src/import-resolver/types.ts
@@ -3,13 +3,26 @@
  * Links a local name (used in template/code) to its source module path.
  */
 export interface ImportBinding {
-	/** The local name used in the file (e.g., `MyButton`, `default as Btn` → `Btn`) */
+	/**
+	 * The local name used in the file (e.g., `MyButton`, `default as Btn` → `Btn`).
+	 *
+	 * For dynamic imports (`type === 'dynamic'`), this is set to `'*'` as a sentinel
+	 * value because dynamic imports have no local binding name. Use the `type` field
+	 * to distinguish dynamic imports from namespace imports (which also use `'*'`
+	 * for `importedName`).
+	 */
 	readonly localName: string;
-	/** The imported name from the source module (e.g., `default`, `MyButton`, or `*` for namespace) */
+	/** The imported name from the source module (e.g., `default`, `MyButton`, or `*` for namespace/dynamic) */
 	readonly importedName: string;
 	/** The module specifier string (e.g., `./components/Button.vue`, `@/lib/utils`) */
 	readonly source: string;
-	/** The type of import binding */
+	/**
+	 * The type of import binding:
+	 * - `'default'` — `import X from '...'`
+	 * - `'named'` — `import { X } from '...'`
+	 * - `'namespace'` — `import * as X from '...'`
+	 * - `'dynamic'` — `import('...')` with a string literal specifier
+	 */
 	readonly type: 'default' | 'named' | 'namespace' | 'dynamic';
 }
 

--- a/packages/@markuplint/pretenders/src/import-resolver/types.ts
+++ b/packages/@markuplint/pretenders/src/import-resolver/types.ts
@@ -10,7 +10,7 @@ export interface ImportBinding {
 	/** The module specifier string (e.g., `./components/Button.vue`, `@/lib/utils`) */
 	readonly source: string;
 	/** The type of import binding */
-	readonly type: 'default' | 'named' | 'namespace';
+	readonly type: 'default' | 'named' | 'namespace' | 'dynamic';
 }
 
 /**

--- a/packages/@markuplint/pretenders/src/index.ts
+++ b/packages/@markuplint/pretenders/src/index.ts
@@ -10,12 +10,13 @@
  * - {@link templateScanner} — Scans Vue, Svelte, and Astro SFC files using markuplint's parsers
  * - {@link analyzeImports} — Extracts import bindings from component script blocks
  * - {@link resolveComponentImport} — Resolves component template usage to import source paths
+ * - {@link resolveBarrelExport} — Resolves barrel file re-exports to original source modules
  */
 
 export { jsxScanner } from './jsx/index.js';
 export { templateScanner } from './template/index.js';
 export { scan } from './scan.js';
 export type { ScanOptions } from './scan.js';
-export { analyzeImports, resolveComponentImport } from './import-resolver/index.js';
+export { analyzeImports, resolveComponentImport, resolveBarrelExport } from './import-resolver/index.js';
 export type { ImportBinding, ImportAnalysisResult } from './import-resolver/types.js';
 export type * from './types.js';

--- a/packages/@markuplint/pretenders/src/index.ts
+++ b/packages/@markuplint/pretenders/src/index.ts
@@ -5,12 +5,25 @@
  * in source files. Pretenders allow markuplint to understand which native HTML
  * elements a component renders, enabling accurate linting of component-based code.
  *
+ * ## Scanning
+ *
  * - {@link scan} — Unified entry point that dispatches to the appropriate scanner by file extension
  * - {@link jsxScanner} — Scans JSX/TSX files using the TypeScript compiler API
  * - {@link templateScanner} — Scans Vue, Svelte, and Astro SFC files using markuplint's parsers
+ *
+ * ## Import resolution
+ *
  * - {@link analyzeImports} — Extracts import bindings from component script blocks
- * - {@link resolveComponentImport} — Resolves component template usage to import source paths
- * - {@link resolveBarrelExport} — Resolves barrel file re-exports to original source modules
+ *   (Vue `<script setup>`, Vue Options API, Svelte, Astro, MDX)
+ * - {@link resolveComponentImport} — Resolves a component name to its import binding,
+ *   including Vue kebab-case → PascalCase normalization
+ * - {@link resolveBarrelExport} — Resolves barrel file (`index.ts`/`index.js`) re-exports
+ *   to original source modules. Call this separately after `analyzeImports` when an import
+ *   source points to a directory with a barrel index.
+ *
+ * Dynamic imports (`import('./path')`) are included in bindings with `type: 'dynamic'`
+ * and `localName: '*'` as a sentinel. Check `type === 'dynamic'` to distinguish from
+ * namespace imports.
  */
 
 export { jsxScanner } from './jsx/index.js';

--- a/packages/@markuplint/pretenders/src/jsx/index.ts
+++ b/packages/@markuplint/pretenders/src/jsx/index.ts
@@ -76,6 +76,10 @@ const defaultOptions: Required<PretenderScanJSXOptions> = {
  * - HOC / wrapper function patterns
  * - Fragment and provider component transparency
  * - `@pretends null` JSDoc tag to opt out a component
+ *
+ * @param files - Absolute file paths to scan (relative paths cause a `ReferenceError`)
+ * @param options - JSX scanner configuration (fragment patterns, styled-components, wrappers, etc.)
+ * @returns Discovered pretender mappings for all components found in the given files
  */
 export const jsxScanner = createScanner<PretenderScanJSXOptions>(
 	(files, options = defaultOptions): Promise<Pretender[]> => {

--- a/packages/@markuplint/pretenders/src/template/index.ts
+++ b/packages/@markuplint/pretenders/src/template/index.ts
@@ -18,6 +18,10 @@ import { parseComponent } from './parse-component.js';
  * Parses component files using markuplint's existing framework parsers,
  * extracts root elements at depth=0, detects static attributes and slot usage,
  * and registers component-to-element mappings via PretenderDirector.
+ *
+ * @param files - Absolute file paths to scan (relative paths cause a `ReferenceError`)
+ * @param options - Template scanner configuration (cwd, component names to ignore)
+ * @returns Discovered pretender mappings for all components found in the given files
  */
 export const templateScanner = createScanner<PretenderScanTemplateOptions>(async (files, options) => {
 	const cwd = options?.cwd ?? process.cwd();

--- a/packages/markuplint/src/api/ml-engine.ts
+++ b/packages/markuplint/src/api/ml-engine.ts
@@ -152,7 +152,14 @@ export class MLEngine extends Emitter<MLEngineEventMap> {
 
 		if (verifyResult instanceof Error) {
 			this.emit('lint-error', this.#file.path, sourceCode, verifyResult);
-			const errMessage = verifyResult.stack ?? verifyResult.message;
+			// Accessing `.stack` can throw in Deno when source map resolution
+			// encounters invalid mappings (e.g., negative column values).
+			let errMessage: string;
+			try {
+				errMessage = verifyResult.stack ?? verifyResult.message;
+			} catch {
+				errMessage = verifyResult.message;
+			}
 			log('exec: error %O', errMessage);
 			return {
 				violations: [


### PR DESCRIPTION
Fixes #3359

## What is the purpose of this PR?

- [x] Add a new core feature
- [x] Improve or refactor core features

### Description

This PR extends the import resolver to support Vue Options API component registration and adds barrel file re-export resolution.

#### Key Changes

1. **Vue Options API Support**
   - Added `extractVueScript()` to extract regular `<script>` blocks (non-setup)
   - Added `extractVueOptionsApiComponents()` to parse the `components: { ... }` property
   - Modified `analyzeImports()` to fall back to Options API when no `<script setup>` is found
   - Only imports registered in the `components` property are returned as bindings

2. **Dynamic Import Support**
   - Extended `parseImports()` to recognize dynamic imports with string literal specifiers (`import('./path')`)
   - Dynamic imports are included in bindings with `type: 'dynamic'` and `localName: '*'` as a sentinel
   - Template literal and variable specifiers remain excluded

3. **Barrel File Resolution**
   - Added new `resolveBarrelExport()` utility to resolve named imports from barrel directories
   - Supports `index.ts`, `index.js`, `index.mts`, `index.mjs` index files
   - Handles both default re-exports (`export { default as X }`) and named re-exports (`export { X }`)
   - Single-level resolution only (nested barrel chains not followed)

4. **Documentation Updates**
   - Updated README to clarify supported frameworks and new capabilities
   - Added usage examples for barrel resolution
   - Improved API documentation with clearer parameter descriptions

#### Test Coverage

- Added comprehensive test suite for `extractVueScript()` covering regular scripts, TypeScript, and script setup exclusion
- Added test suite for `extractVueOptionsApiComponents()` covering shorthand, aliased, and multiline component registration
- Added test suite for `resolveBarrelExport()` with temporary file system fixtures
- Extended `parseImports` tests to cover dynamic imports with string literals
- Extended `analyzeImports` tests to cover Options API resolution and preference ordering

## Checklist

- [x] Add a new core feature
  - [x] Add comprehensive tests for all new functions
  - [x] Update README documentation with examples
  - [x] Update JSDoc comments for new exports

https://claude.ai/code/session_011UfMyvEQ1o2G35WBBGBVCs