### PR TITLE
docs: restructure setup section with prerequisites

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,26 +92,7 @@ Worktree operations use [`git-wt`](https://github.com/k1LoW/git-wt) (`git wt`). 
 
 #### GitHub CLI (`gh`)
 
-Commands such as `/pr`, `/release`, `/issue`, and `/sponsors` require `gh` (GitHub CLI). Install it beforehand if not already available:
-
-```bash
-# macOS
-brew install gh
-
-# Linux (Debian/Ubuntu)
-(type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) \
-  && sudo mkdir -p -m 755 /etc/apt/keyrings \
-  && out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-  && cat $out | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
-  && sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
-  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-  && sudo apt update \
-  && sudo apt install gh -y
-
-# Other platforms: https://github.com/cli/cli#installation
-```
-
-After installation, authenticate with `gh auth login`.
+Commands such as `/pr`, `/release`, `/issue`, and `/sponsors` require `gh` (GitHub CLI). If `gh` is not installed, install it following [the official instructions](https://github.com/cli/cli#installation) and authenticate with `gh auth login`.
 
 #### git-wt
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,9 +88,34 @@ The main working directory MUST stay on `dev` at all times. Any feature branch w
 
 Worktree operations use [`git-wt`](https://github.com/k1LoW/git-wt) (`git wt`). Worktrees are created under `../markuplint-wt/<branch-name>` (`wt.basedir` setting).
 
-### Setup
+### Prerequisites
 
-If `git wt` is not available, install and configure it:
+#### GitHub CLI (`gh`)
+
+`/pr`、`/release`、`/issue`、`/sponsors` などのコマンドは `gh` (GitHub CLI) を使用する。未インストールの場合は事前にインストールすること:
+
+```bash
+# macOS
+brew install gh
+
+# Linux (Debian/Ubuntu)
+(type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) \
+  && sudo mkdir -p -m 755 /etc/apt/keyrings \
+  && out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+  && cat $out | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+  && sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+  && sudo apt update \
+  && sudo apt install gh -y
+
+# その他の環境: https://github.com/cli/cli#installation
+```
+
+インストール後、`gh auth login` で認証を行うこと。
+
+#### git-wt
+
+`git wt` が未インストールの場合:
 
 ```bash
 brew install k1LoW/tap/git-wt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ Worktree operations use [`git-wt`](https://github.com/k1LoW/git-wt) (`git wt`). 
 
 #### GitHub CLI (`gh`)
 
-`/pr`、`/release`、`/issue`、`/sponsors` などのコマンドは `gh` (GitHub CLI) を使用する。未インストールの場合は事前にインストールすること:
+Commands such as `/pr`, `/release`, `/issue`, and `/sponsors` require `gh` (GitHub CLI). Install it beforehand if not already available:
 
 ```bash
 # macOS
@@ -108,14 +108,14 @@ brew install gh
   && sudo apt update \
   && sudo apt install gh -y
 
-# その他の環境: https://github.com/cli/cli#installation
+# Other platforms: https://github.com/cli/cli#installation
 ```
 
-インストール後、`gh auth login` で認証を行うこと。
+After installation, authenticate with `gh auth login`.
 
 #### git-wt
 
-`git wt` が未インストールの場合:
+If `git wt` is not installed, install and configure it:
 
 ```bash
 brew install k1LoW/tap/git-wt


### PR DESCRIPTION
Fixes #???

## What is the purpose of this PR?

- [ ] Fix bug
- [ ] Fix typo
- [x] Update documents
- [ ] Others

### Description

Restructures the setup documentation in CLAUDE.md to better organize prerequisites. The changes:

1. Rename "Setup" section to "Prerequisites" for clarity
2. Add a new subsection for GitHub CLI (`gh`) with installation and authentication instructions
3. Move `git-wt` installation instructions into its own subsection under Prerequisites

This improves the documentation structure by clearly separating different tool requirements and making it easier for contributors to understand what needs to be installed before getting started.

## Checklist

- [x] Update documents

https://claude.ai/code/session_01AR93v1jhxXu8vx1m7mKVxk