### PR TITLE
docs: Add dynamic component scanning feature documentation

### DIFF
--- a/website/.gitignore
+++ b/website/.gitignore
@@ -36,8 +36,6 @@ community/code-of-conduct.md
 # Dynamically created files
 contributors.json
 
-pretenders.json
-
 # Playwright
 playwright-report
 test-results

--- a/website/.markuplintrc
+++ b/website/.markuplintrc
@@ -8,7 +8,7 @@
     ".tsx$": "@markuplint/react-spec"
   },
   "pretenders": {
-    "files": ["./pretenders.json"]
+    "scan": [{ "files": "./src/**/*.tsx" }]
   },
   "rules": {
     "heading-levels": false

--- a/website/docs/guides/besides-html.md
+++ b/website/docs/guides/besides-html.md
@@ -181,7 +181,7 @@ Besides, **spec plugins** include specific attributes and directives each owned.
 
 ## Pretenders
 
-In **React**, **Vue**, and more, It cannot evaluate custom components as HTML elements.
+In **React**, **Vue**, and more, custom components cannot be evaluated as HTML elements. This means markuplint's content model rules — such as [`permitted-contents`](/docs/rules/permitted-contents) — have no way of knowing what a component actually renders. Without this information, a `<Button>` component that renders a `<button>` element is treated as an unknown element, and invalid nesting like `<a><Button /></a>` (interactive content inside interactive content) goes undetected.
 
 <!-- prettier-ignore-start -->
 ```jsx
@@ -193,9 +193,11 @@ In **React**, **Vue**, and more, It cannot evaluate custom components as HTML el
 ```
 <!-- prettier-ignore-end -->
 
-The **Pretenders** feature resolves that.
+The **Pretenders** feature resolves that by telling markuplint what each component renders as.
 
-It evaluates components as rendered HTML elements on each rule if you specify a [selector](./selectors) for a component and properties of an element that it exposes.
+### Manual configuration
+
+You can manually specify a [selector](./selectors) for each component and the HTML element it renders:
 
 ```json class=config
 {
@@ -222,6 +224,8 @@ It evaluates components as rendered HTML elements on each rule if you specify a 
 ```
 <!-- prettier-ignore-end -->
 
+This works well for small projects, but manually maintaining the list becomes tedious as your component library grows. That's where **dynamic scanning** comes in.
+
 See the details of [`pretenders`](/docs/configuration/properties#pretenders) property on the configuration if you want.
 
 ### Dynamic scanning {#pretenders-scan}
@@ -230,14 +234,98 @@ See the details of [`pretenders`](/docs/configuration/properties#pretenders) pro
 This feature is **experimental** and may change in future releases.
 :::
 
-Instead of manually listing every component, you can let markuplint **scan your component files** and discover pretender mappings automatically. The scanner analyzes JSX/TSX, Vue, Svelte, and Astro files to determine which native HTML element each component renders as.
+Instead of manually listing every component, you can let markuplint **scan your component source files** and discover pretender mappings automatically.
 
 ```json class=config
 {
   "pretenders": {
     "scan": [
       {
-        "files": "./src/components/**/*.{tsx,vue,svelte}"
+        "files": "./src/components/**/*.tsx"
+      }
+    ]
+  }
+}
+```
+
+This single configuration replaces what might otherwise be dozens of manual pretender entries. When markuplint runs, it analyzes your component files and determines:
+
+- **Which HTML element** each component renders as its root element
+- **Whether the component accepts children** (slots detection)
+- **Static attributes** on the root element
+
+#### Supported file types
+
+File extensions determine the scanner automatically:
+
+| Extensions                   | Scanner          | Frameworks                 |
+| ---------------------------- | ---------------- | -------------------------- |
+| `.js`, `.jsx`, `.ts`, `.tsx` | JSX scanner      | React, Preact, Solid, etc. |
+| `.vue`                       | Template scanner | Vue                        |
+| `.svelte`                    | Template scanner | Svelte                     |
+| `.astro`                     | Template scanner | Astro                      |
+
+You can scan multiple file types at once:
+
+```json class=config
+{
+  "pretenders": {
+    "scan": [
+      {
+        "files": "./src/components/**/*.tsx"
+      },
+      {
+        "files": "./src/components/**/*.vue",
+        "ignoreComponentNames": ["BaseLayout"]
+      }
+    ]
+  }
+}
+```
+
+#### What the scanner detects
+
+Consider the following React component:
+
+```tsx
+const ProfileCard = ({ children }) => {
+  return <article className="profile">{children}</article>;
+};
+```
+
+The scanner automatically discovers that `ProfileCard` renders as `<article>` and accepts children. This is equivalent to writing:
+
+```json
+{
+  "selector": "ProfileCard",
+  "as": {
+    "element": "article",
+    "slots": true
+  }
+}
+```
+
+Now markuplint can correctly validate that `<ProfileCard>` contains only [flow content](https://html.spec.whatwg.org/multipage/dom.html#flow-content-2) (as `<article>` does), and that nesting `<ProfileCard>` inside a `<p>` would be invalid.
+
+#### Combining scan with manual definitions
+
+You can use `scan` alongside manual `data` definitions. This is useful when the scanner cannot determine the correct mapping for a particular component, or when you want to override the scanned result:
+
+```json class=config
+{
+  "pretenders": {
+    "scan": [
+      {
+        "files": "./src/components/**/*.tsx"
+      }
+    ],
+    "data": [
+      {
+        "selector": "SpecialComponent",
+        "as": {
+          "element": "nav",
+          "aria": { "name": { "fromAttr": "label" } }
+        }
       }
     ]
   }

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/configuration/properties.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/configuration/properties.md
@@ -813,7 +813,9 @@ interface Config {
 
 ### `pretenders`
 
-[**プリテンダー**](/docs/guides/besides-html#pretenders)機能は、カスタムコンポーネントをネイティブのHTML要素のように見せかける機能です。いくつかのルールで、コンポーネントをレンダリングされた結果の要素として評価するために利用します。値が配列であることに注意してください。
+[**プリテンダー**](/docs/guides/besides-html#pretenders)機能は、カスタムコンポーネントをネイティブのHTML要素のように見せかける機能です。いくつかのルールで、コンポーネントをレンダリングされた結果の要素として評価するために利用します。
+
+値はプリテンダー定義の**配列**、または`data`、`scan`などのフィールドを持つ**オブジェクト**のいずれかです。
 
 #### `selector`
 
@@ -979,18 +981,126 @@ const MyIcon = ({ label }) => {
 </div>
 ```
 
+#### `as.slots` {#pretenders/as-slots}
+
+:::caution[実験的機能]
+このプロパティは**実験的**であり、将来のリリースで変更される可能性があります。
+:::
+
+コンポーネントが子要素を受け入れるか、スロットを持つかどうかを指定します。省略可能です。
+
+- **`null`**: コンポーネントは子要素を受け入れない、またはスロットを持ちません。例えば、`<img>`（void要素）としてレンダリングされるコンポーネントです。
+- **`true`**: コンポーネントは子要素を受け入れ、ラッパー要素が最も外側の要素です。
+- **配列**: 複数の名前付きスロット。各スロットは要素仕様として記述されます（高度な使い方）。
+
+```jsx
+// このコンポーネントは子要素を受け入れる — slotsはtrueにすべき
+const Wrapper = ({ children }) => <div>{children}</div>;
+
+// このコンポーネントは子要素を受け入れない — slotsはnullにすべき
+const Icon = props => <img src={props.src} />;
+```
+
+```json class=config
+{
+  "pretenders": [
+    {
+      "selector": "Wrapper",
+      "as": {
+        "element": "div",
+        "slots": true
+      }
+    },
+    {
+      "selector": "Icon",
+      "as": {
+        "element": "img",
+        "slots": null
+      }
+    }
+  ]
+}
+```
+
+#### `scan` {#pretenders/scan}
+
+:::caution[実験的機能]
+このプロパティは**実験的**であり、将来のリリースで変更される可能性があります。
+:::
+
+`pretenders`の**オブジェクト形式**を使用する場合、`scan`フィールドで**動的コンポーネントスキャン**を有効にできます。すべてのコンポーネントを手動でリストアップする代わりに、markuplintがコンポーネントファイルをスキャンしてプリテンダーマッピングを自動的に発見します。
+
+ファイルの拡張子によってスキャナーが決定されます:
+
+- `.js`, `.jsx`, `.ts`, `.tsx` → JSXスキャナー
+- `.vue`, `.svelte`, `.astro` → テンプレートスキャナー
+
+```json class=config
+{
+  "pretenders": {
+    "scan": [
+      {
+        "files": "./src/components/**/*.tsx"
+      },
+      {
+        "files": "./src/components/**/*.vue",
+        "ignoreComponentNames": ["BaseLayout"]
+      }
+    ]
+  }
+}
+```
+
+##### `scan[].files`
+
+スキャンするコンポーネントファイルのglobパターン（またはglobパターンの配列）。必須です。
+
+##### `scan[].ignoreComponentNames`
+
+スキャン結果から除外するコンポーネント名の配列。省略可能です。
+
+#### `data`（オブジェクト形式） {#pretenders/data}
+
+オブジェクト形式を使用する場合、インラインのプリテンダー定義は`data`フィールドに記述します:
+
+```json class=config
+{
+  "pretenders": {
+    "data": [
+      {
+        "selector": "MyComponent",
+        "as": "div"
+      }
+    ],
+    "scan": [
+      {
+        "files": "./src/components/**/*.vue"
+      }
+    ]
+  }
+}
+```
+
 #### インターフェイス {#pretenders/interface}
 
 ```ts
 interface Config {
-  pretenders?: {
-    selector: string;
-    as: string | OriginalNode;
-  }[];
+  pretenders?:
+    | Pretender[]
+    | {
+        data?: Pretender[];
+        scan?: PretenderScanConfig[]; // @experimental
+      };
 }
+
+type Pretender = {
+  selector: string;
+  as: string | OriginalNode;
+};
 
 type OriginalNode = {
   element: string;
+  slots?: null | true | Slot[]; // @experimental
   namespace?: 'svg';
 
   inheritAttrs?: boolean;
@@ -1010,6 +1120,13 @@ type OriginalNode = {
           fromAttr: string;
         };
   };
+};
+
+type Slot = Omit<OriginalNode, 'slots'>; // @experimental
+
+type PretenderScanConfig = {
+  files: string | string[];
+  ignoreComponentNames?: string[];
 };
 ```
 

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/besides-html.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/besides-html.md
@@ -180,7 +180,7 @@ const Component = ({ list }) => {
 
 ## プリテンダー（偽装機能） {#pretenders}
 
-**React**や**Vue**などでは、カスタムコンポーネントをHTML要素として評価ができません。
+**React**や**Vue**などでは、カスタムコンポーネントをHTML要素として評価ができません。つまり、markuplintのコンテンツモデルルール — [`permitted-contents`](/docs/rules/permitted-contents)など — は、コンポーネントが実際に何をレンダリングするか知る手段がありません。この情報がないと、`<button>`要素をレンダリングする`<Button>`コンポーネントは未知の要素として扱われ、`<a><Button /></a>`（インタラクティブコンテンツの中にインタラクティブコンテンツ）のような不正なネストが検出されません。
 
 <!-- prettier-ignore-start -->
 ```jsx
@@ -192,9 +192,11 @@ const Component = ({ list }) => {
 ```
 <!-- prettier-ignore-end -->
 
-**プリテンダー**機能はそれを解決します。
+**プリテンダー**機能は、各コンポーネントが何としてレンダリングされるかをmarkuplintに伝えることでこれを解決します。
 
-コンポーネントとマッチする[セレクタ](./selectors)と、コンポーネントが公開する要素のプロパティを指定すると、各ルールでコンポーネントをレンダリングされたHTML要素として評価します。
+### 手動設定
+
+コンポーネントとマッチする[セレクタ](./selectors)と、コンポーネントが公開する要素を手動で指定できます。
 
 ```json class=config
 {
@@ -221,7 +223,115 @@ const Component = ({ list }) => {
 ```
 <!-- prettier-ignore-end -->
 
+小規模プロジェクトではこの方法で十分ですが、コンポーネントライブラリが大きくなるにつれて手動でリストを管理するのは面倒になります。そこで**動的スキャン**が活躍します。
+
 必要であれば、設定の[`pretenders`](/docs/configuration/properties#pretenders)プロパティの詳細を参照してください。
+
+### 動的スキャン {#pretenders-scan}
+
+:::caution[実験的機能]
+この機能は**実験的**であり、将来のリリースで変更される可能性があります。
+:::
+
+すべてのコンポーネントを手動でリスト化する代わりに、markuplintにコンポーネントの**ソースファイルをスキャン**させ、プリテンダーマッピングを自動的に発見させることができます。
+
+```json class=config
+{
+  "pretenders": {
+    "scan": [
+      {
+        "files": "./src/components/**/*.tsx"
+      }
+    ]
+  }
+}
+```
+
+この1つの設定で、数十の手動プリテンダー定義を置き換えることができます。markuplintは実行時にコンポーネントファイルを解析し、以下を判定します:
+
+- コンポーネントがルート要素として**レンダリングするHTML要素**
+- コンポーネントが**子要素を受け入れるか**どうか（スロット検出）
+- ルート要素の**静的な属性**
+
+#### 対応ファイルタイプ
+
+ファイル拡張子によって使用するスキャナーが自動的に決定されます:
+
+| 拡張子                       | スキャナー             | フレームワーク         |
+| ---------------------------- | ---------------------- | ---------------------- |
+| `.js`, `.jsx`, `.ts`, `.tsx` | JSXスキャナー          | React, Preact, Solid等 |
+| `.vue`                       | テンプレートスキャナー | Vue                    |
+| `.svelte`                    | テンプレートスキャナー | Svelte                 |
+| `.astro`                     | テンプレートスキャナー | Astro                  |
+
+複数のファイルタイプを同時にスキャンできます:
+
+```json class=config
+{
+  "pretenders": {
+    "scan": [
+      {
+        "files": "./src/components/**/*.tsx"
+      },
+      {
+        "files": "./src/components/**/*.vue",
+        "ignoreComponentNames": ["BaseLayout"]
+      }
+    ]
+  }
+}
+```
+
+#### スキャナーが検出するもの
+
+以下のようなReactコンポーネントを例に考えます:
+
+```tsx
+const ProfileCard = ({ children }) => {
+  return <article className="profile">{children}</article>;
+};
+```
+
+スキャナーは、`ProfileCard`が`<article>`としてレンダリングされ、子要素を受け入れることを自動的に発見します。これは以下の手動定義と同等です:
+
+```json
+{
+  "selector": "ProfileCard",
+  "as": {
+    "element": "article",
+    "slots": true
+  }
+}
+```
+
+これにより、markuplintは`<ProfileCard>`が[フローコンテンツ](https://html.spec.whatwg.org/multipage/dom.html#flow-content-2)のみを含むことを正しく検証でき（`<article>`と同様）、`<p>`の中に`<ProfileCard>`をネストすることが不正であると判定できます。
+
+#### スキャンと手動定義の併用
+
+`scan`と手動の`data`定義を併用できます。スキャナーが特定のコンポーネントに対して正しいマッピングを判定できない場合や、スキャン結果をオーバーライドしたい場合に便利です:
+
+```json class=config
+{
+  "pretenders": {
+    "scan": [
+      {
+        "files": "./src/components/**/*.tsx"
+      }
+    ],
+    "data": [
+      {
+        "selector": "SpecialComponent",
+        "as": {
+          "element": "nav",
+          "aria": { "name": { "fromAttr": "label" } }
+        }
+      }
+    ]
+  }
+}
+```
+
+[`pretenders.scan`](/docs/configuration/properties#pretenders/scan)で設定リファレンスの全体を参照してください。
 
 ### `as`属性について
 

--- a/website/package.json
+++ b/website/package.json
@@ -7,7 +7,6 @@
     "site:start": "yarn site:prebuild && docusaurus start",
     "site:build": "yarn site:prebuild && docusaurus build",
     "site:prebuild": "tsx scripts/prebuild/index.mts && npx prettier --write \"./src/**/*{ts,tsx,json,rc,md,mdx,css,scss}\"",
-    "presite:lint": "npx @markuplint/pretenders \"./src/**/*.tsx\" --out \"./pretenders.json\"",
     "site:lint": "prettier --write \"./**/*{js,ts,tsx,mdx}\" \"./*{json,rc,js}\" \"!./build/**/*\" \"!./.docusaurus/**/*\" && eslint --fix \"./{community,docs,i18n,scripts,src}/**/*.{js,ts,tsx}\" \"./*.{js,ts}\" && stylelint \"./src/**/*.css\" && textlint --fix \"./website/i18n/ja\" && cd ../ && yarn cli \"./website/**/*.tsx\"",
     "site:screenshot": "playwright test tests/screenshot.spec.ts",
     "site:up": "yarn upgrade-interactive --latest"


### PR DESCRIPTION
Fixes #???

## What is the purpose of this PR?

- [ ] Fix bug
- [ ] Fix typo
- [x] Update docs
- [ ] Add new rule
- [ ] Add new parser
- [ ] Improve or refactor rules
- [ ] Add a new core feature
- [ ] Improve or refactor core features
- [ ] Others

### Description

This PR documents the new **dynamic component scanning** feature for the `pretenders` configuration. The changes include:

1. **Configuration Documentation** (`properties.md`):
   - Updated the `pretenders` property description to clarify it now accepts both array and object formats
   - Added documentation for the new `as.slots` property (experimental) to specify whether components accept children
   - Added documentation for the `scan` field (experimental) enabling automatic component discovery from source files
   - Added documentation for the `data` field for inline pretender definitions when using object format
   - Updated TypeScript interfaces to reflect the new configuration structure

2. **Guide Documentation** (`besides-html.md`):
   - Expanded the "Pretenders" section with clearer explanation of the problem it solves
   - Added "Manual configuration" subsection documenting the traditional approach
   - Added comprehensive "Dynamic scanning" subsection explaining:
     - How to enable automatic component scanning
     - Supported file types (JSX/TSX, Vue, Svelte, Astro)
     - What the scanner detects (root element, slots, static attributes)
     - How to combine scanning with manual definitions
   - Included practical examples for each approach

3. **Configuration Updates**:
   - Updated `.markuplintrc` to use the new `scan` feature instead of the old `files` approach
   - Removed `pretenders.json` from `.gitignore` as it's no longer needed

The documentation clearly marks the new features as experimental and provides migration guidance from manual to automatic configuration.

## Checklist

- [x] Update documents
  - [x] English documentation (`docs/guides/besides-html.md`)
  - [x] Japanese documentation (`i18n/ja/docusaurus-plugin-content-docs/current/guides/besides-html.md`)
  - [x] Configuration reference (`docs/configuration/properties.md`)
  - [x] Japanese configuration reference (`i18n/ja/docusaurus-plugin-content-docs/current/configuration/properties.md`)

https://claude.ai/code/session_01NXfVXPci9YxDnnEDJXU2iM