### PR TITLE
feat(html-spec): add experimental focusgroup attribute

### DIFF
--- a/packages/@markuplint/html-spec/docs/element-spec-format.ja.md
+++ b/packages/@markuplint/html-spec/docs/element-spec-format.ja.md
@@ -362,16 +362,20 @@ spec.mml_mn.jsonc       # <mml:mn> 要素
 
 スペースまたはカンマ区切りのトークンリストを定義します。
 
-| フィールド        | 型                   | 説明                          |
-| ----------------- | -------------------- | ----------------------------- |
-| `token`           | `string`             | トークンの型名                |
-| `separator`       | `"space" \| "comma"` | 区切り文字                    |
-| `unique`          | `boolean`            | 重複を許可しない              |
-| `caseInsensitive` | `boolean`            | 大文字小文字を区別しない      |
-| `ordered`         | `boolean`            | 順序が重要                    |
-| `number`          | `string`             | 個数制約（`"zeroOrMore"` 等） |
+| フィールド        | 型                       | 説明                                                                      |
+| ----------------- | ------------------------ | ------------------------------------------------------------------------- |
+| `token`           | `string \| { enum: [] }` | トークンの型名（文字列）、またはインライン列挙定義（`enum` オブジェクト） |
+| `separator`       | `"space" \| "comma"`     | 区切り文字                                                                |
+| `unique`          | `boolean`                | 重複を許可しない                                                          |
+| `caseInsensitive` | `boolean`                | 大文字小文字を区別しない                                                  |
+| `ordered`         | `boolean`                | 順序が重要                                                                |
+| `number`          | `string`                 | 個数制約（`"zeroOrMore"` 等）                                             |
+
+`token` が文字列の場合、名前付き型（例: `"Accept"`, `"DOMID"`）を参照します。
+`token` が `enum` を含むオブジェクトの場合、許可されるキーワードのセットをインラインで定義します:
 
 ```jsonc
+// 文字列型名を参照する例
 "accept": {
   "type": {
     "token": "Accept",
@@ -380,6 +384,20 @@ spec.mml_mn.jsonc       # <mml:mn> 要素
     "separator": "comma"
   },
   "condition": "[type='file' i]"
+}
+
+// インライン列挙定義の例
+"focusgroup": {
+  "type": {
+    "token": {
+      "enum": ["toolbar", "tablist", "radiogroup", "listbox", "menu", "menubar", "none",
+               "inline", "block", "wrap", "nowrap", "nomemory"]
+    },
+    "separator": "space",
+    "unique": true,
+    "caseInsensitive": true
+  },
+  "experimental": true
 }
 ```
 

--- a/packages/@markuplint/html-spec/docs/element-spec-format.md
+++ b/packages/@markuplint/html-spec/docs/element-spec-format.md
@@ -263,14 +263,25 @@ set that particular flag.
 { "token": "Accept", "separator": "comma", "unique": true, "caseInsensitive": true }
 ```
 
-| Field             | Description                                      |
-| ----------------- | ------------------------------------------------ |
-| `token`           | Token type name                                  |
-| `separator`       | `"space"` or `"comma"`                           |
-| `unique`          | Whether tokens must be unique                    |
-| `caseInsensitive` | Whether matching is case-insensitive             |
-| `ordered`         | Whether order matters                            |
-| `number`          | Cardinality: `"zeroOrMore"`, `"oneOrMore"`, etc. |
+| Field             | Description                                                             |
+| ----------------- | ----------------------------------------------------------------------- |
+| `token`           | Token type: a string (type name) or an object with `enum` (inline enum) |
+| `separator`       | `"space"` or `"comma"`                                                  |
+| `unique`          | Whether tokens must be unique                                           |
+| `caseInsensitive` | Whether matching is case-insensitive                                    |
+| `ordered`         | Whether order matters                                                   |
+| `number`          | Cardinality: `"zeroOrMore"`, `"oneOrMore"`, etc.                        |
+
+When `token` is a string, it references a named type (e.g., `"Accept"`, `"DOMID"`).
+When `token` is an object with `enum`, it defines an inline set of allowed keywords:
+
+```json
+{
+  "token": { "enum": ["allow-forms", "allow-scripts", "allow-popups"] },
+  "separator": "space",
+  "unique": true
+}
+```
 
 **Number constraint type:**
 

--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -308,6 +308,34 @@
 						"enum": ["enter", "done", "go", "next", "previous", "search", "send"]
 					}
 				},
+				"focusgroup": {
+					"type": {
+						"token": {
+							"enum": [
+								"toolbar",
+								"tablist",
+								"radiogroup",
+								"listbox",
+								"menu",
+								"menubar",
+								"none",
+								"inline",
+								"block",
+								"wrap",
+								"nowrap",
+								"nomemory"
+							]
+						},
+						"separator": "space",
+						"unique": true,
+						"caseInsensitive": true
+					},
+					"experimental": true
+				},
+				"focusgroupstart": {
+					"type": "Boolean",
+					"experimental": true
+				},
 				"headingoffset": {
 					"type": {
 						"type": "integer",

--- a/packages/@markuplint/html-spec/src/spec-common.attributes.jsonc
+++ b/packages/@markuplint/html-spec/src/spec-common.attributes.jsonc
@@ -71,6 +71,36 @@
 				"enum": ["enter", "done", "go", "next", "previous", "search", "send"]
 			}
 		},
+		// https://open-ui.org/components/focusgroup.explainer/
+		"focusgroup": {
+			"type": {
+				"token": {
+					"enum": [
+						"toolbar",
+						"tablist",
+						"radiogroup",
+						"listbox",
+						"menu",
+						"menubar",
+						"none",
+						"inline",
+						"block",
+						"wrap",
+						"nowrap",
+						"nomemory"
+					]
+				},
+				"separator": "space",
+				"unique": true,
+				"caseInsensitive": true
+			},
+			"experimental": true
+		},
+		// https://open-ui.org/components/focusgroup.explainer/
+		"focusgroupstart": {
+			"type": "Boolean",
+			"experimental": true
+		},
 		// https://html.spec.whatwg.org/multipage/sections.html#attr-heading-offset
 		"headingoffset": {
 			"type": {

--- a/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
@@ -1952,3 +1952,65 @@ describe('Disallow user-scalable=no in viewport meta (#716)', () => {
 		expect(violations).toStrictEqual([]);
 	});
 });
+
+describe('focusgroup attribute (#3384)', () => {
+	test('focusgroup with valid behavior keyword', async () => {
+		expect((await mlRuleTest(rule, '<div focusgroup="toolbar"></div>')).violations).toStrictEqual([]);
+	});
+
+	test('focusgroup with multiple valid tokens', async () => {
+		expect((await mlRuleTest(rule, '<div focusgroup="tablist inline wrap"></div>')).violations).toStrictEqual([]);
+	});
+
+	test('focusgroup with all valid tokens', async () => {
+		expect((await mlRuleTest(rule, '<ul focusgroup="menu block nowrap nomemory"></ul>')).violations).toStrictEqual(
+			[],
+		);
+	});
+
+	test('focusgroup with invalid token', async () => {
+		const { violations } = await mlRuleTest(rule, '<div focusgroup="invalid"></div>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 18,
+				message: expect.stringContaining('"focusgroup"'),
+				raw: 'invalid',
+			},
+		]);
+	});
+
+	test('focusgroup with valid and invalid tokens mixed', async () => {
+		const { violations } = await mlRuleTest(rule, '<div focusgroup="toolbar invalidmod"></div>');
+		expect(violations.length).toBe(1);
+		expect(violations[0]!.raw).toBe('invalidmod');
+	});
+
+	test('focusgroup="none" is valid', async () => {
+		expect((await mlRuleTest(rule, '<li focusgroup="none"></li>')).violations).toStrictEqual([]);
+	});
+
+	test('focusgroup is case-insensitive', async () => {
+		expect((await mlRuleTest(rule, '<div focusgroup="TOOLBAR"></div>')).violations).toStrictEqual([]);
+		expect((await mlRuleTest(rule, '<div focusgroup="Menu Inline Wrap"></div>')).violations).toStrictEqual([]);
+	});
+
+	test('focusgroup rejects duplicate tokens', async () => {
+		const { violations } = await mlRuleTest(rule, '<div focusgroup="toolbar toolbar"></div>');
+		expect(violations.length).toBeGreaterThanOrEqual(1);
+	});
+
+	test('focusgroup with empty value is valid (zero tokens allowed)', async () => {
+		expect((await mlRuleTest(rule, '<div focusgroup=""></div>')).violations).toStrictEqual([]);
+	});
+
+	test('focusgroupstart boolean attribute is valid', async () => {
+		expect((await mlRuleTest(rule, '<button focusgroupstart></button>')).violations).toStrictEqual([]);
+	});
+
+	test('focusgroup on any element (global attribute)', async () => {
+		expect((await mlRuleTest(rule, '<nav focusgroup="menubar"></nav>')).violations).toStrictEqual([]);
+		expect((await mlRuleTest(rule, '<span focusgroupstart></span>')).violations).toStrictEqual([]);
+	});
+});


### PR DESCRIPTION
## Summary
- Add `focusgroup` and `focusgroupstart` as experimental global HTML attributes based on the [OpenUI focusgroup explainer](https://open-ui.org/components/focusgroup.explainer/)
- `focusgroup` uses strict inline enum validation for its space-separated token list (`toolbar`, `tablist`, `radiogroup`, `listbox`, `menu`, `menubar`, `none`, `inline`, `block`, `wrap`, `nowrap`, `nomemory`)
- `focusgroupstart` is a boolean attribute designating the initial focus target
- Update documentation to cover the `token: { enum: [...] }` inline enum syntax (was previously undocumented)

## Test plan
- [x] 11 test cases added for `invalid-attr` rule covering focusgroup/focusgroupstart
- [x] Valid single/multiple tokens, all valid tokens, `none` keyword
- [x] Invalid token detection, mixed valid/invalid tokens
- [x] Case-insensitive matching, duplicate token rejection
- [x] Empty value validation, boolean focusgroupstart, global attribute on various elements
- [x] All 2887 existing tests pass
- [x] `yarn lint-check` passes
- [x] `yarn build` passes

Closes #3384

🤖 Generated with [Claude Code](https://claude.com/claude-code)