### PR TITLE
chore(repo): migrate from Volta to mise for Node.js version management

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -455,7 +455,7 @@ jobs:
                   echo "parent: ${{ github.workspace }}/.."
 
             - name: Delete package manager settings
-              run: jq 'del(.packageManager, .volta)' package.json > tmp.json && mv tmp.json package.json
+              run: jq 'del(.packageManager)' package.json > tmp.json && mv tmp.json package.json
 
             - name: Install pnpm
               if: matrix.pm == 'pnpm'

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,4 @@
+[tools]
+node = "24.8.0"
+
+[settings]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Its purpose is all developers are able to better markup and fit each of diverse 
 
 You need:
 
-- Node.js v22 or later (the exact version is pinned in `.mise.toml`; install [mise](https://mise.jdx.dev/) and run `mise install` to match it)
+- Node.js v24 or later (the exact version is pinned in `.mise.toml`; install [mise](https://mise.jdx.dev/) and run `mise install` to match it)
 - Yarn
 
 After cloning this repository, you can also install them through [Docker](https://github.com/markuplint/markuplint/blob/main/Dockerfile).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Its purpose is all developers are able to better markup and fit each of diverse 
 
 You need:
 
-- Node.js v22 or later.
+- Node.js v22 or later (the exact version is pinned in `.mise.toml`; install [mise](https://mise.jdx.dev/) and run `mise install` to match it)
 - Yarn
 
 After cloning this repository, you can also install them through [Docker](https://github.com/markuplint/markuplint/blob/main/Dockerfile).

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20
+FROM node:24
 
 COPY . /markuplint
 

--- a/package.json
+++ b/package.json
@@ -102,10 +102,6 @@
 		}
 	},
 	"packageManager": "yarn@4.12.0",
-	"volta": {
-		"node": "24.8.0",
-		"yarn": "4.12.0"
-	},
 	"resolutions": {
 		"markuplint": "workspace:*"
 	}

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -218,9 +218,5 @@
 		"vscode-languageclient": "9.0.1",
 		"vscode-languageserver": "9.0.1",
 		"vscode-languageserver-textdocument": "1.0.12"
-	},
-	"volta": {
-		"node": "22.22.1",
-		"yarn": "4.12.0"
 	}
 }

--- a/website/package.json
+++ b/website/package.json
@@ -48,9 +48,5 @@
   "engines": {
     "node": ">=22"
   },
-  "volta": {
-    "node": "24.8.0",
-    "yarn": "4.12.0"
-  },
   "packageManager": "yarn@4.12.0"
 }


### PR DESCRIPTION
Fixes #???

## What is the purpose of this PR?

- [ ] Fix bug
- [ ] Fix typo
- [ ] Update specs
- [ ] Add new rule
- [ ] Add new parser
- [ ] Improve or refactor rules
- [ ] Add a new core feature
- [ ] Improve or refactor core features
- [x] Update documents
- [ ] Others

### Description

This PR migrates the project from Volta to [mise](https://mise.jdx.dev/) for Node.js version management.

**Changes:**
- Added `.mise.toml` configuration file pinning Node.js to v24.8.0
- Removed `volta` configuration from `package.json` files (root, vscode, and website packages)
- Updated `CONTRIBUTING.md` to document the new setup process using mise
- Updated `Dockerfile` to use Node.js v24 (matching the pinned version in `.mise.toml`)
- Updated CI workflow to remove volta-related cleanup from the test job

**Rationale:**
Mise provides a more flexible and unified approach to managing development tool versions across the project. This change simplifies version management and aligns with modern development practices.

## Checklist

- [x] Update documents
  - [x] Updated CONTRIBUTING.md with mise setup instructions
  - [x] Updated Dockerfile to match pinned Node.js version
  - [x] Updated CI workflow configuration

https://claude.ai/code/session_0142nPrncuJh6LQvs9tGPAVr