### PR TITLE
test: Add comprehensive directive parsing tests for Astro parser

### DIFF
--- a/packages/@markuplint/astro-parser/ARCHITECTURE.ja.md
+++ b/packages/@markuplint/astro-parser/ARCHITECTURE.ja.md
@@ -2,17 +2,18 @@
 
 ## 概要
 
-`@markuplint/astro-parser` は markuplint における Astro コンポーネントファイル（`.astro`）のパーサーです。`astro-eslint-parser`（`@astrojs/compiler` をラップ）を使用して Astro ソースコードをトークン化し、その結果の AST を markuplint の統一 AST 形式（`MLASTDocument`）に変換します。フロントマターブロック（`---...---`）、式コンテナ（`{expression}`）、テンプレートディレクティブ（例: `class:list`、`set:html`）、ショートハンド属性（`{prop}`）、名前空間対応の要素解決（XHTML vs SVG）など、Astro 固有の構文を処理します。
+`@markuplint/astro-parser` は markuplint における Astro コンポーネントファイル（`.astro`）のパーサーです。`astro-eslint-parser`（`@astrojs/compiler` をラップ）を使用して Astro ソースコードをトークン化し、その結果の AST を markuplint の統一 AST 形式（`MLASTDocument`）に変換します。フロントマターブロック（`---...---`）、式コンテナ（`{expression}`）、テンプレートディレクティブ（例: `class:list`、`set:html`、`client:load`）、ショートハンド属性（`{prop}`）など、Astro 固有の構文を処理します。
 
 ## ディレクトリ構成
 
 ```
 src/
-├── index.ts                — parser インスタンスを再エクスポート
-├── parser.ts               — Parser<Node, State> を拡張する AstroParser クラス
-├── astro-parser.ts         — astro-eslint-parser ラッパーと型の再エクスポート
-├── parser.spec.ts          — AstroParser 統合テスト
-└── astro-parser.spec.ts    — astro-eslint-parser ラッパーテスト
+├── index.ts                    — parser インスタンスを再エクスポート
+├── parser.ts                   — Parser<Node> を拡張する AstroParser クラス
+├── astro-parser.ts             — astro-eslint-parser ラッパーと型の再エクスポート
+├── detect-block-behavior.ts    — .map()/.filter() のブロック動作検出
+├── parser.spec.ts              — AstroParser 統合テスト
+└── astro-parser.spec.ts        — astro-eslint-parser ラッパーテスト
 ```
 
 ## アーキテクチャ図
@@ -27,8 +28,9 @@ flowchart TD
     end
 
     subgraph pkg ["@markuplint/astro-parser"]
-        astroParser["AstroParser\nextends Parser‹Node, State›"]
+        astroParser["AstroParser\nextends Parser‹Node›"]
         astroParseFn["astroParse()\nastro-eslint-parser ラッパー"]
+        detectBlock["detectBlockBehavior()\n.map()/.filter() 検出"]
     end
 
     subgraph downstream ["下流"]
@@ -40,6 +42,7 @@ flowchart TD
     astroEslintParser -->|"parseTemplate()"| astroParseFn
     astroCompiler -->|"Node 型"| astroParseFn
     astroParseFn -->|"RootNode.children"| astroParser
+    detectBlock -->|"blockBehavior"| astroParser
     astroParser -->|"MLASTDocument を生成"| mlCore
 ```
 
@@ -48,7 +51,7 @@ flowchart TD
 ### 継承関係
 
 ```
-Parser<Node, State>  (@markuplint/parser-utils)
+Parser<Node>  (@markuplint/parser-utils)
     └── AstroParser  (このパッケージ)
 ```
 
@@ -62,16 +65,6 @@ Parser<Node, State>  (@markuplint/parser-utils)
 | `selfCloseType`        | `'html+xml'` | HTML void 要素と XML スタイルの自己閉じ（`<Component />`）の両方を受け入れる |
 | `tagNameCaseSensitive` | `true`       | コンポーネント（`<MyComp>`）と HTML 要素（`<div>`）を区別                    |
 
-### State 型
-
-パーサーは `State` 型を通じて内部状態を管理します:
-
-| フィールド | 型       | 用途                                                            |
-| ---------- | -------- | --------------------------------------------------------------- |
-| `scopeNS`  | `string` | 現在の名前空間 URI、デフォルトは `http://www.w3.org/1999/xhtml` |
-
-`scopeNS` 状態は `#updateScopeNS()` によってパーサーが要素を走査する際に更新され、`<svg>` 要素内で SVG 名前空間に切り替わり、`<foreignObject>` 内で XHTML に戻ります。
-
 ### オーバーライドメソッド
 
 | メソッド              | 用途                                                                                                                           |
@@ -79,7 +72,7 @@ Parser<Node, State>  (@markuplint/parser-utils)
 | `tokenize()`          | `astroParse()` を呼び出して Astro AST を取得し、`{ ast: rootNode.children, isFragment: true }` を返す                          |
 | `nodeize()`           | Astro AST ノードを markuplint ノードに変換。ノードタイプ（frontmatter, doctype, text, comment, element, expression）で振り分け |
 | `afterFlattenNodes()` | `{ exposeInvalidNode: false }` で親に委譲                                                                                      |
-| `visitElement()`      | `parseCodeFragment()` で `namelessFragment: true` として生の HTML フラグメントをパースし、名前空間と終了タグ処理で親に委譲     |
+| `visitElement()`      | `parseCodeFragment()` で `namelessFragment: true` として生の HTML フラグメントをパースし、終了タグ処理で親に委譲               |
 | `visitChildren()`     | 親に委譲した後、予期しない兄弟ノードが残っていないことをアサート                                                               |
 | `visitAttr()`         | 波括弧式の値、ショートハンド属性、テンプレートディレクティブを処理                                                             |
 | `detectElementType()` | `/^[A-Z]/` パターンでコンポーネントと HTML 要素を検出（大文字始まりの名前はコンポーネント）                                    |
@@ -119,35 +112,6 @@ Astro の式（`{expression}`）は Astro AST で `type: 'expression'` ノード
 - 最後の子の開始から式の終了までの領域が終了フラグメントになる
 - 間の子は開始フラグメントの psblock 内で通常通り訪問される
 
-## 名前空間スコーピング
-
-`#updateScopeNS()` プライベートメソッドは、パーサーが要素を走査する際に名前空間コンテキストを管理します:
-
-| 条件                                                  | アクション                                           |
-| ----------------------------------------------------- | ---------------------------------------------------- |
-| 現在の名前空間が XHTML で、ノードが `<svg>` 要素      | `scopeNS` を `http://www.w3.org/2000/svg` に切り替え |
-| 現在の名前空間が SVG で、親ノードが `<foreignObject>` | `scopeNS` を `http://www.w3.org/1999/xhtml` に戻す   |
-
-これは `nodeize()` のノードタイプ switch の前に呼び出されるため、すべての子ノードが正しい名前空間を継承します。名前空間は `visitElement()` 内で `overwriteProps: { namespace: this.state.scopeNS }` を通じて要素に適用されます。
-
-名前空間解決の例:
-
-```html
-<div>
-  <!-- XHTML -->
-  <svg>
-    <!-- SVG -->
-    <text />
-    <!-- SVG -->
-    <foreignObject>
-      <!-- SVG -->
-      <div />
-      <!-- XHTML（リセット） -->
-    </foreignObject>
-  </svg>
-</div>
-```
-
 ## 属性処理
 
 ### クォートセット
@@ -173,15 +137,18 @@ Astro の式（`{expression}`）は Astro AST で `type: 'expression'` ノード
 
 Astro テンプレートディレクティブは `name:modifier` 構文を使用します。パーサーは正規表現 `/^([^:]+):([^:]+)$/` でこれらを検出します:
 
-| ディレクティブ | `potentialName` | `isDirective` | 動作                                   |
-| -------------- | --------------- | ------------- | -------------------------------------- |
-| `class:list`   | `'class'`       | `undefined`   | 標準の `class` 属性にマッピング        |
-| `set:html`     | `undefined`     | `true`        | Astro 固有ディレクティブとして扱われる |
-| `set:text`     | `undefined`     | `true`        | Astro 固有ディレクティブとして扱われる |
-| `is:raw`       | `undefined`     | `true`        | Astro 固有ディレクティブとして扱われる |
-| `transition:*` | `undefined`     | `true`        | Astro 固有ディレクティブとして扱われる |
+| ディレクティブプレフィックス | `potentialName` | `isDirective` | 動作                                                  |
+| ---------------------------- | --------------- | ------------- | ----------------------------------------------------- |
+| `class:`                     | `'class'`       | `false`       | 標準の `class` 属性にマッピング                       |
+| `client:`                    | —               | `true`        | Astro クライアントディレクティブ（load, idle 等）     |
+| `server:`                    | —               | `true`        | Astro サーバーディレクティブ（defer）                 |
+| `set:`                       | —               | `true`        | コンテンツディレクティブ（html, text）                |
+| `is:`                        | —               | `true`        | プロパティディレクティブ（inline, raw）               |
+| `define:`                    | —               | `true`        | スタイルディレクティブ（vars）                        |
+| `transition:`                | —               | `true`        | View Transition ディレクティブ（animate, name）       |
+| _（その他すべて）_           | —               | `true`        | キャッチオール: すべての `prefix:name` パターンに適用 |
 
-`class` ディレクティブは特別で、`potentialName: 'class'` を取得するため、`class` 属性に対する markuplint ルールが適用されます。その他すべてのディレクティブは `isDirective: true` を取得し、フレームワーク固有であり標準 HTML 属性として検証すべきでないことを markuplint に伝えます。
+`class:` プレフィックスは特別扱いで、`potentialName: 'class'` を取得するため、`class` 属性に対する markuplint ルールが適用されます。その他のコロン区切りプレフィックスは `default` ケースに該当し `isDirective: true` を取得します。これはフレームワーク固有であり標準 HTML 属性として検証すべきでないことを markuplint に伝えます。
 
 ### 動的な値
 
@@ -199,7 +166,7 @@ Astro テンプレートディレクティブは `name:modifier` 構文を使用
 | **フロントマター**             | サポート（`---...---` psblock）        | 該当なし                                          |
 | **式の構文**                   | `{expr}` を MustacheTag psblock として | `{expr}` を JSXExpressionContainer psblock として |
 | **テンプレートディレクティブ** | `class:list`、`set:html` 等            | 該当なし                                          |
-| **名前空間管理**               | `#updateScopeNS()` で手動管理          | html-parser の `getNamespace()` に委譲            |
+| **名前空間管理**               | 基底 `Parser` に委譲                   | html-parser の `getNamespace()` に委譲            |
 | **コンポーネント検出**         | `/^[A-Z]/` パターン                    | `/^[A-Z]/` パターン                               |
 | **自己閉じタイプ**             | `html+xml`                             | デフォルト（XML のみ）                            |
 | **booleanish 属性**            | 未設定                                 | `booleanish: true`                                |

--- a/packages/@markuplint/astro-parser/ARCHITECTURE.md
+++ b/packages/@markuplint/astro-parser/ARCHITECTURE.md
@@ -2,17 +2,18 @@
 
 ## Overview
 
-`@markuplint/astro-parser` is a parser for Astro component files (`.astro`) in markuplint. It uses `astro-eslint-parser` (which wraps `@astrojs/compiler`) to tokenize Astro source code, then converts the resulting AST into markuplint's unified AST format (`MLASTDocument`). The parser handles Astro-specific syntax including frontmatter blocks (`---...---`), expression containers (`{expression}`), template directives (e.g., `class:list`, `set:html`), shorthand attributes (`{prop}`), and namespace-aware element resolution (XHTML vs SVG).
+`@markuplint/astro-parser` is a parser for Astro component files (`.astro`) in markuplint. It uses `astro-eslint-parser` (which wraps `@astrojs/compiler`) to tokenize Astro source code, then converts the resulting AST into markuplint's unified AST format (`MLASTDocument`). The parser handles Astro-specific syntax including frontmatter blocks (`---...---`), expression containers (`{expression}`), template directives (e.g., `class:list`, `set:html`, `client:load`), and shorthand attributes (`{prop}`).
 
 ## Directory Structure
 
 ```
 src/
-├── index.ts                — Re-exports parser instance
-├── parser.ts               — AstroParser class extending Parser<Node, State>
-├── astro-parser.ts         — astro-eslint-parser wrapper and type re-exports
-├── parser.spec.ts          — AstroParser integration tests
-└── astro-parser.spec.ts    — astro-eslint-parser wrapper tests
+├── index.ts                    — Re-exports parser instance
+├── parser.ts                   — AstroParser class extending Parser<Node>
+├── astro-parser.ts             — astro-eslint-parser wrapper and type re-exports
+├── detect-block-behavior.ts    — Detects .map()/.filter() for block behavior
+├── parser.spec.ts              — AstroParser integration tests
+└── astro-parser.spec.ts        — astro-eslint-parser wrapper tests
 ```
 
 ## Architecture Diagram
@@ -27,8 +28,9 @@ flowchart TD
     end
 
     subgraph pkg ["@markuplint/astro-parser"]
-        astroParser["AstroParser\nextends Parser‹Node, State›"]
+        astroParser["AstroParser\nextends Parser‹Node›"]
         astroParseFn["astroParse()\nastro-eslint-parser wrapper"]
+        detectBlock["detectBlockBehavior()\n.map()/.filter() detection"]
     end
 
     subgraph downstream ["Downstream"]
@@ -40,6 +42,7 @@ flowchart TD
     astroEslintParser -->|"parseTemplate()"| astroParseFn
     astroCompiler -->|"Node types"| astroParseFn
     astroParseFn -->|"RootNode.children"| astroParser
+    detectBlock -->|"blockBehavior"| astroParser
     astroParser -->|"produces MLASTDocument"| mlCore
 ```
 
@@ -48,7 +51,7 @@ flowchart TD
 ### Inheritance
 
 ```
-Parser<Node, State>  (from @markuplint/parser-utils)
+Parser<Node>  (from @markuplint/parser-utils)
     └── AstroParser  (this package)
 ```
 
@@ -62,27 +65,17 @@ The constructor configures the base `Parser` with Astro-specific options:
 | `selfCloseType`        | `'html+xml'` | Accepts both HTML void elements and XML-style self-closing (`<Component />`) |
 | `tagNameCaseSensitive` | `true`       | Distinguishes components (`<MyComp>`) from HTML elements (`<div>`)           |
 
-### State Type
-
-The parser maintains internal state through the `State` type:
-
-| Field     | Type     | Purpose                                                           |
-| --------- | -------- | ----------------------------------------------------------------- |
-| `scopeNS` | `string` | Current namespace URI, defaults to `http://www.w3.org/1999/xhtml` |
-
-The `scopeNS` state is updated by `#updateScopeNS()` as the parser traverses elements, switching to SVG namespace inside `<svg>` elements and back to XHTML inside `<foreignObject>`.
-
 ### Override Methods
 
-| Method                | Purpose                                                                                                                                            |
-| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `tokenize()`          | Calls `astroParse()` to get the Astro AST, returns `{ ast: rootNode.children, isFragment: true }`                                                  |
-| `nodeize()`           | Converts Astro AST nodes to markuplint nodes, dispatching by node type (frontmatter, doctype, text, comment, element, expression)                  |
-| `afterFlattenNodes()` | Delegates to parent with `{ exposeInvalidNode: false }`                                                                                            |
-| `visitElement()`      | Parses the raw HTML fragment via `parseCodeFragment()` with `namelessFragment: true`, then delegates to parent with namespace and end tag handling |
-| `visitChildren()`     | Delegates to parent, then asserts no unexpected sibling nodes remain                                                                               |
-| `visitAttr()`         | Handles curly-brace expression values, shorthand attributes, and template directives                                                               |
-| `detectElementType()` | Detects component vs HTML element using `/^[A-Z]/` pattern (capitalized names are components)                                                      |
+| Method                | Purpose                                                                                                                              |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `tokenize()`          | Calls `astroParse()` to get the Astro AST, returns `{ ast: rootNode.children, isFragment: true }`                                    |
+| `nodeize()`           | Converts Astro AST nodes to markuplint nodes, dispatching by node type (frontmatter, doctype, text, comment, element, expression)    |
+| `afterFlattenNodes()` | Delegates to parent with `{ exposeInvalidNode: false }`                                                                              |
+| `visitElement()`      | Parses the raw HTML fragment via `parseCodeFragment()` with `namelessFragment: true`, then delegates to parent with end tag handling |
+| `visitChildren()`     | Delegates to parent, then asserts no unexpected sibling nodes remain                                                                 |
+| `visitAttr()`         | Handles curly-brace expression values, shorthand attributes, and template directives                                                 |
+| `detectElementType()` | Detects component vs HTML element using `/^[A-Z]/` pattern (capitalized names are components)                                        |
 
 ## Frontmatter Handling
 
@@ -119,35 +112,6 @@ The splitting logic checks whether `firstChild !== lastChild` in the expression'
 - The region from the last child's start to the expression end becomes the closing fragment
 - The children between are visited normally within the opening fragment's psblock
 
-## Namespace Scoping
-
-The `#updateScopeNS()` private method manages namespace context as the parser traverses elements:
-
-| Condition                                                     | Action                                                  |
-| ------------------------------------------------------------- | ------------------------------------------------------- |
-| Current namespace is XHTML and node is `<svg>` element        | Switch `scopeNS` to `http://www.w3.org/2000/svg`        |
-| Current namespace is SVG and parent node is `<foreignObject>` | Switch `scopeNS` back to `http://www.w3.org/1999/xhtml` |
-
-This is called at the beginning of `nodeize()` before the node type switch, so all child nodes inherit the correct namespace. The namespace is applied to elements via `overwriteProps: { namespace: this.state.scopeNS }` in `visitElement()`.
-
-Example namespace resolution:
-
-```html
-<div>
-  <!-- XHTML -->
-  <svg>
-    <!-- SVG -->
-    <text />
-    <!-- SVG -->
-    <foreignObject>
-      <!-- SVG -->
-      <div />
-      <!-- XHTML (reset) -->
-    </foreignObject>
-  </svg>
-</div>
-```
-
 ## Attribute Processing
 
 ### Quote Set
@@ -173,15 +137,18 @@ When an attribute token starts with `{` (e.g., `{prop}`), the parser sets `start
 
 Astro template directives use the `name:modifier` syntax. The parser detects these with the regex `/^([^:]+):([^:]+)$/`:
 
-| Directive      | `potentialName` | `isDirective` | Behavior                            |
-| -------------- | --------------- | ------------- | ----------------------------------- |
-| `class:list`   | `'class'`       | `undefined`   | Maps to standard `class` attribute  |
-| `set:html`     | `undefined`     | `true`        | Treated as Astro-specific directive |
-| `set:text`     | `undefined`     | `true`        | Treated as Astro-specific directive |
-| `is:raw`       | `undefined`     | `true`        | Treated as Astro-specific directive |
-| `transition:*` | `undefined`     | `true`        | Treated as Astro-specific directive |
+| Directive prefix | `potentialName` | `isDirective` | Behavior                                        |
+| ---------------- | --------------- | ------------- | ----------------------------------------------- |
+| `class:`         | `'class'`       | `false`       | Maps to standard `class` attribute              |
+| `client:`        | —               | `true`        | Astro client directive (load, idle, visible...) |
+| `server:`        | —               | `true`        | Astro server directive (defer)                  |
+| `set:`           | —               | `true`        | Content directive (html, text)                  |
+| `is:`            | —               | `true`        | Property directive (inline, raw)                |
+| `define:`        | —               | `true`        | Style directive (vars)                          |
+| `transition:`    | —               | `true`        | View Transition directive (animate, name)       |
+| _(any other)_    | —               | `true`        | Catch-all: any `prefix:name` pattern            |
 
-The `class` directive is special: it gets `potentialName: 'class'` so markuplint rules for the `class` attribute apply. All other directives get `isDirective: true`, which tells markuplint they are framework-specific and should not be validated as standard HTML attributes.
+The `class:` prefix is special-cased: it gets `potentialName: 'class'` so markuplint rules for the `class` attribute apply. All other colon-separated prefixes hit the `default` case and get `isDirective: true`, which tells markuplint they are framework-specific and should not be validated as standard HTML attributes.
 
 ### Dynamic Values
 
@@ -199,7 +166,7 @@ Any attribute whose start quote is `{` gets `isDynamicValue: true`. This applies
 | **Frontmatter**           | Supported (`---...---` psblock) | Not applicable                                  |
 | **Expression syntax**     | `{expr}` as MustacheTag psblock | `{expr}` as JSXExpressionContainer psblock      |
 | **Template directives**   | `class:list`, `set:html`, etc.  | Not applicable                                  |
-| **Namespace management**  | Manual via `#updateScopeNS()`   | Delegates to `getNamespace()` from html-parser  |
+| **Namespace management**  | Delegates to base `Parser`      | Delegates to `getNamespace()` from html-parser  |
 | **Component detection**   | `/^[A-Z]/` pattern              | `/^[A-Z]/` pattern                              |
 | **Self-close type**       | `html+xml`                      | Default (XML-only)                              |
 | **Booleanish attributes** | Not configured                  | `booleanish: true`                              |

--- a/packages/@markuplint/astro-parser/SKILL.md
+++ b/packages/@markuplint/astro-parser/SKILL.md
@@ -29,7 +29,7 @@ for the full guide. The recipes there are the source of truth for procedures.
 
 Also read:
 
-- `ARCHITECTURE.md` -- Package overview, attribute processing, namespace scoping
+- `ARCHITECTURE.md` -- Package overview, attribute processing, directive handling
 - `src/parser.ts` -- AstroParser class (source of truth for override methods)
 - `src/astro-parser.ts` -- astro-eslint-parser wrapper
 
@@ -62,14 +62,14 @@ Modify the SVG/XHTML namespace scoping logic. Follow recipe #2 in `docs/maintena
 
 ### Step 1: Understand the current logic
 
-1. Read `src/parser.ts` — the `#updateScopeNS()` private method
-2. Understand the two conditions: `<svg>` → SVG namespace, `<foreignObject>` parent → XHTML namespace
-3. Note that `scopeNS` is applied in `visitElement()` via `overwriteProps`
+1. Namespace resolution is handled by the base `Parser` class from `@markuplint/parser-utils`
+2. The Astro parser does **not** override namespace logic — there is no `#updateScopeNS()` method
+3. Any namespace changes require modifications in the base `Parser` class or adding an override in `AstroParser`
 
 ### Step 2: Make the change
 
-1. Add or modify conditions in `#updateScopeNS()`
-2. For new namespaces (e.g., MathML), add a new condition checking `originNode.name`
+1. If adding namespace handling to the Astro parser, override the relevant method from the base `Parser`
+2. For new namespaces (e.g., MathML), add a condition checking `originNode.name`
 3. Ensure the namespace URI constant is correct
 
 ### Step 3: Verify

--- a/packages/@markuplint/astro-parser/docs/maintenance.ja.md
+++ b/packages/@markuplint/astro-parser/docs/maintenance.ja.md
@@ -61,22 +61,12 @@ expect(debugMaps).toStrictEqual([
 
 ### 2. 名前空間スコーピングの変更
 
-1. `src/parser.ts` を読む — `#updateScopeNS()` プライベートメソッド
-2. このメソッドには2つの条件がある:
-   - XHTML → SVG: 現在の名前空間が XHTML で、ノードが `<svg>` 要素の場合
-   - SVG → XHTML: 現在の名前空間が SVG で、親が `<foreignObject>` の場合
-3. 新しい名前空間遷移を追加する場合（例: MathML）:
-   ```ts
-   if (
-     parentNS === 'http://www.w3.org/1999/xhtml' &&
-     originNode.type === 'element' &&
-     originNode.name?.toLowerCase() === 'math'
-   ) {
-     this.state.scopeNS = 'http://www.w3.org/1998/Math/MathML';
-   }
-   ```
-4. ビルドとテスト: `yarn build --scope @markuplint/astro-parser && yarn test --scope @markuplint/astro-parser`
-5. `src/parser.spec.ts` に名前空間テストケースを追加:
+名前空間の解決は現在 `@markuplint/parser-utils` の基底 `Parser` クラスが処理しています。Astro パーサーは名前空間ロジックをオーバーライドしていません。
+
+1. カスタム名前空間処理が必要な場合は、`src/parser.ts` の `AstroParser` で該当メソッドをオーバーライド
+2. 新しい名前空間（例: MathML）の場合、要素名を検出して名前空間を切り替えるオーバーライドが必要
+3. ビルドとテスト: `yarn build --scope @markuplint/astro-parser && yarn test --scope @markuplint/astro-parser`
+4. `src/parser.spec.ts` に名前空間テストケースを追加:
    ```ts
    test('MathML namespace', () => {
      const doc = parse('<div><math><mi>x</mi></math></div>');
@@ -161,14 +151,13 @@ yarn build --scope @markuplint/astro-parser && yarn test --scope @markuplint/ast
 
 **症状:** `<svg>` 内の要素が XHTML 名前空間を持つ、または `<foreignObject>` 内の要素が SVG 名前空間を持つ。
 
-**原因:** `#updateScopeNS()` が要素タイプを正しく検出していないか、`scopeNS` 状態がリセットされていない。
+**原因:** 名前空間の解決は `@markuplint/parser-utils` の基底 `Parser` クラスが処理します。Astro パーサーは名前空間ロジックをオーバーライドしていません。
 
 **解決策:**
 
-1. `originNode.type === 'element'` を確認 — 要素ノードのみが名前空間の変更をトリガー
-2. `originNode.name?.toLowerCase()` を確認 — `svg` の比較はケースインセンシティブである必要がある
-3. `parentNode.nodeName === 'foreignObject'` の比較を確認 — これは Astro AST の名前ではなく markuplint のノード名を使用
-4. 特定のネストパターンのテストケースを `src/parser.spec.ts` に追加
+1. 問題が `@markuplint/parser-utils` の基底 `Parser` クラスにあるかどうかを確認
+2. 特定のネストパターンのテストケースを `src/parser.spec.ts` に追加して期待される動作を確認
+3. 問題が上流にある場合は、基底 `Parser` の名前空間処理を調査
 
 ### テンプレートディレクティブが検出されない
 

--- a/packages/@markuplint/astro-parser/docs/maintenance.md
+++ b/packages/@markuplint/astro-parser/docs/maintenance.md
@@ -61,22 +61,12 @@ The second argument `true` to `nodeListToDebugMaps` includes attribute details i
 
 ### 2. Modifying Namespace Scoping
 
-1. Read `src/parser.ts` — the `#updateScopeNS()` private method
-2. The method has two conditions:
-   - XHTML → SVG: when current namespace is XHTML and node is a `<svg>` element
-   - SVG → XHTML: when current namespace is SVG and parent is `<foreignObject>`
-3. To add a new namespace transition (e.g., MathML):
-   ```ts
-   if (
-     parentNS === 'http://www.w3.org/1999/xhtml' &&
-     originNode.type === 'element' &&
-     originNode.name?.toLowerCase() === 'math'
-   ) {
-     this.state.scopeNS = 'http://www.w3.org/1998/Math/MathML';
-   }
-   ```
-4. Build and test: `yarn build --scope @markuplint/astro-parser && yarn test --scope @markuplint/astro-parser`
-5. Add namespace test cases to `src/parser.spec.ts`:
+Namespace resolution is currently handled by the base `Parser` class from `@markuplint/parser-utils`. The Astro parser does not override namespace logic.
+
+1. If you need to add custom namespace handling, you would override the relevant method in `AstroParser` in `src/parser.ts`
+2. For new namespaces (e.g., MathML), the override would need to detect the element name and switch the namespace
+3. Build and test: `yarn build --scope @markuplint/astro-parser && yarn test --scope @markuplint/astro-parser`
+4. Add namespace test cases to `src/parser.spec.ts`:
    ```ts
    test('MathML namespace', () => {
      const doc = parse('<div><math><mi>x</mi></math></div>');
@@ -161,14 +151,13 @@ yarn build --scope @markuplint/astro-parser && yarn test --scope @markuplint/ast
 
 **Symptom:** Elements inside `<svg>` have XHTML namespace, or elements inside `<foreignObject>` have SVG namespace.
 
-**Cause:** `#updateScopeNS()` is not detecting the element type correctly, or the `scopeNS` state is not being reset.
+**Cause:** Namespace resolution is handled by the base `Parser` class from `@markuplint/parser-utils`. The Astro parser does not override namespace logic.
 
 **Solution:**
 
-1. Check that `originNode.type === 'element'` — only element nodes trigger namespace changes
-2. Check `originNode.name?.toLowerCase()` — the comparison must be case-insensitive for `svg`
-3. Check the `parentNode.nodeName === 'foreignObject'` comparison — this uses the markuplint node name, not the Astro AST name
-4. Add a test case with the specific nesting pattern to `src/parser.spec.ts`
+1. Check whether the issue is in the base `Parser` class in `@markuplint/parser-utils`
+2. Add a test case with the specific nesting pattern to `src/parser.spec.ts` to confirm expected behavior
+3. If the issue is upstream, investigate the base `Parser` namespace handling
 
 ### Template directive not detected
 

--- a/packages/@markuplint/astro-parser/src/parser.spec.ts
+++ b/packages/@markuplint/astro-parser/src/parser.spec.ts
@@ -652,3 +652,212 @@ describe('Issue', () => {
 		expect(ast).toBeTruthy();
 	});
 });
+
+describe('Directives', () => {
+	test('server:defer (Astro v5)', () => {
+		const ast = parse('<Component server:defer />');
+		const map = nodeListToDebugMaps(ast.nodeList, true);
+		expect(map).toEqual([
+			'[1:1]>[1:27](0,26)Component: <Component␣server:defer␣/>',
+			'[1:12]>[1:24](11,23)server:defer: server:defer',
+			'  [1:11]>[1:12](10,11)bN: ␣',
+			'  [1:12]>[1:24](11,23)name: server:defer',
+			'  [1:24]>[1:24](23,23)bE: ',
+			'  [1:24]>[1:24](23,23)equal: ',
+			'  [1:24]>[1:24](23,23)aE: ',
+			'  [1:24]>[1:24](23,23)sQ: ',
+			'  [1:24]>[1:24](23,23)value: ',
+			'  [1:24]>[1:24](23,23)eQ: ',
+			'  isDirective: true',
+			'  isDynamicValue: false',
+		]);
+	});
+
+	test('client:load', () => {
+		const ast = parse('<Component client:load />');
+		const map = nodeListToDebugMaps(ast.nodeList, true);
+		expect(map).toEqual([
+			'[1:1]>[1:26](0,25)Component: <Component␣client:load␣/>',
+			'[1:12]>[1:23](11,22)client:load: client:load',
+			'  [1:11]>[1:12](10,11)bN: ␣',
+			'  [1:12]>[1:23](11,22)name: client:load',
+			'  [1:23]>[1:23](22,22)bE: ',
+			'  [1:23]>[1:23](22,22)equal: ',
+			'  [1:23]>[1:23](22,22)aE: ',
+			'  [1:23]>[1:23](22,22)sQ: ',
+			'  [1:23]>[1:23](22,22)value: ',
+			'  [1:23]>[1:23](22,22)eQ: ',
+			'  isDirective: true',
+			'  isDynamicValue: false',
+		]);
+	});
+
+	test('client:only', () => {
+		const ast = parse('<Component client:only="react" />');
+		const map = nodeListToDebugMaps(ast.nodeList, true);
+		expect(map).toEqual([
+			'[1:1]>[1:34](0,33)Component: <Component␣client:only="react"␣/>',
+			'[1:12]>[1:31](11,30)client:only: client:only="react"',
+			'  [1:11]>[1:12](10,11)bN: ␣',
+			'  [1:12]>[1:23](11,22)name: client:only',
+			'  [1:23]>[1:23](22,22)bE: ',
+			'  [1:23]>[1:24](22,23)equal: =',
+			'  [1:24]>[1:24](23,23)aE: ',
+			'  [1:24]>[1:25](23,24)sQ: "',
+			'  [1:25]>[1:30](24,29)value: react',
+			'  [1:30]>[1:31](29,30)eQ: "',
+			'  isDirective: true',
+			'  isDynamicValue: false',
+		]);
+	});
+
+	test('set:html', () => {
+		const ast = parse('<div set:html={rawHTML} />');
+		const map = nodeListToDebugMaps(ast.nodeList, true);
+		expect(map).toEqual([
+			'[1:1]>[1:27](0,26)div: <div␣set:html={rawHTML}␣/>',
+			'[1:6]>[1:24](5,23)set:html: set:html={rawHTML}',
+			'  [1:5]>[1:6](4,5)bN: ␣',
+			'  [1:6]>[1:14](5,13)name: set:html',
+			'  [1:14]>[1:14](13,13)bE: ',
+			'  [1:14]>[1:15](13,14)equal: =',
+			'  [1:15]>[1:15](14,14)aE: ',
+			'  [1:15]>[1:16](14,15)sQ: {',
+			'  [1:16]>[1:23](15,22)value: rawHTML',
+			'  [1:23]>[1:24](22,23)eQ: }',
+			'  isDirective: true',
+			'  isDynamicValue: true',
+		]);
+	});
+
+	test('set:text', () => {
+		const ast = parse('<div set:text={text} />');
+		const map = nodeListToDebugMaps(ast.nodeList, true);
+		expect(map).toEqual([
+			'[1:1]>[1:24](0,23)div: <div␣set:text={text}␣/>',
+			'[1:6]>[1:21](5,20)set:text: set:text={text}',
+			'  [1:5]>[1:6](4,5)bN: ␣',
+			'  [1:6]>[1:14](5,13)name: set:text',
+			'  [1:14]>[1:14](13,13)bE: ',
+			'  [1:14]>[1:15](13,14)equal: =',
+			'  [1:15]>[1:15](14,14)aE: ',
+			'  [1:15]>[1:16](14,15)sQ: {',
+			'  [1:16]>[1:20](15,19)value: text',
+			'  [1:20]>[1:21](19,20)eQ: }',
+			'  isDirective: true',
+			'  isDynamicValue: true',
+		]);
+	});
+
+	test('is:inline', () => {
+		const ast = parse('<script is:inline>console.log("hello")</script>');
+		const map = nodeListToDebugMaps(ast.nodeList, true);
+		expect(map).toEqual([
+			'[1:1]>[1:19](0,18)script: <script␣is:inline>',
+			'[1:9]>[1:18](8,17)is:inline: is:inline',
+			'  [1:8]>[1:9](7,8)bN: ␣',
+			'  [1:9]>[1:18](8,17)name: is:inline',
+			'  [1:18]>[1:18](17,17)bE: ',
+			'  [1:18]>[1:18](17,17)equal: ',
+			'  [1:18]>[1:18](17,17)aE: ',
+			'  [1:18]>[1:18](17,17)sQ: ',
+			'  [1:18]>[1:18](17,17)value: ',
+			'  [1:18]>[1:18](17,17)eQ: ',
+			'  isDirective: true',
+			'  isDynamicValue: false',
+			'[1:39]>[1:48](38,47)script: </script>',
+		]);
+	});
+
+	test('is:raw', () => {
+		const ast = parse('<div is:raw><span>{text}</span></div>');
+		const map = nodeListToDebugMaps(ast.nodeList, true);
+		expect(map).toEqual([
+			'[1:1]>[1:13](0,12)div: <div␣is:raw>',
+			'[1:6]>[1:12](5,11)is:raw: is:raw',
+			'  [1:5]>[1:6](4,5)bN: ␣',
+			'  [1:6]>[1:12](5,11)name: is:raw',
+			'  [1:12]>[1:12](11,11)bE: ',
+			'  [1:12]>[1:12](11,11)equal: ',
+			'  [1:12]>[1:12](11,11)aE: ',
+			'  [1:12]>[1:12](11,11)sQ: ',
+			'  [1:12]>[1:12](11,11)value: ',
+			'  [1:12]>[1:12](11,11)eQ: ',
+			'  isDirective: true',
+			'  isDynamicValue: false',
+			'[1:13]>[1:32](12,31)#text: <span>{text}</span>',
+			'[1:32]>[1:38](31,37)div: </div>',
+		]);
+	});
+
+	test('define:vars', () => {
+		const ast = parse('<style define:vars={{ color }}>div { color: var(--color); }</style>');
+		const map = nodeListToDebugMaps(ast.nodeList, true);
+		expect(map).toEqual([
+			'[1:1]>[1:32](0,31)style: <style␣define:vars={{␣color␣}}>',
+			'[1:8]>[1:31](7,30)define:vars: define:vars={{␣color␣}}',
+			'  [1:7]>[1:8](6,7)bN: ␣',
+			'  [1:8]>[1:19](7,18)name: define:vars',
+			'  [1:19]>[1:19](18,18)bE: ',
+			'  [1:19]>[1:20](18,19)equal: =',
+			'  [1:20]>[1:20](19,19)aE: ',
+			'  [1:20]>[1:21](19,20)sQ: {',
+			'  [1:21]>[1:30](20,29)value: {␣color␣}',
+			'  [1:30]>[1:31](29,30)eQ: }',
+			'  isDirective: true',
+			'  isDynamicValue: true',
+			'[1:60]>[1:68](59,67)style: </style>',
+		]);
+	});
+
+	test('transition:animate', () => {
+		const ast = parse('<div transition:animate="slide">content</div>');
+		const map = nodeListToDebugMaps(ast.nodeList, true);
+		expect(map).toEqual([
+			'[1:1]>[1:33](0,32)div: <div␣transition:animate="slide">',
+			'[1:6]>[1:32](5,31)transition:animate: transition:animate="slide"',
+			'  [1:5]>[1:6](4,5)bN: ␣',
+			'  [1:6]>[1:24](5,23)name: transition:animate',
+			'  [1:24]>[1:24](23,23)bE: ',
+			'  [1:24]>[1:25](23,24)equal: =',
+			'  [1:25]>[1:25](24,24)aE: ',
+			'  [1:25]>[1:26](24,25)sQ: "',
+			'  [1:26]>[1:31](25,30)value: slide',
+			'  [1:31]>[1:32](30,31)eQ: "',
+			'  isDirective: true',
+			'  isDynamicValue: false',
+			'[1:33]>[1:40](32,39)#text: content',
+			'[1:40]>[1:46](39,45)div: </div>',
+		]);
+	});
+
+	test('multiple directives on same element', () => {
+		const ast = parse('<Component client:visible set:html={content} />');
+		const map = nodeListToDebugMaps(ast.nodeList, true);
+		expect(map).toEqual([
+			'[1:1]>[1:48](0,47)Component: <Component␣client:visible␣set:html={content}␣/>',
+			'[1:12]>[1:26](11,25)client:visible: client:visible',
+			'  [1:11]>[1:12](10,11)bN: ␣',
+			'  [1:12]>[1:26](11,25)name: client:visible',
+			'  [1:26]>[1:26](25,25)bE: ',
+			'  [1:26]>[1:26](25,25)equal: ',
+			'  [1:26]>[1:26](25,25)aE: ',
+			'  [1:26]>[1:26](25,25)sQ: ',
+			'  [1:26]>[1:26](25,25)value: ',
+			'  [1:26]>[1:26](25,25)eQ: ',
+			'  isDirective: true',
+			'  isDynamicValue: false',
+			'[1:27]>[1:45](26,44)set:html: set:html={content}',
+			'  [1:26]>[1:27](25,26)bN: ␣',
+			'  [1:27]>[1:35](26,34)name: set:html',
+			'  [1:35]>[1:35](34,34)bE: ',
+			'  [1:35]>[1:36](34,35)equal: =',
+			'  [1:36]>[1:36](35,35)aE: ',
+			'  [1:36]>[1:37](35,36)sQ: {',
+			'  [1:37]>[1:44](36,43)value: content',
+			'  [1:44]>[1:45](43,44)eQ: }',
+			'  isDirective: true',
+			'  isDynamicValue: true',
+		]);
+	});
+});

--- a/packages/@markuplint/astro-parser/src/parser.spec.ts
+++ b/packages/@markuplint/astro-parser/src/parser.spec.ts
@@ -769,7 +769,7 @@ describe('Directives', () => {
 		]);
 	});
 
-	test('is:raw', () => {
+	test('is:raw treats child content as raw text (not parsed HTML)', () => {
 		const ast = parse('<div is:raw><span>{text}</span></div>');
 		const map = nodeListToDebugMaps(ast.nodeList, true);
 		expect(map).toEqual([
@@ -859,5 +859,40 @@ describe('Directives', () => {
 			'  isDirective: true',
 			'  isDynamicValue: true',
 		]);
+	});
+
+	test('class:list is NOT a directive (special-cased to potentialName)', () => {
+		// class: prefix is special-cased in visitAttr — isDirective stays false, potentialName is set
+		const ast = parse('<div class:list={["a", "b"]} />');
+		const map = nodeListToDebugMaps(ast.nodeList, true);
+		expect(map).toContainEqual(expect.stringContaining('isDirective: false'));
+		expect(map).toContainEqual(expect.stringContaining('potentialName: class'));
+	});
+
+	test('client:media with special characters in value', () => {
+		const ast = parse('<Component client:media="(max-width: 600px)" />');
+		const map = nodeListToDebugMaps(ast.nodeList, true);
+		expect(map).toEqual([
+			'[1:1]>[1:48](0,47)Component: <Component␣client:media="(max-width:␣600px)"␣/>',
+			'[1:12]>[1:45](11,44)client:media: client:media="(max-width:␣600px)"',
+			'  [1:11]>[1:12](10,11)bN: ␣',
+			'  [1:12]>[1:24](11,23)name: client:media',
+			'  [1:24]>[1:24](23,23)bE: ',
+			'  [1:24]>[1:25](23,24)equal: =',
+			'  [1:25]>[1:25](24,24)aE: ',
+			'  [1:25]>[1:26](24,25)sQ: "',
+			'  [1:26]>[1:44](25,43)value: (max-width:␣600px)',
+			'  [1:44]>[1:45](43,44)eQ: "',
+			'  isDirective: true',
+			'  isDynamicValue: false',
+		]);
+	});
+
+	test('arbitrary colon-separated attribute is treated as directive', () => {
+		// Any prefix:name pattern triggers isDirective: true (catch-all in switch default)
+		const ast = parse('<div custom:attr="val" />');
+		const map = nodeListToDebugMaps(ast.nodeList, true);
+		expect(map).toContainEqual(expect.stringContaining('isDirective: true'));
+		expect(map).toContainEqual(expect.stringContaining('name: custom:attr'));
 	});
 });


### PR DESCRIPTION
Fixes #???

## What is the purpose of this PR?

- [ ] Fix bug
- [x] Fix typo
- [x] Update specs
- [ ] Add new rule
- [ ] Add new parser
- [ ] Improve or refactor rules
- [ ] Add a new core feature
- [ ] Improve or refactor core features
- [x] Update documents
- [ ] Others

### Description

This PR adds comprehensive test coverage for Astro template directives in the parser and updates documentation to reflect the current implementation.

**Changes:**

1. **Test Coverage** (`parser.spec.ts`):
   - Added 11 new test cases covering various Astro directives:
     - `server:defer` (Astro v5)
     - `client:load`, `client:only`, `client:visible`, `client:media`
     - `set:html`, `set:text`
     - `is:inline`, `is:raw`
     - `define:vars`
     - `transition:animate`
     - Multiple directives on same element
     - Special case: `class:list` (not a directive, uses `potentialName`)
     - Arbitrary colon-separated attributes (catch-all directive handling)

2. **Documentation Updates** (`ARCHITECTURE.md`, `ARCHITECTURE.ja.md`):
   - Removed outdated `State` type documentation (no longer used)
   - Removed namespace scoping section (now handled by base `Parser` class)
   - Updated directive handling table to show all directive prefixes (`client:`, `server:`, `set:`, `is:`, `define:`, `transition:`)
   - Clarified that `class:` is special-cased and other colon-separated patterns are catch-all directives
   - Updated directory structure to include `detect-block-behavior.ts`
   - Updated architecture diagram to show `detectBlockBehavior()` function

3. **Maintenance Guides** (`docs/maintenance.md`, `docs/maintenance.ja.md`):
   - Updated namespace scoping section to clarify it's handled by base `Parser` class
   - Removed implementation details about `#updateScopeNS()` private method
   - Updated troubleshooting section for namespace issues

4. **Skill Guide** (`SKILL.md`):
   - Updated references from "namespace scoping" to "directive handling"
   - Clarified that namespace resolution is in base `Parser` class

### Test Plan

The new test cases verify:
- Directives are correctly parsed with `isDirective: true`
- Directive names and values are properly extracted
- Dynamic values (curly braces) are detected with `isDynamicValue: true`
- Static values are detected with `isDynamicValue: false`
- Multiple directives on the same element are handled correctly
- Special cases like `class:list` are properly identified as non-directives with `potentialName`
- Arbitrary colon-separated attributes are treated as directives (catch-all behavior)

All tests use the existing `nodeListToDebugMaps()` utility to verify AST structure and attribute metadata.

## Checklist

- [x] Update specs
  - [x] Update documentation files to reflect current implementation
- [x] Update documents
  - [x] ARCHITECTURE.md and ARCHITECTURE.ja.md
  - [x] docs/maintenance.md and docs/maintenance.ja.md
  - [x] SKILL.md

https://claude.ai/code/session_01Mg8P4hzCpsNcurt8kbwzNx