### PR TITLE
fix(pretenders): pre-release quality improvements for scan feature

### DIFF
--- a/packages/@markuplint/pretenders/src/dependency-mapper.ts
+++ b/packages/@markuplint/pretenders/src/dependency-mapper.ts
@@ -50,14 +50,10 @@ export function dependencyMapper(
 		const pretender: Pretender = {
 			selector: identifier,
 			as: identity,
+			...(filePath ? { filePath } : {}),
 		};
-		if (filePath) {
-			// @ts-ignore initialize readonly property
-			pretender.filePath = filePath;
-		}
 		if (via.length > 0) {
-			// @ts-ignore
-			pretender._via = via;
+			Object.assign(pretender, { _via: via });
 		}
 
 		linkedPretenders.push(pretender);
@@ -112,8 +108,7 @@ export function propSort<T, P extends keyof T>(propName: P) {
 
 function toLowerCase<T>(value: T): T {
 	if (typeof value === 'string') {
-		// @ts-ignore
-		return value.toLowerCase();
+		return value.toLowerCase() as T;
 	}
 	return value;
 }

--- a/packages/@markuplint/pretenders/src/import-resolver/parse-imports.spec.ts
+++ b/packages/@markuplint/pretenders/src/import-resolver/parse-imports.spec.ts
@@ -275,5 +275,14 @@ describe('parseImports', () => {
 			const result = await parseImports('# Hello World\nSome markdown content');
 			expect(result).toStrictEqual([]);
 		});
+
+		test('concurrent calls do not cause double initialization', async () => {
+			const results = await Promise.all([
+				parseImports("import { A } from './a'"),
+				parseImports("import { B } from './b'"),
+			]);
+			expect(results[0]).toHaveLength(1);
+			expect(results[1]).toHaveLength(1);
+		});
 	});
 });

--- a/packages/@markuplint/pretenders/src/import-resolver/parse-imports.ts
+++ b/packages/@markuplint/pretenders/src/import-resolver/parse-imports.ts
@@ -28,17 +28,15 @@ const RE_DEFAULT_AND_NAMED = /import\s+(\w+)\s*,\s*\{([^}]+)\}\s*from/;
 /** Matches `import X, * as Y from` — default + namespace imports */
 const RE_DEFAULT_AND_NAMESPACE = /import\s+(\w+)\s*,\s*\*\s*as\s+(\w+)\s+from/;
 
-let initialized = false;
+let initPromise: Promise<void> | null = null;
 
 /**
  * Ensures the es-module-lexer WASM module is initialized.
  * Safe to call multiple times; initialization only happens once.
  */
 async function ensureInit() {
-	if (!initialized) {
-		await init;
-		initialized = true;
-	}
+	initPromise ??= init;
+	await initPromise;
 }
 
 /**

--- a/packages/@markuplint/pretenders/src/import-resolver/resolve-barrel.ts
+++ b/packages/@markuplint/pretenders/src/import-resolver/resolve-barrel.ts
@@ -46,7 +46,14 @@ export function resolveBarrelExport(specifier: string, importedName: string, imp
 		return null;
 	}
 
-	const indexSource = fs.readFileSync(indexPath, 'utf8');
+	let indexSource: string;
+	try {
+		indexSource = fs.readFileSync(indexPath, 'utf8');
+	} catch (error: unknown) {
+		// eslint-disable-next-line no-console
+		console.warn(`Failed to read barrel file: ${indexPath}`, error instanceof Error ? error.message : error);
+		return null;
+	}
 	return matchExportedName(indexSource, importedName);
 }
 

--- a/packages/@markuplint/pretenders/src/jsx/create-identify.ts
+++ b/packages/@markuplint/pretenders/src/jsx/create-identify.ts
@@ -12,7 +12,7 @@ import type { PretenderAttr } from '@markuplint/ml-config';
  * @param slots - Whether the component accepts children (`true`) or not (`null`)
  * @returns A simple tag name string or a detailed Identity object
  */
-export function createIndentity(tagName: string, attrs: readonly Attr[], slots: null | true) {
+export function createIdentity(tagName: string, attrs: readonly Attr[], slots: null | true) {
 	if (attrs.length === 0 && slots !== true) {
 		return tagName;
 	}

--- a/packages/@markuplint/pretenders/src/jsx/create-identify.ts
+++ b/packages/@markuplint/pretenders/src/jsx/create-identify.ts
@@ -19,31 +19,16 @@ export function createIdentity(tagName: string, attrs: readonly Attr[], slots: n
 
 	const availableAttrs = attrs.filter(attr => attr.nodeType !== 'spread');
 	const hasSpread = attrs.some(attr => attr.nodeType === 'spread');
-	const pretenderAttrs: PretenderAttr[] = availableAttrs.map(attr => {
-		const pretenderAttr: PretenderAttr = {
-			name: attr.name,
-		};
-		if (attr.nodeType === 'static' && attr.value) {
-			// @ts-ignore initialize readonly property
-			pretenderAttr.value = attr.value;
-		}
-		return pretenderAttr;
-	});
+	const pretenderAttrs: PretenderAttr[] = availableAttrs.map(attr =>
+		attr.nodeType === 'static' && attr.value ? { name: attr.name, value: attr.value } : { name: attr.name },
+	);
 
 	const identify: Identity = {
 		element: tagName,
 		slots,
+		...(pretenderAttrs.length > 0 ? { attrs: pretenderAttrs } : {}),
+		...(hasSpread ? { inheritAttrs: true as const } : {}),
 	};
-
-	if (pretenderAttrs.length > 0) {
-		// @ts-ignore initialize readonly property
-		identify.attrs = pretenderAttrs;
-	}
-
-	if (hasSpread) {
-		// @ts-ignore initialize readonly property
-		identify.inheritAttrs = true;
-	}
 
 	return identify;
 }

--- a/packages/@markuplint/pretenders/src/jsx/index.ts
+++ b/packages/@markuplint/pretenders/src/jsx/index.ts
@@ -261,6 +261,7 @@ export const jsxScanner = createScanner<PretenderScanJSXOptions>(
 						filePath,
 						line,
 						col,
+						`${filePath}#${name}`,
 					);
 				}
 			});
@@ -316,6 +317,7 @@ export const jsxScanner = createScanner<PretenderScanJSXOptions>(
 						filePath,
 						line,
 						col,
+						`${filePath}#${name}`,
 					);
 				}
 			});
@@ -377,7 +379,7 @@ export const jsxScanner = createScanner<PretenderScanJSXOptions>(
 				const attrs = getAttributes(el, sourceFile);
 				const children = getChildren(el, sourceFile);
 				const identity = createIdentity(tagName, attrs, children);
-				director.add(name, identity, filePath, line, col);
+				director.add(name, identity, filePath, line, col, `${filePath}#${name}`);
 			}
 		}
 

--- a/packages/@markuplint/pretenders/src/jsx/index.ts
+++ b/packages/@markuplint/pretenders/src/jsx/index.ts
@@ -28,7 +28,7 @@ import ts from 'typescript';
 import { createScanner } from '../create-scanner.js';
 import { PretenderDirector } from '../pretender-director.js';
 
-import { createIndentity } from './create-identify.js';
+import { createIdentity } from './create-identify.js';
 import { finder } from './finder.js';
 import { getAttributes } from './get-attributes.js';
 import { getChildren } from './get-children.js';
@@ -376,7 +376,7 @@ export const jsxScanner = createScanner<PretenderScanJSXOptions>(
 
 				const attrs = getAttributes(el, sourceFile);
 				const children = getChildren(el, sourceFile);
-				const identity = createIndentity(tagName, attrs, children);
+				const identity = createIdentity(tagName, attrs, children);
 				director.add(name, identity, filePath, line, col);
 			}
 		}

--- a/packages/@markuplint/pretenders/src/scan.spec.ts
+++ b/packages/@markuplint/pretenders/src/scan.spec.ts
@@ -158,6 +158,23 @@ describe('scan', () => {
 		});
 	});
 
+	describe('name collision via scan()', () => {
+		test('same-name template components from different directories are both output', async () => {
+			const result = await scan([templateFixture('subA/Button.vue'), templateFixture('subB/Button.vue')]);
+			expect(result).toHaveLength(2);
+			expect(result).toStrictEqual([
+				expect.objectContaining({
+					selector: 'Button',
+					as: expect.objectContaining({ element: 'button' }),
+				}),
+				expect.objectContaining({
+					selector: 'Button',
+					as: expect.objectContaining({ element: 'div' }),
+				}),
+			]);
+		});
+	});
+
 	describe('edge cases', () => {
 		test('empty file list returns empty result', async () => {
 			const result = await scan([]);

--- a/packages/@markuplint/pretenders/src/template/derive-name.spec.ts
+++ b/packages/@markuplint/pretenders/src/template/derive-name.spec.ts
@@ -58,4 +58,12 @@ describe('deriveName', () => {
 	test('handles camelCase filenames by uppercasing first letter', () => {
 		expect(deriveName('myComponent.vue')).toBe('MyComponent');
 	});
+
+	test('falls back to Index when path has no parent directory', () => {
+		expect(deriveName('index.vue')).toBe('Index');
+	});
+
+	test('empty string returns empty string', () => {
+		expect(deriveName('')).toBe('');
+	});
 });

--- a/packages/@markuplint/pretenders/src/template/derive-name.ts
+++ b/packages/@markuplint/pretenders/src/template/derive-name.ts
@@ -15,7 +15,7 @@ export function deriveName(filePath: string): string {
 	const parsed = path.parse(filePath);
 	const baseName = parsed.name;
 
-	const nameToConvert = baseName === 'index' ? path.basename(parsed.dir) : baseName;
+	const nameToConvert = baseName === 'index' ? path.basename(parsed.dir) || 'index' : baseName;
 
 	return toPascalCase(nameToConvert);
 }

--- a/packages/@markuplint/pretenders/src/template/index.spec.ts
+++ b/packages/@markuplint/pretenders/src/template/index.spec.ts
@@ -165,6 +165,23 @@ describe('templateScanner', () => {
 		});
 	});
 
+	describe('Name collision', () => {
+		test('same-name components from different directories are both registered', async () => {
+			const result = await templateScanner([resolve('subA/Button.vue'), resolve('subB/Button.vue')]);
+			expect(result).toHaveLength(2);
+			expect(result).toStrictEqual([
+				expect.objectContaining({
+					selector: 'Button',
+					as: expect.objectContaining({ element: 'button' }),
+				}),
+				expect.objectContaining({
+					selector: 'Button',
+					as: expect.objectContaining({ element: 'div' }),
+				}),
+			]);
+		});
+	});
+
 	describe('Edge cases', () => {
 		test('rejects relative file paths', () => {
 			expect(() => templateScanner(['relative/path.vue'])).toThrow(ReferenceError);

--- a/packages/@markuplint/pretenders/src/template/index.ts
+++ b/packages/@markuplint/pretenders/src/template/index.ts
@@ -59,7 +59,7 @@ export const templateScanner = createScanner<PretenderScanTemplateOptions>(async
 					}
 				: tagName;
 
-		director.add(componentName, identity, relFilePath, root.line, root.col);
+		director.add(componentName, identity, relFilePath, root.line, root.col, relFilePath);
 	}
 
 	return director.getPretenders();

--- a/packages/@markuplint/pretenders/src/template/parse-component.spec.ts
+++ b/packages/@markuplint/pretenders/src/template/parse-component.spec.ts
@@ -86,6 +86,12 @@ describe('parseComponent', () => {
 	});
 
 	test('returns null when file does not exist (fs.readFileSync throws)', async () => {
-		await expect(parseComponent('/nonexistent/path/Component.vue')).rejects.toThrow();
+		const result = await parseComponent('/nonexistent/path/Component.vue');
+		expect(result).toBeNull();
+	});
+
+	test('returns null when file contains syntax errors (parser.parse throws)', async () => {
+		const result = await parseComponent(path.resolve(fixtureDir, 'Malformed.vue'));
+		expect(result).toBeNull();
 	});
 });

--- a/packages/@markuplint/pretenders/src/template/parse-component.ts
+++ b/packages/@markuplint/pretenders/src/template/parse-component.ts
@@ -49,6 +49,8 @@ async function getParser(framework: FrameworkType): Promise<MLParser | null> {
 		return mod.parser;
 	} catch (error: unknown) {
 		if (isModuleNotFoundError(error)) {
+			// eslint-disable-next-line no-console
+			console.warn(`Parser package "${pkg}" is not installed. Skipping ${framework} files.`);
 			return null;
 		}
 		throw error;

--- a/packages/@markuplint/pretenders/src/template/parse-component.ts
+++ b/packages/@markuplint/pretenders/src/template/parse-component.ts
@@ -73,6 +73,12 @@ export async function parseComponent(filePath: string): Promise<MLASTDocument | 
 		return null;
 	}
 
-	const sourceCode = fs.readFileSync(filePath, 'utf8');
-	return parser.parse(sourceCode);
+	try {
+		const sourceCode = fs.readFileSync(filePath, 'utf8');
+		return parser.parse(sourceCode);
+	} catch (error: unknown) {
+		// eslint-disable-next-line no-console
+		console.warn(`Failed to parse component: ${filePath}`, error instanceof Error ? error.message : error);
+		return null;
+	}
 }

--- a/packages/@markuplint/pretenders/test/fixtures/template/Malformed.vue
+++ b/packages/@markuplint/pretenders/test/fixtures/template/Malformed.vue
@@ -1,0 +1,3 @@
+<template>
+	<div class="valid
+</template>

--- a/packages/@markuplint/pretenders/test/fixtures/template/subA/Button.vue
+++ b/packages/@markuplint/pretenders/test/fixtures/template/subA/Button.vue
@@ -1,0 +1,3 @@
+<template>
+	<button type="submit">A</button>
+</template>

--- a/packages/@markuplint/pretenders/test/fixtures/template/subB/Button.vue
+++ b/packages/@markuplint/pretenders/test/fixtures/template/subB/Button.vue
@@ -1,0 +1,3 @@
+<template>
+	<div class="b">B</div>
+</template>


### PR DESCRIPTION
## Summary

- **Typo fix**: Rename `createIndentity` → `createIdentity`
- **Eliminate `@ts-ignore`**: Replace 6 occurrences with conditional spreads, `as T`, and `Object.assign`
- **Fix TOCTOU race condition**: Replace boolean flag in `ensureInit()` with Promise cache pattern (`??=`)
- **Add error handling**: `parseComponent` and `resolveBarrelExport` now catch fs/parse errors, return `null`, and `console.warn`
- **Fix `deriveName` empty path**: Fallback to `'index'` when `index.vue` has no parent directory
- **Warn on missing parser package**: `getParser` logs `console.warn` when a framework parser is not installed
- **Prevent name collision**: Pass `importPath` to `PretenderDirector.add()` in both JSX and template scanners so same-name components from different directories are correctly registered

## Test plan

- [x] `yarn lint-check` — 0 errors, 0 warnings
- [x] `yarn build` — all 40 packages built successfully
- [x] `yarn test` — 2906 tests passed (183 test files)
- [x] pretenders package: 208 tests passed
- [x] Name collision: verified at both `templateScanner` unit and `scan()` integration levels
- [x] Error handling: tested with nonexistent file + syntax error (`Malformed.vue`)
- [x] TOCTOU: concurrent `Promise.all` call test added

🤖 Generated with [Claude Code](https://claude.com/claude-code)