### PR TITLE
Update worktree base directory to .worktree

### DIFF
--- a/.claude/commands/git.md
+++ b/.claude/commands/git.md
@@ -10,10 +10,11 @@ description: Git manipulation rules
 git rev-parse --show-toplevel
 ```
 
-- If the result is the main repository path (e.g., ends with `/markuplint`), **STOP immediately**
+- Compare the result against the **main repository root** (the directory containing `CLAUDE.md`, `.claude/`, etc.)
+- If they match, you are in the main working directory — **STOP immediately**
 - Warn the user: "You are in the main working directory. Commits must be made in a worktree."
 - Do NOT proceed with any git operations — use `git wt <branch-name> dev` to create a worktree first
-- Only continue if you are confirmed to be inside a worktree
+- If the result is a different path (e.g., inside `.worktree/`), you are in a worktree — proceed
 
 # Commit creation
 

--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -85,11 +85,11 @@ Use the repository's existing Issue templates (`.github/ISSUE_TEMPLATE/`) as the
    - The Issue number is always available at this point (either from the URL or from Step 1b)
 2. Check for existing worktrees: `git wt`
    - If a worktree for this branch already exists, use it
-3. Worktree path: `../markuplint-wt/<branch-name>` (automatically determined by `wt.basedir`)
+3. Worktree path: `.worktree/<branch-name>` (automatically determined by `wt.basedir`)
 4. Execute:
    ```bash
    git wt <branch-name> dev
-   cd ../markuplint-wt/<branch-name>
+   cd .worktree/<branch-name>
    ```
    `wt.hook` により `yarn install` → `yarn build` が自動実行される
 5. **All subsequent work (analysis, edits, commits) MUST happen in the worktree**

--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,6 @@ packages/@markuplint/rules/src/__*
 # Yarn v4 (node_modules mode)
 .yarn/install-state.gz
 .yarn/build-state.yml
+
+# Worktrees
+.worktree/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -46,6 +46,12 @@
 			"url": "/packages/@markuplint/i18n/$schema.json"
 		}
 	],
+	"files.watcherExclude": {
+		"**/.worktree/**": true
+	},
+	"search.exclude": {
+		"**/.worktree/**": true
+	},
 	"vitest.include": ["**/*.spec.{ts,js}"],
 	"github.copilot.enable": {
 		"*": true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ Each package has a `SKILL.md` with package-specific maintenance guidance.
 
 The main working directory MUST stay on `dev` at all times. Any feature branch work — no matter how small (even a single-file docs change) — MUST be done in a worktree.
 
-Worktree operations use [`git-wt`](https://github.com/k1LoW/git-wt) (`git wt`). Worktrees are created under `../markuplint-wt/<branch-name>` (`wt.basedir` setting).
+Worktree operations use [`git-wt`](https://github.com/k1LoW/git-wt) (`git wt`). Worktrees are created under `.worktree/<branch-name>` (`wt.basedir` setting).
 
 ### Prerequisites
 
@@ -100,7 +100,7 @@ If `git wt` is not installed, install and configure it:
 
 ```bash
 brew install k1LoW/tap/git-wt
-git config wt.basedir "../{gitroot}-wt"
+git config wt.basedir ".worktree"
 git config --add wt.hook "yarn install"
 git config --add wt.hook "yarn build"
 ```
@@ -116,7 +116,7 @@ git config --add wt.hook "yarn build"
    `wt.hook` により `yarn install` → `yarn build` が自動実行される
 3. **Move into the worktree**:
    ```bash
-   cd ../markuplint-wt/<branch-name>
+   cd .worktree/<branch-name>
    ```
 4. **Do all edits, commits, and pushes** from within the worktree
 5. **Clean up** when done:


### PR DESCRIPTION
Fixes #???

## What is the purpose of this PR?

- [ ] Fix bug
- [ ] Fix typo
- [x] Update documents
- [ ] Others

### Description

This PR updates the worktree base directory configuration from `../markuplint-wt/` to `.worktree/` for better project organization and consistency.

**Changes:**
- Updated `CLAUDE.md` to reflect the new worktree path (`.worktree/<branch-name>` instead of `../markuplint-wt/<branch-name>`)
- Updated `.claude/commands/issue.md` with the new worktree path
- Updated `.gitignore` to ignore the `.worktree/` directory
- Updated git configuration example to use `git config wt.basedir ".worktree"`

This change keeps worktrees within the project directory structure rather than as sibling directories, improving project organization and making it easier to manage development workflows.

## Checklist

- [x] Update documents
  - [x] Updated development guidelines in `CLAUDE.md`
  - [x] Updated command documentation in `.claude/commands/issue.md`
  - [x] Updated `.gitignore` to exclude worktree directory

https://claude.ai/code/session_01F171KPx5wQS5EkFWLUQZV2