### PR TITLE
chore: add worktree command execution rules

### DIFF
--- a/.claude/commands/git.md
+++ b/.claude/commands/git.md
@@ -2,6 +2,12 @@
 description: Git manipulation rules
 ---
 
+# Git command execution rules
+
+- **ALWAYS `cd` to the worktree root first, then run git commands from there** — do NOT run git commands from the main working directory when operating on a worktree
+- **NEVER chain commands with `&&`** — each command must be executed separately so the AI agent can request user permission per command without blocking the workflow
+- **NEVER use `git -C <path>`** — same reason; permission prompts become disruptive when bundled with path options
+
 # Worktree Guard (MUST RUN FIRST)
 
 **Before doing ANYTHING else, check that you are in a worktree (NOT the main working directory):**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,14 +4,14 @@ Use the following skills and commands for common tasks. **Always invoke the appr
 
 ## Commands (slash commands)
 
-| Command     | Description                                            | File                                        |
-| ----------- | ------------------------------------------------------ | ------------------------------------------- |
-| `/git`      | Commit rules, message format, and package commit order | [git.md](.claude/commands/git.md)           |
-| `/pr`       | Create and push a pull request via `gh pr create`      | [pr.md](.claude/commands/pr.md)             |
-| `/doc`      | Update documentation (README, ARCHITECTURE, JSDoc)     | [doc.md](.claude/commands/doc.md)           |
-| `/release`  | Create GitHub Release notes                            | [release.md](.claude/commands/release.md)   |
+| Command     | Description                                                  | File                                        |
+| ----------- | ------------------------------------------------------------ | ------------------------------------------- |
+| `/git`      | Commit rules, message format, and package commit order       | [git.md](.claude/commands/git.md)           |
+| `/pr`       | Create and push a pull request via `gh pr create`            | [pr.md](.claude/commands/pr.md)             |
+| `/doc`      | Update documentation (README, ARCHITECTURE, JSDoc)           | [doc.md](.claude/commands/doc.md)           |
+| `/release`  | Create GitHub Release notes                                  | [release.md](.claude/commands/release.md)   |
 | `/issue`    | Analyze or create a GitHub Issue and build a resolution plan | [issue.md](.claude/commands/issue.md)       |
-| `/sponsors` | Check and update GitHub Sponsors listings              | [sponsors.md](.claude/commands/sponsors.md) |
+| `/sponsors` | Check and update GitHub Sponsors listings                    | [sponsors.md](.claude/commands/sponsors.md) |
 
 ## Skills
 
@@ -126,6 +126,7 @@ git config --add wt.hook "yarn build"
 
 ### Important Notes
 
+- **ALWAYS `cd` to the worktree root before running ANY commands** — do NOT run commands from the main working directory when operating on a worktree. Do NOT use `&&` to chain commands (each command must be separate so the AI agent can request permission per command). Do NOT use `git -C <path>` (same reason).
 - **Husky hooks do NOT run in worktrees** — run `yarn lint` manually before every commit
 - **NEVER run `git checkout <branch>` or `git switch` in the main working directory** — use worktrees instead
 - If you catch yourself about to create a branch in the main repo, STOP and use a worktree


### PR DESCRIPTION
## Summary

- Add command execution rules for worktree operations to CLAUDE.md and `/git` command
- Always `cd` to worktree root before running commands
- Never chain commands with `&&` (AI agent needs per-command permission prompts)
- Never use `git -C <path>` (same reason)

## Test plan

- [x] `yarn lint-check` — pass
- Documentation-only change, no build/test impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)