### PR TITLE
fix(spec-generator): add fetch retry, status check, and output validation

### DIFF
--- a/packages/@markuplint/spec-generator/src/fetch.ts
+++ b/packages/@markuplint/spec-generator/src/fetch.ts
@@ -7,6 +7,21 @@ import { Bar, Presets } from 'cli-progress';
 const isCI = Boolean(process.env.CI);
 
 /**
+ * Maximum number of retry attempts for failed fetches.
+ */
+const MAX_RETRIES = 3;
+
+/**
+ * Base delay in milliseconds for exponential backoff between retries.
+ */
+const RETRY_BASE_DELAY_MS = 1000;
+
+/**
+ * User-Agent header sent with all fetch requests.
+ */
+const USER_AGENT = 'markuplint-spec-generator (https://github.com/markuplint/markuplint)';
+
+/**
  * In-memory cache mapping URLs to their raw HTML text responses.
  */
 const cache = new Map<string, string>();
@@ -15,6 +30,11 @@ const cache = new Map<string, string>();
  * In-memory cache mapping URLs to their parsed Cheerio DOM instances.
  */
 const domCache = new Map<string, cheerio.CheerioAPI>();
+
+/**
+ * URLs that failed to fetch successfully.
+ */
+const failedUrls: string[] = [];
 
 let total = 1;
 let current = 0;
@@ -47,7 +67,7 @@ export async function fetch(url: string) {
 }
 
 /**
- * Fetches the raw text content of a URL.
+ * Fetches the raw text content of a URL with retry logic and status code validation.
  * Results are cached so repeated requests for the same URL return the cached response.
  * Updates the CLI progress bar on each call.
  *
@@ -61,14 +81,39 @@ export async function fetchText(url: string) {
 	if (cache.has(url)) {
 		text = cache.get(url)!;
 	} else {
-		try {
-			const res = await globalThis.fetch(url);
-			text = await res.text();
-			cache.set(url, text);
-		} catch {
-			cache.set(url, '');
-			text = '';
+		text = '';
+		for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+			try {
+				const res = await globalThis.fetch(url, {
+					headers: { 'User-Agent': USER_AGENT },
+				});
+				if (!res.ok) {
+					// eslint-disable-next-line no-console
+					console.error(
+						`⚠️ Fetch failed: ${url} (HTTP ${res.status} ${res.statusText}, attempt ${attempt}/${MAX_RETRIES})`,
+					);
+					if (res.status === 404 || attempt >= MAX_RETRIES) {
+						failedUrls.push(url);
+						break;
+					}
+					await delay(RETRY_BASE_DELAY_MS * 2 ** (attempt - 1));
+					continue;
+				}
+				text = await res.text();
+				break;
+			} catch (error) {
+				// eslint-disable-next-line no-console
+				console.error(
+					`⚠️ Fetch error: ${url} (${error instanceof Error ? error.message : String(error)}, attempt ${attempt}/${MAX_RETRIES})`,
+				);
+				if (attempt < MAX_RETRIES) {
+					await delay(RETRY_BASE_DELAY_MS * 2 ** (attempt - 1));
+					continue;
+				}
+				failedUrls.push(url);
+			}
 		}
+		cache.set(url, text);
 	}
 	current += 1;
 	bar?.update(current, { process: `🔗 ${url.length > 30 ? `${url.slice(0, 15)}...${url.slice(-15)}` : url}` });
@@ -86,4 +131,17 @@ export function getReferences() {
 	bar?.update(current, { process: '🎉 Finished.' });
 	bar?.stop();
 	return [...cache.keys()].toSorted();
+}
+
+/**
+ * Returns the list of URLs that failed to fetch after all retries.
+ */
+export function getFailedUrls(): readonly string[] {
+	return failedUrls;
+}
+
+function delay(ms: number) {
+	return new Promise<void>(resolve => {
+		setTimeout(resolve, ms);
+	});
 }

--- a/packages/@markuplint/spec-generator/src/index.ts
+++ b/packages/@markuplint/spec-generator/src/index.ts
@@ -6,12 +6,12 @@
  * and content model definitions into a single output file consumed by the markuplint linter.
  */
 
-import type { ExtendedSpec } from '@markuplint/ml-spec';
+import type { ExtendedElementSpec, ExtendedSpec } from '@markuplint/ml-spec';
 
 import { writeFile } from 'node:fs/promises';
 
 import { getAria } from './aria.js';
-import { getReferences } from './fetch.js';
+import { getFailedUrls, getReferences } from './fetch.js';
 import { getGlobalAttrs } from './global-attrs.js';
 import { getElements } from './html-elements.js';
 import { readJson } from './read-json.js';
@@ -46,6 +46,18 @@ export async function main({ outputFilePath, htmlFilePattern, commonAttrsFilePat
 	]);
 
 	const cites = getReferences();
+	const failedUrls = getFailedUrls();
+
+	if (failedUrls.length > 0) {
+		// eslint-disable-next-line no-console
+		console.error(`\n❌ ${failedUrls.length} URL(s) failed to fetch:`);
+		for (const url of failedUrls) {
+			// eslint-disable-next-line no-console
+			console.error(`   - ${url}`);
+		}
+	}
+
+	validateSpecs(specs);
 
 	const json: ExtendedSpec = {
 		cites,
@@ -63,4 +75,24 @@ export async function main({ outputFilePath, htmlFilePattern, commonAttrsFilePat
 
 	// eslint-disable-next-line no-console
 	console.log(`🎁 Output: ${outputFilePath}`);
+}
+
+/**
+ * Validates the generated specs to detect data loss from failed scraping.
+ * Throws an error if the ratio of empty descriptions exceeds the threshold,
+ * preventing broken data from being written.
+ */
+function validateSpecs(specs: readonly ExtendedElementSpec[]) {
+	const threshold = 0.5;
+	const htmlSpecs = specs.filter(s => !s.name.includes(':'));
+	const emptyDescriptions = htmlSpecs.filter(s => !s.description);
+	const emptyRatio = emptyDescriptions.length / htmlSpecs.length;
+
+	if (emptyRatio > threshold) {
+		throw new Error(
+			`Spec validation failed: ${emptyDescriptions.length}/${htmlSpecs.length} HTML elements ` +
+				`(${Math.round(emptyRatio * 100)}%) have empty descriptions. ` +
+				'This likely indicates MDN fetch failures. Aborting to prevent data loss.',
+		);
+	}
 }


### PR DESCRIPTION
## Summary

- `fetch.ts`: HTTP status check (`res.ok`), User-Agent header, retry with exponential backoff (skip 404), error logging
- `index.ts`: Post-generation validation that aborts if >50% of HTML element descriptions are empty (prevents silent data loss)
- Closed PR #3450 which contained broken spec data

Closes #3456

## Test plan

- [x] `yarn up:gen` produces correct `index.json` (no diff from dev)
- [x] 404 errors for obsolete elements are logged once without retry
- [x] Error logging works (verified with 11 expected 404s)
- [x] Build passes
- [x] ESLint + Prettier clean
- [ ] CI workflow should produce correct data with these fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)