### PR TITLE
fix: support TypeScript 6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
 		"typedoc": "0.28.17",
 		"typedoc-plugin-mdn-links": "5.1.1",
 		"typedoc-plugin-resolve-crossmodule-references": "0.3.3",
-		"typescript": "5.9.3",
+		"typescript": "6.0.2",
 		"vitest": "4.0.18"
 	},
 	"config": {

--- a/packages/@markuplint-dev/tsconfig/tsconfig.json
+++ b/packages/@markuplint-dev/tsconfig/tsconfig.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"types": ["node"],
 		"module": "NodeNext",
 		"target": "ES2022",
 		"strict": true,

--- a/packages/@markuplint/ml-core/src/ml-dom/node/document.ts
+++ b/packages/@markuplint/ml-core/src/ml-dom/node/document.ts
@@ -252,6 +252,17 @@ export class MLDocument<T extends RuleConfigValue, O extends PlainData = undefin
 	/**
 	 * **IT THROWS AN ERROR WHEN CALLING THIS.**
 	 *
+	 * @deprecated
+	 * @unsupported
+	 * @implements DOM API: `Document`
+	 */
+	get activeViewTransition(): ViewTransition | null {
+		throw new UnexpectedCallError('Not supported "activeViewTransition" property');
+	}
+
+	/**
+	 * **IT THROWS AN ERROR WHEN CALLING THIS.**
+	 *
 	 * @unsupported
 	 * @implements DOM API: `Document`
 	 */
@@ -383,6 +394,17 @@ export class MLDocument<T extends RuleConfigValue, O extends PlainData = undefin
 	 */
 	get currentScript(): HTMLOrSVGScriptElement | null {
 		throw new UnexpectedCallError('Not supported "currentScript" property');
+	}
+
+	/**
+	 * **IT THROWS AN ERROR WHEN CALLING THIS.**
+	 *
+	 * @deprecated
+	 * @unsupported
+	 * @implements DOM API: `Document`
+	 */
+	get customElementRegistry(): CustomElementRegistry | null {
+		throw new UnexpectedCallError('Not supported "customElementRegistry" property');
 	}
 
 	/**
@@ -955,6 +977,24 @@ export class MLDocument<T extends RuleConfigValue, O extends PlainData = undefin
 		  ) => any)
 		| null {
 		throw new UnexpectedCallError('Not supported "onclose" property');
+	}
+
+	/**
+	 * **IT THROWS AN ERROR WHEN CALLING THIS.**
+	 *
+	 * @deprecated
+	 * @unsupported
+	 * @implements DOM API: `Document`
+	 */
+	get oncommand():
+		| ((
+				// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+				this: GlobalEventHandlers,
+				// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+				ev: Event,
+		  ) => any)
+		| null {
+		throw new UnexpectedCallError('Not supported "oncommand" property');
 	}
 
 	/**

--- a/packages/@markuplint/ml-core/src/ml-dom/node/element.ts
+++ b/packages/@markuplint/ml-core/src/ml-dom/node/element.ts
@@ -370,7 +370,7 @@ export class MLElement<T extends RuleConfigValue, O extends PlainData = undefine
 	 * @unsupported
 	 * @implements DOM API: `Element`
 	 */
-	get ariaControlsElements(): readonly MLElement<T, O>[] {
+	get ariaControlsElements(): readonly MLElement<T, O>[] | null {
 		throw new UnexpectedCallError('Not supported "ariaControlsElements" property');
 	}
 
@@ -392,7 +392,7 @@ export class MLElement<T extends RuleConfigValue, O extends PlainData = undefine
 	 * @unsupported
 	 * @implements DOM API: `Element`
 	 */
-	get ariaDescribedByElements(): readonly MLElement<T, O>[] {
+	get ariaDescribedByElements(): readonly MLElement<T, O>[] | null {
 		throw new UnexpectedCallError('Not supported "ariaDescribedByElements" property');
 	}
 
@@ -414,7 +414,7 @@ export class MLElement<T extends RuleConfigValue, O extends PlainData = undefine
 	 * @unsupported
 	 * @implements DOM API: `Element`
 	 */
-	get ariaDetailsElements(): readonly MLElement<T, O>[] {
+	get ariaDetailsElements(): readonly MLElement<T, O>[] | null {
 		throw new UnexpectedCallError('Not supported "ariaDetailsElements" property');
 	}
 
@@ -436,7 +436,7 @@ export class MLElement<T extends RuleConfigValue, O extends PlainData = undefine
 	 * @unsupported
 	 * @implements DOM API: `Element`
 	 */
-	get ariaErrorMessageElements(): readonly MLElement<T, O>[] {
+	get ariaErrorMessageElements(): readonly MLElement<T, O>[] | null {
 		throw new UnexpectedCallError('Not supported "ariaErrorMessageElements" property');
 	}
 
@@ -458,7 +458,7 @@ export class MLElement<T extends RuleConfigValue, O extends PlainData = undefine
 	 * @unsupported
 	 * @implements DOM API: `Element`
 	 */
-	get ariaFlowToElements(): readonly MLElement<T, O>[] {
+	get ariaFlowToElements(): readonly MLElement<T, O>[] | null {
 		throw new UnexpectedCallError('Not supported "ariaFlowToElements" property');
 	}
 
@@ -524,7 +524,7 @@ export class MLElement<T extends RuleConfigValue, O extends PlainData = undefine
 	 * @unsupported
 	 * @implements DOM API: `Element`
 	 */
-	get ariaLabelledByElements(): readonly MLElement<T, O>[] {
+	get ariaLabelledByElements(): readonly MLElement<T, O>[] | null {
 		throw new UnexpectedCallError('Not supported "ariaLabelledByElements" property');
 	}
 
@@ -601,7 +601,7 @@ export class MLElement<T extends RuleConfigValue, O extends PlainData = undefine
 	 * @unsupported
 	 * @implements DOM API: `Element`
 	 */
-	get ariaOwnsElements(): readonly MLElement<T, O>[] {
+	get ariaOwnsElements(): readonly MLElement<T, O>[] | null {
 		throw new UnexpectedCallError('Not supported "ariaOwnsElements" property');
 	}
 
@@ -981,6 +981,17 @@ export class MLElement<T extends RuleConfigValue, O extends PlainData = undefine
 	 * @unsupported
 	 * @implements DOM API: `Element`
 	 */
+	get customElementRegistry(): CustomElementRegistry | null {
+		throw new UnexpectedCallError('Not supported "customElementRegistry" property');
+	}
+
+	/**
+	 * **IT THROWS AN ERROR WHEN CALLING THIS.**
+	 *
+	 * @deprecated
+	 * @unsupported
+	 * @implements DOM API: `Element`
+	 */
 	get dataset(): DOMStringMap {
 		throw new UnexpectedCallError('Not supported "dataset" property');
 	}
@@ -1179,7 +1190,7 @@ export class MLElement<T extends RuleConfigValue, O extends PlainData = undefine
 	 * @unsupported
 	 * @implements DOM API: `Element`
 	 */
-	get nonce(): string | undefined {
+	get nonce(): string {
 		throw new UnexpectedCallError('Not supported "nonce" property');
 	}
 
@@ -1524,6 +1535,24 @@ export class MLElement<T extends RuleConfigValue, O extends PlainData = undefine
 		  ) => any)
 		| null {
 		throw new UnexpectedCallError('Not supported "onclose" property');
+	}
+
+	/**
+	 * **IT THROWS AN ERROR WHEN CALLING THIS.**
+	 *
+	 * @deprecated
+	 * @unsupported
+	 * @implements DOM API: `Element`
+	 */
+	get oncommand():
+		| ((
+				// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+				this: GlobalEventHandlers,
+				// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+				ev: Event,
+		  ) => any)
+		| null {
+		throw new UnexpectedCallError('Not supported "oncommand" property');
 	}
 
 	/**
@@ -3838,6 +3867,11 @@ export class MLElement<T extends RuleConfigValue, O extends PlainData = undefine
 	 * @implements DOM API: `Element`
 	 * @see https://dom.spec.whatwg.org/#ref-for-dom-element-matches%E2%91%A0
 	 */
+	matches<K extends keyof HTMLElementTagNameMap>(selectors: K): this is HTMLElementTagNameMap[K];
+	matches<K extends keyof SVGElementTagNameMap>(selectors: K): this is SVGElementTagNameMap[K];
+	matches<K extends keyof MathMLElementTagNameMap>(selectors: K): this is MathMLElementTagNameMap[K];
+	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+	matches(selectors: string, scope?: MLParentNode<T, O>): boolean;
 	matches(
 		selector: string,
 		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types

--- a/packages/@markuplint/ml-core/src/ml-dom/node/node.ts
+++ b/packages/@markuplint/ml-core/src/ml-dom/node/node.ts
@@ -890,6 +890,21 @@ export abstract class MLNode<
 	}
 
 	/**
+	 * **IT THROWS AN ERROR WHEN CALLING THIS.**
+	 *
+	 * @unsupported
+	 * @implements DOM API: `Node`
+	 */
+	moveBefore(
+		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+		node: Node,
+		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+		child: Node | null,
+	): Node {
+		throw new UnexpectedCallError('Not supported "moveBefore" method');
+	}
+
+	/**
 	 * @implements `@markuplint/ml-core` API: `MLNode`
 	 */
 	is<NType extends NodeType>(nodeType: NType): this is NodeTypeOf<NType, T, O> {

--- a/packages/@markuplint/test-tools/src/index.ts
+++ b/packages/@markuplint/test-tools/src/index.ts
@@ -45,7 +45,6 @@ export function createJSDOMElement(
 		globalThis.Element = dom.window.Element;
 		globalThis.getComputedStyle = dom.window.getComputedStyle.bind(dom.window);
 		if (matches) {
-			 
 			dom.window.Element.prototype.matches = function (this: Element, selector: string) {
 				return matches.call(this, selector);
 			} as any;
@@ -58,7 +57,6 @@ export function createJSDOMElement(
 	globalThis.Element = dom.window.Element;
 	globalThis.getComputedStyle = dom.window.getComputedStyle.bind(dom.window);
 	if (matches) {
-		 
 		dom.window.Element.prototype.matches = function (this: Element, selector: string) {
 			return matches.call(this, selector);
 		} as any;

--- a/packages/@markuplint/test-tools/src/index.ts
+++ b/packages/@markuplint/test-tools/src/index.ts
@@ -45,9 +45,10 @@ export function createJSDOMElement(
 		globalThis.Element = dom.window.Element;
 		globalThis.getComputedStyle = dom.window.getComputedStyle.bind(dom.window);
 		if (matches) {
-			dom.window.Element.prototype.matches = function (selector: string) {
+			 
+			dom.window.Element.prototype.matches = function (this: Element, selector: string) {
 				return matches.call(this, selector);
-			};
+			} as any;
 		}
 		return dom.window.document.querySelector('html') as Element;
 	}
@@ -57,9 +58,10 @@ export function createJSDOMElement(
 	globalThis.Element = dom.window.Element;
 	globalThis.getComputedStyle = dom.window.getComputedStyle.bind(dom.window);
 	if (matches) {
-		dom.window.Element.prototype.matches = function (selector: string) {
+		 
+		dom.window.Element.prototype.matches = function (this: Element, selector: string) {
 			return matches.call(this, selector);
-		};
+		} as any;
 	}
 
 	const containerTag = html.indexOf('<td') === 0 ? 'tr' : 'div';

--- a/test/isolated-env/ts/tsconfig.json
+++ b/test/isolated-env/ts/tsconfig.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"types": ["node"],
 		"target": "ESNext",
 		"module": "NodeNext",
 		"moduleResolution": "NodeNext"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,3 @@
 {
-	"extends": ["@markuplint-dev/tsconfig"],
-	"compilerOptions": {
-		"baseUrl": ".",
-		"paths": {
-			"@markuplint/*": ["./packages/@markuplint/*/src"],
-			"*": ["./packages/*/src"]
-		}
-	}
+	"extends": ["@markuplint-dev/tsconfig"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12036,7 +12036,7 @@ __metadata:
     typedoc: "npm:0.28.17"
     typedoc-plugin-mdn-links: "npm:5.1.1"
     typedoc-plugin-resolve-crossmodule-references: "npm:0.3.3"
-    typescript: "npm:5.9.3"
+    typescript: "npm:6.0.2"
     vitest: "npm:4.0.18"
   languageName: unknown
   linkType: soft
@@ -17943,6 +17943,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:6.0.2":
+  version: 6.0.2
+  resolution: "typescript@npm:6.0.2"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/4b860b0bf87cc0fee0f66d8ef2640b5a8a8a8c74d1129adb82e389e5f97124383823c47946bef8a73ede371461143a3aa8544399d2133c7b2e4f07e81860af7f
+  languageName: node
+  linkType: hard
+
 "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A>=3 < 6#optional!builtin<compat/typescript>":
   version: 5.9.3
   resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
@@ -17950,6 +17960,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/ad09fdf7a756814dce65bc60c1657b40d44451346858eea230e10f2e95a289d9183b6e32e5c11e95acc0ccc214b4f36289dcad4bf1886b0adb84d711d336a430
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A6.0.2#optional!builtin<compat/typescript>":
+  version: 6.0.2
+  resolution: "typescript@patch:typescript@npm%3A6.0.2#optional!builtin<compat/typescript>::version=6.0.2&hash=5786d5"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/49f0b84fc6ca55653e77752b8a61beabc09ee3dae5d965c31596225aa6ef213c5727b1d2e895b900416dc603854ba0872ac4a812c2a4ed6793a601f9c675de02
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Update TypeScript from 5.9.3 to 6.0.2
- Remove deprecated `baseUrl` and `paths` from root `tsconfig.json`
- Add `types: ["node"]` to `@markuplint-dev/tsconfig` (TS 6 defaults `types` to `[]`)
- Add DOM stubs for TS 6 `lib.dom.d.ts` updates:
  - `MLNode.moveBefore()`
  - `MLElement.customElementRegistry`, `MLElement.oncommand`
  - `MLElement.matches()` overload signatures (type predicates)
  - `MLElement.aria*Elements` nullable update
  - `MLElement.nonce` type update (`string | undefined` → `string`)
  - `MLDocument.activeViewTransition`, `MLDocument.customElementRegistry`, `MLDocument.oncommand`
- Fix `test-tools` `matches()` stub for TS 6 overloaded signature

Closes #3487
Supersedes #3481

## Test plan

- [x] `yarn build` passes (0 errors)
- [x] `yarn test` passes (all 2962 tests)
- [x] `yarn lint-check` passes (ESLint + Prettier OK; CSpell skipped in worktree — known issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)