### PR TITLE
feat(markuplint): add experimental bulk suppressions

### DIFF
--- a/packages/markuplint/README.md
+++ b/packages/markuplint/README.md
@@ -89,6 +89,12 @@ Options
 	--severity-parse-error                 Specifies the severity level of parse errors. Supports "error", "warning", and "off". Default: "error".
 	--max-count                            Limit the number of violations shown. Default: 0 (no limit).
 	--max-warnings                         Number of warnings to trigger nonzero exit code. Default: -1 (no limit).
+	--progressive-output                   Output results immediately after processing each file. Default: false.
+
+	--suppress                             [Experimental] Generate/update suppressions file for all current errors.
+	--suppress-rule RULE_ID                [Experimental] Suppress only the specified rule.
+	--prune-suppressions                   [Experimental] Remove stale entries from the suppressions file.
+	--suppressions-location PATH           [Experimental] Custom path for the suppressions file. Default: "markuplint-suppressions.json".
 
 	--init                                 Initialize settings interactively.
 	--search                               Search lines of codes that include the target element by selectors.
@@ -101,6 +107,34 @@ Examples
 	$ markuplint "**/*.html" --max-count=10
 	$ cat verifyee.html | markuplint
 ```
+
+### Bulk Suppressions (Experimental)
+
+> **This feature is experimental and may change in future releases.**
+
+When introducing new rules to an existing project, you can suppress current violations and enforce rules only on new code.
+
+**Typical workflow:**
+
+```bash
+# 1. Enable new rules in your config, then suppress all current errors
+$ markuplint --suppress "src/**/*.html"
+
+# 2. Commit the generated suppressions file to your repository
+$ git add markuplint-suppressions.json
+
+# 3. From now on, only new violations are reported
+$ markuplint "src/**/*.html"
+
+# 4. As you fix existing violations, clean up stale entries
+$ markuplint --prune-suppressions "src/**/*.html"
+```
+
+- Only `error`-severity violations are suppressed; `warning` and `info` always pass through.
+- If the number of violations for a file+rule pair **exceeds** the suppressed count, **all** violations for that pair are reported.
+- `--suppress` always exits with code 0 (success).
+
+See [ESLint's Bulk Suppressions](https://eslint.org/docs/latest/use/suppressions) for the reference design. Tracking issue: [#3503](https://github.com/markuplint/markuplint/issues/3503).
 
 ## Documentation
 

--- a/packages/markuplint/src/cli/bootstrap.ts
+++ b/packages/markuplint/src/cli/bootstrap.ts
@@ -32,6 +32,11 @@ Options
 	--max-warnings                         Number of warnings to trigger nonzero exit code. Default: -1 (no limit).
 	--progressive-output                   Output results immediately after processing each file. Default: false.
 
+	--suppress                             [Experimental] Generate/update suppressions file for all current errors.
+	--suppress-rule RULE_ID                [Experimental] Suppress only the specified rule.
+	--prune-suppressions                   [Experimental] Remove stale entries from the suppressions file.
+	--suppressions-location PATH           [Experimental] Custom path for the suppressions file. Default: "markuplint-suppressions.json".
+
 	--init                                 Initialize settings interactively.
 	--search                               Search lines of codes that include the target element by selectors.
 
@@ -136,6 +141,20 @@ export const cli = meow(help, {
 			type: 'boolean',
 			// TODO: It will be changed to `true` in the next major version.
 			default: false,
+		},
+		suppress: {
+			type: 'boolean',
+			default: false,
+		},
+		suppressRule: {
+			type: 'string',
+		},
+		pruneSuppressions: {
+			type: 'boolean',
+			default: false,
+		},
+		suppressionsLocation: {
+			type: 'string',
 		},
 	},
 });

--- a/packages/markuplint/src/cli/command.ts
+++ b/packages/markuplint/src/cli/command.ts
@@ -1,16 +1,26 @@
 import type { CLIOptions } from './bootstrap.js';
 import type { APIOptions } from '../api/types.js';
 import type { Target } from '@markuplint/file-resolver';
-import type { Severity, SeverityOptions } from '@markuplint/ml-config';
+import type { Severity, SeverityOptions, Violation } from '@markuplint/ml-config';
 
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
 import { resolveFiles } from '@markuplint/file-resolver';
 import { ViolationCollector } from '@markuplint/ml-core';
+import { isFatalError } from '@markuplint/shared';
 
 import { MLEngine } from '../api/index.js';
 import { log } from '../debug.js';
+import {
+	applySuppressions,
+	generateSuppressions,
+	mergeSuppressions,
+	pruneSuppressions,
+	readSuppressionsFile,
+	resolveSuppressionsPath,
+	writeSuppressionsFile,
+} from '../suppressions/index.js';
 
 import { outputDryRunDiff } from './dry-run-output.js';
 import { output } from './output.js';
@@ -34,6 +44,22 @@ export async function command(files: readonly Readonly<Target>[], options: CLIOp
 		process.stderr.write('Warning: --fix-dry-run takes precedence over --fix. Files will not be modified.\n');
 	}
 	const fix = options.fix || fixDryRun;
+
+	// Mutual exclusion checks for suppressions flags
+	const isSuppressMode = options.suppress || options.suppressRule != null;
+	const isPruneMode = options.pruneSuppressions;
+
+	if (isSuppressMode && fix) {
+		process.stderr.write(
+			'Warning: --suppress counts violations from the original code, not from the fixed result. Consider running --fix first, then --suppress.\n',
+		);
+	}
+
+	if (isSuppressMode && isPruneMode) {
+		process.stderr.write('Error: --suppress/--suppress-rule and --prune-suppressions cannot be used together.\n');
+		return true;
+	}
+
 	const configFile =
 		options.config &&
 		(path.isAbsolute(options.config) ? options.config : path.resolve(process.cwd(), options.config));
@@ -168,21 +194,114 @@ export async function command(files: readonly Readonly<Target>[], options: CLIOp
 		}
 	}
 
+	// --- Suppressions handling ---
+	const suppressionsFilePath = resolveSuppressionsPath(options.suppressionsLocation);
+	const collectedViolationsByFile = collector.groupByFile();
+
+	if (isSuppressMode) {
+		// Suppress mode: generate/update suppressions file
+		const existing = await readSuppressionsFile(suppressionsFilePath);
+		const generated = generateSuppressions(collectedViolationsByFile, suppressionsFilePath, options.suppressRule);
+		const merged = mergeSuppressions(existing, generated);
+		await writeSuppressionsFile(suppressionsFilePath, merged);
+
+		let totalSuppressed = 0;
+		let totalRules = 0;
+		for (const rules of Object.values(generated)) {
+			for (const entry of Object.values(rules)) {
+				totalSuppressed += entry.count;
+				totalRules++;
+			}
+		}
+		process.stderr.write(
+			`[Experimental] ${totalSuppressed} violation(s) for ${totalRules} rule(s) suppressed in ${path.relative(process.cwd(), suppressionsFilePath)}\n`,
+		);
+		return false;
+	}
+
+	if (isPruneMode) {
+		// Prune mode: remove stale entries
+		const existing = await readSuppressionsFile(suppressionsFilePath);
+		if (Object.keys(existing).length === 0) {
+			process.stderr.write('No suppressions file found. Nothing to prune.\n');
+			return false;
+		}
+		const pruned = pruneSuppressions(collectedViolationsByFile, existing, suppressionsFilePath);
+		await writeSuppressionsFile(suppressionsFilePath, pruned);
+
+		const existingCount = Object.values(existing).reduce((sum, rules) => sum + Object.keys(rules).length, 0);
+		const prunedCount = Object.values(pruned).reduce((sum, rules) => sum + Object.keys(rules).length, 0);
+		const removedCount = existingCount - prunedCount;
+		process.stderr.write(
+			`[Experimental] Suppressions pruned: ${removedCount} entry/entries removed, ${prunedCount} remaining.\n`,
+		);
+		return false;
+	}
+
+	// Normal lint mode: apply suppressions if file exists
+	let outputViolationsByFile = collectedViolationsByFile;
+	let suppressionsApplied = false;
+
+	try {
+		await fs.access(suppressionsFilePath);
+		const suppressionsData = await readSuppressionsFile(suppressionsFilePath);
+		if (Object.keys(suppressionsData).length > 0) {
+			const { filtered, unusedEntries } = applySuppressions(
+				collectedViolationsByFile,
+				suppressionsData,
+				suppressionsFilePath,
+			);
+			outputViolationsByFile = filtered;
+			suppressionsApplied = true;
+
+			if (unusedEntries.length > 0) {
+				process.stderr.write(
+					`[Experimental] ${unusedEntries.length} unused suppression entry/entries found. Run with --prune-suppressions to clean up.\n`,
+				);
+			}
+
+			// Recalculate hasError and totalWarningCount from filtered violations
+			hasError = false;
+			totalWarningCount = 0;
+			for (const violations of filtered.values()) {
+				const errorCount = violations.filter(v => v.severity === 'error').length;
+				const warningCount = violations.filter(v => v.severity === 'warning').length;
+				totalWarningCount += warningCount;
+				if (errorCount > 0 || (warningCount > 0 && !options.allowWarnings)) {
+					hasError = true;
+				}
+			}
+		}
+	} catch (error) {
+		if (isFatalError(error)) {
+			throw error;
+		}
+		// Suppressions file does not exist or is unreadable, proceed normally
+	}
+
 	// Output results
 	if (format === 'json') {
-		const jsonOutput = collector.toArray();
-		process.stdout.write(JSON.stringify(jsonOutput, null, 2) + '\n');
+		if (suppressionsApplied) {
+			// Build filtered array with filePath
+			const jsonOutput: (Violation & { filePath: string })[] = [];
+			for (const [filePath, violations] of outputViolationsByFile) {
+				for (const violation of violations) {
+					jsonOutput.push({ ...violation, filePath });
+				}
+			}
+			process.stdout.write(JSON.stringify(jsonOutput, null, 2) + '\n');
+		} else {
+			const jsonOutput = collector.toArray();
+			process.stdout.write(JSON.stringify(jsonOutput, null, 2) + '\n');
+		}
 		return false;
 	}
 
 	// Progressive出力が無効の場合のみループ後に出力
 	if (!options.progressiveOutput) {
-		// For standard/simple/github output, group violations by file
-		const violationsByFile = collector.groupByFile();
-
 		// Output per file - include processed files without violations
 		for (const filePath of processedFiles) {
-			const violations = violationsByFile.get(filePath) || [];
+			const violations = outputViolationsByFile.get(filePath) || [];
 			const content = filesContent.get(filePath) || { sourceCode: '', fixedCode: '' };
 
 			if (violations.length === 0 && !options.problemOnly) {

--- a/packages/markuplint/src/cli/suppressions.spec.ts
+++ b/packages/markuplint/src/cli/suppressions.spec.ts
@@ -1,0 +1,144 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { execa } from '@markuplint/test-tools';
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+
+const entryFilePath = path.resolve(import.meta.dirname, '../../bin/markuplint.mjs');
+const fixtureDir = path.resolve(import.meta.dirname, '../../test/suppressions');
+const targetFile = path.join(fixtureDir, 'target.html');
+
+describe('Bulk Suppressions CLI', () => {
+	let tmpDir: string;
+
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'markuplint-suppress-test-'));
+	});
+
+	afterEach(async () => {
+		await fs.rm(tmpDir, { recursive: true, force: true });
+	});
+
+	test('--suppress creates suppressions file', async () => {
+		const suppressionsFile = path.join(tmpDir, 'markuplint-suppressions.json');
+
+		const { exitCode, stderr } = await execa(
+			entryFilePath,
+			['--suppress', '--suppressions-location', suppressionsFile, targetFile],
+			{ reject: false },
+		);
+
+		expect(exitCode).toBe(0);
+		expect(stderr).toContain('[Experimental]');
+		expect(stderr).toContain('2 violation(s)');
+
+		const content = JSON.parse(await fs.readFile(suppressionsFile, 'utf8'));
+		const keys = Object.keys(content);
+		expect(keys).toHaveLength(1);
+
+		const fileEntry = content[keys[0]!]!;
+		expect(fileEntry['attr-duplication']).toStrictEqual({ count: 2 });
+	});
+
+	test('normal lint suppresses errors when suppressions file exists', async () => {
+		const suppressionsFile = path.join(tmpDir, 'markuplint-suppressions.json');
+
+		// First, generate suppressions
+		await execa(entryFilePath, ['--suppress', '--suppressions-location', suppressionsFile, targetFile], {
+			reject: false,
+		});
+
+		// Now lint with suppressions
+		const { exitCode, stdout } = await execa(
+			entryFilePath,
+			['--no-color', '--format', 'json', '--suppressions-location', suppressionsFile, targetFile],
+			{ reject: false },
+		);
+
+		expect(exitCode).toBe(0);
+		const violations = JSON.parse(stdout);
+		// Only warning should remain (case-sensitive-attr-name)
+		expect(violations).toHaveLength(1);
+		expect(violations[0].ruleId).toBe('case-sensitive-attr-name');
+		expect(violations[0].severity).toBe('warning');
+	});
+
+	test('reports ALL violations when count exceeds suppressed count', async () => {
+		const suppressionsFile = path.join(tmpDir, 'markuplint-suppressions.json');
+
+		// Write a suppressions file with count=1 (less than actual 2 violations)
+		const relPath = path.relative(tmpDir, targetFile).split(path.sep).join('/');
+		const suppressionsData = {
+			[relPath]: { 'attr-duplication': { count: 1 } },
+		};
+		await fs.writeFile(suppressionsFile, JSON.stringify(suppressionsData), 'utf8');
+
+		const { stdout } = await execa(
+			entryFilePath,
+			['--no-color', '--format', 'json', '--suppressions-location', suppressionsFile, targetFile],
+			{ reject: false },
+		);
+
+		const violations = JSON.parse(stdout);
+		// All 3 violations should be reported (2 errors + 1 warning)
+		const errors = violations.filter((v: { severity: string }) => v.severity === 'error');
+		expect(errors).toHaveLength(2);
+	});
+
+	test('--suppress-rule only suppresses specified rule', async () => {
+		const suppressionsFile = path.join(tmpDir, 'markuplint-suppressions.json');
+
+		const { exitCode } = await execa(
+			entryFilePath,
+			['--suppress-rule', 'attr-duplication', '--suppressions-location', suppressionsFile, targetFile],
+			{ reject: false },
+		);
+
+		expect(exitCode).toBe(0);
+
+		const content = JSON.parse(await fs.readFile(suppressionsFile, 'utf8'));
+		const keys = Object.keys(content);
+		const fileEntry = content[keys[0]!]!;
+		expect(fileEntry['attr-duplication']).toBeDefined();
+		// case-sensitive-attr-name is a warning, not suppressed
+		expect(fileEntry['case-sensitive-attr-name']).toBeUndefined();
+	});
+
+	test('--prune-suppressions removes stale entries', async () => {
+		const suppressionsFile = path.join(tmpDir, 'markuplint-suppressions.json');
+
+		// Write suppressions with a stale entry
+		const relPath = path.relative(tmpDir, targetFile).split(path.sep).join('/');
+		const suppressionsData = {
+			[relPath]: {
+				'attr-duplication': { count: 2 },
+				'nonexistent-rule': { count: 5 },
+			},
+		};
+		await fs.writeFile(suppressionsFile, JSON.stringify(suppressionsData), 'utf8');
+
+		const { exitCode, stderr } = await execa(
+			entryFilePath,
+			['--prune-suppressions', '--suppressions-location', suppressionsFile, targetFile],
+			{ reject: false },
+		);
+
+		expect(exitCode).toBe(0);
+		expect(stderr).toContain('1 entry/entries removed');
+
+		const content = JSON.parse(await fs.readFile(suppressionsFile, 'utf8'));
+		const fileEntry = content[Object.keys(content)[0]!]!;
+		expect(fileEntry['attr-duplication']).toBeDefined();
+		expect(fileEntry['nonexistent-rule']).toBeUndefined();
+	});
+
+	test('--suppress and --prune-suppressions together is an error', async () => {
+		const { exitCode, stderr } = await execa(entryFilePath, ['--suppress', '--prune-suppressions', targetFile], {
+			reject: false,
+		});
+
+		expect(exitCode).toBe(1);
+		expect(stderr).toContain('cannot be used together');
+	});
+});

--- a/packages/markuplint/src/suppressions/apply-suppressions.spec.ts
+++ b/packages/markuplint/src/suppressions/apply-suppressions.spec.ts
@@ -1,0 +1,103 @@
+import type { Violation } from '@markuplint/ml-config';
+
+import { describe, it, expect } from 'vitest';
+
+import { applySuppressions } from './apply-suppressions.js';
+
+function v(ruleId: string, severity: 'error' | 'warning' | 'info' = 'error'): Violation {
+	return { ruleId, severity, message: 'test', line: 1, col: 1, raw: '' };
+}
+
+describe('applySuppressions', () => {
+	const suppressionsPath = '/project/markuplint-suppressions.json';
+
+	it('suppresses all errors when count <= suppressed count', () => {
+		const violations = new Map<string, Violation[]>([['/project/src/a.html', [v('rule-a'), v('rule-a')]]]);
+		const suppressions = {
+			'src/a.html': { 'rule-a': { count: 3 } },
+		};
+
+		const { filtered } = applySuppressions(violations, suppressions, suppressionsPath);
+		expect(filtered.get('/project/src/a.html')).toStrictEqual([]);
+	});
+
+	it('reports ALL violations when count > suppressed count', () => {
+		const violations = new Map<string, Violation[]>([
+			['/project/src/a.html', [v('rule-a'), v('rule-a'), v('rule-a')]],
+		]);
+		const suppressions = {
+			'src/a.html': { 'rule-a': { count: 2 } },
+		};
+
+		const { filtered } = applySuppressions(violations, suppressions, suppressionsPath);
+		expect(filtered.get('/project/src/a.html')).toHaveLength(3);
+	});
+
+	it('passes through warning and info violations', () => {
+		const violations = new Map<string, Violation[]>([
+			['/project/src/a.html', [v('rule-a', 'error'), v('rule-b', 'warning'), v('rule-c', 'info')]],
+		]);
+		const suppressions = {
+			'src/a.html': { 'rule-a': { count: 1 } },
+		};
+
+		const { filtered } = applySuppressions(violations, suppressions, suppressionsPath);
+		const result = filtered.get('/project/src/a.html')!;
+		expect(result).toHaveLength(2);
+		expect(result[0]!.severity).toBe('warning');
+		expect(result[1]!.severity).toBe('info');
+	});
+
+	it('passes through violations for files not in suppressions', () => {
+		const violations = new Map<string, Violation[]>([['/project/src/unknown.html', [v('rule-a')]]]);
+
+		const { filtered } = applySuppressions(violations, {}, suppressionsPath);
+		expect(filtered.get('/project/src/unknown.html')).toHaveLength(1);
+	});
+
+	it('passes through violations for rules not in suppressions', () => {
+		const violations = new Map<string, Violation[]>([['/project/src/a.html', [v('rule-unknown')]]]);
+		const suppressions = {
+			'src/a.html': { 'rule-a': { count: 1 } },
+		};
+
+		const { filtered } = applySuppressions(violations, suppressions, suppressionsPath);
+		expect(filtered.get('/project/src/a.html')).toHaveLength(1);
+	});
+
+	it('detects unused suppression entries', () => {
+		const violations = new Map<string, Violation[]>([['/project/src/a.html', [v('rule-a')]]]);
+		const suppressions = {
+			'src/a.html': { 'rule-a': { count: 1 }, 'rule-b': { count: 2 } },
+			'src/deleted.html': { 'rule-c': { count: 1 } },
+		};
+
+		const { unusedEntries } = applySuppressions(violations, suppressions, suppressionsPath);
+		expect(unusedEntries).toContain('src/a.html:rule-b');
+		expect(unusedEntries).toContain('src/deleted.html:rule-c');
+		expect(unusedEntries).not.toContain('src/a.html:rule-a');
+	});
+
+	it('handles mixed scenario: one suppressed, one over limit, one unknown', () => {
+		const violations = new Map<string, Violation[]>([
+			['/project/src/a.html', [v('rule-a'), v('rule-a'), v('rule-b'), v('rule-b'), v('rule-b'), v('rule-c')]],
+		]);
+		const suppressions = {
+			'src/a.html': {
+				'rule-a': { count: 2 }, // exact match → suppressed
+				'rule-b': { count: 1 }, // exceeded → all reported
+			},
+		};
+
+		const { filtered } = applySuppressions(violations, suppressions, suppressionsPath);
+		const result = filtered.get('/project/src/a.html')!;
+
+		// rule-a: 2 violations, count=2 → suppressed (0 remaining)
+		// rule-b: 3 violations, count=1 → all 3 reported
+		// rule-c: 1 violation, not in suppressions → reported
+		expect(result).toHaveLength(4);
+		expect(result.filter(r => r.ruleId === 'rule-a')).toHaveLength(0);
+		expect(result.filter(r => r.ruleId === 'rule-b')).toHaveLength(3);
+		expect(result.filter(r => r.ruleId === 'rule-c')).toHaveLength(1);
+	});
+});

--- a/packages/markuplint/src/suppressions/apply-suppressions.ts
+++ b/packages/markuplint/src/suppressions/apply-suppressions.ts
@@ -1,0 +1,102 @@
+import type { Violation } from '@markuplint/ml-config';
+
+import type { SuppressionsData } from './types.js';
+
+import { toRelativePath } from './suppressions-file.js';
+
+/**
+ * @experimental
+ * Result of applying suppressions to violations.
+ */
+export type ApplySuppressionsResult = {
+	/** Violations after filtering out suppressed ones. */
+	readonly filtered: Map<string, Violation[]>;
+	/** List of unused suppression entries (as "filePath:ruleId" strings). */
+	readonly unusedEntries: readonly string[];
+};
+
+/**
+ * @experimental
+ * Applies suppressions to collected violations.
+ *
+ * For each file+ruleId pair:
+ * - If current error count <= suppressed count: all error violations for that rule are removed.
+ * - If current error count > suppressed count: ALL violations are kept (reported).
+ *
+ * Warning and info violations always pass through unmodified.
+ *
+ * @param violationsByFile - Map of absolute file paths to violations.
+ * @param suppressions - The loaded suppressions data.
+ * @param suppressionsFilePath - Absolute path to the suppressions file.
+ * @returns Filtered violations and a list of unused suppression entries.
+ */
+
+export function applySuppressions(
+	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+	violationsByFile: ReadonlyMap<string, readonly Violation[]>,
+	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+	suppressions: SuppressionsData,
+	suppressionsFilePath: string,
+): ApplySuppressionsResult {
+	const filtered = new Map<string, Violation[]>();
+	const usedEntries = new Set<string>();
+
+	for (const [absolutePath, violations] of violationsByFile) {
+		const relPath = toRelativePath(absolutePath, suppressionsFilePath);
+		const fileSuppressions = suppressions[relPath];
+
+		if (!fileSuppressions) {
+			// No suppressions for this file, pass all through
+			filtered.set(absolutePath, [...violations]);
+			continue;
+		}
+
+		// Count error violations per ruleId
+		const errorCounts = new Map<string, number>();
+		for (const v of violations) {
+			if (v.severity === 'error') {
+				errorCounts.set(v.ruleId, (errorCounts.get(v.ruleId) ?? 0) + 1);
+			}
+		}
+
+		// Determine which rules are suppressed.
+		// ESLint-compatible behavior: if current count exceeds the suppressed count,
+		// ALL violations are reported (not just the delta). This conservative approach
+		// avoids hiding regressions — if violations grew, the user sees the full picture.
+		const suppressedRules = new Set<string>();
+		for (const [ruleId, entry] of Object.entries(fileSuppressions)) {
+			const currentCount = errorCounts.get(ruleId) ?? 0;
+			if (currentCount > 0 && currentCount <= entry.count) {
+				suppressedRules.add(ruleId);
+			}
+			if (currentCount > 0) {
+				usedEntries.add(`${relPath}:${ruleId}`);
+			}
+		}
+
+		// Filter violations
+		const fileFiltered: Violation[] = [];
+		for (const v of violations) {
+			if (v.severity === 'error' && suppressedRules.has(v.ruleId)) {
+				// Suppressed, skip
+				continue;
+			}
+			fileFiltered.push(v);
+		}
+
+		filtered.set(absolutePath, fileFiltered);
+	}
+
+	// Find unused entries
+	const unusedEntries: string[] = [];
+	for (const [relPath, rules] of Object.entries(suppressions)) {
+		for (const ruleId of Object.keys(rules)) {
+			const key = `${relPath}:${ruleId}`;
+			if (!usedEntries.has(key)) {
+				unusedEntries.push(key);
+			}
+		}
+	}
+
+	return { filtered, unusedEntries };
+}

--- a/packages/markuplint/src/suppressions/generate-suppressions.spec.ts
+++ b/packages/markuplint/src/suppressions/generate-suppressions.spec.ts
@@ -1,0 +1,67 @@
+import type { Violation } from '@markuplint/ml-config';
+
+import { describe, it, expect } from 'vitest';
+
+import { generateSuppressions } from './generate-suppressions.js';
+
+function v(ruleId: string, severity: 'error' | 'warning' | 'info' = 'error'): Violation {
+	return { ruleId, severity, message: 'test', line: 1, col: 1, raw: '' };
+}
+
+describe('generateSuppressions', () => {
+	const suppressionsPath = '/project/markuplint-suppressions.json';
+
+	it('counts error violations per file and rule', () => {
+		const map = new Map<string, Violation[]>([
+			['/project/src/a.html', [v('rule-a'), v('rule-a'), v('rule-b')]],
+			['/project/src/b.html', [v('rule-c')]],
+		]);
+
+		const result = generateSuppressions(map, suppressionsPath);
+		expect(result).toStrictEqual({
+			'src/a.html': {
+				'rule-a': { count: 2 },
+				'rule-b': { count: 1 },
+			},
+			'src/b.html': {
+				'rule-c': { count: 1 },
+			},
+		});
+	});
+
+	it('ignores warning and info violations', () => {
+		const map = new Map<string, Violation[]>([
+			['/project/src/a.html', [v('rule-a', 'error'), v('rule-b', 'warning'), v('rule-c', 'info')]],
+		]);
+
+		const result = generateSuppressions(map, suppressionsPath);
+		expect(result).toStrictEqual({
+			'src/a.html': {
+				'rule-a': { count: 1 },
+			},
+		});
+	});
+
+	it('filters by specific rule when filterRule is provided', () => {
+		const map = new Map<string, Violation[]>([['/project/src/a.html', [v('rule-a'), v('rule-a'), v('rule-b')]]]);
+
+		const result = generateSuppressions(map, suppressionsPath, 'rule-a');
+		expect(result).toStrictEqual({
+			'src/a.html': {
+				'rule-a': { count: 2 },
+			},
+		});
+	});
+
+	it('returns empty object when no error violations exist', () => {
+		const map = new Map<string, Violation[]>([['/project/src/a.html', [v('rule-a', 'warning')]]]);
+
+		const result = generateSuppressions(map, suppressionsPath);
+		expect(result).toStrictEqual({});
+	});
+
+	it('returns empty object for empty input', () => {
+		const result = generateSuppressions(new Map(), suppressionsPath);
+		expect(result).toStrictEqual({});
+	});
+});

--- a/packages/markuplint/src/suppressions/generate-suppressions.ts
+++ b/packages/markuplint/src/suppressions/generate-suppressions.ts
@@ -1,0 +1,49 @@
+import type { Violation } from '@markuplint/ml-config';
+
+import type { SuppressionsData } from './types.js';
+
+import { toRelativePath } from './suppressions-file.js';
+
+/**
+ * @experimental
+ * Generates suppressions data from collected violations.
+ * Only error-severity violations are counted.
+ *
+ * @param violationsByFile - Map of absolute file paths to their violations.
+ * @param suppressionsFilePath - Absolute path to the suppressions file (used for relative path calculation).
+ * @param filterRule - If provided, only count violations for this specific ruleId.
+ * @returns The generated suppressions data.
+ */
+export function generateSuppressions(
+	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+	violationsByFile: ReadonlyMap<string, readonly Violation[]>,
+	suppressionsFilePath: string,
+	filterRule?: string,
+): SuppressionsData {
+	const data: SuppressionsData = {};
+
+	for (const [absolutePath, violations] of violationsByFile) {
+		const counts: Record<string, number> = {};
+
+		for (const v of violations) {
+			if (v.severity !== 'error') {
+				continue;
+			}
+			if (filterRule && v.ruleId !== filterRule) {
+				continue;
+			}
+			counts[v.ruleId] = (counts[v.ruleId] ?? 0) + 1;
+		}
+
+		if (Object.keys(counts).length > 0) {
+			const relPath = toRelativePath(absolutePath, suppressionsFilePath);
+			const rules: Record<string, { count: number }> = {};
+			for (const [ruleId, count] of Object.entries(counts)) {
+				rules[ruleId] = { count };
+			}
+			data[relPath] = rules;
+		}
+	}
+
+	return data;
+}

--- a/packages/markuplint/src/suppressions/index.ts
+++ b/packages/markuplint/src/suppressions/index.ts
@@ -1,0 +1,24 @@
+/**
+ * @experimental Bulk Suppressions for markuplint.
+ *
+ * Allows recording existing violations in a JSON file and suppressing them
+ * during subsequent lint runs, so new code is strictly enforced while
+ * existing violations are addressed incrementally.
+ *
+ * @see https://github.com/markuplint/markuplint/issues/3503
+ * @see https://eslint.org/docs/latest/use/suppressions — Reference design
+ */
+
+export type { SuppressionsData, SuppressionEntry } from './types.js';
+export type { ApplySuppressionsResult } from './apply-suppressions.js';
+export { applySuppressions } from './apply-suppressions.js';
+export { generateSuppressions } from './generate-suppressions.js';
+export { mergeSuppressions } from './merge-suppressions.js';
+export { pruneSuppressions } from './prune-suppressions.js';
+export {
+	readSuppressionsFile,
+	writeSuppressionsFile,
+	resolveSuppressionsPath,
+	toRelativePath,
+	toAbsolutePath,
+} from './suppressions-file.js';

--- a/packages/markuplint/src/suppressions/merge-suppressions.spec.ts
+++ b/packages/markuplint/src/suppressions/merge-suppressions.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+
+import { mergeSuppressions } from './merge-suppressions.js';
+
+describe('mergeSuppressions', () => {
+	it('returns incoming when existing is empty', () => {
+		const incoming = { 'a.html': { 'rule-a': { count: 2 } } };
+		expect(mergeSuppressions({}, incoming)).toStrictEqual(incoming);
+	});
+
+	it('returns existing when incoming is empty', () => {
+		const existing = { 'a.html': { 'rule-a': { count: 2 } } };
+		expect(mergeSuppressions(existing, {})).toStrictEqual(existing);
+	});
+
+	it('takes the maximum count for overlapping entries', () => {
+		const existing = { 'a.html': { 'rule-a': { count: 3 } } };
+		const incoming = { 'a.html': { 'rule-a': { count: 5 } } };
+		expect(mergeSuppressions(existing, incoming)).toStrictEqual({
+			'a.html': { 'rule-a': { count: 5 } },
+		});
+	});
+
+	it('keeps existing count when it is higher', () => {
+		const existing = { 'a.html': { 'rule-a': { count: 5 } } };
+		const incoming = { 'a.html': { 'rule-a': { count: 2 } } };
+		expect(mergeSuppressions(existing, incoming)).toStrictEqual({
+			'a.html': { 'rule-a': { count: 5 } },
+		});
+	});
+
+	it('preserves non-overlapping entries from both sides', () => {
+		const existing = { 'a.html': { 'rule-a': { count: 1 } } };
+		const incoming = { 'b.html': { 'rule-b': { count: 2 } } };
+		expect(mergeSuppressions(existing, incoming)).toStrictEqual({
+			'a.html': { 'rule-a': { count: 1 } },
+			'b.html': { 'rule-b': { count: 2 } },
+		});
+	});
+
+	it('merges multiple rules within the same file', () => {
+		const existing = { 'a.html': { 'rule-a': { count: 1 } } };
+		const incoming = { 'a.html': { 'rule-b': { count: 2 } } };
+		expect(mergeSuppressions(existing, incoming)).toStrictEqual({
+			'a.html': {
+				'rule-a': { count: 1 },
+				'rule-b': { count: 2 },
+			},
+		});
+	});
+});

--- a/packages/markuplint/src/suppressions/merge-suppressions.ts
+++ b/packages/markuplint/src/suppressions/merge-suppressions.ts
@@ -1,0 +1,39 @@
+import type { SuppressionsData } from './types.js';
+
+/**
+ * @experimental
+ * Merges incoming suppressions into existing suppressions.
+ * For overlapping entries, takes the maximum count.
+ *
+ * @param existing - The current suppressions data.
+ * @param incoming - The new suppressions data to merge.
+ * @returns The merged suppressions data.
+ */
+// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+export function mergeSuppressions(existing: SuppressionsData, incoming: SuppressionsData): SuppressionsData {
+	// Uses max(count) to ensure running --suppress multiple times is idempotent
+	// and never accidentally lowers a suppression threshold. Counts are only
+	// reduced explicitly via --prune-suppressions.
+	const merged: SuppressionsData = {};
+
+	// Collect all file paths
+	const allFiles = new Set([...Object.keys(existing), ...Object.keys(incoming)]);
+
+	for (const filePath of allFiles) {
+		const existingRules = existing[filePath] ?? {};
+		const incomingRules = incoming[filePath] ?? {};
+
+		const allRules = new Set([...Object.keys(existingRules), ...Object.keys(incomingRules)]);
+		const mergedRules: Record<string, { count: number }> = {};
+
+		for (const ruleId of allRules) {
+			const existingCount = existingRules[ruleId]?.count ?? 0;
+			const incomingCount = incomingRules[ruleId]?.count ?? 0;
+			mergedRules[ruleId] = { count: Math.max(existingCount, incomingCount) };
+		}
+
+		merged[filePath] = mergedRules;
+	}
+
+	return merged;
+}

--- a/packages/markuplint/src/suppressions/prune-suppressions.spec.ts
+++ b/packages/markuplint/src/suppressions/prune-suppressions.spec.ts
@@ -1,0 +1,94 @@
+import type { Violation } from '@markuplint/ml-config';
+
+import { describe, it, expect } from 'vitest';
+
+import { pruneSuppressions } from './prune-suppressions.js';
+
+function v(ruleId: string, severity: 'error' | 'warning' | 'info' = 'error'): Violation {
+	return { ruleId, severity, message: 'test', line: 1, col: 1, raw: '' };
+}
+
+describe('pruneSuppressions', () => {
+	const suppressionsPath = '/project/markuplint-suppressions.json';
+
+	it('removes entries with 0 current violations', () => {
+		const violations = new Map<string, Violation[]>([['/project/src/a.html', []]]);
+		const existing = {
+			'src/a.html': { 'rule-a': { count: 3 } },
+		};
+
+		const result = pruneSuppressions(violations, existing, suppressionsPath);
+		expect(result).toStrictEqual({});
+	});
+
+	it('updates count when current < suppressed', () => {
+		const violations = new Map<string, Violation[]>([['/project/src/a.html', [v('rule-a'), v('rule-a')]]]);
+		const existing = {
+			'src/a.html': { 'rule-a': { count: 5 } },
+		};
+
+		const result = pruneSuppressions(violations, existing, suppressionsPath);
+		expect(result).toStrictEqual({
+			'src/a.html': { 'rule-a': { count: 2 } },
+		});
+	});
+
+	it('keeps count when current >= suppressed', () => {
+		const violations = new Map<string, Violation[]>([
+			['/project/src/a.html', [v('rule-a'), v('rule-a'), v('rule-a')]],
+		]);
+		const existing = {
+			'src/a.html': { 'rule-a': { count: 2 } },
+		};
+
+		const result = pruneSuppressions(violations, existing, suppressionsPath);
+		expect(result).toStrictEqual({
+			'src/a.html': { 'rule-a': { count: 2 } },
+		});
+	});
+
+	it('removes file entries when all rules are removed', () => {
+		const violations = new Map<string, Violation[]>();
+		const existing = {
+			'src/a.html': { 'rule-a': { count: 1 } },
+			'src/b.html': { 'rule-b': { count: 2 } },
+		};
+
+		const result = pruneSuppressions(violations, existing, suppressionsPath);
+		expect(result).toStrictEqual({});
+	});
+
+	it('handles mixed scenario: some rules removed, some updated, some kept', () => {
+		const violations = new Map<string, Violation[]>([
+			['/project/src/a.html', [v('rule-b'), v('rule-c'), v('rule-c'), v('rule-c')]],
+		]);
+		const existing = {
+			'src/a.html': {
+				'rule-a': { count: 3 }, // 0 violations → removed
+				'rule-b': { count: 5 }, // 1 < 5 → updated to 1
+				'rule-c': { count: 2 }, // 3 >= 2 → kept as 2
+			},
+		};
+
+		const result = pruneSuppressions(violations, existing, suppressionsPath);
+		expect(result).toStrictEqual({
+			'src/a.html': {
+				'rule-b': { count: 1 },
+				'rule-c': { count: 2 },
+			},
+		});
+	});
+
+	it('ignores warning violations in count', () => {
+		const violations = new Map<string, Violation[]>([
+			['/project/src/a.html', [v('rule-a', 'warning'), v('rule-a', 'warning')]],
+		]);
+		const existing = {
+			'src/a.html': { 'rule-a': { count: 2 } },
+		};
+
+		const result = pruneSuppressions(violations, existing, suppressionsPath);
+		// 0 error violations → entry removed
+		expect(result).toStrictEqual({});
+	});
+});

--- a/packages/markuplint/src/suppressions/prune-suppressions.ts
+++ b/packages/markuplint/src/suppressions/prune-suppressions.ts
@@ -1,0 +1,70 @@
+import type { Violation } from '@markuplint/ml-config';
+
+import type { SuppressionsData } from './types.js';
+
+import { toRelativePath } from './suppressions-file.js';
+
+/**
+ * @experimental
+ * Prunes stale entries from suppressions data based on current violations.
+ *
+ * - Entries with 0 current violations are removed entirely.
+ * - Entries with current count < suppressed count are updated to the current count.
+ * - Entries with current count >= suppressed count are kept as-is.
+ * - Empty file entries (all rules removed) are removed from the top-level.
+ *
+ * @param currentViolations - Map of absolute file paths to current violations.
+ * @param existing - The current suppressions data.
+ * @param suppressionsFilePath - Absolute path to the suppressions file.
+ * @returns The pruned suppressions data.
+ */
+export function pruneSuppressions(
+	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+	currentViolations: ReadonlyMap<string, readonly Violation[]>,
+	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+	existing: SuppressionsData,
+	suppressionsFilePath: string,
+): SuppressionsData {
+	// Build a lookup: relPath → ruleId → error count
+	const currentCounts = new Map<string, Map<string, number>>();
+	for (const [absolutePath, violations] of currentViolations) {
+		const relPath = toRelativePath(absolutePath, suppressionsFilePath);
+		const ruleCounts = new Map<string, number>();
+		for (const v of violations) {
+			if (v.severity === 'error') {
+				ruleCounts.set(v.ruleId, (ruleCounts.get(v.ruleId) ?? 0) + 1);
+			}
+		}
+		currentCounts.set(relPath, ruleCounts);
+	}
+
+	const pruned: SuppressionsData = {};
+
+	for (const [filePath, rules] of Object.entries(existing)) {
+		const fileCounts = currentCounts.get(filePath);
+		const prunedRules: Record<string, { count: number }> = {};
+
+		for (const [ruleId, entry] of Object.entries(rules)) {
+			const currentCount = fileCounts?.get(ruleId) ?? 0;
+
+			if (currentCount === 0) {
+				// No more violations, remove entry
+				continue;
+			}
+
+			if (currentCount < entry.count) {
+				// Reduced violations, update count
+				prunedRules[ruleId] = { count: currentCount };
+			} else {
+				// Same or more violations, keep as-is
+				prunedRules[ruleId] = entry;
+			}
+		}
+
+		if (Object.keys(prunedRules).length > 0) {
+			pruned[filePath] = prunedRules;
+		}
+	}
+
+	return pruned;
+}

--- a/packages/markuplint/src/suppressions/suppressions-file.spec.ts
+++ b/packages/markuplint/src/suppressions/suppressions-file.spec.ts
@@ -100,8 +100,9 @@ describe('suppressions-file', () => {
 
 	describe('toRelativePath / toAbsolutePath', () => {
 		it('round-trips correctly', () => {
-			const suppressionsPath = '/project/markuplint-suppressions.json';
-			const absFilePath = '/project/src/index.html';
+			// Use path.resolve to get platform-native absolute paths
+			const suppressionsPath = path.resolve('/project', 'markuplint-suppressions.json');
+			const absFilePath = path.resolve('/project', 'src', 'index.html');
 
 			const rel = toRelativePath(absFilePath, suppressionsPath);
 			expect(rel).toBe('src/index.html');
@@ -111,8 +112,8 @@ describe('suppressions-file', () => {
 		});
 
 		it('uses forward slashes (POSIX)', () => {
-			const suppressionsPath = '/project/markuplint-suppressions.json';
-			const absFilePath = '/project/src/deep/nested/file.html';
+			const suppressionsPath = path.resolve('/project', 'markuplint-suppressions.json');
+			const absFilePath = path.resolve('/project', 'src', 'deep', 'nested', 'file.html');
 
 			const rel = toRelativePath(absFilePath, suppressionsPath);
 			expect(rel).not.toContain('\\');

--- a/packages/markuplint/src/suppressions/suppressions-file.spec.ts
+++ b/packages/markuplint/src/suppressions/suppressions-file.spec.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import {
+	readSuppressionsFile,
+	writeSuppressionsFile,
+	resolveSuppressionsPath,
+	toRelativePath,
+	toAbsolutePath,
+} from './suppressions-file.js';
+
+describe('suppressions-file', () => {
+	let tmpDir: string;
+
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'markuplint-test-'));
+	});
+
+	afterEach(async () => {
+		await fs.rm(tmpDir, { recursive: true, force: true });
+	});
+
+	describe('readSuppressionsFile', () => {
+		it('returns empty object when file does not exist', async () => {
+			const result = await readSuppressionsFile(path.join(tmpDir, 'nonexistent.json'));
+			expect(result).toStrictEqual({});
+		});
+
+		it('parses a valid JSON file', async () => {
+			const data = {
+				'src/index.html': {
+					'attr-duplication': { count: 3 },
+				},
+			};
+			const filePath = path.join(tmpDir, 'suppressions.json');
+			await fs.writeFile(filePath, JSON.stringify(data), 'utf8');
+
+			const result = await readSuppressionsFile(filePath);
+			expect(result).toStrictEqual(data);
+		});
+
+		it('throws a descriptive error on malformed JSON', async () => {
+			const filePath = path.join(tmpDir, 'bad.json');
+			await fs.writeFile(filePath, '{invalid json', 'utf8');
+
+			await expect(readSuppressionsFile(filePath)).rejects.toThrow('Failed to parse suppressions file');
+		});
+	});
+
+	describe('writeSuppressionsFile', () => {
+		it('writes sorted JSON with tab indentation', async () => {
+			const filePath = path.join(tmpDir, 'out.json');
+			const data = {
+				'src/b.html': { 'z-rule': { count: 1 } },
+				'src/a.html': { 'a-rule': { count: 2 } },
+			};
+
+			await writeSuppressionsFile(filePath, data);
+
+			const content = await fs.readFile(filePath, 'utf8');
+			const parsed = JSON.parse(content);
+
+			// Keys should be sorted
+			const keys = Object.keys(parsed);
+			expect(keys).toStrictEqual(['src/a.html', 'src/b.html']);
+
+			// Nested keys should be sorted too
+			expect(Object.keys(parsed['src/a.html'])).toStrictEqual(['a-rule']);
+		});
+
+		it('deletes the file when data is empty', async () => {
+			const filePath = path.join(tmpDir, 'out.json');
+			await fs.writeFile(filePath, '{}', 'utf8');
+
+			await writeSuppressionsFile(filePath, {});
+
+			await expect(fs.access(filePath)).rejects.toThrow();
+		});
+	});
+
+	describe('resolveSuppressionsPath', () => {
+		it('defaults to markuplint-suppressions.json in CWD', () => {
+			const result = resolveSuppressionsPath();
+			expect(result).toBe(path.resolve(process.cwd(), 'markuplint-suppressions.json'));
+		});
+
+		it('resolves a relative custom path from CWD', () => {
+			const result = resolveSuppressionsPath('custom/path.json');
+			expect(result).toBe(path.resolve(process.cwd(), 'custom/path.json'));
+		});
+
+		it('passes through an absolute path', () => {
+			const absPath = '/absolute/path/suppressions.json';
+			const result = resolveSuppressionsPath(absPath);
+			expect(result).toBe(absPath);
+		});
+	});
+
+	describe('toRelativePath / toAbsolutePath', () => {
+		it('round-trips correctly', () => {
+			const suppressionsPath = '/project/markuplint-suppressions.json';
+			const absFilePath = '/project/src/index.html';
+
+			const rel = toRelativePath(absFilePath, suppressionsPath);
+			expect(rel).toBe('src/index.html');
+
+			const abs = toAbsolutePath(rel, suppressionsPath);
+			expect(abs).toBe(absFilePath);
+		});
+
+		it('uses forward slashes (POSIX)', () => {
+			const suppressionsPath = '/project/markuplint-suppressions.json';
+			const absFilePath = '/project/src/deep/nested/file.html';
+
+			const rel = toRelativePath(absFilePath, suppressionsPath);
+			expect(rel).not.toContain('\\');
+			expect(rel).toBe('src/deep/nested/file.html');
+		});
+	});
+});

--- a/packages/markuplint/src/suppressions/suppressions-file.ts
+++ b/packages/markuplint/src/suppressions/suppressions-file.ts
@@ -1,0 +1,117 @@
+import type { SuppressionsData } from './types.js';
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import { isFatalError } from '@markuplint/shared';
+
+const DEFAULT_FILE_NAME = 'markuplint-suppressions.json';
+
+/**
+ * @experimental
+ * Resolves the absolute path to the suppressions file.
+ *
+ * @param customPath - Optional custom path (relative or absolute). Defaults to `markuplint-suppressions.json` in CWD.
+ * @returns The absolute file path.
+ */
+export function resolveSuppressionsPath(customPath?: string): string {
+	if (customPath) {
+		return path.isAbsolute(customPath) ? customPath : path.resolve(process.cwd(), customPath);
+	}
+	return path.resolve(process.cwd(), DEFAULT_FILE_NAME);
+}
+
+/**
+ * @experimental
+ * Reads and parses a suppressions JSON file.
+ * Returns an empty object if the file does not exist.
+ *
+ * @param filePath - Absolute path to the suppressions file.
+ * @returns The parsed suppressions data, or an empty object if the file does not exist.
+ */
+export async function readSuppressionsFile(filePath: string): Promise<SuppressionsData> {
+	try {
+		const content = await fs.readFile(filePath, 'utf8');
+		return JSON.parse(content) as SuppressionsData;
+	} catch (error) {
+		if (error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === 'ENOENT') {
+			return {};
+		}
+		if (error instanceof SyntaxError) {
+			// User may have manually edited and broken the JSON — Tier 2, not Fatal
+			throw new Error(`Failed to parse suppressions file "${filePath}": ${error.message}`, { cause: error });
+		}
+		if (isFatalError(error)) {
+			throw error;
+		}
+		throw error;
+	}
+}
+
+/**
+ * @experimental
+ * Writes suppressions data to a JSON file with sorted keys.
+ * Deletes the file if data is empty.
+ *
+ * @param filePath - Absolute path to the suppressions file.
+ * @param data - The suppressions data to write.
+ */
+// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+export async function writeSuppressionsFile(filePath: string, data: SuppressionsData): Promise<void> {
+	// If empty, delete the file rather than leaving an empty JSON object.
+	// This avoids committing a useless file to the repository.
+	if (Object.keys(data).length === 0) {
+		try {
+			await fs.unlink(filePath);
+		} catch (error) {
+			if (isFatalError(error)) {
+				throw error;
+			}
+			// ENOENT is expected when the file doesn't already exist
+		}
+		return;
+	}
+
+	// Sort top-level keys and nested keys
+	const sorted: SuppressionsData = {};
+	for (const fileKey of Object.keys(data).toSorted()) {
+		const rules = data[fileKey];
+		const sortedRules: Record<string, { count: number }> = {};
+		for (const ruleKey of Object.keys(rules!).toSorted()) {
+			sortedRules[ruleKey] = rules![ruleKey]!;
+		}
+		sorted[fileKey] = sortedRules;
+	}
+
+	const content = JSON.stringify(sorted, null, '\t') + '\n';
+	await fs.writeFile(filePath, content, 'utf8');
+}
+
+/**
+ * @experimental
+ * Converts an absolute file path to a relative path based on the suppressions file location.
+ * Always uses POSIX separators for cross-platform consistency.
+ *
+ * @param absoluteFilePath - The absolute path to the linted file.
+ * @param suppressionsFilePath - The absolute path to the suppressions file.
+ * @returns The relative path using POSIX separators.
+ */
+export function toRelativePath(absoluteFilePath: string, suppressionsFilePath: string): string {
+	const dir = path.dirname(suppressionsFilePath);
+	const rel = path.relative(dir, absoluteFilePath);
+	// Normalize to POSIX separators
+	return rel.split(path.sep).join('/');
+}
+
+/**
+ * @experimental
+ * Converts a relative path (from the suppressions file) back to an absolute path.
+ *
+ * @param relativeFilePath - The relative path stored in the suppressions file.
+ * @param suppressionsFilePath - The absolute path to the suppressions file.
+ * @returns The absolute file path.
+ */
+export function toAbsolutePath(relativeFilePath: string, suppressionsFilePath: string): string {
+	const dir = path.dirname(suppressionsFilePath);
+	return path.resolve(dir, relativeFilePath);
+}

--- a/packages/markuplint/src/suppressions/types.ts
+++ b/packages/markuplint/src/suppressions/types.ts
@@ -1,0 +1,20 @@
+/**
+ * @experimental
+ * A single suppression entry representing the count of suppressed violations
+ * for a specific rule in a specific file.
+ */
+export type SuppressionEntry = {
+	readonly count: number;
+};
+
+/**
+ * @experimental
+ * The full suppressions data structure.
+ * Top-level keys are relative file paths, values are maps of ruleId to suppression entry.
+ *
+ * **Format note (Phase 1):** The current flat structure `{ filePath: { ruleId: { count } } }`
+ * has no version envelope. If Phase 2 adds a `scope` field to entries, existing files
+ * remain compatible (new fields are additive). Should a breaking format change ever be
+ * needed, introduce a `{ version: N, suppressions: { ... } }` wrapper and migrate.
+ */
+export type SuppressionsData = Record<string, Record<string, SuppressionEntry>>;

--- a/packages/markuplint/test/suppressions/.markuplintrc
+++ b/packages/markuplint/test/suppressions/.markuplintrc
@@ -1,0 +1,6 @@
+{
+	"rules": {
+		"attr-duplication": true,
+		"case-sensitive-attr-name": true
+	}
+}

--- a/packages/markuplint/test/suppressions/target.html
+++ b/packages/markuplint/test/suppressions/target.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+<head>
+	<title>Test</title>
+</head>
+<body>
+	<div class="a" class="b"></div>
+	<div class="c" class="d"></div>
+	<div ID="bar"></div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Add ESLint-compatible bulk suppressions feature (experimental, Phase 1)
- Record existing error violations in `markuplint-suppressions.json` and suppress them during subsequent lint runs
- New CLI flags: `--suppress`, `--suppress-rule`, `--prune-suppressions`, `--suppressions-location`

## Design

- **Count-based matching**: file path + rule ID + violation count (same approach as ESLint/Stylelint)
- Only `error` severity violations are suppressed; `warning`/`info` pass through
- If current count exceeds suppressed count, ALL violations are reported (ESLint-compatible)
- Suppressions file intended to be committed to the repository

## New files

| Module | Purpose |
|---|---|
| `suppressions/types.ts` | Type definitions (`SuppressionsData`, `SuppressionEntry`) |
| `suppressions/suppressions-file.ts` | JSON file read/write, path resolution |
| `suppressions/generate-suppressions.ts` | Generate suppressions from violations |
| `suppressions/apply-suppressions.ts` | Filter violations against suppressions |
| `suppressions/merge-suppressions.ts` | Merge existing + new suppressions (max count) |
| `suppressions/prune-suppressions.ts` | Remove stale entries |

## Test plan

- [x] Unit tests: 34 tests across 5 spec files (generate, apply, merge, prune, file I/O)
- [x] CLI integration tests: 6 tests with `execa` (suppress, filter, exceed, suppress-rule, prune, mutual exclusion)
- [x] ESLint + Prettier: 0 errors, 0 warnings (new code)
- [x] Error handling: `isFatalError` guards on all catch blocks per three-tier model
- [x] Cross-platform: POSIX path normalization for suppressions file keys

Closes #3503

🤖 Generated with [Claude Code](https://claude.com/claude-code)