### PR TITLE
docs(website): add bulk suppressions documentation

### DIFF
--- a/website/docs/guides/cli.md
+++ b/website/docs/guides/cli.md
@@ -16,27 +16,31 @@ And returns `1` if the result has problems one or more.
 
 ## Options
 
-| Long Option                | Short Option | Argument                                 | Default    | Description                                                           |
-| -------------------------- | ------------ | ---------------------------------------- | ---------- | --------------------------------------------------------------------- |
-| `--config`                 | `-c`         | File path                                | none       | A configuration file path                                             |
-| `--fix`                    | none         | none                                     | false      | Fix target files if the rule supports.                                |
-| `--fix-dry-run`            | none         | none                                     | false      | Preview what `--fix` would change without modifying files.            |
-| `--format`                 | `-f`         | `JSON`, `Simple`, `GitHub` or `Standard` | `Standard` | Select output format.                                                 |
-| `--no-search-config`       | none         | none                                     | false      | No search a configure file automatically.                             |
-| `--ignore-ext`             | none         | none                                     | false      | Evaluate files that are received even though the type of extension.   |
-| `--no-import-preset-rules` | none         | none                                     | false      | No import preset rules.                                               |
-| `--locale`                 | none         | Language code (example: `en`)            | OS setting | Locale of the message of violation.                                   |
-| `--no-color`               | none         | none                                     | false      | Output no color.                                                      |
-| `--problem-only`           | `-p`         | none                                     | false      | Output only problems.                                                 |
-| `--allow-warnings`         | none         | none                                     | true       | Return status code 0 even if there are warnings.                      |
-| `--no-allow-empty-input`   | none         | none                                     | false      | Return status code 1 even if there are no input files.                |
-| `--show-config`            | none         | empty, `details`                         | none       | Output computed configuration of the target file.                     |
-| `--verbose`                | none         | none                                     | false      | Output with detailed information.                                     |
-| `--include-node-modules`   | none         | none                                     | false      | Include files in node_modules directory.                              |
-| `--severity-parse-error`   | none         | `error`, `warning` or `off`              | `error`    | Specifies the severity level of parse errors.                         |
-| `--max-count`              | none         | Number                                   | `0`        | Limit the number of violations shown. `0` means no limit.             |
-| `--max-warnings`           | none         | Number                                   | `-1`       | Number of warnings to trigger nonzero exit code. `-1` means no limit. |
-| `--progressive-output`     | none         | none                                     | false      | Output results immediately after processing each file.                |
+| Long Option                | Short Option | Argument                                 | Default                        | Description                                                                  |
+| -------------------------- | ------------ | ---------------------------------------- | ------------------------------ | ---------------------------------------------------------------------------- |
+| `--config`                 | `-c`         | File path                                | none                           | A configuration file path                                                    |
+| `--fix`                    | none         | none                                     | false                          | Fix target files if the rule supports.                                       |
+| `--fix-dry-run`            | none         | none                                     | false                          | Preview what `--fix` would change without modifying files.                   |
+| `--format`                 | `-f`         | `JSON`, `Simple`, `GitHub` or `Standard` | `Standard`                     | Select output format.                                                        |
+| `--no-search-config`       | none         | none                                     | false                          | No search a configure file automatically.                                    |
+| `--ignore-ext`             | none         | none                                     | false                          | Evaluate files that are received even though the type of extension.          |
+| `--no-import-preset-rules` | none         | none                                     | false                          | No import preset rules.                                                      |
+| `--locale`                 | none         | Language code (example: `en`)            | OS setting                     | Locale of the message of violation.                                          |
+| `--no-color`               | none         | none                                     | false                          | Output no color.                                                             |
+| `--problem-only`           | `-p`         | none                                     | false                          | Output only problems.                                                        |
+| `--allow-warnings`         | none         | none                                     | true                           | Return status code 0 even if there are warnings.                             |
+| `--no-allow-empty-input`   | none         | none                                     | false                          | Return status code 1 even if there are no input files.                       |
+| `--show-config`            | none         | empty, `details`                         | none                           | Output computed configuration of the target file.                            |
+| `--verbose`                | none         | none                                     | false                          | Output with detailed information.                                            |
+| `--include-node-modules`   | none         | none                                     | false                          | Include files in node_modules directory.                                     |
+| `--severity-parse-error`   | none         | `error`, `warning` or `off`              | `error`                        | Specifies the severity level of parse errors.                                |
+| `--max-count`              | none         | Number                                   | `0`                            | Limit the number of violations shown. `0` means no limit.                    |
+| `--max-warnings`           | none         | Number                                   | `-1`                           | Number of warnings to trigger nonzero exit code. `-1` means no limit.        |
+| `--progressive-output`     | none         | none                                     | false                          | Output results immediately after processing each file.                       |
+| `--suppress`               | none         | none                                     | false                          | **[Experimental]** Generate/update suppressions file for all current errors. |
+| `--suppress-rule`          | none         | Rule ID                                  | none                           | **[Experimental]** Suppress only the specified rule.                         |
+| `--prune-suppressions`     | none         | none                                     | false                          | **[Experimental]** Remove stale entries from the suppressions file.          |
+| `--suppressions-location`  | none         | File path                                | `markuplint-suppressions.json` | **[Experimental]** Custom path for the suppressions file.                    |
 
 ## Particular run
 
@@ -148,3 +152,34 @@ $ markuplint "**/*.html"
 - Debugging issues with specific files in large projects
 
 **Note:** This option will default to `true` in the next major version of Markuplint.
+
+### `--suppress` / `--suppress-rule` {#suppress}
+
+:::caution Experimental
+This feature is experimental and may change in future releases.
+:::
+
+Record existing violations in a suppressions file so that rules are enforced only on new code. See [Bulk Suppressions](./ignoring-code.md#bulk-suppressions) for the full guide.
+
+```shell
+# Suppress all current error violations
+$ markuplint "**/*.html" --suppress
+
+# Suppress only a specific rule
+$ markuplint "**/*.html" --suppress-rule attr-duplication
+
+# Use a custom suppressions file path
+$ markuplint "**/*.html" --suppress --suppressions-location .config/suppressions.json
+```
+
+### `--prune-suppressions` {#prune-suppressions}
+
+:::caution Experimental
+This feature is experimental and may change in future releases.
+:::
+
+Remove stale entries from the suppressions file after fixing violations.
+
+```shell
+$ markuplint "**/*.html" --prune-suppressions
+```

--- a/website/docs/guides/ignoring-code.md
+++ b/website/docs/guides/ignoring-code.md
@@ -72,3 +72,72 @@ Use [`overrides`](/docs/configuration/properties#overrides) property with [`over
 ```
 
 Replace the `[[target-rule-id]]` portion with [the rule ID](/docs/rules) you would like to disable as appropriate.
+
+## Bulk Suppressions {#bulk-suppressions}
+
+:::caution Experimental
+This feature is experimental and may change in future releases.
+:::
+
+When introducing new rules to an existing project, you can suppress all current violations and enforce rules only on new code. This is useful when fixing all existing violations at once is not practical.
+
+### Workflow
+
+```shell
+# 1. Enable new rules in your config, then suppress all current errors
+$ markuplint --suppress "src/**/*.html"
+
+# 2. Commit the generated suppressions file to your repository
+$ git add markuplint-suppressions.json
+
+# 3. From now on, only new violations are reported
+$ markuplint "src/**/*.html"
+
+# 4. As you fix existing violations, clean up stale entries
+$ markuplint --prune-suppressions "src/**/*.html"
+```
+
+### How it works
+
+The `--suppress` command records current `error`-severity violations in a `markuplint-suppressions.json` file. On subsequent runs, markuplint reads this file and suppresses the recorded violations. If the number of violations for a file+rule pair **exceeds** the suppressed count, **all** violations for that pair are reported — this prevents new regressions from being hidden.
+
+Each entry includes an optional **scope selector** that narrows the suppression to a specific DOM subtree. The scope is computed automatically using the [Lowest Common Ancestor (LCA)](https://en.wikipedia.org/wiki/Lowest_common_ancestor) of all violation nodes.
+
+```json title="markuplint-suppressions.json"
+{
+  "src/index.html": {
+    "attr-duplication": { "count": 3, "scope": "#main-nav > ul" }
+  }
+}
+```
+
+### Key behaviors
+
+- Only `error`-severity violations are suppressed; `warning` and `info` always pass through
+- `--suppress` always exits with code 0 (success)
+- `--suppress` and `--prune-suppressions` cannot be used together
+- The suppressions file should be committed to your repository
+
+### CLI options
+
+| Option                           | Description                                                                     |
+| -------------------------------- | ------------------------------------------------------------------------------- |
+| `--suppress`                     | Record all current error violations                                             |
+| `--suppress-rule <rule>`         | Record only violations for the specified rule                                   |
+| `--prune-suppressions`           | Remove entries for violations that have been fixed                              |
+| `--suppressions-location <path>` | Custom path for the suppressions file (default: `markuplint-suppressions.json`) |
+
+### Scope selector
+
+The scope selector narrows suppression to a specific part of the document. It is generated automatically and uses the following strategy (in priority order):
+
+1. **`#id`** — if the ancestor has an `id` attribute
+2. **`tag.class`** — if the ancestor has CSS classes
+3. **`tag[role="..."]`** — if the ancestor has a `role` attribute (or `type` for `<input>`)
+4. **`tag:nth-of-type(n)`** — to disambiguate same-tag siblings
+
+If the scope cannot be narrowed (e.g., violations span the entire document), the suppression applies to the whole file.
+
+When a scope selector no longer matches any element (e.g., after refactoring), the suppression remains active and `--prune-suppressions` will recommend cleanup. **Broken scopes never cause new violations to be hidden.**
+
+For the full design rationale, see the [Bulk Suppressions design document](https://github.com/markuplint/markuplint/blob/dev/docs/architectures/BULK-SUPPRESSIONS.md).

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/cli.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/cli.md
@@ -14,27 +14,31 @@ CLIはターゲットとなるHTMLファイルを可変長引数として受け�
 
 ## オプション
 
-| 正規形オプション           | 省略形オプション | 引数                                         | デフォルト値 | 解説                                                          |
-| -------------------------- | ---------------- | -------------------------------------------- | ------------ | ------------------------------------------------------------- |
-| `--config`                 | `-c`             | ファイルパス                                 | なし         | 設定ファイルのパス                                            |
-| `--fix`                    | なし             | なし                                         | false        | ルールが対応していれば対象ファイルを修正します                |
-| `--fix-dry-run`            | なし             | なし                                         | false        | `--fix` の変更内容をファイルを変更せずにプレビューします      |
-| `--format`                 | `-f`             | `JSON`、`Simple`、`GitHub`もしくは`Standard` | `Standard`   | 出力形式                                                      |
-| `--no-search-config`       | なし             | なし                                         | false        | 設定ファイルを自動で検索しません                              |
-| `--ignore-ext`             | なし             | なし                                         | false        | 拡張子の種類に関わらず受け取ったファイルを評価します          |
-| `--no-import-preset-rules` | なし             | なし                                         | false        | 組み込みルールを利用しません                                  |
-| `--locale`                 | なし             | 言語コード（例：`ja`）                       | OS設定による | メッセージの言語                                              |
-| `--no-color`               | なし             | なし                                         | false        | 出力をカラーリングしません                                    |
-| `--problem-only`           | `-p`             | なし                                         | false        | 違反結果のみ出力します                                        |
-| `--allow-warnings`         | なし             | なし                                         | true         | `warning`ではステータスコード`0`を返します                    |
-| `--no-allow-empty-input`   | なし             | なし                                         | false        | ファイルが見つからなかった場合にステータスコード`1`を返します |
-| `--show-config`            | none             | 値なし, `details`                            | 値なし       | 対象ファイルの適用された設定を出力します                      |
-| `--verbose`                | なし             | なし                                         | false        | 詳細な情報も同時に出力します                                  |
-| `--include-node-modules`   | なし             | なし                                         | false        | `node_module`ディレクトリ内のファイルを含めて評価します       |
-| `--severity-parse-error`   | なし             | `error`、`warning`もしくは`off`              | `error`      | パースエラーの深刻度レベルを指定します                        |
-| `--max-count`              | なし             | 数値                                         | `0`          | 表示する違反数を制限します。`0`は制限なしを意味します         |
-| `--max-warnings`           | なし             | 数値                                         | `-1`         | 警告数の上限を設定します。`-1`は制限なしを意味します          |
-| `--progressive-output`     | なし             | なし                                         | false        | 各ファイルの処理完了後に即座に結果を出力します                |
+| 正規形オプション           | 省略形オプション | 引数                                         | デフォルト値                   | 解説                                                              |
+| -------------------------- | ---------------- | -------------------------------------------- | ------------------------------ | ----------------------------------------------------------------- |
+| `--config`                 | `-c`             | ファイルパス                                 | なし                           | 設定ファイルのパス                                                |
+| `--fix`                    | なし             | なし                                         | false                          | ルールが対応していれば対象ファイルを修正します                    |
+| `--fix-dry-run`            | なし             | なし                                         | false                          | `--fix` の変更内容をファイルを変更せずにプレビューします          |
+| `--format`                 | `-f`             | `JSON`、`Simple`、`GitHub`もしくは`Standard` | `Standard`                     | 出力形式                                                          |
+| `--no-search-config`       | なし             | なし                                         | false                          | 設定ファイルを自動で検索しません                                  |
+| `--ignore-ext`             | なし             | なし                                         | false                          | 拡張子の種類に関わらず受け取ったファイルを評価します              |
+| `--no-import-preset-rules` | なし             | なし                                         | false                          | 組み込みルールを利用しません                                      |
+| `--locale`                 | なし             | 言語コード（例：`ja`）                       | OS設定による                   | メッセージの言語                                                  |
+| `--no-color`               | なし             | なし                                         | false                          | 出力をカラーリングしません                                        |
+| `--problem-only`           | `-p`             | なし                                         | false                          | 違反結果のみ出力します                                            |
+| `--allow-warnings`         | なし             | なし                                         | true                           | `warning`ではステータスコード`0`を返します                        |
+| `--no-allow-empty-input`   | なし             | なし                                         | false                          | ファイルが見つからなかった場合にステータスコード`1`を返します     |
+| `--show-config`            | none             | 値なし, `details`                            | 値なし                         | 対象ファイルの適用された設定を出力します                          |
+| `--verbose`                | なし             | なし                                         | false                          | 詳細な情報も同時に出力します                                      |
+| `--include-node-modules`   | なし             | なし                                         | false                          | `node_module`ディレクトリ内のファイルを含めて評価します           |
+| `--severity-parse-error`   | なし             | `error`、`warning`もしくは`off`              | `error`                        | パースエラーの深刻度レベルを指定します                            |
+| `--max-count`              | なし             | 数値                                         | `0`                            | 表示する違反数を制限します。`0`は制限なしを意味します             |
+| `--max-warnings`           | なし             | 数値                                         | `-1`                           | 警告数の上限を設定します。`-1`は制限なしを意味します              |
+| `--progressive-output`     | なし             | なし                                         | false                          | 各ファイルの処理完了後に即座に結果を出力します                    |
+| `--suppress`               | なし             | なし                                         | false                          | **[実験的]** 現在の全エラー違反をsuppressionsファイルに記録します |
+| `--suppress-rule`          | なし             | ルールID                                     | なし                           | **[実験的]** 指定ルールの違反のみ記録します                       |
+| `--prune-suppressions`     | なし             | なし                                         | false                          | **[実験的]** suppressionsファイルから不要なエントリを削除します   |
+| `--suppressions-location`  | なし             | ファイルパス                                 | `markuplint-suppressions.json` | **[実験的]** suppressionsファイルのカスタムパス                   |
 
 ## Particular run
 
@@ -145,3 +149,34 @@ $ markuplint "**/*.html"
 - 大規模プロジェクトでの特定ファイルの問題デバッグ
 
 **注意:** このオプションはMarkuplintの次回メジャーバージョンでデフォルトが`true`に変更されます。
+
+### `--suppress` / `--suppress-rule` {#suppress}
+
+:::caution 実験的機能
+この機能は実験的であり、今後のリリースで変更される可能性があります。
+:::
+
+既存の違反をsuppressionsファイルに記録し、新規コードに対してのみルールを適用します。詳しくは[一括抑制](./ignoring-code.md#bulk-suppressions)を参照してください。
+
+```shell
+# 現在の全エラー違反を抑制
+$ markuplint "**/*.html" --suppress
+
+# 特定のルールのみ抑制
+$ markuplint "**/*.html" --suppress-rule attr-duplication
+
+# カスタムパスでsuppressionsファイルを指定
+$ markuplint "**/*.html" --suppress --suppressions-location .config/suppressions.json
+```
+
+### `--prune-suppressions` {#prune-suppressions}
+
+:::caution 実験的機能
+この機能は実験的であり、今後のリリースで変更される可能性があります。
+:::
+
+修正済みの違反に対応する不要なエントリをsuppressionsファイルから削除します。
+
+```shell
+$ markuplint "**/*.html" --prune-suppressions
+```

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/ignoring-code.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/ignoring-code.md
@@ -72,3 +72,72 @@
 ```
 
 `[[target-rule-id]]`の部分は無効化したい[ルールID](/docs/rules/)に適宜変えてください。
+
+## 一括抑制（Bulk Suppressions） {#bulk-suppressions}
+
+:::caution 実験的機能
+この機能は実験的であり、今後のリリースで変更される可能性があります。
+:::
+
+既存プロジェクトに新しいルールを導入する際、現在の違反をすべて抑制し、新規コードに対してのみルールを適用できます。既存の違反を一度に修正するのが現実的でない場合に有用です。
+
+### ワークフロー
+
+```shell
+# 1. 設定ファイルで新しいルールを有効化した後、現在のエラーをすべて抑制
+$ markuplint --suppress "src/**/*.html"
+
+# 2. 生成されたsuppressionsファイルをリポジトリにコミット
+$ git add markuplint-suppressions.json
+
+# 3. 以降は新規の違反のみが報告される
+$ markuplint "src/**/*.html"
+
+# 4. 既存の違反を修正したら、不要なエントリを削除
+$ markuplint --prune-suppressions "src/**/*.html"
+```
+
+### 仕組み
+
+`--suppress`コマンドは、現在の`error`レベルの違反を`markuplint-suppressions.json`ファイルに記録します。以降の実行時にこのファイルを読み込み、記録された違反を抑制します。ファイル＋ルールの組み合わせで違反数が抑制カウントを**超えた**場合、その組み合わせの**すべての**違反が報告されます。これにより新しいリグレッションが隠されることを防ぎます。
+
+各エントリには、抑制を特定のDOMサブツリーに絞り込むオプションの**スコープセレクタ**が含まれます。スコープは、すべての違反ノードの[最小共通祖先（LCA: Lowest Common Ancestor）](https://en.wikipedia.org/wiki/Lowest_common_ancestor)を使用して自動的に計算されます。
+
+```json title="markuplint-suppressions.json"
+{
+  "src/index.html": {
+    "attr-duplication": { "count": 3, "scope": "#main-nav > ul" }
+  }
+}
+```
+
+### 主な動作
+
+- `error`レベルの違反のみが抑制対象です。`warning`と`info`は常にパススルーされます
+- `--suppress`は常に終了コード0（成功）を返します
+- `--suppress`と`--prune-suppressions`は同時に使用できません
+- suppressionsファイルはリポジトリにコミットすることを推奨します
+
+### CLIオプション
+
+| オプション                       | 説明                                                                             |
+| -------------------------------- | -------------------------------------------------------------------------------- |
+| `--suppress`                     | 現在の全エラー違反を記録                                                         |
+| `--suppress-rule <rule>`         | 指定ルールの違反のみ記録                                                         |
+| `--prune-suppressions`           | 修正済みの違反のエントリを削除                                                   |
+| `--suppressions-location <path>` | suppressionsファイルのカスタムパス（デフォルト: `markuplint-suppressions.json`） |
+
+### スコープセレクタ
+
+スコープセレクタはドキュメントの特定の部分に抑制を絞り込みます。自動的に生成され、以下の戦略が優先順位順に使用されます:
+
+1. **`#id`** — 祖先に`id`属性がある場合
+2. **`tag.class`** — 祖先にCSSクラスがある場合
+3. **`tag[role="..."]`** — 祖先に`role`属性がある場合（`<input>`の場合は`type`も対象）
+4. **`tag:nth-of-type(n)`** — 同名の兄弟要素を区別するため
+
+スコープを絞れない場合（例: 違反がドキュメント全体に分散している場合）、抑制はファイル全体に適用されます。
+
+スコープセレクタが要素にマッチしなくなった場合（例: リファクタリング後）、抑制は維持され`--prune-suppressions`がクリーンアップを推奨します。**壊れたスコープが新しい違反を隠すことはありません。**
+
+詳しい設計理念については、[Bulk Suppressions設計ドキュメント](https://github.com/markuplint/markuplint/blob/dev/docs/architectures/BULK-SUPPRESSIONS.md)を参照してください。


### PR DESCRIPTION
## Summary

- Add bulk suppressions documentation to the website (en + ja)
- Reflects features from #3507 (Phase 1) and #3513 (Phase 2)

## Changes

### CLI guide (`guides/cli.md`)
- Add 4 new experimental flags to the options table
- Add `--suppress` / `--suppress-rule` detailed section with usage examples
- Add `--prune-suppressions` detailed section

### Ignoring code guide (`guides/ignoring-code.md`)
- Add "Bulk Suppressions" section covering:
  - Workflow (suppress → lint → prune cycle)
  - How it works (count-based matching + scope selector)
  - Key behaviors
  - CLI options reference
  - Scope selector strategy (id → class → role/type → nth-of-type)
  - Link to design document

### Localization
- All changes applied to both English and Japanese versions

## Test plan
- [x] Documentation only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)