### PR TITLE
fix(file-resolver): handle ERR_PACKAGE_PATH_NOT_EXPORTED in generalImport

### DIFF
--- a/packages/@markuplint/file-resolver/src/general-import.spec.ts
+++ b/packages/@markuplint/file-resolver/src/general-import.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from 'vitest';
+
+import { generalImport } from './general-import.js';
+
+test('imports a JSON subpath from a package whose exports map does not include it', async () => {
+	// @markuplint-test/react has "exports": { ".": "./index.js" } — no ./pretenders.json entry.
+	// generalImport should fall back to resolving the absolute path via ERR_PACKAGE_PATH_NOT_EXPORTED handling.
+	const result = await generalImport<{ data: unknown[] }>('@markuplint-test/react/pretenders.json');
+	expect(result).not.toBeNull();
+	expect(result!.data).toStrictEqual([
+		{
+			selector: 'Sample',
+			as: 'div',
+			filePath: 'sample.jsx:1:16',
+		},
+	]);
+});
+
+test('returns null for a non-existent subpath in a package with exports map', async () => {
+	const result = await generalImport('@markuplint-test/react/does-not-exist.json');
+	expect(result).toBeNull();
+});
+
+test('imports a JSON subpath from a scoped package without exports map', async () => {
+	// @markuplint-test/react-pkg-pretenders has no "exports" field,
+	// so direct import of package.json should work normally.
+	const result = await generalImport<{ name: string }>('@markuplint-test/react-pkg-pretenders/package.json');
+	expect(result).not.toBeNull();
+	expect(result!.name).toBe('@markuplint-test/react-pkg-pretenders');
+});

--- a/packages/@markuplint/file-resolver/src/general-import.ts
+++ b/packages/@markuplint/file-resolver/src/general-import.ts
@@ -58,6 +58,31 @@ export async function generalImport<T>(name: string): Promise<T | null> {
 			}
 		}
 
+		// When a package has an "exports" map that does not include the requested subpath,
+		// Node.js throws ERR_PACKAGE_PATH_NOT_EXPORTED. Resolve the package directory from
+		// the error message and construct an absolute path to the target file.
+		if (
+			error instanceof Error &&
+			// @ts-ignore
+			'code' in error &&
+			// @ts-ignore
+			error.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED'
+		) {
+			const pkgJsonMatch = /in (\S[^\n]*[/\\]package\.json)/.exec(error.message)?.[1];
+			if (pkgJsonMatch) {
+				const pkgDir = path.dirname(pkgJsonMatch);
+				const packageName = name.startsWith('@') ? name.split('/').slice(0, 2).join('/') : name.split('/')[0];
+				const subpath = packageName ? name.slice(packageName.length + 1) : '';
+				if (subpath) {
+					const candidate = path.join(pkgDir, subpath);
+					gLog('ERR_PACKAGE_PATH_NOT_EXPORTED fallback: try "%s"', candidate);
+					const result = await generalImport<T>(candidate);
+					cache.set(name, result);
+					return result;
+				}
+			}
+		}
+
 		if (error instanceof Error) {
 			const { filePath, packageName } =
 				/Missing\s"(?<filePath>[^"]+)"\sspecifier\sin\s"(?<packageName>[^"]+)"\spackage/.exec(error.message)

--- a/packages/@markuplint/file-resolver/src/general-import.ts
+++ b/packages/@markuplint/file-resolver/src/general-import.ts
@@ -68,6 +68,8 @@ export async function generalImport<T>(name: string): Promise<T | null> {
 			// @ts-ignore
 			error.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED'
 		) {
+			// Node.js error message format (may change across versions):
+			// Package subpath './foo' is not defined by "exports" in /path/to/package.json
 			const pkgJsonMatch = /in (\S[^\n]*[/\\]package\.json)/.exec(error.message)?.[1];
 			if (pkgJsonMatch) {
 				const pkgDir = path.dirname(pkgJsonMatch);
@@ -80,6 +82,11 @@ export async function generalImport<T>(name: string): Promise<T | null> {
 					cache.set(name, result);
 					return result;
 				}
+			} else {
+				gLogError(
+					'ERR_PACKAGE_PATH_NOT_EXPORTED but could not parse package.json path from: %s',
+					error.message,
+				);
 			}
 		}
 
@@ -100,11 +107,15 @@ export async function generalImport<T>(name: string): Promise<T | null> {
 		}
 
 		if (path.isAbsolute(name) && name.endsWith('.json')) {
-			const file = await fs.readFile(name, 'utf8');
-			const json = JSON.parse(file);
-			gLogSuccess('Success by readFile("%s") and JSON.parse: %O', name, json);
-			cache.set(name, json);
-			return json;
+			try {
+				const file = await fs.readFile(name, 'utf8');
+				const json = JSON.parse(file);
+				gLogSuccess('Success by readFile("%s") and JSON.parse: %O', name, json);
+				cache.set(name, json);
+				return json;
+			} catch (readError) {
+				gLogError('Error in readFile("%s"): %O', name, readError);
+			}
 		}
 
 		gLogError('Error in `import()`: %O', error);


### PR DESCRIPTION
## Summary

- Fix `generalImport()` to handle `ERR_PACKAGE_PATH_NOT_EXPORTED` when a package's exports map does not include the requested subpath (e.g., `pretenders.json`)
- Wrap `fs.readFile` JSON fallback in try/catch to prevent ENOENT propagation for non-existent absolute paths
- Add direct unit tests for `generalImport()` covering the new fallback path

## Context

Surfaced by PR #3424 (vitest 4.0.18 → 4.1.2) where vitest's module resolution changes exposed a latent bug: `generalImport('@pkg/pretenders.json')` silently returned `null` when the package had an exports map without `./pretenders.json`, causing pretender resolution to fail.

The fix parses the package directory from the Node.js error message and constructs an absolute path to the target file, which is then resolved via the existing absolute-path fallback.

Closes #3516

## Test plan

- [x] `generalImport` direct unit tests (3 tests) — subpath with restrictive exports, non-existent subpath, normal package
- [x] `resolve-pretenders` integration tests (8 tests) — existing tests continue to pass
- [x] Full test suite (3037 tests passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)