### PR TITLE
chore: add CI watch step to /pr command

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -8,3 +8,12 @@ description: Create and push a pull request
    - All three must pass. Fix any failures before continuing.
 3. Review the changes on the current topic branch using appropriate `git` commands.
 4. Generate and execute a one-liner `gh pr create` command to create a pull request.
+5. **CI watch (MANDATORY after PR creation or additional pushes):**
+   - Run `gh pr checks <PR_NUMBER> --watch` to monitor all CI checks.
+   - **If any check fails:**
+     1. Inspect the failed check logs (`gh run view <RUN_ID> --log-failed`).
+     2. Fix the issue in the worktree.
+     3. Run the relevant local verification (`yarn lint-check`, `yarn build`, `yarn test`) to confirm the fix.
+     4. Commit, push, and run `gh pr checks <PR_NUMBER> --watch` again.
+     5. Repeat until all checks pass.
+   - **If all checks pass:** Report the result to the user with the PR URL.


### PR DESCRIPTION
## Summary

- Add CI watch step to the `/pr` command
- After PR creation or additional pushes, monitor CI via `gh pr checks --watch`
- On failure: inspect logs, fix, push, and re-watch
- On success: report to the user with PR URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)