### PR TITLE
feat: add isExposed and mayBeFocusable ARIA algorithms (Phase 2-3d)

### DIFF
--- a/crates/README.md
+++ b/crates/README.md
@@ -7,9 +7,9 @@ Rust implementation of markuplint's core components: DOM layer and type validati
 ```
 crates/
 ├── markuplint-core/      MLAST serde types (deserialization from JSON)
-├── markuplint-dom/       Arena-based DOM tree (builder + traversal)
+├── markuplint-dom/       Arena-based DOM tree (builder + traversal + attr helpers)
 ├── markuplint-napi/      Node.js bridge via napi-rs v3
-├── markuplint-rules/     Content model matching with full CSS selector support
+├── markuplint-rules/     Content model matching + ARIA algorithms (isExposed, mayBeFocusable)
 ├── markuplint-selector/  CSS selector parser + matcher (with :model/:role/:aria)
 └── markuplint-types/     Type validation and spec data (serde types, lookup)
 ```
@@ -41,6 +41,7 @@ Content model validation rules. Bridges `markuplint-types` (spec data) and `mark
 - **Content model matching engine**: order, choice, quantifiers, backtracking (ported from `@markuplint/rules/permitted-contents/`)
 - **CSS selector integration**: `:not()`, `:has()`, `:is()` via arena bridge to `markuplint-selector`
 - **Arena bridge**: converts lightweight `ChildNodeInfo` to minimal `DomArena` for selector evaluation
+- **ARIA algorithms** (Phase 2-3d): `is_exposed()` (WAI-ARIA §6.4 accessibility tree exposure), `may_be_focusable()` (interactive content heuristic)
 
 ### markuplint-types
 

--- a/crates/markuplint-dom/src/helpers.rs
+++ b/crates/markuplint-dom/src/helpers.rs
@@ -1,0 +1,39 @@
+//! Convenience helpers for querying DOM nodes in a `DomArena`.
+
+use markuplint_core::mlast::MLASTAttr;
+
+use crate::arena::{DomArena, NodeId};
+use crate::node::ElementData;
+
+/// Get the value of an attribute by name (case-insensitive).
+///
+/// Returns the raw value string from the attribute's value token.
+/// Returns `None` if the node is not an element or the attribute is not found.
+#[must_use]
+pub fn get_attr_value<'a>(arena: &'a DomArena, node_id: NodeId, attr_name: &str) -> Option<&'a str> {
+    let el = arena.get(node_id)?.as_element()?;
+    get_attr_value_from_el(el, attr_name)
+}
+
+/// Get the value of an attribute from an `ElementData` (case-insensitive name match).
+///
+/// Returns the raw value token string. Only matches `HTMLAttr` variants (skips spread attrs).
+#[must_use]
+pub fn get_attr_value_from_el<'a>(el: &'a ElementData, attr_name: &str) -> Option<&'a str> {
+    for attr in &el.attributes {
+        if let MLASTAttr::HTMLAttr(html_attr) = attr
+            && html_attr.node_name.eq_ignore_ascii_case(attr_name)
+        {
+            return Some(&html_attr.value.raw);
+        }
+    }
+    None
+}
+
+/// Check if an element has an attribute (case-insensitive).
+///
+/// Returns `false` if the node is not an element.
+#[must_use]
+pub fn has_attr(arena: &DomArena, node_id: NodeId, attr_name: &str) -> bool {
+    get_attr_value(arena, node_id, attr_name).is_some()
+}

--- a/crates/markuplint-dom/src/lib.rs
+++ b/crates/markuplint-dom/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod arena;
 pub mod builder;
+pub mod helpers;
 pub mod node;
 pub mod traversal;

--- a/crates/markuplint-rules/src/aria/is_exposed.rs
+++ b/crates/markuplint-rules/src/aria/is_exposed.rs
@@ -1,0 +1,511 @@
+//! Accessibility tree exposure check.
+//!
+//! Ports `packages/@markuplint/ml-spec/src/algorithm/aria/is-exposed.ts`.
+//! Determines whether an element is included in the accessibility tree
+//! per WAI-ARIA 1.2 §6.4.
+
+use markuplint_dom::arena::{DomArena, NodeId};
+use markuplint_dom::helpers;
+use markuplint_types::spec::aria::{self, ARIAVersion};
+use markuplint_types::spec::lookup;
+use markuplint_types::spec::types::MLMLSpec;
+
+/// Check whether an element is exposed in the accessibility tree.
+///
+/// Applies WAI-ARIA exclusion/inclusion rules, SVG rendering rules,
+/// and HTML metadata element filtering.
+pub fn is_exposed(spec: &MLMLSpec, arena: &DomArena, node_id: NodeId, version: ARIAVersion) -> bool {
+    // WAI-ARIA exclusion rules
+    if is_excluding(spec, arena, node_id, version) {
+        return false;
+    }
+
+    let Some(node) = arena.get(node_id) else {
+        return true;
+    };
+    let Some(el) = node.as_element() else {
+        return true;
+    };
+
+    let tag_name = &el.base.node_name;
+
+    // Unknown, deprecated, or obsolete elements → exposed (conservative)
+    let Some(el_spec) = lookup::get_spec(spec, tag_name) else {
+        return true;
+    };
+    if el_spec.deprecated == Some(true) || el_spec.obsolete.is_some() {
+        return true;
+    }
+
+    // HTML/SVG spec element check
+    if !is_exposed_element(spec, arena, node_id, tag_name) {
+        return false;
+    }
+
+    // WAI-ARIA inclusion rules
+    if is_including(spec, arena, node_id, version) {
+        return true;
+    }
+
+    // Default: exposed
+    true
+}
+
+/// WAI-ARIA exclusion rules (§6.4.1).
+fn is_excluding(spec: &MLMLSpec, arena: &DomArena, node_id: NodeId, version: ARIAVersion) -> bool {
+    // 1. Elements with display:none, visibility:hidden, or hidden attribute
+    //    (including ancestors)
+    {
+        let mut current = Some(node_id);
+        while let Some(cid) = current {
+            if has_display_none_or_visibility_hidden(arena, cid) || helpers::has_attr(arena, cid, "hidden") {
+                return true;
+            }
+            current = arena.get(cid).and_then(markuplint_dom::node::DomNode::parent_id);
+        }
+    }
+
+    // 2. Elements with presentation/none as first role
+    if let Some(role_attr) = helpers::get_attr_value(arena, node_id, "role") {
+        let first_role = role_attr.split_ascii_whitespace().next().unwrap_or("");
+        if is_presentational(first_role) {
+            return true;
+        }
+    }
+
+    // 3. Elements with aria-hidden="true" (including ancestors)
+    {
+        let mut current = Some(node_id);
+        while let Some(cid) = current {
+            if helpers::get_attr_value(arena, cid, "aria-hidden") == Some("true") {
+                return true;
+            }
+            current = arena.get(cid).and_then(markuplint_dom::node::DomNode::parent_id);
+        }
+    }
+
+    // 4. Descendants of elements with childrenPresentational: true
+    //    Note: Uses base implicit role lookup (no full getComputedRole yet).
+    //    Full implementation deferred to Phase 2-3b (getComputedRole).
+    {
+        let mut current = arena.get(node_id).and_then(markuplint_dom::node::DomNode::parent_id);
+        while let Some(pid) = current {
+            if let Some(parent_el) = arena.get(pid).and_then(|n| n.as_element()) {
+                let parent_tag = &parent_el.base.node_name;
+                // Check explicit role first
+                if let Some(role_attr) = helpers::get_attr_value(arena, pid, "role") {
+                    let first_role = role_attr.split_ascii_whitespace().next().unwrap_or("");
+                    if let Some(role_spec) = aria::get_role_spec(spec, first_role, version)
+                        && role_spec.children_presentational == Some(true)
+                    {
+                        return true;
+                    }
+                } else if let Some(implicit_role) = aria::get_base_implicit_role(spec, parent_tag)
+                    && let Some(role_spec) = aria::get_role_spec(spec, implicit_role, version)
+                    && role_spec.children_presentational == Some(true)
+                {
+                    return true;
+                }
+            }
+            current = arena.get(pid).and_then(markuplint_dom::node::DomNode::parent_id);
+        }
+    }
+
+    false
+}
+
+/// WAI-ARIA inclusion rules (§6.4.2).
+fn is_including(spec: &MLMLSpec, arena: &DomArena, node_id: NodeId, version: ARIAVersion) -> bool {
+    // Skip if aria-hidden="true"
+    if helpers::get_attr_value(arena, node_id, "aria-hidden") == Some("true") {
+        return false;
+    }
+
+    // Has explicit (non-implicit) role → included
+    if let Some(role_attr) = helpers::get_attr_value(arena, node_id, "role") {
+        let first_role = role_attr.split_ascii_whitespace().next().unwrap_or("");
+        if !first_role.is_empty()
+            && let Some(role_spec) = aria::get_role_spec(spec, first_role, version)
+            && !role_spec.is_abstract.unwrap_or(false)
+        {
+            return true;
+        }
+    }
+
+    // Has global WAI-ARIA attribute → included
+    let aria_spec = aria::get_aria_spec(spec, version);
+    if let Some(el) = arena.get(node_id).and_then(|n| n.as_element()) {
+        for attr in &el.attributes {
+            if let markuplint_core::mlast::MLASTAttr::HTMLAttr(html_attr) = attr {
+                let attr_name = &html_attr.node_name;
+                if aria_spec
+                    .props
+                    .iter()
+                    .any(|p| p.is_global == Some(true) && p.name == *attr_name)
+                {
+                    return true;
+                }
+            }
+        }
+    }
+
+    false
+}
+
+/// Check if element is exposed per HTML/SVG spec rules.
+fn is_exposed_element(spec: &MLMLSpec, arena: &DomArena, node_id: NodeId, tag_name: &str) -> bool {
+    // SVG renderable check
+    if let Some(svg_tags) = spec.def.content_models.get("#SVGRenderable")
+        && svg_tags.iter().any(|t| t.eq_ignore_ascii_case(tag_name))
+    {
+        return true;
+    }
+
+    // Metadata elements are not exposed
+    if let Some(metadata_tags) = spec.def.content_models.get("#metadata")
+        && metadata_tags.iter().any(|t| t.eq_ignore_ascii_case(tag_name))
+    {
+        return false;
+    }
+
+    // input[type=hidden] is not exposed
+    if tag_name.eq_ignore_ascii_case("input")
+        && let Some(type_val) = helpers::get_attr_value(arena, node_id, "type")
+        && type_val.eq_ignore_ascii_case("hidden")
+    {
+        return false;
+    }
+
+    true
+}
+
+/// Check if role name is presentational (none/presentation).
+fn is_presentational(role: &str) -> bool {
+    role.eq_ignore_ascii_case("presentation") || role.eq_ignore_ascii_case("none")
+}
+
+/// Check for inline style `display:none` or `visibility:hidden`.
+fn has_display_none_or_visibility_hidden(arena: &DomArena, node_id: NodeId) -> bool {
+    let Some(style) = helpers::get_attr_value(arena, node_id, "style") else {
+        return false;
+    };
+    let lower = style.to_ascii_lowercase();
+    (lower.contains("display") && lower.contains("none")) || (lower.contains("visibility") && lower.contains("hidden"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::aria::may_be_focusable::tests::make_arena;
+    use markuplint_core::mlast::{ElementType, MLASTAttr, MLASTHTMLAttr, MLASTToken, NamespaceURI};
+    use markuplint_dom::arena::DomArenaBuilder;
+    use markuplint_dom::node::{DocumentData, DomNode, ElementData, NodeBase};
+    use markuplint_types::spec::load_spec;
+
+    fn spec() -> MLMLSpec {
+        load_spec(include_str!("../../../../packages/@markuplint/html-spec/index.json")).unwrap()
+    }
+
+    /// Build a simple parent > child arena for testing ancestor checks.
+    fn make_nested(
+        parent_tag: &str,
+        parent_attrs: &[(&str, &str)],
+        child_tag: &str,
+        child_attrs: &[(&str, &str)],
+    ) -> (DomArena, NodeId) {
+        let empty_token = || MLASTToken {
+            uuid: String::new(),
+            raw: String::new(),
+            offset: 0,
+            line: 1,
+            col: 1,
+        };
+
+        let make_attrs = |attrs: &[(&str, &str)]| -> Vec<MLASTAttr> {
+            attrs
+                .iter()
+                .map(|(name, value)| {
+                    MLASTAttr::HTMLAttr(Box::new(MLASTHTMLAttr {
+                        uuid: String::new(),
+                        raw: format!("{name}=\"{value}\""),
+                        offset: 0,
+                        line: 1,
+                        col: 1,
+                        node_name: name.to_string(),
+                        spaces_before_name: empty_token(),
+                        name: MLASTToken {
+                            raw: name.to_string(),
+                            ..empty_token()
+                        },
+                        spaces_before_equal: empty_token(),
+                        equal: MLASTToken {
+                            raw: "=".to_string(),
+                            ..empty_token()
+                        },
+                        spaces_after_equal: empty_token(),
+                        start_quote: MLASTToken {
+                            raw: "\"".to_string(),
+                            ..empty_token()
+                        },
+                        value: MLASTToken {
+                            raw: value.to_string(),
+                            ..empty_token()
+                        },
+                        end_quote: MLASTToken {
+                            raw: "\"".to_string(),
+                            ..empty_token()
+                        },
+                        is_dynamic_value: None,
+                        is_directive: None,
+                        potential_name: None,
+                        potential_value: None,
+                        value_type: None,
+                        candidate: None,
+                        is_duplicatable: false,
+                    }))
+                })
+                .collect()
+        };
+
+        let mut builder = DomArenaBuilder::new();
+        let doc_id = builder.push(DomNode::Document(DocumentData {
+            id: 0,
+            raw: String::new(),
+            is_fragment: true,
+            unknown_parse_error: None,
+            children: vec![],
+        }));
+        let parent_id = builder.push(DomNode::Element(ElementData {
+            base: NodeBase {
+                id: 1,
+                uuid: "parent".to_string(),
+                raw: format!("<{parent_tag}>"),
+                offset: 0,
+                line: 1,
+                col: 1,
+                node_name: parent_tag.to_string(),
+                parent: Some(doc_id),
+                children: vec![],
+                next_sibling: None,
+                prev_sibling: None,
+                depth: 1,
+            },
+            namespace: NamespaceURI::XHTML,
+            element_type: ElementType::Html,
+            is_fragment: false,
+            attributes: make_attrs(parent_attrs),
+            has_spread_attr: false,
+            block_behavior: None,
+            pair_node_id: None,
+            tag_open_char: "<".to_string(),
+            tag_close_char: ">".to_string(),
+            is_ghost: false,
+        }));
+        let child_id = builder.push(DomNode::Element(ElementData {
+            base: NodeBase {
+                id: 2,
+                uuid: "child".to_string(),
+                raw: format!("<{child_tag}>"),
+                offset: 0,
+                line: 1,
+                col: 1,
+                node_name: child_tag.to_string(),
+                parent: Some(parent_id),
+                children: vec![],
+                next_sibling: None,
+                prev_sibling: None,
+                depth: 2,
+            },
+            namespace: NamespaceURI::XHTML,
+            element_type: ElementType::Html,
+            is_fragment: false,
+            attributes: make_attrs(child_attrs),
+            has_spread_attr: false,
+            block_behavior: None,
+            pair_node_id: None,
+            tag_open_char: "<".to_string(),
+            tag_close_char: ">".to_string(),
+            is_ghost: false,
+        }));
+        if let Some(DomNode::Document(doc)) = builder.get_mut(doc_id) {
+            doc.children.push(parent_id);
+        }
+        if let Some(DomNode::Element(p)) = builder.get_mut(parent_id) {
+            p.base.children.push(child_id);
+        }
+        (builder.finish(), child_id)
+    }
+
+    #[test]
+    fn basic_div_exposed() {
+        let s = spec();
+        let (arena, id) = make_arena("div", &[]);
+        assert!(is_exposed(&s, &arena, id, ARIAVersion::V1_2));
+    }
+
+    #[test]
+    fn aria_hidden_true_excluded() {
+        let s = spec();
+        let (arena, id) = make_arena("div", &[("aria-hidden", "true")]);
+        assert!(!is_exposed(&s, &arena, id, ARIAVersion::V1_2));
+    }
+
+    #[test]
+    fn role_presentation_excluded() {
+        let s = spec();
+        let (arena, id) = make_arena("div", &[("role", "presentation")]);
+        assert!(!is_exposed(&s, &arena, id, ARIAVersion::V1_2));
+    }
+
+    #[test]
+    fn role_presentation_child_exposed() {
+        let s = spec();
+        let (arena, child) = make_nested("div", &[("role", "presentation")], "span", &[]);
+        assert!(is_exposed(&s, &arena, child, ARIAVersion::V1_2));
+    }
+
+    #[test]
+    fn aria_hidden_ancestor_excludes_child() {
+        let s = spec();
+        let (arena, child) = make_nested("div", &[("aria-hidden", "true")], "span", &[]);
+        assert!(!is_exposed(&s, &arena, child, ARIAVersion::V1_2));
+    }
+
+    #[test]
+    fn display_none_ancestor_excludes_child() {
+        let s = spec();
+        let (arena, child) = make_nested("div", &[("style", "display: none;")], "span", &[]);
+        assert!(!is_exposed(&s, &arena, child, ARIAVersion::V1_2));
+    }
+
+    #[test]
+    fn hidden_attr_ancestor_excludes_child() {
+        let s = spec();
+        let (arena, child) = make_nested("div", &[("hidden", "")], "span", &[]);
+        assert!(!is_exposed(&s, &arena, child, ARIAVersion::V1_2));
+    }
+
+    #[test]
+    fn hidden_until_found_excludes_child() {
+        let s = spec();
+        let (arena, child) = make_nested("div", &[("hidden", "until-found")], "span", &[]);
+        assert!(!is_exposed(&s, &arena, child, ARIAVersion::V1_2));
+    }
+
+    #[test]
+    fn children_presentational_button() {
+        let s = spec();
+        let (arena, child) = make_nested("button", &[], "span", &[]);
+        assert!(!is_exposed(&s, &arena, child, ARIAVersion::V1_2));
+    }
+
+    #[test]
+    fn hidden_button_child_excluded() {
+        let s = spec();
+        let (arena, _child) = make_nested("button", &[("hidden", "")], "span", &[]);
+        let parent_id = 1; // button
+        assert!(!is_exposed(&s, &arena, parent_id, ARIAVersion::V1_2));
+    }
+
+    #[test]
+    fn input_text_exposed() {
+        let s = spec();
+        let (arena, id) = make_arena("input", &[("type", "text")]);
+        assert!(is_exposed(&s, &arena, id, ARIAVersion::V1_2));
+    }
+
+    #[test]
+    fn input_hidden_not_exposed() {
+        let s = spec();
+        let (arena, id) = make_arena("input", &[("type", "hidden")]);
+        assert!(!is_exposed(&s, &arena, id, ARIAVersion::V1_2));
+    }
+
+    #[test]
+    fn meta_not_exposed() {
+        let s = spec();
+        let (arena, id) = make_arena("meta", &[]);
+        assert!(!is_exposed(&s, &arena, id, ARIAVersion::V1_2));
+    }
+
+    #[test]
+    fn style_not_exposed() {
+        let s = spec();
+        let (arena, id) = make_arena("style", &[]);
+        assert!(!is_exposed(&s, &arena, id, ARIAVersion::V1_2));
+    }
+
+    #[test]
+    fn script_not_exposed() {
+        let s = spec();
+        let (arena, id) = make_arena("script", &[]);
+        assert!(!is_exposed(&s, &arena, id, ARIAVersion::V1_2));
+    }
+
+    #[test]
+    fn recent_elements_exposed() {
+        let s = spec();
+        for tag in &[
+            "canvas", "dialog", "details", "summary", "meter", "progress", "picture", "ruby", "time",
+        ] {
+            let (arena, id) = make_arena(tag, &[]);
+            assert!(is_exposed(&s, &arena, id, ARIAVersion::V1_2), "{tag} should be exposed");
+        }
+    }
+
+    #[test]
+    fn unknown_elements_exposed() {
+        let s = spec();
+        for tag in &["unknown", "font", "x-component"] {
+            let (arena, id) = make_arena(tag, &[]);
+            assert!(is_exposed(&s, &arena, id, ARIAVersion::V1_2), "{tag} should be exposed");
+        }
+    }
+
+    // --- Edge case tests (from QA review) ---
+
+    #[test]
+    fn aria_hidden_false_does_not_override_parent_true() {
+        // WAI-ARIA: aria-hidden="true" on parent overrides aria-hidden="false" on descendant
+        let s = spec();
+        let (arena, child) = make_nested("div", &[("aria-hidden", "true")], "span", &[("aria-hidden", "false")]);
+        assert!(!is_exposed(&s, &arena, child, ARIAVersion::V1_2));
+    }
+
+    #[test]
+    fn multiple_roles_uses_first() {
+        let s = spec();
+        let (arena, id) = make_arena("div", &[("role", "presentation link")]);
+        // First role is "presentation" → excluded
+        assert!(!is_exposed(&s, &arena, id, ARIAVersion::V1_2));
+    }
+
+    #[test]
+    fn empty_role_is_exposed() {
+        let s = spec();
+        let (arena, id) = make_arena("div", &[("role", "")]);
+        assert!(is_exposed(&s, &arena, id, ARIAVersion::V1_2));
+    }
+
+    #[test]
+    fn display_none_on_self() {
+        let s = spec();
+        let (arena, id) = make_arena("div", &[("style", "display: none;")]);
+        assert!(!is_exposed(&s, &arena, id, ARIAVersion::V1_2));
+    }
+
+    #[test]
+    fn visibility_hidden_on_self() {
+        let s = spec();
+        let (arena, id) = make_arena("div", &[("style", "visibility: hidden;")]);
+        assert!(!is_exposed(&s, &arena, id, ARIAVersion::V1_2));
+    }
+
+    #[test]
+    fn invalid_node_id_returns_true() {
+        let s = spec();
+        let (arena, _) = make_arena("div", &[]);
+        // NodeId 999 does not exist
+        assert!(is_exposed(&s, &arena, 999, ARIAVersion::V1_2));
+    }
+}

--- a/crates/markuplint-rules/src/aria/may_be_focusable.rs
+++ b/crates/markuplint-rules/src/aria/may_be_focusable.rs
@@ -1,0 +1,315 @@
+//! Heuristic check for whether an element may potentially be focusable.
+//!
+//! Ports `packages/@markuplint/ml-spec/src/algorithm/html/may-be-focusable.ts`.
+//!
+//! This is a static heuristic — it does NOT account for runtime state such as
+//! `disabled`, `inert`, or CSS `display:none`. Those are checked separately by
+//! the caller (e.g., `getComputedRole`).
+
+use markuplint_dom::arena::{DomArena, NodeId};
+use markuplint_dom::helpers;
+use markuplint_types::spec::lookup;
+use markuplint_types::spec::types::MLMLSpec;
+
+/// Check if an element may potentially be focusable.
+///
+/// Returns `true` if the element is interactive content, has a `tabindex`
+/// attribute, or is contenteditable. Does NOT check `disabled`/`inert`.
+pub fn may_be_focusable(spec: &MLMLSpec, arena: &DomArena, node_id: NodeId) -> bool {
+    let Some(node) = arena.get(node_id) else {
+        return false;
+    };
+    let Some(el) = node.as_element() else {
+        return false;
+    };
+
+    let tag_name = &el.base.node_name;
+
+    // Check interactive content category from spec
+    if let Some(interactive_tags) = lookup::get_content_model_tags(spec, "#interactive") {
+        for selector in interactive_tags {
+            if matches_simple_selector(tag_name, selector, arena, node_id) {
+                return true;
+            }
+        }
+    }
+
+    // Check tabindex attribute
+    if helpers::has_attr(arena, node_id, "tabindex") {
+        return true;
+    }
+
+    // Check contenteditable (not false)
+    if let Some(val) = helpers::get_attr_value(arena, node_id, "contenteditable")
+        && !val.eq_ignore_ascii_case("false")
+    {
+        return true;
+    }
+
+    false
+}
+
+/// Simple selector matching for interactive content selectors.
+///
+/// Handles patterns like `"a[href]"`, `"input:not([type='hidden' i])"`, `"button"`.
+/// For complex selectors, falls back to tag-name-only matching (conservative: may
+/// over-report focusability, which is safe for a heuristic check).
+fn matches_simple_selector(tag_name: &str, selector: &str, arena: &DomArena, node_id: NodeId) -> bool {
+    // Extract tag name (before `[` or `:`)
+    let sel_tag = selector.find(['[', ':']).map_or(selector, |pos| &selector[..pos]);
+
+    if !sel_tag.eq_ignore_ascii_case(tag_name) {
+        return false;
+    }
+
+    // Tag name matches. Check attribute requirements.
+    // Pattern: "tag[attr]" means attribute must be present.
+    if let Some(bracket_pos) = selector.find('[') {
+        let rest = &selector[bracket_pos..];
+        // Handle ":not([attr...])" — inverted attribute check
+        if selector[..bracket_pos].contains(":not(") {
+            // :not([type='hidden' i]) — exclude if attribute matches the value
+            // For this heuristic, we check the positive case: if the element
+            // matches the :not condition, it's NOT focusable.
+            if let Some(inner) = extract_not_attr_condition(rest) {
+                return !matches_attr_condition(arena, node_id, &inner);
+            }
+            // Complex :not() — conservatively return true (tag matches)
+            return true;
+        }
+        // Positive attribute check: "tag[attr]"
+        if let Some(attr_name) = rest.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
+            return helpers::has_attr(arena, node_id, attr_name);
+        }
+        // Complex attribute selector — tag matches, conservatively return true
+        return true;
+    }
+
+    // Simple tag name match with no attribute condition
+    true
+}
+
+/// Extract attribute name and value from a `:not([attr='value' i])` pattern.
+fn extract_not_attr_condition(s: &str) -> Option<AttrCondition> {
+    // Expected pattern: "[type='hidden' i])" or "[type='hidden'])"
+    let inner = s.strip_prefix("[")?.strip_suffix("])")?;
+    if let Some(eq_pos) = inner.find('=') {
+        let attr_name = &inner[..eq_pos];
+        let rest = &inner[eq_pos + 1..];
+        let value = rest.trim_matches(|c: char| c == '\'' || c == '"' || c == ' ' || c == 'i');
+        Some(AttrCondition {
+            name: attr_name.to_string(),
+            value: Some(value.to_string()),
+        })
+    } else {
+        Some(AttrCondition {
+            name: inner.to_string(),
+            value: None,
+        })
+    }
+}
+
+struct AttrCondition {
+    name: String,
+    value: Option<String>,
+}
+
+fn matches_attr_condition(arena: &DomArena, node_id: NodeId, cond: &AttrCondition) -> bool {
+    if let Some(expected) = &cond.value {
+        helpers::get_attr_value(arena, node_id, &cond.name).is_some_and(|v| v.eq_ignore_ascii_case(expected))
+    } else {
+        helpers::has_attr(arena, node_id, &cond.name)
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use markuplint_types::spec::load_spec;
+
+    fn spec() -> MLMLSpec {
+        load_spec(include_str!("../../../../packages/@markuplint/html-spec/index.json")).unwrap()
+    }
+
+    pub(crate) fn make_arena(tag: &str, attrs: &[(&str, &str)]) -> (DomArena, NodeId) {
+        use markuplint_core::mlast::{ElementType, MLASTAttr, MLASTHTMLAttr, MLASTToken, NamespaceURI};
+        use markuplint_dom::arena::DomArenaBuilder;
+        use markuplint_dom::node::{DocumentData, DomNode, ElementData, NodeBase};
+
+        let empty_token = || MLASTToken {
+            uuid: String::new(),
+            raw: String::new(),
+            offset: 0,
+            line: 1,
+            col: 1,
+        };
+
+        let attributes: Vec<MLASTAttr> = attrs
+            .iter()
+            .map(|(name, value)| {
+                MLASTAttr::HTMLAttr(Box::new(MLASTHTMLAttr {
+                    uuid: String::new(),
+                    raw: format!("{name}=\"{value}\""),
+                    offset: 0,
+                    line: 1,
+                    col: 1,
+                    node_name: name.to_string(),
+                    spaces_before_name: empty_token(),
+                    name: MLASTToken {
+                        raw: name.to_string(),
+                        ..empty_token()
+                    },
+                    spaces_before_equal: empty_token(),
+                    equal: MLASTToken {
+                        raw: "=".to_string(),
+                        ..empty_token()
+                    },
+                    spaces_after_equal: empty_token(),
+                    start_quote: MLASTToken {
+                        raw: "\"".to_string(),
+                        ..empty_token()
+                    },
+                    value: MLASTToken {
+                        raw: value.to_string(),
+                        ..empty_token()
+                    },
+                    end_quote: MLASTToken {
+                        raw: "\"".to_string(),
+                        ..empty_token()
+                    },
+                    is_dynamic_value: None,
+                    is_directive: None,
+                    potential_name: None,
+                    potential_value: None,
+                    value_type: None,
+                    candidate: None,
+                    is_duplicatable: false,
+                }))
+            })
+            .collect();
+
+        let mut builder = DomArenaBuilder::new();
+        let doc_id = builder.push(DomNode::Document(DocumentData {
+            id: 0,
+            raw: String::new(),
+            is_fragment: true,
+            unknown_parse_error: None,
+            children: vec![],
+        }));
+        let el_id = builder.push(DomNode::Element(ElementData {
+            base: NodeBase {
+                id: 1,
+                uuid: "el-1".to_string(),
+                raw: format!("<{tag}>"),
+                offset: 0,
+                line: 1,
+                col: 1,
+                node_name: tag.to_string(),
+                parent: Some(doc_id),
+                children: vec![],
+                next_sibling: None,
+                prev_sibling: None,
+                depth: 1,
+            },
+            namespace: NamespaceURI::XHTML,
+            element_type: ElementType::Html,
+            is_fragment: false,
+            attributes,
+            has_spread_attr: false,
+            block_behavior: None,
+            pair_node_id: None,
+            tag_open_char: "<".to_string(),
+            tag_close_char: ">".to_string(),
+            is_ghost: false,
+        }));
+        if let Some(DomNode::Document(doc)) = builder.get_mut(doc_id) {
+            doc.children.push(el_id);
+        }
+        (builder.finish(), el_id)
+    }
+
+    #[test]
+    fn button_is_focusable() {
+        let s = spec();
+        let (arena, id) = make_arena("button", &[]);
+        assert!(may_be_focusable(&s, &arena, id));
+    }
+
+    #[test]
+    fn input_is_focusable() {
+        let s = spec();
+        let (arena, id) = make_arena("input", &[]);
+        assert!(may_be_focusable(&s, &arena, id));
+    }
+
+    #[test]
+    fn a_with_href_is_focusable() {
+        let s = spec();
+        let (arena, id) = make_arena("a", &[("href", "https://example.com")]);
+        assert!(may_be_focusable(&s, &arena, id));
+    }
+
+    #[test]
+    fn a_without_href_not_focusable() {
+        let s = spec();
+        let (arena, id) = make_arena("a", &[]);
+        assert!(!may_be_focusable(&s, &arena, id));
+    }
+
+    #[test]
+    fn div_not_focusable() {
+        let s = spec();
+        let (arena, id) = make_arena("div", &[]);
+        assert!(!may_be_focusable(&s, &arena, id));
+    }
+
+    #[test]
+    fn div_with_tabindex_is_focusable() {
+        let s = spec();
+        let (arena, id) = make_arena("div", &[("tabindex", "0")]);
+        assert!(may_be_focusable(&s, &arena, id));
+    }
+
+    #[test]
+    fn div_with_negative_tabindex_is_focusable() {
+        let s = spec();
+        let (arena, id) = make_arena("div", &[("tabindex", "-1")]);
+        assert!(may_be_focusable(&s, &arena, id));
+    }
+
+    #[test]
+    fn contenteditable_is_focusable() {
+        let s = spec();
+        let (arena, id) = make_arena("div", &[("contenteditable", "true")]);
+        assert!(may_be_focusable(&s, &arena, id));
+    }
+
+    #[test]
+    fn contenteditable_false_not_focusable() {
+        let s = spec();
+        let (arena, id) = make_arena("div", &[("contenteditable", "false")]);
+        assert!(!may_be_focusable(&s, &arena, id));
+    }
+
+    #[test]
+    fn select_is_focusable() {
+        let s = spec();
+        let (arena, id) = make_arena("select", &[]);
+        assert!(may_be_focusable(&s, &arena, id));
+    }
+
+    #[test]
+    fn textarea_is_focusable() {
+        let s = spec();
+        let (arena, id) = make_arena("textarea", &[]);
+        assert!(may_be_focusable(&s, &arena, id));
+    }
+
+    #[test]
+    fn contenteditable_empty_is_focusable() {
+        // contenteditable="" is equivalent to contenteditable="true"
+        let s = spec();
+        let (arena, id) = make_arena("div", &[("contenteditable", "")]);
+        assert!(may_be_focusable(&s, &arena, id));
+    }
+}

--- a/crates/markuplint-rules/src/aria/mod.rs
+++ b/crates/markuplint-rules/src/aria/mod.rs
@@ -1,0 +1,7 @@
+//! ARIA computation algorithms.
+//!
+//! Ports the TypeScript implementation from
+//! `packages/@markuplint/ml-spec/src/algorithm/aria/`.
+
+pub mod is_exposed;
+pub mod may_be_focusable;

--- a/crates/markuplint-rules/src/lib.rs
+++ b/crates/markuplint-rules/src/lib.rs
@@ -15,4 +15,5 @@
 //! markuplint-rules   (content model matching, depends on both)
 //! ```
 
+pub mod aria;
 pub mod content_model;


### PR DESCRIPTION
## Summary

- Add DOM attribute helpers (`get_attr_value`, `has_attr`) to `markuplint-dom`
- Implement `is_exposed()` — WAI-ARIA §6.4 accessibility tree exposure check
- Implement `may_be_focusable()` — interactive content focusability heuristic

### is_exposed

Determines whether an element is included in the accessibility tree. Applies:
- **Exclusion rules**: CSS hidden (style regex), `hidden` attr, `aria-hidden="true"` (ancestor walk), presentational role, `childrenPresentational`
- **Element filtering**: metadata elements, `input[type=hidden]`, SVG renderable
- **Inclusion rules**: explicit role, global WAI-ARIA attributes

### may_be_focusable

Static heuristic check: interactive content category (from spec), `[tabindex]`, `[contenteditable]`.
Does NOT check `disabled`/`inert` — caller handles those (separation of concerns, matching TS design).

## Test plan

- [x] `cargo test -p markuplint-rules -- aria` — 38 tests pass
- [x] `cargo clippy -- -D warnings` — 0 warnings
- [x] `cargo fmt --check` — clean

Edge case tests from QA review:
- aria-hidden="false" override by parent aria-hidden="true"
- Multiple roles (`role="presentation link"`)
- Empty role attribute
- `display:none` / `visibility:hidden` on self
- Invalid node_id
- `contenteditable=""`

## Related

- Closes #3502
- Part of Phase 2-3 (#3178)
- Prerequisite for #3500 (getComputedRole) and #3501 (accname)

🤖 Generated with [Claude Code](https://claude.com/claude-code)