### PR TITLE
feat: Rust-native lint pipeline with Rule trait and NAPI lint()

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -464,10 +464,12 @@ version = "0.0.0"
 dependencies = [
  "markuplint-core",
  "markuplint-dom",
+ "markuplint-rules",
  "markuplint-types",
  "napi",
  "napi-build",
  "napi-derive",
+ "serde_json",
 ]
 
 [[package]]
@@ -478,6 +480,7 @@ dependencies = [
  "markuplint-dom",
  "markuplint-selector",
  "markuplint-types",
+ "serde",
  "serde_json",
 ]
 

--- a/crates/README.md
+++ b/crates/README.md
@@ -33,6 +33,7 @@ Exposes Rust modules to Node.js via napi-rs. This crate compiles to a platform-s
 - **NapiDom**: DOM tree from MLAST JSON with traversal queries
 - **Primitive validators**: `isInt`, `isUint`, `isFloat`, `isQuantity`, `range`, `splitUnit`
 - **CSS value matching**: `matchCssSyntax(syntax, value)` and `matchCssProperty(syntax, value)` — validates CSS values against Value Definition Syntax, including calc() type checking and var() validation
+- **`lint(mlastJson, configJson, specJson)`**: Full lint pipeline — runs all enabled Rust rules and returns violations
 
 ### markuplint-rules
 
@@ -42,6 +43,8 @@ Content model validation rules. Bridges `markuplint-types` (spec data) and `mark
 - **CSS selector integration**: `:not()`, `:has()`, `:is()` via arena bridge to `markuplint-selector`
 - **Arena bridge**: converts lightweight `ChildNodeInfo` to minimal `DomArena` for selector evaluation
 - **ARIA algorithms**: `get_computed_role()` (Phase 2-3b), `get_accname()` (Phase 2-3c: AccName 1.2 §4.3.2), `is_exposed()` (Phase 2-3d), `may_be_focusable()`
+- **Lint engine**: `Rule` trait, `lint()` function (MLAST + config + spec → violations), config parsing
+- **Built-in rules**: `attr-duplication`
 
 ### markuplint-types
 

--- a/crates/markuplint-napi/Cargo.toml
+++ b/crates/markuplint-napi/Cargo.toml
@@ -10,7 +10,9 @@ crate-type = ["cdylib"]
 [dependencies]
 markuplint-core = { path = "../markuplint-core" }
 markuplint-dom = { path = "../markuplint-dom" }
+markuplint-rules = { path = "../markuplint-rules" }
 markuplint-types = { path = "../markuplint-types" }
+serde_json = { workspace = true }
 napi = { version = "3", features = ["serde-json"] }
 napi-derive = "3"
 

--- a/crates/markuplint-napi/src/lib.rs
+++ b/crates/markuplint-napi/src/lib.rs
@@ -361,3 +361,66 @@ pub fn match_css_property(syntax: String, value: String) -> CssMatchResult {
         },
     }
 }
+
+// ============================================================
+// Lint pipeline
+// ============================================================
+
+/// A lint violation reported by a Rust rule.
+#[napi(object)]
+pub struct NapiViolation {
+    /// Rule identifier (e.g., `"attr-duplication"`).
+    pub rule_id: String,
+    /// Severity: `"error"`, `"warning"`, or `"info"`.
+    pub severity: String,
+    /// Human-readable message.
+    pub message: String,
+    /// 1-based line number.
+    pub line: u32,
+    /// 1-based column number.
+    pub col: u32,
+    /// Raw source text at the violation location.
+    pub raw: String,
+}
+
+/// Run Rust-native lint rules on an MLAST document.
+///
+/// Takes MLAST JSON (from any markuplint parser), a rule config JSON, and
+/// spec JSON (html-spec). Returns an array of violations.
+///
+/// Config format: `{ "rules": { "attr-duplication": true, ... } }`
+///
+/// # Errors
+///
+/// Throws a napi error if MLAST, spec, or config JSON fails to parse.
+#[napi]
+#[allow(clippy::needless_pass_by_value)]
+pub fn lint(mlast_json: String, config_json: String, spec_json: String) -> napi::Result<Vec<NapiViolation>> {
+    let arena = builder::build_from_json(&mlast_json)
+        .map_err(|e| napi::Error::from_reason(format!("MLAST parse error: {e}")))?;
+    let spec = markuplint_types::spec::load_spec(&spec_json)
+        .map_err(|e| napi::Error::from_reason(format!("Spec parse error: {e}")))?;
+    let config = serde_json::from_str::<markuplint_rules::lint::LintConfig>(&config_json)
+        .map_err(|e| napi::Error::from_reason(format!("Config parse error: {e}")))?;
+
+    let result = markuplint_rules::lint::lint(&arena, &spec, &config);
+
+    let violations = result
+        .violations
+        .into_iter()
+        .map(|v| NapiViolation {
+            rule_id: v.rule_id,
+            severity: match v.severity {
+                markuplint_rules::violation::Severity::Error => "error".to_string(),
+                markuplint_rules::violation::Severity::Warning => "warning".to_string(),
+                markuplint_rules::violation::Severity::Info => "info".to_string(),
+            },
+            message: v.message,
+            line: v.line,
+            col: v.col,
+            raw: v.raw,
+        })
+        .collect::<Vec<_>>();
+
+    Ok(violations)
+}

--- a/crates/markuplint-rules/Cargo.toml
+++ b/crates/markuplint-rules/Cargo.toml
@@ -9,8 +9,7 @@ markuplint-core = { path = "../markuplint-core" }
 markuplint-dom = { path = "../markuplint-dom" }
 markuplint-selector = { path = "../markuplint-selector" }
 markuplint-types = { path = "../markuplint-types" }
-
-[dev-dependencies]
+serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 
 [lints]

--- a/crates/markuplint-rules/src/lib.rs
+++ b/crates/markuplint-rules/src/lib.rs
@@ -1,19 +1,22 @@
-//! Rule implementations for markuplint.
+//! Lint rules and execution engine for markuplint.
 //!
-//! This crate exists to break a circular dependency: `markuplint-selector`
-//! depends on `markuplint-types` for spec data, so `markuplint-types` cannot
-//! depend on `markuplint-selector`. Content model matching needs both spec
-//! data (from `markuplint-types`) and CSS selector evaluation (from
-//! `markuplint-selector`), so it lives here — above both in the dependency
-//! graph.
+//! This crate contains:
+//! - **Rule trait and registry** (`rule.rs`, `rules/`)
+//! - **Lint function** (`lint.rs`) — MLAST + config + spec → violations
+//! - **ARIA algorithms** (`aria/`) — computed role, accname, isExposed
+//! - **Content model matching** (`content_model/`)
 //!
 //! ```text
-//! markuplint-types   (spec data, no selector dep)
+//! markuplint-types   (spec data)
 //!       ↑
-//! markuplint-selector (CSS selectors, depends on types)
+//! markuplint-selector (CSS selectors)
 //!       ↑
-//! markuplint-rules   (content model matching, depends on both)
+//! markuplint-rules   (rules + lint engine)
 //! ```
 
 pub mod aria;
 pub mod content_model;
+pub mod lint;
+pub mod rule;
+pub mod rules;
+pub mod violation;

--- a/crates/markuplint-rules/src/lint.rs
+++ b/crates/markuplint-rules/src/lint.rs
@@ -1,0 +1,218 @@
+//! Top-level lint function: MLAST JSON + config → violations.
+//!
+//! This is the main entry point for Rust-native linting. It:
+//! 1. Builds a DOM arena from MLAST JSON
+//! 2. Loads spec data
+//! 3. Parses rule config
+//! 4. Runs enabled rules
+//! 5. Returns violations as JSON
+
+use markuplint_dom::arena::DomArena;
+use markuplint_dom::builder;
+use markuplint_types::spec::load_spec;
+use markuplint_types::spec::types::MLMLSpec;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::rule::{Rule, RuleConfig};
+use crate::rules::attr_duplication::AttrDuplication;
+use crate::violation::{Severity, Violation};
+
+/// Lint configuration for enabled rules.
+#[derive(Debug, Deserialize)]
+pub struct LintConfig {
+    /// Rule configurations: `{ "rule-id": true | "error" | { severity, value, options } }`.
+    #[serde(default)]
+    pub rules: std::collections::HashMap<String, Value>,
+}
+
+/// Lint result.
+#[derive(Debug, Serialize)]
+pub struct LintResult {
+    /// Violations found.
+    pub violations: Vec<Violation>,
+}
+
+/// Run lint on MLAST JSON with the given config and spec.
+///
+/// Returns a `LintResult` with all violations found.
+pub fn lint(arena: &DomArena, spec: &MLMLSpec, config: &LintConfig) -> LintResult {
+    let rules = get_all_rules();
+    let mut violations = Vec::new();
+
+    for rule in &rules {
+        let rule_id = rule.id();
+
+        // Check if rule is enabled in config
+        let Some(rule_config_value) = config.rules.get(rule_id) else {
+            continue;
+        };
+
+        // Parse rule config
+        let Some(rule_config) = parse_rule_config(rule_config_value) else {
+            continue; // disabled
+        };
+
+        let rule_violations = rule.verify(arena, spec, &rule_config);
+        violations.extend(rule_violations);
+    }
+
+    // Sort by line, then col
+    violations.sort_by(|a, b| a.line.cmp(&b.line).then(a.col.cmp(&b.col)));
+
+    LintResult { violations }
+}
+
+/// Convenience: lint from raw JSON strings.
+///
+/// # Errors
+///
+/// Returns an error string if MLAST, spec, or config JSON parsing fails.
+pub fn lint_from_json(mlast_json: &str, config_json: &str, spec_json: &str) -> Result<String, String> {
+    let arena = builder::build_from_json(mlast_json).map_err(|e| format!("MLAST parse error: {e}"))?;
+    let spec = load_spec(spec_json).map_err(|e| format!("Spec parse error: {e}"))?;
+    let config: LintConfig = serde_json::from_str(config_json).map_err(|e| format!("Config parse error: {e}"))?;
+
+    let result = lint(&arena, &spec, &config);
+    serde_json::to_string(&result).map_err(|e| format!("Serialization error: {e}"))
+}
+
+/// Parse a rule config value into `RuleConfig`.
+///
+/// Handles formats:
+/// - `true` → enabled with default severity (error)
+/// - `false` → disabled
+/// - `"error"` / `"warning"` / `"info"` → severity only
+/// - `{ "severity": "warning", "value": ..., "options": ... }` → full config
+fn parse_rule_config(value: &Value) -> Option<RuleConfig> {
+    match value {
+        Value::Bool(true) => Some(RuleConfig::default()),
+        Value::String(s) => {
+            let severity = match s.as_str() {
+                "error" => Severity::Error,
+                "warning" => Severity::Warning,
+                "info" => Severity::Info,
+                _ => return None,
+            };
+            Some(RuleConfig {
+                severity,
+                ..Default::default()
+            })
+        }
+        Value::Object(obj) => {
+            let severity = obj
+                .get("severity")
+                .and_then(|v| v.as_str())
+                .map_or(Severity::Error, |s| match s {
+                    "warning" => Severity::Warning,
+                    "info" => Severity::Info,
+                    _ => Severity::Error,
+                });
+            let rule_value = obj.get("value").cloned().unwrap_or(Value::Bool(true));
+            let options = obj.get("options").cloned().unwrap_or(Value::Null);
+            Some(RuleConfig {
+                severity,
+                value: rule_value,
+                options,
+            })
+        }
+        _ => None,
+    }
+}
+
+/// Get all registered rules.
+fn get_all_rules() -> Vec<Box<dyn Rule>> {
+    vec![Box::new(AttrDuplication)]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_rule_config_true() {
+        let config = parse_rule_config(&Value::Bool(true));
+        assert!(config.is_some());
+        assert_eq!(config.unwrap().severity, Severity::Error);
+    }
+
+    #[test]
+    fn parse_rule_config_false() {
+        assert!(parse_rule_config(&Value::Bool(false)).is_none());
+    }
+
+    #[test]
+    fn parse_rule_config_severity_string() {
+        let config = parse_rule_config(&Value::String("warning".to_string()));
+        assert!(config.is_some());
+        assert_eq!(config.unwrap().severity, Severity::Warning);
+    }
+
+    #[test]
+    fn parse_rule_config_object() {
+        let value = serde_json::json!({
+            "severity": "info",
+            "value": true,
+            "options": { "allowDataAttrs": true }
+        });
+        let config = parse_rule_config(&value);
+        assert!(config.is_some());
+        let config = config.unwrap();
+        assert_eq!(config.severity, Severity::Info);
+        assert_eq!(config.value, Value::Bool(true));
+    }
+
+    // --- Integration test: full pipeline ---
+
+    #[test]
+    fn lint_pipeline_finds_duplicate_attrs() {
+        use crate::rules::attr_duplication::tests::make_element_with_attrs;
+
+        let arena = make_element_with_attrs("div", &[("class", "a"), ("class", "b")]);
+        let spec = load_spec(include_str!("../../../packages/@markuplint/html-spec/index.json")).unwrap();
+        let config = LintConfig {
+            rules: [("attr-duplication".to_string(), Value::Bool(true))]
+                .into_iter()
+                .collect(),
+        };
+
+        let result = lint(&arena, &spec, &config);
+        assert_eq!(result.violations.len(), 1);
+        assert_eq!(result.violations[0].rule_id, "attr-duplication");
+        assert_eq!(result.violations[0].severity, Severity::Error);
+        assert_eq!(result.violations[0].line, 1);
+    }
+
+    #[test]
+    fn lint_pipeline_disabled_rule_no_violations() {
+        use crate::rules::attr_duplication::tests::make_element_with_attrs;
+
+        let arena = make_element_with_attrs("div", &[("class", "a"), ("class", "b")]);
+        let spec = load_spec(include_str!("../../../packages/@markuplint/html-spec/index.json")).unwrap();
+        let config = LintConfig {
+            rules: [("attr-duplication".to_string(), Value::Bool(false))]
+                .into_iter()
+                .collect(),
+        };
+
+        let result = lint(&arena, &spec, &config);
+        assert!(result.violations.is_empty());
+    }
+
+    #[test]
+    fn lint_pipeline_severity_override() {
+        use crate::rules::attr_duplication::tests::make_element_with_attrs;
+
+        let arena = make_element_with_attrs("div", &[("id", "a"), ("id", "b")]);
+        let spec = load_spec(include_str!("../../../packages/@markuplint/html-spec/index.json")).unwrap();
+        let config = LintConfig {
+            rules: [("attr-duplication".to_string(), Value::String("warning".to_string()))]
+                .into_iter()
+                .collect(),
+        };
+
+        let result = lint(&arena, &spec, &config);
+        assert_eq!(result.violations.len(), 1);
+        assert_eq!(result.violations[0].severity, Severity::Warning);
+    }
+}

--- a/crates/markuplint-rules/src/rule.rs
+++ b/crates/markuplint-rules/src/rule.rs
@@ -1,0 +1,40 @@
+//! Rule trait and registry for Rust-native lint rules.
+
+use markuplint_dom::arena::DomArena;
+use markuplint_types::spec::types::MLMLSpec;
+use serde_json::Value;
+
+use crate::violation::Violation;
+
+/// A lint rule that can verify a DOM tree and report violations.
+pub trait Rule: Send + Sync {
+    /// Rule identifier (e.g., `"attr-duplication"`).
+    fn id(&self) -> &str;
+
+    /// Verify the DOM tree and return violations.
+    ///
+    /// `config` is the rule-specific configuration value from the user's
+    /// markuplint config (e.g., `true`, `"error"`, or `{ "severity": "warning", "value": ... }`).
+    fn verify(&self, arena: &DomArena, spec: &MLMLSpec, config: &RuleConfig) -> Vec<Violation>;
+}
+
+/// Parsed rule configuration.
+#[derive(Debug, Clone)]
+pub struct RuleConfig {
+    /// Severity override (default: error).
+    pub severity: crate::violation::Severity,
+    /// Rule-specific value (the `value` field from config).
+    pub value: Value,
+    /// Rule-specific options (the `options` field from config).
+    pub options: Value,
+}
+
+impl Default for RuleConfig {
+    fn default() -> Self {
+        Self {
+            severity: crate::violation::Severity::Error,
+            value: Value::Bool(true),
+            options: Value::Null,
+        }
+    }
+}

--- a/crates/markuplint-rules/src/rules/attr_duplication.rs
+++ b/crates/markuplint-rules/src/rules/attr_duplication.rs
@@ -1,0 +1,243 @@
+//! `attr-duplication` rule: reports duplicate attributes on elements.
+//!
+//! Ports `packages/@markuplint/rules/src/attr-duplication/`.
+
+use std::collections::HashMap;
+
+use markuplint_core::mlast::MLASTAttr;
+use markuplint_dom::arena::DomArena;
+use markuplint_types::spec::types::MLMLSpec;
+
+use crate::rule::{Rule, RuleConfig};
+use crate::violation::Violation;
+
+/// The `attr-duplication` rule.
+pub struct AttrDuplication;
+
+impl Rule for AttrDuplication {
+    fn id(&self) -> &'static str {
+        "attr-duplication"
+    }
+
+    fn verify(&self, arena: &DomArena, _spec: &MLMLSpec, config: &RuleConfig) -> Vec<Violation> {
+        let mut violations = Vec::new();
+
+        for (_node_id, el) in arena.elements() {
+            let mut seen: HashMap<String, usize> = HashMap::new();
+
+            for attr in &el.attributes {
+                let MLASTAttr::HTMLAttr(html_attr) = attr else {
+                    continue;
+                };
+
+                let name_lower = html_attr.node_name.to_ascii_lowercase();
+                let count = seen.entry(name_lower.clone()).or_insert(0);
+                *count += 1;
+
+                if *count > 1 {
+                    violations.push(Violation {
+                        rule_id: self.id().to_string(),
+                        severity: config.severity.clone(),
+                        message: format!("The attribute \"{}\" is duplicated", html_attr.node_name),
+                        line: html_attr.name.line,
+                        col: html_attr.name.col,
+                        raw: html_attr.raw.clone(),
+                    });
+                }
+            }
+        }
+
+        violations
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use crate::violation::Severity;
+    use markuplint_types::spec::load_spec;
+
+    fn spec() -> MLMLSpec {
+        load_spec(include_str!("../../../../packages/@markuplint/html-spec/index.json")).unwrap()
+    }
+
+    /// Build a test arena with one element having specific attributes.
+    pub(crate) fn make_element_with_attrs(tag: &str, attrs: &[(&str, &str)]) -> DomArena {
+        use markuplint_core::mlast::{ElementType, MLASTHTMLAttr, MLASTToken, NamespaceURI};
+        use markuplint_dom::arena::DomArenaBuilder;
+        use markuplint_dom::node::{DocumentData, DomNode, ElementData, NodeBase};
+
+        let empty_token = || MLASTToken {
+            uuid: String::new(),
+            raw: String::new(),
+            offset: 0,
+            line: 1,
+            col: 1,
+        };
+
+        let mut col = 1u32 + tag.len() as u32 + 1; // after "<tag "
+        let attributes: Vec<MLASTAttr> = attrs
+            .iter()
+            .map(|(name, value)| {
+                let attr_col = col;
+                col += name.len() as u32 + 2 + value.len() as u32 + 1; // name="value" + space
+                MLASTAttr::HTMLAttr(Box::new(MLASTHTMLAttr {
+                    uuid: String::new(),
+                    raw: format!("{name}=\"{value}\""),
+                    offset: 0,
+                    line: 1,
+                    col: attr_col,
+                    node_name: name.to_string(),
+                    spaces_before_name: empty_token(),
+                    name: MLASTToken {
+                        raw: name.to_string(),
+                        line: 1,
+                        col: attr_col,
+                        ..empty_token()
+                    },
+                    spaces_before_equal: empty_token(),
+                    equal: MLASTToken {
+                        raw: "=".to_string(),
+                        ..empty_token()
+                    },
+                    spaces_after_equal: empty_token(),
+                    start_quote: MLASTToken {
+                        raw: "\"".to_string(),
+                        ..empty_token()
+                    },
+                    value: MLASTToken {
+                        raw: value.to_string(),
+                        ..empty_token()
+                    },
+                    end_quote: MLASTToken {
+                        raw: "\"".to_string(),
+                        ..empty_token()
+                    },
+                    is_dynamic_value: None,
+                    is_directive: None,
+                    potential_name: None,
+                    potential_value: None,
+                    value_type: None,
+                    candidate: None,
+                    is_duplicatable: false,
+                }))
+            })
+            .collect();
+
+        let mut builder = DomArenaBuilder::new();
+        let doc_id = builder.push(DomNode::Document(DocumentData {
+            id: 0,
+            raw: String::new(),
+            is_fragment: true,
+            unknown_parse_error: None,
+            children: vec![],
+        }));
+        let el_id = builder.push(DomNode::Element(ElementData {
+            base: NodeBase {
+                id: 0,
+                uuid: "el".to_string(),
+                raw: format!("<{tag}>"),
+                offset: 0,
+                line: 1,
+                col: 1,
+                node_name: tag.to_string(),
+                parent: Some(doc_id),
+                children: vec![],
+                next_sibling: None,
+                prev_sibling: None,
+                depth: 1,
+            },
+            namespace: NamespaceURI::XHTML,
+            element_type: ElementType::Html,
+            is_fragment: false,
+            attributes,
+            has_spread_attr: false,
+            block_behavior: None,
+            pair_node_id: None,
+            tag_open_char: "<".to_string(),
+            tag_close_char: ">".to_string(),
+            is_ghost: false,
+        }));
+        if let Some(DomNode::Element(e)) = builder.get_mut(el_id) {
+            e.base.id = el_id;
+        }
+        if let Some(DomNode::Document(d)) = builder.get_mut(doc_id) {
+            d.children = vec![el_id];
+        }
+        builder.finish()
+    }
+
+    #[test]
+    fn no_duplicate_attrs() {
+        let arena = make_element_with_attrs("div", &[("class", "a"), ("id", "b")]);
+        let s = spec();
+        let rule = AttrDuplication;
+        let violations = rule.verify(&arena, &s, &RuleConfig::default());
+        assert!(violations.is_empty());
+    }
+
+    #[test]
+    fn duplicate_class_attr() {
+        let arena = make_element_with_attrs("div", &[("class", "a"), ("class", "b")]);
+        let s = spec();
+        let rule = AttrDuplication;
+        let violations = rule.verify(&arena, &s, &RuleConfig::default());
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].rule_id, "attr-duplication");
+        assert_eq!(violations[0].message, "The attribute \"class\" is duplicated");
+    }
+
+    #[test]
+    fn duplicate_case_insensitive() {
+        let arena = make_element_with_attrs("div", &[("Class", "a"), ("class", "b")]);
+        let s = spec();
+        let rule = AttrDuplication;
+        let violations = rule.verify(&arena, &s, &RuleConfig::default());
+        assert_eq!(violations.len(), 1);
+    }
+
+    #[test]
+    fn triple_duplicate() {
+        let arena = make_element_with_attrs("div", &[("id", "a"), ("id", "b"), ("id", "c")]);
+        let s = spec();
+        let rule = AttrDuplication;
+        let violations = rule.verify(&arena, &s, &RuleConfig::default());
+        assert_eq!(violations.len(), 2); // 2nd and 3rd are duplicates
+    }
+
+    #[test]
+    fn no_attrs_no_violation() {
+        let arena = make_element_with_attrs("div", &[]);
+        let s = spec();
+        let rule = AttrDuplication;
+        let violations = rule.verify(&arena, &s, &RuleConfig::default());
+        assert!(violations.is_empty());
+    }
+
+    #[test]
+    fn severity_from_config() {
+        let arena = make_element_with_attrs("div", &[("id", "a"), ("id", "b")]);
+        let s = spec();
+        let rule = AttrDuplication;
+        let config = RuleConfig {
+            severity: Severity::Warning,
+            ..Default::default()
+        };
+        let violations = rule.verify(&arena, &s, &config);
+        assert_eq!(violations[0].severity, Severity::Warning);
+    }
+
+    #[test]
+    fn violation_location_is_accurate() {
+        // <div class="a" class="b"> → second class starts at col after first attr
+        let arena = make_element_with_attrs("div", &[("class", "a"), ("class", "b")]);
+        let s = spec();
+        let rule = AttrDuplication;
+        let violations = rule.verify(&arena, &s, &RuleConfig::default());
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].line, 1);
+        // col should be > 1 (after <div and first class="a")
+        assert!(violations[0].col > 1, "col should be after first attribute");
+        assert!(!violations[0].raw.is_empty(), "raw should contain the attribute text");
+    }
+}

--- a/crates/markuplint-rules/src/rules/mod.rs
+++ b/crates/markuplint-rules/src/rules/mod.rs
@@ -1,0 +1,3 @@
+//! Built-in lint rules.
+
+pub mod attr_duplication;

--- a/crates/markuplint-rules/src/violation.rs
+++ b/crates/markuplint-rules/src/violation.rs
@@ -1,0 +1,30 @@
+//! Violation types for lint results.
+
+use serde::Serialize;
+
+/// Severity level of a violation.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Severity {
+    Error,
+    Warning,
+    Info,
+}
+
+/// A lint violation reported by a rule.
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Violation {
+    /// Rule identifier (e.g., `"attr-duplication"`).
+    pub rule_id: String,
+    /// Severity level.
+    pub severity: Severity,
+    /// Human-readable message describing the violation.
+    pub message: String,
+    /// 1-based line number.
+    pub line: u32,
+    /// 1-based column number.
+    pub col: u32,
+    /// Raw source text at the violation location.
+    pub raw: String,
+}


### PR DESCRIPTION
## Summary

Establishes the full Rust-native lint pipeline: **MLAST JSON → Rust DOM → Rule engine → Violations**.

### New components

**`markuplint-rules`:**
- `Violation` type with `Severity` (error/warning/info) + location (line, col, raw)
- `Rule` trait: `verify(arena, spec, config) -> Vec<Violation>`
- `RuleConfig`: severity, value, options — parsed from JSON config
- `lint()` function: iterate enabled rules, collect and sort violations
- `attr-duplication`: first built-in Rust rule

**`markuplint-napi`:**
- `lint(mlastJson, configJson, specJson)` — single NAPI function for the entire pipeline
- Returns `NapiViolation[]` to Node.js
- Errors propagated via `napi::Result` (not silently swallowed)

### Architecture

```
TS parsers → MLAST JSON ──→ Rust: lint(mlast, config, spec) → Violation[]
                                   ├── DOM construction
                                   ├── Rule iteration
                                   └── Violation collection
```

Only parsers and config resolution remain in TS.
VS Code extension calls the same `lint()` via NAPI.

## Test plan

- [x] `cargo test -p markuplint-rules` — 318 tests pass (222 ARIA + 82 content model + 14 new)
  - 6 attr-duplication unit tests (duplicate, case-insensitive, triple, no attrs, severity)
  - 4 config parsing tests (true/false/string/object)
  - 3 integration pipeline tests (full lint, disabled rule, severity override)
  - 1 violation location accuracy test
- [x] `cargo test` (all crates) — all pass
- [x] `cargo clippy -- -D warnings` — 0 warnings
- [x] `cargo fmt --check` — clean

## Related

- Part of #3178 (Rust rewrite)
- Implements Phase 5-1 (attr-duplication) + Phase 8-1/8-2 (lint engine + FFI consolidation)
- Next: TS-side integration test (call NAPI `lint()` from CLI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)