### PR TITLE
chore(deps): update eslint-plugin-unicorn to v64

### DIFF
--- a/packages/@markuplint-dev/eslint-config/package.json
+++ b/packages/@markuplint-dev/eslint-config/package.json
@@ -23,7 +23,7 @@
 		"eslint-plugin-n": "17.24.0",
 		"eslint-plugin-regexp": "3.1.0",
 		"eslint-plugin-sort-class-members": "1.21.0",
-		"eslint-plugin-unicorn": "63.0.0",
+		"eslint-plugin-unicorn": "64.0.0",
 		"globals": "17.4.0",
 		"typescript-eslint": "8.57.2"
 	}

--- a/packages/@markuplint/pug-parser/src/index.spec.ts
+++ b/packages/@markuplint/pug-parser/src/index.spec.ts
@@ -765,7 +765,7 @@ a(href=url) Another link
 - var btnType = 'info'
 - var btnSize = 'lg'
 button(type='button' class='btn btn-' + btnType + ' btn-' + btnSize)
-button(type='button' class=\`btn btn-$\{btnType} btn-$\{btnSize}\`)
+button(type='button' class=\`btn btn-\${btnType} btn-\${btnSize}\`)
 			`,
 		);
 		const map = nodeListToDebugMaps(doc.nodeList, true);

--- a/packages/@markuplint/spec-generator/src/scraping.ts
+++ b/packages/@markuplint/spec-generator/src/scraping.ts
@@ -181,7 +181,7 @@ function getAttributes(
 ) {
 	const $section = $(`.content-section[aria-labelledby="${id}"]`);
 	const attributes: Record<string, Attribute> = {};
-	for (const dt of $section.find('> dl > dt').toArray()) {
+	for (const dt of $section.find('> dl > dt')) {
 		const $dt = $(dt);
 		const name = $dt.find('code').text().trim();
 		if (!name) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1537,7 +1537,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-community/eslint-utils@npm:^4.1.2, @eslint-community/eslint-utils@npm:^4.2.0, @eslint-community/eslint-utils@npm:^4.5.0, @eslint-community/eslint-utils@npm:^4.8.0, @eslint-community/eslint-utils@npm:^4.9.0, @eslint-community/eslint-utils@npm:^4.9.1":
+"@eslint-community/eslint-utils@npm:^4.1.2, @eslint-community/eslint-utils@npm:^4.2.0, @eslint-community/eslint-utils@npm:^4.5.0, @eslint-community/eslint-utils@npm:^4.8.0, @eslint-community/eslint-utils@npm:^4.9.1":
   version: 4.9.1
   resolution: "@eslint-community/eslint-utils@npm:4.9.1"
   dependencies:
@@ -2182,7 +2182,7 @@ __metadata:
     eslint-plugin-n: "npm:17.24.0"
     eslint-plugin-regexp: "npm:3.1.0"
     eslint-plugin-sort-class-members: "npm:1.21.0"
-    eslint-plugin-unicorn: "npm:63.0.0"
+    eslint-plugin-unicorn: "npm:64.0.0"
     globals: "npm:17.4.0"
     typescript-eslint: "npm:8.57.2"
   languageName: unknown
@@ -6242,7 +6242,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ci-info@npm:^4.0.0, ci-info@npm:^4.3.1":
+"ci-info@npm:^4.0.0, ci-info@npm:^4.4.0":
   version: 4.4.0
   resolution: "ci-info@npm:4.4.0"
   checksum: 10c0/44156201545b8dde01aa8a09ee2fe9fc7a73b1bef9adbd4606c9f61c8caeeb73fb7a575c88b0443f7b4edb5ee45debaa59ed54ba5f99698339393ca01349eb3a
@@ -6752,7 +6752,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js-compat@npm:^3.46.0":
+"core-js-compat@npm:^3.49.0":
   version: 3.49.0
   resolution: "core-js-compat@npm:3.49.0"
   dependencies:
@@ -8199,29 +8199,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-unicorn@npm:63.0.0":
-  version: 63.0.0
-  resolution: "eslint-plugin-unicorn@npm:63.0.0"
+"eslint-plugin-unicorn@npm:64.0.0":
+  version: 64.0.0
+  resolution: "eslint-plugin-unicorn@npm:64.0.0"
   dependencies:
     "@babel/helper-validator-identifier": "npm:^7.28.5"
-    "@eslint-community/eslint-utils": "npm:^4.9.0"
+    "@eslint-community/eslint-utils": "npm:^4.9.1"
     change-case: "npm:^5.4.4"
-    ci-info: "npm:^4.3.1"
+    ci-info: "npm:^4.4.0"
     clean-regexp: "npm:^1.0.0"
-    core-js-compat: "npm:^3.46.0"
+    core-js-compat: "npm:^3.49.0"
     find-up-simple: "npm:^1.0.1"
-    globals: "npm:^16.4.0"
+    globals: "npm:^17.4.0"
     indent-string: "npm:^5.0.0"
     is-builtin-module: "npm:^5.0.0"
     jsesc: "npm:^3.1.0"
     pluralize: "npm:^8.0.0"
     regexp-tree: "npm:^0.1.27"
     regjsparser: "npm:^0.13.0"
-    semver: "npm:^7.7.3"
+    semver: "npm:^7.7.4"
     strip-indent: "npm:^4.1.1"
   peerDependencies:
     eslint: ">=9.38.0"
-  checksum: 10c0/bc3550322a2b008ea9252e1a94a4f12a6c96c4387be563a5d62b879078cbe6b01c957843d31ec7d09fd8d8cf287ac00f8b93666721ff916b0166d4e82c80926c
+  checksum: 10c0/802b556ecaf93fe36217d8bcd9f79b53cc4156bbb75c06f06128a0bd32b2ec94a808dbc5e4c36228895cf6eb0df705337a47b409272ffdc99a40cb08487cb029
   languageName: node
   linkType: hard
 
@@ -9448,7 +9448,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globals@npm:17.4.0":
+"globals@npm:17.4.0, globals@npm:^17.4.0":
   version: 17.4.0
   resolution: "globals@npm:17.4.0"
   checksum: 10c0/2be9e8c2b9035836f13d420b22f0247a328db82967d3bebfc01126d888ed609305f06c05895914e969653af5c6ba35fd7a0920f3e6c869afa60666c810630feb
@@ -9459,13 +9459,6 @@ __metadata:
   version: 15.15.0
   resolution: "globals@npm:15.15.0"
   checksum: 10c0/f9ae80996392ca71316495a39bec88ac43ae3525a438b5626cd9d5ce9d5500d0a98a266409605f8cd7241c7acf57c354a48111ea02a767ba4f374b806d6861fe
-  languageName: node
-  linkType: hard
-
-"globals@npm:^16.4.0":
-  version: 16.5.0
-  resolution: "globals@npm:16.5.0"
-  checksum: 10c0/615241dae7851c8012f5aa0223005b1ed6607713d6813de0741768bd4ddc39353117648f1a7086b4b0fa45eae733f1c0a0fe369aa4e543bb63f8de8990178ea9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Update `eslint-plugin-unicorn` from v63 to v64
- Fix `unicorn/consistent-template-literal-escape` violation in pug-parser
- Fix `unicorn/no-useless-iterator-to-array` violation in spec-generator

Closes #3528

🤖 Generated with [Claude Code](https://claude.com/claude-code)