### PR TITLE
feat: enable TypeScript type-checking for spec files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,9 +64,11 @@ Each package has a `SKILL.md` with package-specific maintenance guidance.
 
 ### Test
 
-- **Full test**: `yarn test` (no arguments)
-- **Single file/directory**: `npx vitest run <path>`
+- **Full test**: `yarn test` (no arguments) — includes `--typecheck` (TypeScript type-checking of spec files)
+- **Single file/directory**: `npx vitest run <path>` (runtime tests only, no type-checking)
+- **Single file with type-checking**: `npx vitest --typecheck run <path>`
 - **NEVER use**: `npx lerna run test`, `yarn test --scope @markuplint/*`, or any other variant
+- **NEVER use**: `npx tsc --noEmit` — does not work correctly in this monorepo (no root `include`, `composite` conflicts with `--noEmit` in build mode)
 
 ### Lint
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ When you wrote code then:
 
 - Format and lint code through `yarn lint`.
 - Check to build successfully through `yarn build`.
-- Test your code through `yarn test`.
+- Test your code through `yarn test` (this also runs TypeScript type-checking on spec files).
 - Push to the topic branch and open a pull request.
 - Assign reviewer:
   - For the improved code: @yusukehirao

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"build": "lerna run build",
 		"clean": "lerna run clean",
 		"dev": "lerna run --parallel dev",
-		"test": "vitest run",
+		"test": "vitest --typecheck run",
 		"test:coverage": "vitest run --coverage",
 		"lint": "run-p lint:eslint lint:prettier lint:spellcheck lint:github-actions",
 		"lint:eslint": "npx eslint --fix \"./{packages,vscode}/**/*.{ts,mjs,cjs,spec.js}\"",

--- a/packages/markuplint/src/reporter/github-reporter.spec.ts
+++ b/packages/markuplint/src/reporter/github-reporter.spec.ts
@@ -8,6 +8,7 @@ describe('githubReporter', () => {
 			filePath: '/path/to/file.html',
 			fixedCode: '',
 			sourceCode: '',
+			status: 'processed',
 			violations: [],
 		});
 		expect(result).toEqual([]);
@@ -18,6 +19,7 @@ describe('githubReporter', () => {
 			filePath: '/path/to/file.html',
 			fixedCode: '',
 			sourceCode: '',
+			status: 'processed',
 			violations: [
 				{
 					severity: 'error',
@@ -70,6 +72,7 @@ describe('githubReporter', () => {
 			filePath: '/path/to/file.html',
 			fixedCode: '',
 			sourceCode: '',
+			status: 'processed',
 			violations: [
 				{
 					severity: 'error',
@@ -93,6 +96,7 @@ describe('githubReporter', () => {
 			filePath: '/path/to/file.html',
 			fixedCode: '',
 			sourceCode: '',
+			status: 'processed',
 			violations: [
 				{
 					severity: 'error',
@@ -117,6 +121,7 @@ describe('githubReporter', () => {
 			filePath: '/path/to/file.html',
 			fixedCode: '',
 			sourceCode: '',
+			status: 'processed',
 			violations: [
 				{
 					severity: 'warning',
@@ -136,6 +141,7 @@ describe('githubReporter', () => {
 			filePath: '/path/to/file.html',
 			fixedCode: '',
 			sourceCode: '',
+			status: 'processed',
 			violations: [
 				{
 					severity: 'warning',


### PR DESCRIPTION
## Summary

Closes #3533

- Add `--typecheck` flag to `yarn test` so spec files are type-checked during test execution via `vitest --typecheck`
- Fix type errors in `github-reporter.spec.ts` (missing required `status` property on `MLResultInfo`)
- Document the change in CLAUDE.md and CONTRIBUTING.md

### Why `npx tsc --noEmit` doesn't work

This monorepo uses per-package project references with `composite: true`. The root `tsconfig.json` has no `include`/`files` directive, so `npx tsc --noEmit` from the root either compiles everything incorrectly or fails with TS6310 errors in `--build` mode. `vitest --typecheck` solves this by running `tsc` type-checking alongside test execution without conflicting with the composite project setup.

### Why these errors weren't caught before

Each package's `tsconfig.build.json` excludes `*.spec.ts` files, and `vitest` uses esbuild for transpilation (no type-checking). Only VS Code IDE users would see these errors.

## Test plan

- [x] `yarn test` passes (197 files, 3037 tests, Type Errors: no errors)
- [x] `yarn build` passes
- [x] ESLint / Prettier pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)