### PR TITLE
feat(html-spec): add loading attribute type for audio and video elements

### DIFF
--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -49194,7 +49194,7 @@
 				"#GlobalEventAttrs": true,
 				"#HTMLEmbededAndMediaContentAttrs": ["src", "preload", "autoplay", "loop", "muted", "controls"],
 				"#HTMLGlobalAttrs": true,
-				"#HTMLLinkAndFetchingAttrs": ["crossorigin"]
+				"#HTMLLinkAndFetchingAttrs": ["crossorigin", "loading"]
 			},
 			"attributes": {
 				"autoplay": {
@@ -55689,7 +55689,7 @@
 					"width"
 				],
 				"#HTMLGlobalAttrs": true,
-				"#HTMLLinkAndFetchingAttrs": ["crossorigin"]
+				"#HTMLLinkAndFetchingAttrs": ["crossorigin", "loading"]
 			},
 			"attributes": {
 				"autoplay": {

--- a/packages/@markuplint/html-spec/src/spec.audio.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.audio.jsonc
@@ -32,7 +32,7 @@
 		"#HTMLGlobalAttrs": true,
 		"#GlobalEventAttrs": true,
 		"#ARIAAttrs": true,
-		"#HTMLLinkAndFetchingAttrs": ["crossorigin"],
+		"#HTMLLinkAndFetchingAttrs": ["crossorigin", "loading"],
 		"#HTMLEmbededAndMediaContentAttrs": ["src", "preload", "autoplay", "loop", "muted", "controls"]
 	},
 	"attributes": {},

--- a/packages/@markuplint/html-spec/src/spec.video.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.video.jsonc
@@ -32,7 +32,7 @@
 		"#HTMLGlobalAttrs": true,
 		"#GlobalEventAttrs": true,
 		"#ARIAAttrs": true,
-		"#HTMLLinkAndFetchingAttrs": ["crossorigin"],
+		"#HTMLLinkAndFetchingAttrs": ["crossorigin", "loading"],
 		"#HTMLEmbededAndMediaContentAttrs": [
 			"src",
 			"preload",


### PR DESCRIPTION
## Summary

- Add `loading` to `#HTMLLinkAndFetchingAttrs` reference for `<audio>` and `<video>` elements
- Provides enum type validation (`lazy`/`eager`) with `invalidValueDefault` and `missingValueDefault` of `eager`
- The shared type definition already existed in `spec-common.attributes.jsonc`; only the per-element references were missing

Closes #3542

## Test plan

- [x] `yarn test` — 197 files, 3037 tests passed
- [x] `yarn lint` — passed (CSpell worktree known issue only)
- [x] `yarn build` — passed
- [x] Idempotency verification (`yarn up:gen` × 2) — stable output

🤖 Generated with [Claude Code](https://claude.com/claude-code)