### PR TITLE
docs: add markuplint skills for AI coding agents

### DIFF
--- a/skills/markuplint-configure/SKILL.md
+++ b/skills/markuplint-configure/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: markuplint-configure
+description: Add, remove, or adjust Markuplint rules for specific files or elements. Analyzes violations, proposes scope-appropriate configuration changes, and confirms with the user.
+disable-model-invocation: true
+argument-hint: "[file:line or rule-name]"
+---
+
+# markuplint-configure
+
+Add, remove, or adjust Markuplint rules.
+
+## When to Use
+
+- "Add a rule for ..." / "Enable the ... rule"
+- "Disable this warning" / "Ignore this error"
+- "Configure markuplint for this file"
+- "This markuplint warning is wrong"
+- "Apply ... rule only to this section"
+- User points to a specific file/line and asks about a Markuplint violation
+
+## Steps
+
+### 1. Understand the Context
+
+If `$ARGUMENTS` contains a file path or line reference, read that file first.
+
+Run Markuplint on the target to see current violations:
+
+```shell
+npx markuplint "path/to/file.html" --format JSON
+```
+
+If no specific file, run on the project and summarize.
+
+### 2. Identify What the User Wants
+
+Determine the intent:
+
+- **Add a rule** — enable a new rule or change its value
+- **Disable a rule** — turn off a rule globally or for specific elements
+- **Adjust scope** — change where a rule applies
+
+If unclear, **use AskUserQuestion** to clarify.
+
+### 3. Determine the Scope
+
+**Use AskUserQuestion to confirm the intended scope.**
+
+| User intent | Scope | Where to configure |
+| --- | --- | --- |
+| "I don't want this rule anywhere" | Project-wide | `rules` in config |
+| "I don't want this in certain files" | File-level | `excludeFiles` or `overrides` |
+| "I don't want this on specific elements" | Element-level | `nodeRules` or `childNodeRules` |
+
+**Important distinction for file-level scope — ask the user:**
+
+- **`excludeFiles`**: Markuplint completely ignores the file. VS Code extension won't show warnings either. Use when the file should never be linted.
+- **`overrides`** with `overrideMode: "merge"`: Markuplint still processes the file but with different rules. VS Code shows remaining warnings. Use when you want partial coverage.
+- **npm script glob**: Only affects CLI/CI runs. VS Code still lints everything. Use when VS Code warnings are acceptable but CI should skip certain files.
+
+### 4. Determine Element-Level Configuration
+
+If the scope is element-level, choose between:
+
+- **`nodeRules`** — applies to the matched element itself
+- **`childNodeRules`** — applies to children of the matched element. Add `"inheritance": true` to affect all descendants, not just direct children.
+
+The AI agent should propose a CSS selector based on the code context. Use the element's class, ID, tag name, or attributes to build the selector.
+
+For rule details, fetch the rule's documentation:
+`https://markuplint.dev/docs/rules/{rule-id}`
+
+### 5. Propose the Change
+
+Show the user the exact configuration change before applying.
+
+**Always explain:**
+- What the change does
+- What the trade-off is
+- If there's a better alternative
+
+Example proposals:
+
+#### Disable a named rule from a preset
+
+```json
+{
+  "rules": {
+    "a11y/specific-rule": false
+  }
+}
+```
+
+#### Element-specific rule with nodeRules
+
+```json
+{
+  "nodeRules": [
+    {
+      "selector": ".legacy-component",
+      "rules": {
+        "class-naming": false
+      }
+    }
+  ]
+}
+```
+
+#### Descendants of a section with childNodeRules
+
+```json
+{
+  "childNodeRules": [
+    {
+      "selector": ".legacy-section",
+      "inheritance": true,
+      "rules": {
+        "wai-aria": false
+      }
+    }
+  ]
+}
+```
+
+#### File-level exclusion
+
+```json
+{
+  "excludeFiles": ["./src/legacy/**/*"]
+}
+```
+
+#### File-level override
+
+```json
+{
+  "overrideMode": "merge",
+  "overrides": {
+    "./src/legacy/**/*": {
+      "rules": {
+        "character-reference": false
+      }
+    }
+  }
+}
+```
+
+### 6. Confirm with AskUserQuestion
+
+**Never modify the config file without user confirmation.**
+
+### 7. Apply and Verify
+
+1. Update `.markuplintrc` using `Edit` tool
+2. Run lint again on the same target
+3. Report the before/after violation count to confirm the change worked
+
+## Quick Reference: Common Configurations
+
+These are frequently requested. Propose them directly when relevant:
+
+### OGP (Open Graph Protocol)
+
+```json
+{
+  "nodeRules": [
+    {
+      "selector": "meta[property]",
+      "rules": {
+        "invalid-attr": {
+          "options": {
+            "allowAttrs": ["property"]
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+### Allow custom data attributes
+
+```json
+{
+  "rules": {
+    "invalid-attr": {
+      "options": {
+        "allowAttrs": ["data-testid"]
+      }
+    }
+  }
+}
+```
+
+### Selector tips
+
+- Ancestor matching: use `:is(nav *)` (NOT `:closest()` — it is deprecated)
+- For selector syntax details: https://markuplint.dev/docs/guides/selectors
+- For all config properties: https://markuplint.dev/docs/configuration/properties

--- a/skills/markuplint-setup/SKILL.md
+++ b/skills/markuplint-setup/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: markuplint-setup
+description: Set up Markuplint in a project from scratch. Detects framework, creates config, runs initial lint, and guides the user through rule adoption with Bulk Suppressions support.
+disable-model-invocation: true
+argument-hint: "[target-glob]"
+---
+
+# markuplint-setup
+
+Set up Markuplint in a project from scratch.
+
+## When to Use
+
+- "Set up markuplint" / "Add markuplint to this project"
+- "I want to lint my HTML"
+- "Install markuplint"
+
+## Steps
+
+### 1. Check Existing Installation
+
+- Check `package.json` for `markuplint` and `@markuplint/*` packages
+- Check for config files (`.markuplintrc*`, `markuplint.config.*`)
+- If already installed, tell the user and suggest `/markuplint-configure` instead
+
+### 2. Detect Project Type
+
+Scan the project:
+
+- **Package manager**: check for `package-lock.json` / `yarn.lock` / `pnpm-lock.yaml`
+- **Framework**: check `package.json` dependencies for `react`, `vue`, `svelte`, `astro`, `@alpinejs/csp`, etc. Also check file extensions (`.jsx`, `.tsx`, `.vue`, `.svelte`, `.astro`, `.pug`, `.php`)
+- **Monorepo**: check for `workspaces` in `package.json` or `lerna.json` / `nx.json` / `turbo.json`
+
+### 3. Choose Preset and Packages
+
+Use `WebFetch` to get the latest supported syntaxes and preset information:
+
+- Presets: fetch https://markuplint.dev/docs/guides/presets
+- Framework parsers: fetch https://markuplint.dev/docs/guides/beyond-html
+
+**Use AskUserQuestion to confirm:**
+
+1. Detected framework — is it correct?
+2. Which preset to use? (recommend based on framework)
+
+### 4. Install Packages
+
+Install using the detected package manager. Example:
+
+```shell
+npm install -D markuplint @markuplint/jsx-parser @markuplint/react-spec
+```
+
+**Do NOT use `npx markuplint --init`** — it requires interactive terminal input.
+
+### 5. Create Configuration File
+
+Write `.markuplintrc` directly. Keep it minimal — only include what's needed for the detected framework.
+
+Static HTML needs no `parser` or `specs`:
+
+```json
+{
+  "extends": ["markuplint:recommended"]
+}
+```
+
+Framework projects need parser and spec:
+
+```json
+{
+  "extends": ["markuplint:recommended-react"],
+  "parser": {
+    "\\.[jt]sx$": "@markuplint/jsx-parser"
+  },
+  "specs": {
+    "\\.[jt]sx$": "@markuplint/react-spec"
+  }
+}
+```
+
+Refer to https://markuplint.dev/docs/guides/beyond-html for the exact parser/spec package names and file patterns for each framework.
+
+#### When to use JavaScript/TypeScript config
+
+If the project uses external config plugins or shared configs that require fine-grained merging, recommend `markuplint.config.ts` (or `.js`) with spread syntax — similar to ESLint's flat config pattern:
+
+```ts
+import type { Config } from '@markuplint/ml-config';
+import reactConfig from '@example/markuplint-config-react';
+
+const config: Config = {
+  ...reactConfig,
+  rules: {
+    ...reactConfig.rules,
+    'class-naming': '/^[a-z][a-z0-9-]*$/',
+  },
+};
+
+export default config;
+```
+
+This gives full control over merge order and avoids the limitations of JSON `extends` (which uses a fixed merge strategy). Use JSON for simple setups; use JS/TS when composing multiple configs.
+
+### 6. Run Initial Lint
+
+Run Markuplint and capture the results:
+
+```shell
+npx markuplint "$ARGUMENTS" --format JSON
+```
+
+If `$ARGUMENTS` is empty, ask the user for the target glob (e.g., `"src/**/*.html"`).
+
+Summarize:
+- Total violation count
+- Breakdown by rule (which rules have the most violations)
+- Whether violations are concentrated in specific files/directories
+
+### 7. Rule-by-Rule Adoption Decision
+
+**Use AskUserQuestion for each rule that has violations.** Present rules one at a time (or batch related rules).
+
+For each rule, explain what it checks (fetch the rule page if needed: `https://markuplint.dev/docs/rules/{rule-id}`) and offer options:
+
+1. **Keep as error** — fix all violations now
+2. **Downgrade to warning** — keep but don't block CI
+3. **Bulk suppress** — record current violations, enforce only on new code
+4. **Disable** — turn off the rule
+
+**When to recommend Bulk Suppressions:**
+- Many violations in legacy code that won't be touched soon
+- The rule is valuable for new code
+
+**When to recommend disabling:**
+- The rule doesn't fit the project's architecture or conventions
+- The rule conflicts with a template engine being used
+
+### 8. Apply Decisions
+
+- Update `.markuplintrc` with disabled/warning rules
+- If Bulk Suppressions were chosen, run: `npx markuplint "$TARGET" --suppress`
+- Tell the user to commit `markuplint-suppressions.json`
+
+### 9. Add npm Script
+
+Add a lint script to `package.json`:
+
+```json
+{
+  "scripts": {
+    "lint:html": "markuplint \"src/**/*.html\""
+  }
+}
+```
+
+Adjust the glob to match the project's source files and framework extensions.

--- a/skills/markuplint/SKILL.md
+++ b/skills/markuplint/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: markuplint
+description: Reference knowledge for Markuplint HTML linter. Covers violation interpretation, CLI usage, config patterns, and documentation URLs. Auto-loaded when working with HTML linting.
+---
+
+# Markuplint
+
+Reference knowledge for working with Markuplint.
+
+## What is Markuplint
+
+An HTML linter that checks conformance with HTML Standard, WAI-ARIA, and project-specific rules. Supports JSX, Vue, Svelte, Astro, Pug, PHP, and more via parser plugins.
+
+- Official site: https://markuplint.dev
+- GitHub: https://github.com/markuplint/markuplint
+- Playground: https://playground.markuplint.dev
+
+## Reading Violation Messages
+
+Format: `message (ruleId) [named-rule]`
+
+```
+The attribute name is duplicated (attr-duplication) [html-standard/attr-duplication]
+```
+
+- **`ruleId`** (`attr-duplication`) — the base rule. Always present.
+- **`named-rule`** (`html-standard/attr-duplication`) — preset-defined alias. Present only for named rules. The `namespace/` prefix indicates which preset defined it (e.g., `a11y/`, `html-standard/`, `performance/`).
+- **`severity`** — `error` (exit code 1), `warning` (exit code 0 by default), or `info`.
+
+To look up any rule: `https://markuplint.dev/docs/rules/{ruleId}`
+
+## CLI Quick Reference
+
+```shell
+# Basic lint
+npx markuplint "src/**/*.html"
+
+# JSON output (for programmatic use)
+npx markuplint "src/**/*.html" --format JSON
+
+# Auto-fix (rules that support it)
+npx markuplint "src/**/*.html" --fix
+
+# Preview fixes without writing
+npx markuplint "src/**/*.html" --fix-dry-run
+
+# Suppress current violations for gradual adoption
+npx markuplint "src/**/*.html" --suppress
+
+# Clean up fixed suppressions
+npx markuplint "src/**/*.html" --prune-suppressions
+
+# GitHub Actions annotations
+npx markuplint "src/**/*.html" --format GitHub
+
+# Limit output for large projects
+npx markuplint "src/**/*.html" --max-count=50
+```
+
+Always quote glob patterns to prevent shell expansion.
+
+## Config Patterns
+
+### Disable a named rule
+
+```json
+{ "rules": { "a11y/html-lang": false } }
+```
+
+### Disable all rules in a namespace
+
+```json
+{ "rules": { "a11y/*": false } }
+```
+
+### Change severity
+
+```json
+{ "rules": { "a11y/html-lang": "warning" } }
+```
+
+### Element-specific rules
+
+`nodeRules` — targets the matched element. `childNodeRules` — targets descendants (add `"inheritance": true` for all descendants, not just direct children).
+
+### Ancestor matching
+
+Use `:is(selector *)`. Do NOT use `:closest()` — it is deprecated.
+
+```json
+{ "selector": "div:is(nav *)" }
+```
+
+## Common Issues and Fixes
+
+### OGP / Open Graph `property` attribute
+
+The `property` attribute is not in the HTML spec. See: https://markuplint.dev/docs/rules/invalid-attr#the-open-graph-protocol
+
+### `invalid-attr` with frameworks
+
+Install the framework's spec plugin (e.g., `@markuplint/react-spec`). See: https://markuplint.dev/docs/guides/beyond-html#why-need-the-spec-plugins
+
+### `character-reference` false positives with template engines
+
+Some template syntaxes trigger false positives. Disable partially or report: https://markuplint.dev/docs/rules/character-reference
+
+### `--init` is interactive only
+
+`npx markuplint --init` requires terminal input. AI agents should write `.markuplintrc` directly.
+
+## Documentation URLs
+
+| Topic | URL |
+| --- | --- |
+| All rules | `https://markuplint.dev/docs/rules` |
+| Specific rule | `https://markuplint.dev/docs/rules/{rule-id}` |
+| Presets | `https://markuplint.dev/docs/guides/presets` |
+| Framework setup | `https://markuplint.dev/docs/guides/beyond-html` |
+| Config properties | `https://markuplint.dev/docs/configuration/properties` |
+| Selectors | `https://markuplint.dev/docs/guides/selectors` |
+| CLI options | `https://markuplint.dev/docs/guides/cli` |
+| FAQ | `https://markuplint.dev/docs/guides/faq` |
+| Migration (v4→v5) | `https://markuplint.dev/docs/migration/v4-to-v5` |
+
+Use `WebFetch` on these URLs when you need current details.


### PR DESCRIPTION
## Summary

Add 3 installable skills for AI coding agents (Claude Code, Cursor, etc.) to use Markuplint effectively.

### Skills added

| Skill | Type | Auto-loaded | Purpose |
|-------|------|-------------|---------|
| `markuplint` | Reference | Yes | Violation interpretation, CLI usage, config patterns, documentation URLs |
| `markuplint-setup` | Task | No (`/markuplint-setup`) | Set up Markuplint from scratch — framework detection, preset selection, initial lint, rule-by-rule adoption with Bulk Suppressions |
| `markuplint-configure` | Task | No (`/markuplint-configure`) | Add/remove/adjust rules — scope determination (project/file/element), excludeFiles vs overrides vs nodeRules/childNodeRules |

### Design decisions

- **No hardcoded data** — skills reference `markuplint.dev` URLs via `WebFetch` for always-current information
- **500 lines limit** per SKILL.md (Claude Code official recommendation)
- **`--init` is interactive** — skills write `.markuplintrc` directly instead
- **JS/TS config** recommended when composing external config plugins (spread syntax, like ESLint flat config)

## Test plan

- [ ] Documentation only — no code changes
- [ ] `yarn build` passes
- [ ] `yarn test` passes (3037 tests)

Closes #3553

🤖 Generated with [Claude Code](https://claude.com/claude-code)