### PR TITLE
fix(html-spec): override MDN incorrect experimental flag on audio loading attribute

### DIFF
--- a/packages/@markuplint/html-spec/src/spec.audio.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.audio.jsonc
@@ -35,7 +35,13 @@
 		"#HTMLLinkAndFetchingAttrs": ["crossorigin", "loading"],
 		"#HTMLEmbededAndMediaContentAttrs": ["src", "preload", "autoplay", "loop", "muted", "controls"]
 	},
-	"attributes": {},
+	"attributes": {
+		"loading": {
+			// MDN incorrectly marks this as experimental, but it is defined in the HTML Living Standard.
+			// https://html.spec.whatwg.org/multipage/media.html#the-audio-element
+			"experimental": false
+		}
+	},
 	"aria": {
 		"implicitRole": false,
 		"permittedRoles": ["application"],


### PR DESCRIPTION
## Summary
- MDN incorrectly marks `audio` element's `loading` attribute as experimental
- The `loading` attribute is defined in the [HTML Living Standard](https://html.spec.whatwg.org/multipage/media.html#the-audio-element) as a standard attribute
- Added `"experimental": false` override in `spec.audio.jsonc` to prevent the auto-generated spec from inheriting MDN's incorrect classification

Closes #3569

## Test plan
- [x] `yarn build` passes
- [x] `yarn test` passes (199 files, 3052 tests)
- [x] `yarn up:gen` generates correct output with `"experimental": false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)