### PR TITLE
test: add nu-html-checker compatibility benchmark

### DIFF
--- a/.claude/commands/nu-validator.md
+++ b/.claude/commands/nu-validator.md
@@ -1,5 +1,6 @@
 ---
 description: Run nu-html-checker compatibility benchmark
+disable-model-invocation: true
 ---
 
 Run the nu-html-checker compatibility test suite against markuplint and generate a report.

--- a/.claude/commands/nu-validator.md
+++ b/.claude/commands/nu-validator.md
@@ -1,0 +1,42 @@
+---
+description: Run nu-html-checker compatibility benchmark
+---
+
+Run the nu-html-checker compatibility test suite against markuplint and generate a report.
+
+## Step 1: Ensure submodule is available
+
+Check if `tests/external/validator/tests/html` exists.
+
+- **If missing**, run:
+  ```
+  git submodule update --init tests/external/validator
+  ```
+- **If present**, optionally update to latest:
+  ```
+  git submodule update --remote tests/external/validator
+  ```
+
+## Step 2: Ensure build is up to date
+
+Run `yarn build` if not already done in this session.
+
+## Step 3: Generate the report
+
+```
+node --experimental-strip-types tests/external/nu-validator-report.ts
+```
+
+This produces `tests/external/nu-validator-report.md`.
+
+## Step 4: Show the report
+
+Read and display the generated `tests/external/nu-validator-report.md` to the user.
+
+## Step 5 (optional): Run as vitest
+
+If the user wants pass/fail CI-style output:
+
+```
+npx vitest run --config vitest.nu-validator.config.ts
+```

--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,6 @@ packages/@markuplint/rules/src/__*
 
 # Worktrees
 .worktree/
+
+# Generated reports
+tests/external/nu-validator-report.md

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,5 @@
+[submodule "tests/external/validator"]
+	path = tests/external/validator
+	url = https://github.com/validator/validator.git
+	branch = main
+	shallow = true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,14 +4,15 @@ Use the following skills and commands for common tasks. **Always invoke the appr
 
 ## Commands (slash commands)
 
-| Command     | Description                                                  | File                                        |
-| ----------- | ------------------------------------------------------------ | ------------------------------------------- |
-| `/git`      | Commit rules, message format, and package commit order       | [git.md](.claude/commands/git.md)           |
-| `/pr`       | Create and push a pull request via `gh pr create`            | [pr.md](.claude/commands/pr.md)             |
-| `/doc`      | Update documentation (README, ARCHITECTURE, JSDoc)           | [doc.md](.claude/commands/doc.md)           |
-| `/release`  | Create GitHub Release notes                                  | [release.md](.claude/commands/release.md)   |
-| `/issue`    | Analyze or create a GitHub Issue and build a resolution plan | [issue.md](.claude/commands/issue.md)       |
-| `/sponsors` | Check and update GitHub Sponsors listings                    | [sponsors.md](.claude/commands/sponsors.md) |
+| Command         | Description                                                  | File                                                |
+| --------------- | ------------------------------------------------------------ | --------------------------------------------------- |
+| `/git`          | Commit rules, message format, and package commit order       | [git.md](.claude/commands/git.md)                   |
+| `/pr`           | Create and push a pull request via `gh pr create`            | [pr.md](.claude/commands/pr.md)                     |
+| `/doc`          | Update documentation (README, ARCHITECTURE, JSDoc)           | [doc.md](.claude/commands/doc.md)                   |
+| `/release`      | Create GitHub Release notes                                  | [release.md](.claude/commands/release.md)           |
+| `/issue`        | Analyze or create a GitHub Issue and build a resolution plan | [issue.md](.claude/commands/issue.md)               |
+| `/sponsors`     | Check and update GitHub Sponsors listings                    | [sponsors.md](.claude/commands/sponsors.md)         |
+| `/nu-validator` | Run nu-html-checker compatibility benchmark                  | [nu-validator.md](.claude/commands/nu-validator.md) |
 
 ## Skills
 

--- a/tests/external/README.md
+++ b/tests/external/README.md
@@ -1,0 +1,88 @@
+# nu-html-checker Compatibility Benchmark
+
+Runs [markuplint](https://markuplint.dev/) against the [nu-html-checker](https://github.com/validator/validator) (validator.w3.org) test suite to measure HTML validation coverage.
+
+## Setup
+
+The nu-validator test suite is included as a git submodule. It is **not** fetched by default.
+
+```bash
+# Fetch the submodule (first time)
+git submodule update --init tests/external/validator
+
+# Update to the latest nu-validator tests
+git submodule update --remote tests/external/validator
+```
+
+## Run
+
+### Generate a Markdown report
+
+```bash
+node --experimental-strip-types tests/external/nu-validator-report.ts
+```
+
+Produces `tests/external/nu-validator-report.md` (git-ignored).
+
+### Run as vitest (CI-style pass/fail)
+
+```bash
+npx vitest run --config vitest.nu-validator.config.ts
+```
+
+## Test Categories
+
+| # | Category | Source directory | markuplint rules | Description |
+|---|----------|----------------|-----------------|-------------|
+| 1 | Content Model | `html/elements/model-*` | All | Child element placement per HTML content model |
+| 2 | Deprecated Elements | `html/obsolete/` | `deprecated-element` | Obsolete elements (e.g., `<center>`, `<font>`) |
+| 3 | Required Attributes | `html/assertions/*missing*` | `required-attr` | Missing required attributes (e.g., `img[alt]`) |
+| 4 | Invalid Attributes | `html/elements/` (non-model) | All | Attribute existence and value validation |
+| 5 | Global Attributes | `html/attributes/` | All | Global attribute validation (e.g., `lang`, `class`) |
+| 6 | ID Duplication | `html/assertions/*duplicate-id*` | `id-duplication` | Duplicate `id` attribute values |
+| 7 | ARIA | `html-aria/` | All | WAI-ARIA roles, states, and properties |
+| 8 | Assertions | `html/assertions/` (other) | All | Cross-element constraints not covered above |
+| 9 | Data Types | `html/datatypes/` | All | Attribute value type validation (color, date, URL, etc.) |
+
+## nu-validator Test File Convention
+
+Test expectations are encoded in the filename:
+
+| Pattern | Meaning | Benchmark behavior |
+|---------|---------|-------------------|
+| `*-novalid.html` | nu-validator expects an **error** | markuplint must report >= 1 violation |
+| `*-isvalid.html` | nu-validator expects **no error** | markuplint must report 0 violations |
+| `*-haswarn.html` | nu-validator expects a **warning** | **Skipped** (markuplint has no warn/error distinction) |
+| Other | Treated as **valid** | markuplint must report 0 violations |
+
+Expected error messages are recorded in `validator/tests/messages.json`.
+
+## Reading the Report
+
+The generated report contains:
+
+- **Summary** — Pass/fail rates per category
+- **Missed Errors** — Files where nu-validator expects an error but markuplint found none, categorized by reason:
+  - *Bad value*: Attribute value type checks (URLs, colors, dates) — the largest gap
+  - *Forbidden code point*: Unicode control characters
+  - *Must-not constraint*: Complex cross-element rules
+- **Parse Errors** — Valid files that markuplint's parser could not handle (separated from false positives)
+- **False Positives** — Files nu-validator considers valid but markuplint flags, grouped by rule
+- **Content Model Failures** — Detailed breakdown of content model test results
+
+## File Structure
+
+```
+tests/external/
+├── validator/                  ← git submodule (validator/validator)
+├── nu-validator-utils.ts       ← Shared config and helpers
+├── nu-validator-report.ts      ← Report generator script
+├── nu-validator.spec.ts        ← Vitest test suite
+├── nu-validator-report.md      ← Generated report (git-ignored)
+└── README.md                   ← This file
+```
+
+## Maintenance
+
+- **Adding a new markuplint rule to the benchmark**: Update `allRulesConfig` in `nu-validator-utils.ts` and add a test category in both `nu-validator-report.ts` and `nu-validator.spec.ts`.
+- **nu-validator message format changes**: Update the pattern classification in `formatReport()` inside `nu-validator-report.ts`.

--- a/tests/external/nu-validator-report.ts
+++ b/tests/external/nu-validator-report.ts
@@ -1,0 +1,367 @@
+/**
+ * nu-html-checker compatibility report generator.
+ *
+ * Runs markuplint against the nu-html-checker test suite and outputs
+ * a structured report with pass/fail rates and failure analysis.
+ *
+ * Setup:
+ *   git submodule update --init tests/external/validator
+ *
+ * Run:
+ *   node --experimental-strip-types tests/external/nu-validator-report.ts
+ *
+ * Update to latest:
+ *   git submodule update --remote tests/external/validator
+ */
+import { readFileSync, existsSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { mlTest } from 'markuplint';
+import type { Config } from '@markuplint/ml-config';
+
+import {
+	allRulesConfig,
+	getExpectedResult,
+	collectTestableHtmlFiles,
+	relPath,
+} from './nu-validator-utils.ts';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const VALIDATOR_TESTS_DIR = path.resolve(__dirname, 'validator/tests');
+const MESSAGES_PATH = path.join(VALIDATOR_TESTS_DIR, 'messages.json');
+
+// ── Types ───────────────────────────────────────────────────
+
+interface TestResult {
+	file: string;
+	expected: 'error' | 'valid';
+	actual: 'error' | 'clean';
+	pass: boolean;
+	parseError: boolean;
+	violations: Array<{ ruleId: string; message: string; line: number; col: number }>;
+}
+
+interface CategoryReport {
+	name: string;
+	results: TestResult[];
+}
+
+// ── Test runner ─────────────────────────────────────────────
+
+async function runFile(
+	filePath: string,
+	config: Config,
+): Promise<TestResult> {
+	const sourceCode = readFileSync(filePath, 'utf-8');
+	const { violations } = await mlTest(sourceCode, config);
+	const expected = getExpectedResult(path.basename(filePath)) as 'error' | 'valid';
+	const actual = violations.length > 0 ? 'error' : 'clean';
+	const parseError = violations.some(v => v.ruleId === 'parse-error');
+
+	let pass: boolean;
+	if (expected === 'error') {
+		pass = actual === 'error';
+	} else {
+		pass = actual === 'clean';
+	}
+
+	return {
+		file: relPath(filePath, VALIDATOR_TESTS_DIR),
+		expected,
+		actual,
+		pass,
+		parseError,
+		violations: violations.map(v => ({
+			ruleId: v.ruleId,
+			message: v.message,
+			line: v.line,
+			col: v.col,
+		})),
+	};
+}
+
+async function runCategory(
+	name: string,
+	files: string[],
+	config: Config,
+): Promise<CategoryReport> {
+	const results: TestResult[] = [];
+	for (const file of files) {
+		results.push(await runFile(file, config));
+	}
+	return { name, results };
+}
+
+// ── Report formatting ───────────────────────────────────────
+
+function formatReport(categories: CategoryReport[], nuMessages: Record<string, string>): string {
+	const lines: string[] = [];
+	const now = new Date().toISOString().slice(0, 19).replace('T', ' ');
+	lines.push(`# nu-html-checker Compatibility Report`);
+	lines.push(`Generated: ${now}\n`);
+
+	// ── Legend ──
+	lines.push('## Legend\n');
+	lines.push('- **Pass**: markuplint\'s result matches nu-validator\'s expectation');
+	lines.push('- **Fail**: markuplint\'s result differs from nu-validator\'s expectation');
+	lines.push('- **Missed Error**: nu-validator expects an error but markuplint reports none (false negative)');
+	lines.push('- **False Positive**: nu-validator considers valid but markuplint reports violations');
+	lines.push('- **Parse Error**: markuplint\'s parser failed on a valid file (parser limitation)');
+	lines.push('- **Rate**: Pass / Total — higher is better\n');
+	lines.push('### Missed Error Reasons\n');
+	lines.push('- **Bad value**: nu-validator checks attribute value types (URL format, color codes, dates, etc.) deeply; markuplint checks attribute existence but not value format');
+	lines.push('- **Forbidden code point**: Unicode control character detection — not implemented in markuplint');
+	lines.push('- **Must-not constraint**: Complex cross-element constraints (e.g., "main must not appear inside article")');
+	lines.push('- **Attribute not allowed on element**: Conditional attribute restrictions based on element state');
+	lines.push('- **Stray element**: Elements appearing where no element is expected\n');
+
+	// ── Summary table ──
+	let totalPass = 0;
+	let totalFail = 0;
+
+	lines.push('## Summary\n');
+	lines.push('| Category | Pass | Fail | Total | Rate |');
+	lines.push('|----------|------|------|-------|------|');
+
+	for (const cat of categories) {
+		const pass = cat.results.filter(r => r.pass).length;
+		const fail = cat.results.filter(r => !r.pass).length;
+		const total = pass + fail;
+		const rate = total > 0 ? ((pass / total) * 100).toFixed(1) : '—';
+		totalPass += pass;
+		totalFail += fail;
+		lines.push(`| ${cat.name} | ${pass} | ${fail} | ${total} | ${rate}% |`);
+	}
+
+	const totalAll = totalPass + totalFail;
+	const totalRate = totalAll > 0 ? ((totalPass / totalAll) * 100).toFixed(1) : '—';
+	lines.push(`| **TOTAL** | **${totalPass}** | **${totalFail}** | **${totalAll}** | **${totalRate}%** |`);
+	lines.push('');
+
+	// ── Failure analysis ──
+	lines.push('## Failure Analysis\n');
+
+	const missedErrors: TestResult[] = [];
+	const falsePositives: TestResult[] = [];
+	const parseErrors: TestResult[] = [];
+
+	for (const cat of categories) {
+		for (const r of cat.results) {
+			if (!r.pass) {
+				if (r.expected === 'error' && r.actual === 'clean') {
+					missedErrors.push(r);
+				} else if (r.expected === 'valid' && r.actual === 'error') {
+					if (r.parseError && r.violations.every(v => v.ruleId === 'parse-error')) {
+						parseErrors.push(r);
+					} else {
+						falsePositives.push(r);
+					}
+				}
+			}
+		}
+	}
+
+	// ── Missed errors by nu-validator message pattern ──
+	lines.push(`### Missed Errors (${missedErrors.length} files)\n`);
+	lines.push('markuplint reported no violation, but nu-validator expected an error.\n');
+
+	// Message pattern classification.
+	// These patterns match the error messages in nu-validator's tests/messages.json.
+	// If nu-validator changes its message format, update the patterns below.
+	const msgCategories: Record<string, string[]> = {};
+	for (const r of missedErrors) {
+		const nuMsg = nuMessages[r.file] ?? '';
+		let cat: string;
+		if (nuMsg.startsWith('Bad value')) {
+			cat = 'Bad value (attribute value type validation)';
+		} else if (nuMsg.includes('not allowed on element')) {
+			cat = 'Attribute not allowed on element';
+		} else if (nuMsg.includes('must not')) {
+			cat = 'Must-not constraint';
+		} else if (nuMsg.includes('Forbidden code point')) {
+			cat = 'Forbidden code point';
+		} else if (nuMsg.includes('Stray')) {
+			cat = 'Stray element';
+		} else if (nuMsg) {
+			cat = 'Other';
+		} else {
+			cat = 'No message in messages.json';
+		}
+		(msgCategories[cat] ??= []).push(r.file);
+	}
+
+	lines.push('| Reason | Count | % of Missed |');
+	lines.push('|--------|-------|-------------|');
+	const sorted = Object.entries(msgCategories).sort((a, b) => b[1].length - a[1].length);
+	for (const [reason, files] of sorted) {
+		const pct = ((files.length / missedErrors.length) * 100).toFixed(1);
+		lines.push(`| ${reason} | ${files.length} | ${pct}% |`);
+	}
+	lines.push('');
+
+	// ── Parse errors (separate from false positives) ──
+	if (parseErrors.length > 0) {
+		lines.push(`### Parse Errors (${parseErrors.length} files)\n`);
+		lines.push('markuplint failed to parse these valid files (parser limitation).\n');
+		for (const r of parseErrors) {
+			const msg = r.violations.map(v => v.message).join('; ');
+			lines.push(`- \`${r.file}\`: ${msg}`);
+		}
+		lines.push('');
+	}
+
+	// ── False positives ──
+	lines.push(`### False Positives (${falsePositives.length} files)\n`);
+	lines.push('markuplint reported violations on files nu-validator considers valid.\n');
+
+	const fpByRule: Record<string, string[]> = {};
+	for (const r of falsePositives) {
+		for (const v of r.violations) {
+			(fpByRule[v.ruleId] ??= []).push(`${r.file} — ${v.message}`);
+		}
+	}
+
+	for (const [ruleId, entries] of Object.entries(fpByRule).sort((a, b) => b[1].length - a[1].length)) {
+		lines.push(`#### ${ruleId} (${entries.length} violations)\n`);
+		for (const entry of entries) {
+			lines.push(`- ${entry}`);
+		}
+		lines.push('');
+	}
+
+	// ── Content Model detail ──
+	const cmCat = categories.find(c => c.name === 'Content Model');
+	if (cmCat) {
+		const cmFails = cmCat.results.filter(r => !r.pass);
+		if (cmFails.length > 0) {
+			lines.push(`### Content Model Failures (${cmFails.length} files)\n`);
+			for (const r of cmFails) {
+				const nuMsg = nuMessages[r.file] ?? '(no message)';
+				const tag = r.expected === 'error' ? 'MISSED' : 'FALSE-POS';
+				lines.push(`- **[${tag}]** \`${r.file}\`: ${nuMsg}`);
+			}
+			lines.push('');
+		}
+	}
+
+	return lines.join('\n');
+}
+
+// ── Main ────────────────────────────────────────────────────
+
+async function main() {
+	if (!existsSync(path.join(VALIDATOR_TESTS_DIR, 'html'))) {
+		console.error('Submodule not found. Run: git submodule update --init tests/external/validator');
+		process.exit(1);
+	}
+
+	const nuMessages: Record<string, string> = existsSync(MESSAGES_PATH)
+		? JSON.parse(readFileSync(MESSAGES_PATH, 'utf-8'))
+		: {};
+
+	const elementsDir = path.join(VALIDATOR_TESTS_DIR, 'html/elements');
+	const obsoleteDir = path.join(VALIDATOR_TESTS_DIR, 'html/obsolete');
+	const assertionsDir = path.join(VALIDATOR_TESTS_DIR, 'html/assertions');
+	const attrsDir = path.join(VALIDATOR_TESTS_DIR, 'html/attributes');
+	const ariaDir = path.join(VALIDATOR_TESTS_DIR, 'html-aria');
+	const datatypesDir = path.join(VALIDATOR_TESTS_DIR, 'html/datatypes');
+
+	console.log('Running nu-html-checker compatibility tests...\n');
+
+	const categories: CategoryReport[] = [];
+	let done = 0;
+	const totalSteps = 9;
+
+	// 1. Content Model (all rules to catch cross-rule errors)
+	const modelFiles = collectTestableHtmlFiles(elementsDir).filter(f => path.basename(f).startsWith('model-'));
+	process.stdout.write(`[1/${totalSteps}] Content Model (${modelFiles.length} files)...`);
+	categories.push(await runCategory('Content Model', modelFiles, allRulesConfig));
+	done += modelFiles.length;
+	console.log(` done (${done} total)`);
+
+	// 2. Deprecated Elements
+	const obsoleteFiles = collectTestableHtmlFiles(obsoleteDir).filter(
+		f => getExpectedResult(path.basename(f)) === 'error',
+	);
+	process.stdout.write(`[2/${totalSteps}] Deprecated Elements (${obsoleteFiles.length} files)...`);
+	categories.push(await runCategory('Deprecated Elements', obsoleteFiles, { rules: { 'deprecated-element': true } }));
+	done += obsoleteFiles.length;
+	console.log(` done (${done} total)`);
+
+	// 3. Required Attributes
+	const requiredAttrFiles = collectTestableHtmlFiles(assertionsDir).filter(f => {
+		const b = path.basename(f);
+		return b.includes('missing') && b.includes('-novalid');
+	});
+	process.stdout.write(`[3/${totalSteps}] Required Attributes (${requiredAttrFiles.length} files)...`);
+	categories.push(await runCategory('Required Attributes', requiredAttrFiles, { rules: { 'required-attr': true } }));
+	done += requiredAttrFiles.length;
+	console.log(` done (${done} total)`);
+
+	// 4. Invalid Attributes (per-element, novalid + isvalid, excluding model-*)
+	const elemAttrFiles = collectTestableHtmlFiles(elementsDir).filter(f => {
+		const b = path.basename(f);
+		return (b.includes('-novalid') || b.includes('-isvalid')) && !b.startsWith('model-');
+	});
+	process.stdout.write(`[4/${totalSteps}] Invalid Attributes (${elemAttrFiles.length} files)...`);
+	categories.push(await runCategory('Invalid Attributes', elemAttrFiles, allRulesConfig));
+	done += elemAttrFiles.length;
+	console.log(` done (${done} total)`);
+
+	// 5. Global Attributes
+	const globalAttrFiles = collectTestableHtmlFiles(attrsDir);
+	process.stdout.write(`[5/${totalSteps}] Global Attributes (${globalAttrFiles.length} files)...`);
+	categories.push(await runCategory('Global Attributes', globalAttrFiles, allRulesConfig));
+	done += globalAttrFiles.length;
+	console.log(` done (${done} total)`);
+
+	// 6. ID Duplication
+	const idFiles = collectTestableHtmlFiles(assertionsDir).filter(f =>
+		path.basename(f).toLowerCase().includes('duplicate-id') && getExpectedResult(path.basename(f)) === 'error',
+	);
+	process.stdout.write(`[6/${totalSteps}] ID Duplication (${idFiles.length} files)...`);
+	categories.push(await runCategory('ID Duplication', idFiles, { rules: { 'id-duplication': true } }));
+	done += idFiles.length;
+	console.log(` done (${done} total)`);
+
+	// 7. ARIA
+	const ariaFiles = collectTestableHtmlFiles(ariaDir);
+	process.stdout.write(`[7/${totalSteps}] ARIA (${ariaFiles.length} files)...`);
+	categories.push(await runCategory('ARIA', ariaFiles, allRulesConfig));
+	done += ariaFiles.length;
+	console.log(` done (${done} total)`);
+
+	// 8. Assertions (all, excluding already-covered missing-* and duplicate-id)
+	const coveredAssertions = new Set([...requiredAttrFiles, ...idFiles].map(f => f));
+	const otherAssertionFiles = collectTestableHtmlFiles(assertionsDir).filter(f => !coveredAssertions.has(f));
+	process.stdout.write(`[8/${totalSteps}] Assertions (${otherAssertionFiles.length} files)...`);
+	categories.push(await runCategory('Assertions', otherAssertionFiles, allRulesConfig));
+	done += otherAssertionFiles.length;
+	console.log(` done (${done} total)`);
+
+	// 9. Data Types
+	const datatypeFiles = collectTestableHtmlFiles(datatypesDir);
+	process.stdout.write(`[9/${totalSteps}] Data Types (${datatypeFiles.length} files)...`);
+	categories.push(await runCategory('Data Types', datatypeFiles, allRulesConfig));
+	done += datatypeFiles.length;
+	console.log(` done (${done} total)`);
+
+	// Generate report
+	const report = formatReport(categories, nuMessages);
+
+	const outPath = path.resolve(__dirname, 'nu-validator-report.md');
+	writeFileSync(outPath, report);
+	console.log(`\nReport written to: ${outPath}`);
+
+	// Also print summary to stdout
+	const totalPass = categories.reduce((s, c) => s + c.results.filter(r => r.pass).length, 0);
+	const totalAll = categories.reduce((s, c) => s + c.results.length, 0);
+	console.log(`\n  Pass: ${totalPass} / ${totalAll} (${((totalPass / totalAll) * 100).toFixed(1)}%)`);
+}
+
+main().catch(err => {
+	console.error(err);
+	process.exit(1);
+});

--- a/tests/external/nu-validator-utils.ts
+++ b/tests/external/nu-validator-utils.ts
@@ -1,0 +1,97 @@
+/**
+ * Shared utilities for nu-html-checker compatibility tests.
+ */
+import { readdirSync, statSync, existsSync } from 'node:fs';
+import path from 'node:path';
+
+import type { Config } from '@markuplint/ml-config';
+
+/**
+ * markuplint config enabling all HTML validation rules used in
+ * the nu-validator compatibility benchmark.
+ *
+ * When adding a new markuplint rule to the benchmark, update this
+ * config AND add a corresponding test category in both
+ * nu-validator-report.ts and nu-validator.spec.ts.
+ */
+export const allRulesConfig: Config = {
+	rules: {
+		'permitted-contents': true,
+		'required-attr': true,
+		'invalid-attr': true,
+		'deprecated-element': true,
+		'deprecated-attr': true,
+		'id-duplication': true,
+		'wai-aria': true,
+	},
+};
+
+/**
+ * Determines expected test result from nu-validator filename convention:
+ * - `*-novalid.html` → should have errors
+ * - `*-haswarn.html` → warning expected (skipped — markuplint has no warn/error distinction)
+ * - `*-isvalid.html` → should have no errors
+ * - other            → treated as valid
+ *
+ * @param filename - The HTML test filename (e.g., `model-novalid.html`)
+ * @returns The expected result category
+ * @see https://github.com/validator/validator/blob/main/tests/
+ */
+export function getExpectedResult(filename: string): 'error' | 'valid' | 'warn' {
+	if (filename.includes('-novalid')) return 'error';
+	if (filename.includes('-haswarn')) return 'warn';
+	if (filename.includes('-isvalid')) return 'valid';
+	return 'valid';
+}
+
+/**
+ * Returns true if the file is testable (not a haswarn file).
+ *
+ * @param filename - The HTML test filename
+ * @returns Whether the file should be included in benchmarks
+ */
+export function isTestable(filename: string): boolean {
+	return getExpectedResult(filename) !== 'warn';
+}
+
+/**
+ * Collects HTML test files recursively from a directory.
+ *
+ * @param dir - The directory to search
+ * @returns Absolute paths to all `.html` files found
+ */
+export function collectHtmlFiles(dir: string): string[] {
+	const files: string[] = [];
+	if (!existsSync(dir)) return files;
+	for (const entry of readdirSync(dir)) {
+		const full = path.join(dir, entry);
+		const stat = statSync(full);
+		if (stat.isDirectory()) {
+			files.push(...collectHtmlFiles(full));
+		} else if (entry.endsWith('.html')) {
+			files.push(full);
+		}
+	}
+	return files;
+}
+
+/**
+ * Collects testable HTML files (excluding haswarn) from a directory.
+ *
+ * @param dir - The directory to search
+ * @returns Absolute paths to testable `.html` files
+ */
+export function collectTestableHtmlFiles(dir: string): string[] {
+	return collectHtmlFiles(dir).filter(f => isTestable(path.basename(f)));
+}
+
+/**
+ * Returns a relative path from the validator tests dir for display.
+ *
+ * @param filePath - Absolute path to the file
+ * @param validatorTestsDir - Absolute path to the validator tests root
+ * @returns The relative path for use in reports and test names
+ */
+export function relPath(filePath: string, validatorTestsDir: string): string {
+	return path.relative(validatorTestsDir, filePath);
+}

--- a/tests/external/nu-validator.spec.ts
+++ b/tests/external/nu-validator.spec.ts
@@ -1,0 +1,207 @@
+/**
+ * nu-html-checker (https://github.com/validator/validator) compatibility tests.
+ *
+ * These tests run markuplint against the nu-html-checker test suite to
+ * benchmark HTML validation coverage.
+ *
+ * Setup (submodule must be fetched manually):
+ *   git submodule update --init tests/external/validator
+ *
+ * Run:
+ *   npx vitest run --config vitest.nu-validator.config.ts
+ *
+ * Update to latest:
+ *   git submodule update --remote tests/external/validator
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, test, expect } from 'vitest';
+
+import { mlTest } from 'markuplint';
+import type { Config } from '@markuplint/ml-config';
+
+import {
+	allRulesConfig,
+	getExpectedResult,
+	collectTestableHtmlFiles,
+	relPath,
+} from './nu-validator-utils.js';
+
+const VALIDATOR_TESTS_DIR = path.resolve(__dirname, 'validator/tests');
+const SUBMODULE_AVAILABLE = existsSync(path.join(VALIDATOR_TESTS_DIR, 'html'));
+
+/**
+ * Generates test cases for a list of HTML files.
+ */
+function generateTests(files: string[], config: Config) {
+	for (const filePath of files) {
+		const rel = relPath(filePath, VALIDATOR_TESTS_DIR);
+		const expected = getExpectedResult(path.basename(filePath));
+
+		if (expected === 'error') {
+			test(`${rel} should report violations`, async () => {
+				const sourceCode = readFileSync(filePath, 'utf-8');
+				const { violations } = await mlTest(sourceCode, config);
+				expect(
+					violations.length,
+					`Expected violations for ${rel} but got none`,
+				).toBeGreaterThan(0);
+			});
+		} else if (expected === 'valid') {
+			test(`${rel} should pass without violations`, async () => {
+				const sourceCode = readFileSync(filePath, 'utf-8');
+				const { violations } = await mlTest(sourceCode, config);
+				expect(
+					violations,
+					`Expected no violations for ${rel} but got:\n${violations.map(v => `  [${v.line}:${v.col}] (${v.ruleId}) ${v.message}`).join('\n')}`,
+				).toHaveLength(0);
+			});
+		}
+		// warn files are skipped — markuplint has no warn/error distinction
+	}
+}
+
+const SKIP_MSG = 'validator submodule not found — run: git submodule update --init tests/external/validator';
+
+// ============================================================
+// 1. Content Model Tests (all rules)
+// ============================================================
+describe('nu-validator: Content Model', () => {
+	const elementsDir = path.join(VALIDATOR_TESTS_DIR, 'html/elements');
+	if (!SUBMODULE_AVAILABLE) {
+		test.skip(SKIP_MSG, () => {});
+		return;
+	}
+
+	const modelFiles = collectTestableHtmlFiles(elementsDir).filter(f => path.basename(f).startsWith('model-'));
+	generateTests(modelFiles, allRulesConfig);
+});
+
+// ============================================================
+// 2. Deprecated/Obsolete Element Tests
+// ============================================================
+describe('nu-validator: Deprecated Elements', () => {
+	const obsoleteDir = path.join(VALIDATOR_TESTS_DIR, 'html/obsolete');
+	if (!SUBMODULE_AVAILABLE) {
+		test.skip(SKIP_MSG, () => {});
+		return;
+	}
+
+	const files = collectTestableHtmlFiles(obsoleteDir).filter(
+		f => getExpectedResult(path.basename(f)) === 'error',
+	);
+	generateTests(files, { rules: { 'deprecated-element': true } });
+});
+
+// ============================================================
+// 3. Required Attribute Tests
+// ============================================================
+describe('nu-validator: Required Attributes', () => {
+	const assertionsDir = path.join(VALIDATOR_TESTS_DIR, 'html/assertions');
+	if (!SUBMODULE_AVAILABLE) {
+		test.skip(SKIP_MSG, () => {});
+		return;
+	}
+
+	const requiredAttrFiles = collectTestableHtmlFiles(assertionsDir).filter(f => {
+		const basename = path.basename(f);
+		return basename.includes('missing') && basename.includes('-novalid');
+	});
+	generateTests(requiredAttrFiles, { rules: { 'required-attr': true } });
+});
+
+// ============================================================
+// 4. Invalid Attribute Tests (per-element)
+// ============================================================
+describe('nu-validator: Invalid Attributes', () => {
+	const elementsDir = path.join(VALIDATOR_TESTS_DIR, 'html/elements');
+	if (!SUBMODULE_AVAILABLE) {
+		test.skip(SKIP_MSG, () => {});
+		return;
+	}
+
+	const attrFiles = collectTestableHtmlFiles(elementsDir).filter(f => {
+		const basename = path.basename(f);
+		return (basename.includes('-novalid') || basename.includes('-isvalid')) && !basename.startsWith('model-');
+	});
+	generateTests(attrFiles, allRulesConfig);
+});
+
+// ============================================================
+// 5. Global Attribute Tests
+// ============================================================
+describe('nu-validator: Global Attributes', () => {
+	const attrsDir = path.join(VALIDATOR_TESTS_DIR, 'html/attributes');
+	if (!SUBMODULE_AVAILABLE) {
+		test.skip(SKIP_MSG, () => {});
+		return;
+	}
+
+	const files = collectTestableHtmlFiles(attrsDir);
+	generateTests(files, allRulesConfig);
+});
+
+// ============================================================
+// 6. ID Duplication Tests
+// ============================================================
+describe('nu-validator: ID Duplication', () => {
+	const assertionsDir = path.join(VALIDATOR_TESTS_DIR, 'html/assertions');
+	if (!SUBMODULE_AVAILABLE) {
+		test.skip(SKIP_MSG, () => {});
+		return;
+	}
+
+	const idFiles = collectTestableHtmlFiles(assertionsDir).filter(f =>
+		path.basename(f).toLowerCase().includes('duplicate-id'),
+	);
+	generateTests(idFiles, { rules: { 'id-duplication': true } });
+});
+
+// ============================================================
+// 7. ARIA Tests
+// ============================================================
+describe('nu-validator: ARIA', () => {
+	const ariaDir = path.join(VALIDATOR_TESTS_DIR, 'html-aria');
+	if (!SUBMODULE_AVAILABLE) {
+		test.skip(SKIP_MSG, () => {});
+		return;
+	}
+
+	const files = collectTestableHtmlFiles(ariaDir);
+	generateTests(files, allRulesConfig);
+});
+
+// ============================================================
+// 8. Assertions (other)
+// ============================================================
+describe('nu-validator: Assertions', () => {
+	const assertionsDir = path.join(VALIDATOR_TESTS_DIR, 'html/assertions');
+	if (!SUBMODULE_AVAILABLE) {
+		test.skip(SKIP_MSG, () => {});
+		return;
+	}
+
+	// Exclude files already covered by Required Attributes and ID Duplication
+	const files = collectTestableHtmlFiles(assertionsDir).filter(f => {
+		const basename = path.basename(f);
+		const isMissing = basename.includes('missing') && basename.includes('-novalid');
+		const isDuplicateId = basename.toLowerCase().includes('duplicate-id');
+		return !isMissing && !isDuplicateId;
+	});
+	generateTests(files, allRulesConfig);
+});
+
+// ============================================================
+// 9. Data Type Tests
+// ============================================================
+describe('nu-validator: Data Types', () => {
+	const datatypesDir = path.join(VALIDATOR_TESTS_DIR, 'html/datatypes');
+	if (!SUBMODULE_AVAILABLE) {
+		test.skip(SKIP_MSG, () => {});
+		return;
+	}
+
+	const files = collectTestableHtmlFiles(datatypesDir);
+	generateTests(files, allRulesConfig);
+});

--- a/vitest.nu-validator.config.ts
+++ b/vitest.nu-validator.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		include: ['./tests/external/**/*.spec.ts'],
+		testTimeout: 30_000,
+	},
+});


### PR DESCRIPTION
## Summary

- nu-html-checker (validator.w3.org) のテストスイート (~4,000件) を git submodule として追加し、markuplint の HTML バリデーション精度をベンチマークする仕組みを構築
- 9カテゴリ (Content Model, Deprecated Elements, Required Attributes, Invalid Attributes, Global Attributes, ID Duplication, ARIA, Assertions, Data Types) で検証
- 現時点の結果: **1,589 / 3,985 pass (39.9%)**

### 追加ファイル

| ファイル | 用途 |
|----------|------|
| `.gitmodules` | nu-validator submodule 定義 (optional, shallow) |
| `tests/external/nu-validator-utils.ts` | 共通設定・ヘルパー |
| `tests/external/nu-validator-report.ts` | Markdown レポート生成スクリプト |
| `tests/external/nu-validator.spec.ts` | vitest テストスイート |
| `vitest.nu-validator.config.ts` | 専用 vitest config |
| `tests/external/README.md` | セットアップ・実行手順・レポートの読み方 |
| `.claude/commands/nu-validator.md` | `/nu-validator` スラッシュコマンド |

### 実行方法

```bash
# submodule 取得 (初回のみ)
git submodule update --init tests/external/validator

# レポート生成
node --experimental-strip-types tests/external/nu-validator-report.ts

# vitest 実行
npx vitest run --config vitest.nu-validator.config.ts
```

### 既存テストへの影響

- `yarn test` には含まれない (vitest include パターンが `packages/` のみ)
- submodule は `git clone` 時に取得されない (デフォルト動作)
- CI への影響なし

## Test plan

- [x] `yarn build` pass
- [x] `yarn test` pass (199 files, 3062 tests)
- [x] `node --experimental-strip-types tests/external/nu-validator-report.ts` でレポート生成確認
- [x] `npx vitest run --config vitest.nu-validator.config.ts` で 3,985 テスト実行確認