### PR TITLE
fix(types): allow empty string for BCP47 type (lang="" is valid)

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -156,6 +156,11 @@
 		"yearless",
 		"Yusuke",
 
+		// nu-validator test file naming convention
+		"isvalid",
+		"novalid",
+		"haswarn",
+
 		// Specs
 		"closedby",
 		"khern",

--- a/packages/@markuplint/rules/src/attr-check.spec.ts
+++ b/packages/@markuplint/rules/src/attr-check.spec.ts
@@ -42,14 +42,10 @@ test('BrowsingContextNameOrKeyword', () => {
 });
 
 test('BCP47', () => {
-	expect(valueCheck(t, 'lang', '', 'BCP47')).toStrictEqual([
-		'the "lang" attribute must not be empty. It expects the BCP47 format (https://tools.ietf.org/rfc/bcp/bcp47.html)',
-		{
-			col: 0,
-			line: 0,
-			raw: '',
-		},
-	]);
+	// Empty string is valid per HTML LS (language set to unknown)
+	expect(valueCheck(t, 'lang', '', 'BCP47')).toBe(false);
+	// Invalid BCP47 should return error
+	expect(valueCheck(t, 'lang', ':::', 'BCP47')).not.toBe(false);
 });
 
 test('DateTime', () => {

--- a/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
@@ -2014,3 +2014,9 @@ describe('focusgroup attribute (#3384)', () => {
 		expect((await mlRuleTest(rule, '<span focusgroupstart></span>')).violations).toStrictEqual([]);
 	});
 });
+
+test('empty lang attribute is valid (language set to unknown)', async () => {
+	expect((await mlRuleTest(rule, '<html lang=""></html>')).violations).toStrictEqual([]);
+	expect((await mlRuleTest(rule, '<html lang></html>')).violations).toStrictEqual([]);
+	expect((await mlRuleTest(rule, '<div lang=""></div>')).violations).toStrictEqual([]);
+});

--- a/packages/@markuplint/types/src/check.spec.ts
+++ b/packages/@markuplint/types/src/check.spec.ts
@@ -45,7 +45,8 @@ test('BCP47', () => {
 	expect(check('en-US', 'BCP47').matched).toBe(true);
 	expect(check('ja', 'BCP47').matched).toBe(true);
 	expect(check(' ja ', 'BCP47').matched).toBe(false);
-	expect(check('', 'BCP47').matched).toBe(false);
+	// Empty string is valid per HTML LS (language set to unknown)
+	expect(check('', 'BCP47').matched).toBe(true);
 	expect(check('zh/cn', 'BCP47').matched).toBe(false);
 });
 

--- a/packages/@markuplint/types/src/defs.ts
+++ b/packages/@markuplint/types/src/defs.ts
@@ -233,7 +233,9 @@ export const defs: Defs = {
 			},
 		],
 		ref: 'https://tools.ietf.org/rfc/bcp/bcp47.html',
-		is: matches(isBCP47(), { reason: 'unexpected-token' }),
+		// Empty string is valid per HTML LS: "the language is set to unknown"
+		// https://html.spec.whatwg.org/multipage/dom.html#the-lang-and-xml:lang-attributes
+		is: value => (value === '' ? matched() : matches(isBCP47(), { reason: 'unexpected-token' })(value)),
 	},
 
 	/**


### PR DESCRIPTION
Closes #3585

## Summary

- `lang=""` and `<html lang>` (valueless) are valid per HTML Living Standard — empty string means "language unknown"
- The BCP47 type checker in `@markuplint/types` now accepts empty string as valid
- The fix is at the `defs.ts` registry level, keeping `isBCP47` as a pure RFC validator

## Changes

- `packages/@markuplint/types/src/defs.ts` — Add empty string guard before BCP47 check
- `packages/@markuplint/types/src/check.spec.ts` — Update BCP47 empty string test
- `packages/@markuplint/rules/src/attr-check.spec.ts` — Update valueCheck test + add invalid case
- `packages/@markuplint/rules/src/invalid-attr/index.spec.ts` — Add integration test for `<html lang="">`

## Spec reference

> If the attribute's value is the empty string, the language is set to unknown.
> — https://html.spec.whatwg.org/multipage/dom.html#the-lang-and-xml:lang-attributes

## Test plan

- [x] `yarn build` pass
- [x] `yarn test` pass (199 files, 3063 tests)
- [x] `npx vitest run packages/@markuplint/types/src/check.spec.ts` — BCP47 empty string now matched
- [x] `npx vitest run packages/@markuplint/rules/src/invalid-attr/index.spec.ts` — `<html lang="">` no violations