### PR TITLE
fix(html-spec): add dir as required attribute for bdo element

### DIFF
--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -49361,7 +49361,8 @@
 			},
 			"attributes": {
 				"dir": {
-					"description": "The direction in which text should be rendered in this element's contents. Possible values are: ltr: Indicates that the text should go in a left-to-right direction. rtl: Indicates that the text should go in a right-to-left direction."
+					"description": "The direction in which text should be rendered in this element's contents. Possible values are: ltr: Indicates that the text should go in a left-to-right direction. rtl: Indicates that the text should go in a right-to-left direction.",
+					"required": true
 				}
 			}
 		},

--- a/packages/@markuplint/html-spec/src/spec.bdo.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.bdo.jsonc
@@ -14,7 +14,13 @@
 		"#GlobalEventAttrs": true,
 		"#ARIAAttrs": true
 	},
-	"attributes": {},
+	"attributes": {
+		// https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-bdo-element
+		// "The dir global content attribute is required on this element."
+		"dir": {
+			"required": true
+		}
+	},
 	"aria": {
 		"implicitRole": "generic",
 		"permittedRoles": true,

--- a/packages/@markuplint/rules/src/required-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/required-attr/index.spec.ts
@@ -849,3 +849,17 @@ describe('ignoreAttrs option (#690)', () => {
 		]);
 	});
 });
+
+test('bdo requires dir attribute', async () => {
+	expect((await mlRuleTest(rule, '<bdo>text</bdo>')).violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 1,
+			message: 'The "bdo" element expects the "dir" attribute',
+			raw: '<bdo>',
+		},
+	]);
+	expect((await mlRuleTest(rule, '<bdo dir="ltr">text</bdo>')).violations).toStrictEqual([]);
+	expect((await mlRuleTest(rule, '<bdo dir="rtl">text</bdo>')).violations).toStrictEqual([]);
+});


### PR DESCRIPTION
Closes #3593

## Summary

- Add `dir` as a required attribute for the `<bdo>` element in `spec.bdo.jsonc`
- The HTML Living Standard states: "The dir global content attribute is required on this element."

## Changes

- `packages/@markuplint/html-spec/src/spec.bdo.jsonc` — Add `dir: { required: true }`
- `packages/@markuplint/html-spec/index.json` — Regenerated via `yarn up:gen`
- `packages/@markuplint/rules/src/required-attr/index.spec.ts` — Add test for bdo dir required

## Spec reference

> The dir global content attribute is required on this element.
> — https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-bdo-element

## Test plan

- [x] `yarn build` pass
- [x] `yarn test` pass (199 files, 3065 tests)
- [x] Idempotency verified