### PR TITLE
feat(html-spec): add conditional attribute constraints for script element

### DIFF
--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -54167,7 +54167,10 @@
 				"async": {
 					"description": "For classic scripts, if the async attribute is present, then the classic script will be fetched in parallel to parsing and evaluated as soon as it is available. For module scripts, if the async attribute is present then the scripts and all their dependencies will be fetched in parallel to parsing and evaluated as soon as they are available. Warning: This attribute must not be used if the src attribute is absent (i.e., for inline scripts) for classic scripts, in this case it would have no effect. This attribute allows the elimination of parser-blocking JavaScript where the browser would have to load and evaluate scripts before continuing to parse. defer has a similar effect in this case. If the attribute is specified with the defer attribute, the element will act as if only the async attribute is specified. This is a boolean attribute: the presence of a boolean attribute on an element represents the true value, and the absence of the attribute represents the false value. See Browser compatibility for notes on browser support. See also Async scripts for asm.js.",
 					"type": "Boolean",
-					"condition": ["[src]", "[type='module' i]"],
+					"condition": [
+						":not([type='importmap' i]):not([type='speculationrules' i])[src]",
+						"[type='module' i]"
+					],
 					"ineffective": ":not([src]):not([type='module' i])"
 				},
 				"attributionsrc": {
@@ -54182,27 +54185,31 @@
 						},
 						"separator": "space",
 						"unique": true
-					}
+					},
+					"condition": ":not([type='importmap' i]):not([type='speculationrules' i])"
 				},
 				"charset": {
 					"description": "If present, its value must be an ASCII case-insensitive match for utf-8. It's unnecessary to specify the charset attribute, because documents must use UTF-8, and the script element inherits its character encoding from the document.",
-					"deprecated": true
+					"deprecated": true,
+					"condition": "[src]"
 				},
 				"crossorigin": {
-					"description": "Normal script elements pass minimal information to the window.onerror for scripts which do not pass the standard CORS checks. To allow error logging for sites which use a separate domain for static media, use this attribute. See CORS settings attributes for a more descriptive explanation of its valid arguments."
+					"description": "Normal script elements pass minimal information to the window.onerror for scripts which do not pass the standard CORS checks. To allow error logging for sites which use a separate domain for static media, use this attribute. See CORS settings attributes for a more descriptive explanation of its valid arguments.",
+					"condition": ":not([type='importmap' i]):not([type='speculationrules' i])"
 				},
 				"defer": {
 					"description": "This Boolean attribute is set to indicate to a browser that the script is meant to be executed after the document has been parsed, but before firing DOMContentLoaded event. Scripts with the defer attribute will prevent the DOMContentLoaded event from firing until the script has loaded and finished evaluating. Warning: This attribute must not be used if the src attribute is absent (i.e., for inline scripts), in this case it would have no effect. The defer attribute has no effect on module scripts — they defer by default. Scripts with the defer attribute will execute in the order in which they appear in the document. This attribute allows the elimination of parser-blocking JavaScript where the browser would have to load and evaluate scripts before continuing to parse. async has a similar effect in this case. If the attribute is specified with the async attribute, the element will act as if only the async attribute is specified.",
 					"type": "Boolean",
-					"condition": "[src]",
+					"condition": ":not([type='importmap' i]):not([type='speculationrules' i])[src]",
 					"ineffective": ["[type='module' i]", ":not([src])", "[async]"]
 				},
 				"fetchpriority": {
-					"description": "Provides a hint of the relative priority to use when fetching an external script. Allowed values: high Fetch the external script at a high priority relative to other external scripts. low Fetch the external script at a low priority relative to other external scripts. auto Don't set a preference for the fetch priority. This is the default. It is used if no value or an invalid value is set."
+					"description": "Provides a hint of the relative priority to use when fetching an external script. Allowed values: high Fetch the external script at a high priority relative to other external scripts. low Fetch the external script at a low priority relative to other external scripts. auto Don't set a preference for the fetch priority. This is the default. It is used if no value or an invalid value is set.",
+					"condition": ":not([type='importmap' i]):not([type='speculationrules' i])"
 				},
 				"integrity": {
 					"description": "This attribute contains inline metadata that a user agent can use to verify that a fetched resource has been delivered without unexpected manipulation. The attribute must not be specified when the src attribute is absent. See Subresource Integrity.",
-					"condition": "[src]"
+					"condition": ":not([type='importmap' i]):not([type='speculationrules' i])[src]"
 				},
 				"language": {
 					"description": "Like the type attribute, this attribute identifies the scripting language in use. Unlike the type attribute, however, this attribute's possible values were never standardized. The type attribute should be used instead.",
@@ -54212,17 +54219,19 @@
 				"nomodule": {
 					"description": "This Boolean attribute is set to indicate that the script should not be executed in browsers that support ES modules — in effect, this can be used to serve fallback scripts to older browsers that do not support modular JavaScript code.",
 					"type": "Boolean",
-					"condition": ":not([type='module' i])"
+					"condition": ":not([type='module' i]):not([type='importmap' i]):not([type='speculationrules' i])"
 				},
 				"nonce": {
 					"description": "A cryptographic nonce (number used once) to allow scripts in a script-src Content-Security-Policy. The server must generate a unique nonce value each time it transmits a policy. It is critical to provide a nonce that cannot be guessed as bypassing a resource's policy is otherwise trivial."
 				},
 				"referrerpolicy": {
-					"description": "Indicates which referrer to send when fetching the script, or resources fetched by the script: no-referrer: The Referer header will not be sent. no-referrer-when-downgrade: The Referer header will not be sent to origins without TLS (HTTPS). origin: The sent referrer will be limited to the origin of the referring page: its scheme, host, and port. origin-when-cross-origin: The referrer sent to other origins will be limited to the scheme, the host, and the port. Navigations on the same origin will still include the path. same-origin: A referrer will be sent for same origin, but cross-origin requests will contain no referrer information. strict-origin: Only send the origin of the document as the referrer when the protocol security level stays the same (HTTPS→HTTPS), but don't send it to a less secure destination (HTTPS→HTTP). strict-origin-when-cross-origin (default): Send a full URL when performing a same-origin request, only send the origin when the protocol security level stays the same (HTTPS→HTTPS), and send no header to a less secure destination (HTTPS→HTTP). unsafe-url: The referrer will include the origin and the path (but not the fragment, password, or username). This value is unsafe, because it leaks origins and paths from TLS-protected resources to insecure origins. Note: An empty string value (\"\") is both the default value, and a fallback value if referrerpolicy is not supported. If referrerpolicy is not explicitly specified on the <script> element, it will adopt a higher-level referrer policy, i.e., one set on the whole document or domain. If a higher-level policy is not available, the empty string is treated as being equivalent to strict-origin-when-cross-origin."
+					"description": "Indicates which referrer to send when fetching the script, or resources fetched by the script: no-referrer: The Referer header will not be sent. no-referrer-when-downgrade: The Referer header will not be sent to origins without TLS (HTTPS). origin: The sent referrer will be limited to the origin of the referring page: its scheme, host, and port. origin-when-cross-origin: The referrer sent to other origins will be limited to the scheme, the host, and the port. Navigations on the same origin will still include the path. same-origin: A referrer will be sent for same origin, but cross-origin requests will contain no referrer information. strict-origin: Only send the origin of the document as the referrer when the protocol security level stays the same (HTTPS→HTTPS), but don't send it to a less secure destination (HTTPS→HTTP). strict-origin-when-cross-origin (default): Send a full URL when performing a same-origin request, only send the origin when the protocol security level stays the same (HTTPS→HTTPS), and send no header to a less secure destination (HTTPS→HTTP). unsafe-url: The referrer will include the origin and the path (but not the fragment, password, or username). This value is unsafe, because it leaks origins and paths from TLS-protected resources to insecure origins. Note: An empty string value (\"\") is both the default value, and a fallback value if referrerpolicy is not supported. If referrerpolicy is not explicitly specified on the <script> element, it will adopt a higher-level referrer policy, i.e., one set on the whole document or domain. If a higher-level policy is not available, the empty string is treated as being equivalent to strict-origin-when-cross-origin.",
+					"condition": ":not([type='importmap' i]):not([type='speculationrules' i])"
 				},
 				"src": {
 					"description": "This attribute specifies the URI of an external script; this can be used as an alternative to embedding a script directly within a document.",
-					"type": "URL"
+					"type": "URL",
+					"condition": ":not([type='importmap' i]):not([type='speculationrules' i])"
 				},
 				"type": {
 					"description": "This attribute indicates the type of script represented. The value of this attribute will be one of the following: Attribute is not set (default), an empty string, or a JavaScript MIME type Indicates that the script is a \"classic script\", containing JavaScript code. Authors are encouraged to omit the attribute if the script refers to JavaScript code rather than specify a MIME type. JavaScript MIME types are listed in the IANA media types specification. importmap This value indicates that the body of the element contains an import map. The import map is a JSON object that developers can use to control how the browser resolves module specifiers when importing JavaScript modules. module This value causes the code to be treated as a JavaScript module. The processing of the script contents is deferred. The charset and defer attributes have no effect. For information on using module, see our JavaScript modules guide. Unlike classic scripts, module scripts require the use of the CORS protocol for cross-origin fetching. speculationrules Experimental This value indicates that the body of the element contains speculation rules. Speculation rules take the form of a JSON object that determine what resources should be prefetched or prerendered by the browser. This is part of the Speculation Rules API. Any other value The embedded content is treated as a data block, and won't be processed by the browser. Developers must use a valid MIME type that is not a JavaScript MIME type to denote data blocks. All of the other attributes will be ignored, including the src attribute.",

--- a/packages/@markuplint/html-spec/src/spec.script.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.script.jsonc
@@ -17,16 +17,13 @@
 	},
 	"attributes": {
 		// https://html.spec.whatwg.org/multipage/scripting.html#attr-script-src
+		// importmap and speculationrules must not have src
 		"src": {
-			"type": "URL"
+			"type": "URL",
+			"condition": ":not([type='importmap' i]):not([type='speculationrules' i])"
 		},
 		// https://html.spec.whatwg.org/multipage/scripting.html#attr-script-type
 		"type": {
-			// When used to include data blocks the data must be embedded inline,
-			// the format of the data must be given using the type attribute,
-			// and the contents of the script element must conform to the requirements defined for the format used.
-			// The src, async, nomodule, defer, crossorigin, integrity,
-			// and referrerpolicy attributes must not be specified.
 			"type": [
 				"MIMEType",
 				{
@@ -36,28 +33,38 @@
 			]
 		},
 		// https://html.spec.whatwg.org/multipage/scripting.html#attr-script-nomodule
+		// Must not be used with type=module, importmap, or speculationrules
 		"nomodule": {
 			"type": "Boolean",
-			"condition": ":not([type='module' i])"
+			"condition": ":not([type='module' i]):not([type='importmap' i]):not([type='speculationrules' i])"
 		},
 		// https://html.spec.whatwg.org/multipage/scripting.html#attr-script-async
+		// Must not be used with importmap or speculationrules
 		"async": {
 			"type": "Boolean",
-			"condition": ["[src]", "[type='module' i]"],
+			"condition": [":not([type='importmap' i]):not([type='speculationrules' i])[src]", "[type='module' i]"],
 			"ineffective": ":not([src]):not([type='module' i])"
 		},
 		// https://html.spec.whatwg.org/multipage/scripting.html#attr-script-defer
+		// Must not be used with importmap or speculationrules; requires src
+		// For type=module, defer is ineffective (not disallowed)
 		"defer": {
 			"type": "Boolean",
-			"condition": "[src]",
-			// The `defer` attribute affects the element that has the async attribute if it doesn't support the async
+			"condition": ":not([type='importmap' i]):not([type='speculationrules' i])[src]",
 			"ineffective": ["[type='module' i]", ":not([src])", "[async]"]
 		},
 		// https://html.spec.whatwg.org/multipage/scripting.html#attr-script-integrity
+		// Must not be used with importmap or speculationrules; requires src
 		"integrity": {
+			"condition": ":not([type='importmap' i]):not([type='speculationrules' i])[src]"
+		},
+		// https://html.spec.whatwg.org/multipage/scripting.html#attr-script-charset
+		// Must not be used without src
+		"charset": {
 			"condition": "[src]"
 		},
 		// https://html.spec.whatwg.org/multipage/urls-and-fetching.html#blocking-attributes
+		// Must not be used with importmap or speculationrules
 		"blocking": {
 			"type": {
 				"token": {
@@ -65,7 +72,21 @@
 				},
 				"separator": "space",
 				"unique": true
-			}
+			},
+			"condition": ":not([type='importmap' i]):not([type='speculationrules' i])"
+		},
+		// crossorigin: must not be used with importmap or speculationrules
+		// (overrides the definition from #HTMLLinkAndFetchingAttrs)
+		"crossorigin": {
+			"condition": ":not([type='importmap' i]):not([type='speculationrules' i])"
+		},
+		// referrerpolicy: must not be used with importmap or speculationrules
+		"referrerpolicy": {
+			"condition": ":not([type='importmap' i]):not([type='speculationrules' i])"
+		},
+		// fetchpriority: must not be used with importmap or speculationrules
+		"fetchpriority": {
+			"condition": ":not([type='importmap' i]):not([type='speculationrules' i])"
 		}
 	},
 	"aria": {

--- a/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
@@ -2027,3 +2027,102 @@ test('script type="speculationrules" is valid', async () => {
 			.violations,
 	).toStrictEqual([]);
 });
+
+describe('script conditional attributes (#3631)', () => {
+	test('importmap must not have src', async () => {
+		const { violations } = await mlRuleTest(rule, '<script type="importmap" src="map.json"></script>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 26,
+				message: 'The "src" attribute is disallowed',
+				raw: 'src',
+			},
+		]);
+	});
+
+	test('speculationrules must not have src', async () => {
+		const { violations } = await mlRuleTest(rule, '<script type="speculationrules" src="rules.json"></script>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 33,
+				message: 'The "src" attribute is disallowed',
+				raw: 'src',
+			},
+		]);
+	});
+
+	test('importmap must not have async', async () => {
+		const { violations } = await mlRuleTest(rule, '<script type="importmap" async></script>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 26,
+				message: 'The "async" attribute is disallowed',
+				raw: 'async',
+			},
+		]);
+	});
+
+	test('importmap must not have defer', async () => {
+		const { violations } = await mlRuleTest(rule, '<script type="importmap" defer></script>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 26,
+				message: 'The "defer" attribute is disallowed',
+				raw: 'defer',
+			},
+		]);
+	});
+
+	test('importmap must not have nomodule', async () => {
+		const { violations } = await mlRuleTest(rule, '<script type="importmap" nomodule></script>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 26,
+				message: 'The "nomodule" attribute is disallowed',
+				raw: 'nomodule',
+			},
+		]);
+	});
+
+	test('module with defer is not disallowed (handled by ineffective-attr)', async () => {
+		// defer on module scripts is ineffective, not disallowed
+		expect((await mlRuleTest(rule, '<script type="module" src="m.js" defer></script>')).violations).toStrictEqual(
+			[],
+		);
+	});
+
+	test('charset requires src', async () => {
+		const { violations } = await mlRuleTest(rule, '<script charset="utf-8">x</script>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 9,
+				message: 'The "charset" attribute is disallowed',
+				raw: 'charset',
+			},
+		]);
+	});
+
+	test('valid: module with async', async () => {
+		expect((await mlRuleTest(rule, '<script type="module" async>x</script>')).violations).toStrictEqual([]);
+	});
+
+	test('valid: classic with src and defer', async () => {
+		expect((await mlRuleTest(rule, '<script src="app.js" defer></script>')).violations).toStrictEqual([]);
+	});
+
+	test('valid: classic with src and async', async () => {
+		expect((await mlRuleTest(rule, '<script src="app.js" async></script>')).violations).toStrictEqual([]);
+	});
+});


### PR DESCRIPTION
Closes #3631

## Summary

Add `condition` constraints to `<script>` element attributes based on `type` value, following the HTML Living Standard.

### Constraints added

| Attribute | Disallowed when |
|-----------|----------------|
| `src` | `type=importmap`, `type=speculationrules` |
| `async` | `type=importmap`, `type=speculationrules` (only allowed with `src` or `type=module`) |
| `defer` | `type=importmap`, `type=speculationrules` (requires `src`; ineffective with `type=module`) |
| `nomodule` | `type=module`, `type=importmap`, `type=speculationrules` |
| `crossorigin` | `type=importmap`, `type=speculationrules` |
| `referrerpolicy` | `type=importmap`, `type=speculationrules` |
| `integrity` | `type=importmap`, `type=speculationrules` (requires `src`) |
| `fetchpriority` | `type=importmap`, `type=speculationrules` |
| `blocking` | `type=importmap`, `type=speculationrules` |
| `charset` | requires `src` |

### Design note

`defer` on `type=module` is **ineffective** (handled by `ineffective-attr` rule), not **disallowed**. This preserves the existing behavior where `ineffective-attr` reports it as a warning.

## Spec reference

- https://html.spec.whatwg.org/multipage/scripting.html#the-script-element

## Test plan

- [x] `yarn build` pass
- [x] `yarn test` pass (199 files, 3075 tests)
- [x] Idempotency verified
- [x] `ineffective-attr` tests still pass (defer on module = warning, not error)