### PR TITLE
feat(types): add URL validation with strict checks

### DIFF
--- a/packages/@markuplint/types/src/defs.ts
+++ b/packages/@markuplint/types/src/defs.ts
@@ -10,6 +10,7 @@ import { checkSerializedPermissionsPolicy } from './w3c/check-serialized-permiss
 import { checkAutoComplete } from './whatwg/check-autocomplete.js';
 import { checkDateTime } from './whatwg/check-datetime/index.js';
 import { checkMIMEType } from './whatwg/check-mime-type.js';
+import { checkURL } from './whatwg/check-url.js';
 import { isAbsURL } from './whatwg/is-abs-url.js';
 import { isBrowserContextName } from './whatwg/is-browser-context-name.js';
 import { isCustomElementName } from './whatwg/is-custom-element-name.js';
@@ -239,21 +240,14 @@ export const defs: Defs = {
 	},
 
 	/**
-	 * **NO IMPLEMENT NEVER**
-	 *
-	 * We can evaluate the absolute URL through WHATWG API,
-	 * but it isn't easy to check the relative URL.
-	 * And the relative URL expects almost all of the characters.
-	 * In short, this checking is meaningless.
-	 *
-	 * So it always returns the matched object.
-	 *
-	 * If you want to expect the URL without multi-byte characters,
-	 * it should use another rule.
+	 * Validates a URL (potentially surrounded by spaces) per WHATWG URL Standard.
+	 * Uses `new URL()` for structural parsing plus strict checks for illegal
+	 * whitespace, malformed percent-encoding, and C0 control characters.
+	 * Relative URLs are resolved against a dummy base for syntax validation.
 	 */
 	URL: {
 		ref: 'https://html.spec.whatwg.org/multipage/urls-and-fetching.html#valid-url-potentially-surrounded-by-spaces',
-		is: () => matched(),
+		is: checkURL(),
 	},
 
 	/**

--- a/packages/@markuplint/types/src/whatwg/check-url.spec.ts
+++ b/packages/@markuplint/types/src/whatwg/check-url.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from 'vitest';
+
+import { checkURL } from './check-url.js';
+
+const check = checkURL();
+
+test('valid absolute URLs', () => {
+	expect(check('https://example.com').matched).toBe(true);
+	expect(check('http://example.com/path?q=1#hash').matched).toBe(true);
+	expect(check('mailto:user@example.com').matched).toBe(true);
+	expect(check('tel:+1234567890').matched).toBe(true);
+});
+
+test('valid relative URLs', () => {
+	expect(check('/path/to/page').matched).toBe(true);
+	expect(check('relative/path').matched).toBe(true);
+	expect(check('../parent').matched).toBe(true);
+	expect(check('#fragment').matched).toBe(true);
+	expect(check('?query=1').matched).toBe(true);
+});
+
+test('empty URL is valid', () => {
+	expect(check('').matched).toBe(true);
+});
+
+test('URL with surrounding spaces is valid', () => {
+	expect(check('  https://example.com  ').matched).toBe(true);
+});
+
+test('illegal whitespace (tab)', () => {
+	expect(check('http://exa\tmple.com').matched).toBe(false);
+});
+
+test('illegal whitespace (newline)', () => {
+	expect(check('http://example.\ncom').matched).toBe(false);
+});
+
+test('illegal whitespace (CR)', () => {
+	expect(check('http://example.\rcom').matched).toBe(false);
+});
+
+test('malformed percent-encoding', () => {
+	expect(check('http://example.com/a%ZZ').matched).toBe(false);
+	expect(check('http://example.com/%').matched).toBe(false);
+	expect(check('http://example.com/%2').matched).toBe(false);
+});
+
+test('valid percent-encoding', () => {
+	expect(check('http://example.com/%20path').matched).toBe(true);
+	expect(check('/path/%E3%81%82').matched).toBe(true);
+});
+
+test('C0 control characters', () => {
+	expect(check('http://example.com/\u0000').matched).toBe(false);
+	expect(check('http://example.com/\u0008').matched).toBe(false);
+	expect(check('http://example.com/\u007F').matched).toBe(false);
+});
+
+test('space in URL (unencoded)', () => {
+	// Spaces in path cause new URL() to fail for absolute URLs
+	// For relative URLs with dummy base, space is allowed by new URL()
+	// but nu-validator rejects it. This is a known limitation.
+	expect(check('http://example.com/path with space').matched).toBe(false);
+});
+
+test('backslash in path', () => {
+	// new URL() normalizes backslash to forward slash (validation error in strict mode)
+	// We don't catch this currently — known limitation
+	expect(check('http://example.com\\path').matched).toBe(true);
+});
+
+test('javascript: scheme', () => {
+	// javascript: URLs are syntactically valid
+	expect(check('javascript:void(0)').matched).toBe(true);
+});
+
+test('data: scheme', () => {
+	expect(check('data:text/html,<h1>Hello</h1>').matched).toBe(true);
+});

--- a/packages/@markuplint/types/src/whatwg/check-url.ts
+++ b/packages/@markuplint/types/src/whatwg/check-url.ts
@@ -1,0 +1,104 @@
+import type { CustomSyntaxChecker } from '../types.js';
+
+import { log } from '../debug.js';
+import { matched, unmatched } from '../match-result.js';
+
+/**
+ * Dummy base URL for resolving relative URLs.
+ * Used only for syntax validation — the actual base URL is irrelevant.
+ * Matches the approach used by nu-html-checker (galimatias).
+ */
+const DUMMY_BASE = 'http://example.org/foo/bar';
+
+/**
+ * Characters that are illegal in URLs per WHATWG URL Standard.
+ * Tabs and newlines are stripped during parsing but are validation errors.
+ *
+ * @see https://url.spec.whatwg.org/#url-code-points
+ */
+// eslint-disable-next-line no-control-regex
+const ILLEGAL_WHITESPACE = /[\t\n\r]/;
+
+/**
+ * Malformed percent-encoding: `%` not followed by exactly two hex digits.
+ */
+const MALFORMED_PERCENT = /%(?![0-9A-F]{2})/i;
+
+/**
+ * C0 control characters (U+0000–U+001F) and DEL (U+007F) are forbidden
+ * in URLs. Excludes TAB/LF/CR which are caught by ILLEGAL_WHITESPACE.
+ */
+// eslint-disable-next-line no-control-regex
+const C0_CONTROL = /[\u0000-\u0008\v\u000E-\u001F\u007F]/;
+
+/**
+ * Unencoded space in URL body (after trimming leading/trailing spaces).
+ * `new URL()` accepts spaces by percent-encoding them, but the WHATWG spec
+ * considers them a validation error. nu-validator rejects them.
+ */
+const UNENCODED_SPACE = / /;
+
+/**
+ * Validates a URL string (potentially surrounded by spaces) per the WHATWG
+ * URL Standard. Accepts both absolute and relative URLs.
+ *
+ * Uses `new URL()` for structural parsing and adds strict checks matching
+ * the nu-html-checker's galimatias StrictErrorHandler behavior:
+ * - Illegal whitespace (tabs, newlines) in URL
+ * - Malformed percent-encoding
+ * - C0 control characters
+ * - URLs that fail `new URL()` parsing (even with a dummy base)
+ *
+ * @see https://html.spec.whatwg.org/multipage/urls-and-fetching.html#valid-url-potentially-surrounded-by-spaces
+ * @see https://url.spec.whatwg.org/#url-code-points
+ */
+export const checkURL: CustomSyntaxChecker = () =>
+	function checkURL(value) {
+		log('CHECK: url');
+
+		const trimmed = value.trim();
+
+		// Empty URL is valid for some attributes (e.g., <a href="">)
+		// The spec says "valid URL potentially surrounded by spaces"
+		// and the empty string resolves to the document's URL.
+		if (trimmed === '') {
+			return matched();
+		}
+
+		// Check for illegal whitespace (tab, newline, CR)
+		if (ILLEGAL_WHITESPACE.test(trimmed)) {
+			return unmatched(trimmed, 'unexpected-token');
+		}
+
+		// Check for C0 control characters
+		if (C0_CONTROL.test(trimmed)) {
+			return unmatched(trimmed, 'unexpected-token');
+		}
+
+		// Check for malformed percent-encoding
+		if (MALFORMED_PERCENT.test(trimmed)) {
+			return unmatched(trimmed, 'unexpected-token');
+		}
+
+		// Check for unencoded spaces
+		if (UNENCODED_SPACE.test(trimmed)) {
+			return unmatched(trimmed, 'unexpected-token');
+		}
+
+		// Try parsing as absolute URL first
+		try {
+			new URL(trimmed);
+			return matched();
+		} catch {
+			// Not a valid absolute URL — try as relative
+		}
+
+		// Try parsing as relative URL with dummy base
+		try {
+			new URL(trimmed, DUMMY_BASE);
+			return matched();
+		} catch {
+			// Both absolute and relative parsing failed
+			return unmatched(trimmed, 'unexpected-token');
+		}
+	};


### PR DESCRIPTION
Closes #3595

## Summary

Replace the `URL` type's always-pass checker (`() => matched()`) with actual validation using `new URL()` plus strict checks matching nu-html-checker's galimatias StrictErrorHandler.

### What is now detected

| Check | Example |
|-------|---------|
| Illegal whitespace | `http://exa\tmple.com` |
| Unencoded spaces | `http://example.com/path with space` |
| Malformed percent-encoding | `http://example.com/a%ZZ` |
| C0 control characters | `http://example.com/\x00path` |
| Structurally invalid URLs | URLs that fail `new URL()` parsing |

### Approach

1. `new URL(value)` for absolute URLs
2. `new URL(value, 'http://example.org/foo/bar')` for relative URLs (dummy base, syntax-only)
3. Pre-checks for forbidden characters before URL parsing
4. Empty string is still valid (per spec, resolves to document URL)

### Known limitations

- Backslash as path delimiter (`http://example.com\path`) not detected — `new URL()` normalizes it
- Some host validation differences from galimatias (IDNA edge cases)

## Impact

~1,831 missed errors in the nu-validator benchmark. The actual improvement depends on how many of these are caught by the new checks vs. requiring deeper URL parsing (host validation, port range, etc.).

## Test plan

- [x] `yarn build` pass
- [x] `yarn test` pass (200 files, 3089 tests)
- [x] 14 new unit tests for check-url.ts