### PR TITLE
fix: skip hasinfo files in nu-validator benchmark

### DIFF
--- a/tests/external/README.md
+++ b/tests/external/README.md
@@ -52,7 +52,8 @@ Test expectations are encoded in the filename:
 |---------|---------|-------------------|
 | `*-novalid.html` | nu-validator expects an **error** | markuplint must report >= 1 violation |
 | `*-isvalid.html` | nu-validator expects **no error** | markuplint must report 0 violations |
-| `*-haswarn.html` | nu-validator expects a **warning** | **Skipped** (markuplint has no warn/error distinction) |
+| `*-haswarn.html` | nu-validator expects a **warning** | **Skipped** (markuplint has no warn/info distinction) |
+| `*-hasinfo.html` | nu-validator expects an **info** message | **Skipped** (markuplint has no warn/info distinction) |
 | Other | Treated as **valid** | markuplint must report 0 violations |
 
 Expected error messages are recorded in `validator/tests/messages.json`.

--- a/tests/external/nu-validator-utils.ts
+++ b/tests/external/nu-validator-utils.ts
@@ -29,29 +29,36 @@ export const allRulesConfig: Config = {
 /**
  * Determines expected test result from nu-validator filename convention:
  * - `*-novalid.html` → should have errors
- * - `*-haswarn.html` → warning expected (skipped — markuplint has no warn/error distinction)
+ * - `*-haswarn.html` → warning expected (skipped)
+ * - `*-hasinfo.html` → info expected (skipped)
  * - `*-isvalid.html` → should have no errors
  * - other            → treated as valid
  *
+ * haswarn and hasinfo files are skipped because markuplint has no
+ * warn/info severity distinction — it would either false-positive
+ * (reporting error on an info-level issue) or false-negative
+ * (not detecting the info-level issue at all).
+ *
  * @param filename - The HTML test filename (e.g., `model-novalid.html`)
  * @returns The expected result category
- * @see https://github.com/validator/validator/blob/main/tests/
+ * @see https://github.com/validator/validator/blob/main/src/nu/validator/client/TestRunner.java
  */
-export function getExpectedResult(filename: string): 'error' | 'valid' | 'warn' {
+export function getExpectedResult(filename: string): 'error' | 'valid' | 'skip' {
 	if (filename.includes('-novalid')) return 'error';
-	if (filename.includes('-haswarn')) return 'warn';
+	if (filename.includes('-haswarn')) return 'skip';
+	if (filename.includes('-hasinfo')) return 'skip';
 	if (filename.includes('-isvalid')) return 'valid';
 	return 'valid';
 }
 
 /**
- * Returns true if the file is testable (not a haswarn file).
+ * Returns true if the file is testable (not a haswarn/hasinfo file).
  *
  * @param filename - The HTML test filename
  * @returns Whether the file should be included in benchmarks
  */
 export function isTestable(filename: string): boolean {
-	return getExpectedResult(filename) !== 'warn';
+	return getExpectedResult(filename) !== 'skip';
 }
 
 /**

--- a/tests/external/nu-validator.spec.ts
+++ b/tests/external/nu-validator.spec.ts
@@ -58,7 +58,7 @@ function generateTests(files: string[], config: Config) {
 				).toHaveLength(0);
 			});
 		}
-		// warn files are skipped — markuplint has no warn/error distinction
+		// haswarn/hasinfo files are skipped — markuplint has no warn/info distinction
 	}
 }
 


### PR DESCRIPTION
## Summary

Skip `*-hasinfo.html` files in the nu-validator benchmark, same as `*-haswarn.html`.

nu-validator's TestRunner classifies files into 4 categories:
- `*-novalid.html` → expects error
- `*-haswarn.html` → expects warning (already skipped)
- `*-hasinfo.html` → expects info message (**was incorrectly treated as valid**)
- other → expects no error

markuplint has no warn/info severity distinction, so hasinfo files should be excluded from the benchmark. Previously these 7 files were treated as "valid" — if markuplint reported any violation, it counted as a false positive.

## Impact

- 5 files removed from total (3,985 → 3,980)
- 4 rel-typo hasinfo files removed from false positives
- Rate unchanged at 58.3% but denominator is now accurate

## Benchmark result

Pass: 2,321 / 3,980 (58.3%)