### PR TITLE
feat(html-spec): add touch event handler attributes

### DIFF
--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -753,6 +753,18 @@
 				"onwebkittransitionend": {
 					"type": "FunctionBody",
 					"deprecated": true
+				},
+				"ontouchstart": {
+					"type": "FunctionBody"
+				},
+				"ontouchend": {
+					"type": "FunctionBody"
+				},
+				"ontouchmove": {
+					"type": "FunctionBody"
+				},
+				"ontouchcancel": {
+					"type": "FunctionBody"
 				}
 			},
 			"#HTMLLinkAndFetchingAttrs": {

--- a/packages/@markuplint/html-spec/src/spec-common.attributes.jsonc
+++ b/packages/@markuplint/html-spec/src/spec-common.attributes.jsonc
@@ -635,6 +635,22 @@
 		"onwebkittransitionend": {
 			"type": "FunctionBody",
 			"deprecated": true
+		},
+		// https://w3c.github.io/touch-events/#extensions-to-the-globaleventhandlers-mixin
+		"ontouchstart": {
+			"type": "FunctionBody"
+		},
+		// https://w3c.github.io/touch-events/#extensions-to-the-globaleventhandlers-mixin
+		"ontouchend": {
+			"type": "FunctionBody"
+		},
+		// https://w3c.github.io/touch-events/#extensions-to-the-globaleventhandlers-mixin
+		"ontouchmove": {
+			"type": "FunctionBody"
+		},
+		// https://w3c.github.io/touch-events/#extensions-to-the-globaleventhandlers-mixin
+		"ontouchcancel": {
+			"type": "FunctionBody"
 		}
 	},
 	"#HTMLLinkAndFetchingAttrs": {


### PR DESCRIPTION
Closes #3660

## Summary

Add `ontouchstart`, `ontouchend`, `ontouchmove`, and `ontouchcancel` to `#GlobalEventAttrs` in `spec-common.attributes.jsonc`.

These are defined in the [Touch Events specification](https://w3c.github.io/touch-events/#extensions-to-the-globaleventhandlers-mixin) as extensions to the `GlobalEventHandlers` mixin.

## Changes

- `packages/@markuplint/html-spec/src/spec-common.attributes.jsonc` — Add 4 touch event handlers
- `packages/@markuplint/html-spec/index.json` — Regenerated via `yarn up:gen`

## Test plan

- [x] `yarn build` pass
- [x] `yarn test` pass (200 files, 3089 tests)
- [x] Idempotency verified