### PR TITLE
fix(types): reject zero and negative srcset descriptors

### DIFF
--- a/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
@@ -2126,3 +2126,21 @@ describe('script conditional attributes (#3631)', () => {
 		expect((await mlRuleTest(rule, '<script src="app.js" async></script>')).violations).toStrictEqual([]);
 	});
 });
+
+describe('srcset validation (#3599)', () => {
+	test('[invalid-attr-issue-3599-001] srcset rejects zero width descriptor', async () => {
+		const { violations } = await mlRuleTest(rule, '<img srcset="x 0w" sizes="100vw" src=x alt=x>');
+		expect(violations.length).toBeGreaterThan(0);
+	});
+
+	test('[invalid-attr-issue-3599-002] srcset rejects zero density descriptor', async () => {
+		const { violations } = await mlRuleTest(rule, '<img srcset="x 0x" src=x alt=x>');
+		expect(violations.length).toBeGreaterThan(0);
+	});
+
+	test('[invalid-attr-issue-3599-003] srcset accepts valid width descriptor', async () => {
+		expect((await mlRuleTest(rule, '<img srcset="x 100w" sizes="100vw" src=x alt=x>')).violations).toStrictEqual(
+			[],
+		);
+	});
+});

--- a/packages/@markuplint/types/src/check.spec.ts
+++ b/packages/@markuplint/types/src/check.spec.ts
@@ -68,6 +68,14 @@ test('Srcset', () => {
 	expect(check('a.jpg 480w, b.jpg', 'Srcset').matched).toBe(false);
 	expect(check('a.jpg 480w, b.jpg 2x', 'Srcset').matched).toBe(false);
 	expect(check('a.jpg 480w, b.jpg 2x, c.jpg', 'Srcset').matched).toBe(false);
+
+	// Width descriptor must be > 0
+	expect(check('a.jpg 0w', 'Srcset').matched).toBe(false);
+
+	// Pixel density descriptor must be > 0
+	expect(check('a.jpg 0x', 'Srcset').matched).toBe(false);
+	expect(check('a.jpg 0.0x', 'Srcset').matched).toBe(false);
+	expect(check('a.jpg -1x', 'Srcset').matched).toBe(false);
 });
 
 test('IconSize', () => {

--- a/packages/@markuplint/types/src/defs.ts
+++ b/packages/@markuplint/types/src/defs.ts
@@ -493,7 +493,8 @@ export const defs: Defs = {
 					const { num, unit } = splitUnit(descriptor.value);
 					switch (unit) {
 						case 'w': {
-							if (!isUint(num)) {
+							// Width descriptor must be a positive integer (> 0)
+							if (!isUint(num) || Number(num) <= 0) {
 								return unmatched(value, 'unexpected-token', {
 									expects: [
 										{
@@ -507,7 +508,8 @@ export const defs: Defs = {
 							break;
 						}
 						case 'x': {
-							if (!isFloat(num)) {
+							// Pixel density descriptor must be a positive number (> 0)
+							if (!isFloat(num) || Number(num) <= 0) {
 								return unmatched(value, 'unexpected-token', {
 									expects: [
 										{


### PR DESCRIPTION
Closes #3599

## Summary

Width descriptors (`w`) must be a positive integer (> 0) and pixel density descriptors (`x`) must be a positive number (> 0) per the HTML spec. Previously `0w`, `0x`, and `-1x` were accepted because `isUint`/`isFloat` allow zero.

## Changes

- `packages/@markuplint/types/src/defs.ts` — Add `Number(num) <= 0` check for both `w` and `x` descriptors
- `packages/@markuplint/types/src/check.spec.ts` — 4 unit tests (`0w`, `0x`, `0.0x`, `-1x`)
- `packages/@markuplint/rules/src/invalid-attr/index.spec.ts` — 3 integration tests via `invalid-attr` rule

## Spec reference

- https://html.spec.whatwg.org/multipage/images.html#srcset-attributes
  - Width: "a valid non-negative integer greater than zero"
  - Density: "a valid floating-point number greater than zero"

## Test plan

- [x] `yarn build` pass
- [x] `yarn test` pass (200 files, 3089 tests)