### PR TITLE
fix(html-spec): reject empty optgroup label attribute

### DIFF
--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -53578,7 +53578,7 @@
 				},
 				"label": {
 					"description": "The name of the group of options, which the browser can use when labeling the options in the user interface. This attribute is mandatory if this element is used.",
-					"type": "Any",
+					"type": "NoEmptyAny",
 					"required": true
 				}
 			}

--- a/packages/@markuplint/html-spec/src/spec.optgroup.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.optgroup.jsonc
@@ -17,8 +17,11 @@
 	},
 	"attributes": {
 		// https://html.spec.whatwg.org/multipage/form-elements.html#attr-optgroup-label
+		// https://html.spec.whatwg.org/multipage/form-elements.html#attr-optgroup-label
+		// "This attribute is mandatory."
+		// The label must not be empty — it provides the group name for the UI.
 		"label": {
-			"type": "Any",
+			"type": "NoEmptyAny",
 			"required": true
 		}
 	},


### PR DESCRIPTION
Closes #3623

## Summary

Change the `label` attribute type on `<optgroup>` from `Any` to `NoEmptyAny`. The HTML spec states this attribute is mandatory and provides the group name for the UI — an empty string is meaningless.

## Changes

- `packages/@markuplint/html-spec/src/spec.optgroup.jsonc` — `type: "Any"` → `type: "NoEmptyAny"`
- `packages/@markuplint/html-spec/index.json` — Regenerated

## Spec reference

> The label attribute must be specified. Its value gives the name of the group.
> — https://html.spec.whatwg.org/multipage/form-elements.html#attr-optgroup-label

## Test plan

- [x] `yarn build` pass
- [x] `yarn test` pass (200 files, 3092 tests)
- [x] Idempotency verified