### PR TITLE
feat(types): add SRI hash validation for integrity attribute

### DIFF
--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -823,7 +823,7 @@
 					}
 				},
 				"integrity": {
-					"type": "Any"
+					"type": "SRIHash"
 				},
 				"media": {
 					"type": "<media-query-list>"

--- a/packages/@markuplint/html-spec/src/spec-common.attributes.jsonc
+++ b/packages/@markuplint/html-spec/src/spec-common.attributes.jsonc
@@ -722,7 +722,7 @@
 		// https://html.spec.whatwg.org/multipage/semantics.html#attr-link-integrity
 		"integrity": {
 			// The type is hash-source (https://w3c.github.io/webappsec-subresource-integrity/#integrity-metadata-description)
-			"type": "Any"
+			"type": "SRIHash"
 		},
 		// https://html.spec.whatwg.org/multipage/semantics.html#attr-link-media
 		"media": {

--- a/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
@@ -2144,3 +2144,16 @@ describe('srcset validation (#3599)', () => {
 		);
 	});
 });
+
+describe('integrity SRI hash validation (#3626)', () => {
+	test('[invalid-attr-issue-3626-001] integrity rejects md5 hash', async () => {
+		const { violations } = await mlRuleTest(rule, '<script src="x" integrity="md5-abc123"></script>');
+		expect(violations.length).toBeGreaterThan(0);
+	});
+
+	test('[invalid-attr-issue-3626-002] integrity accepts sha256 hash', async () => {
+		expect(
+			(await mlRuleTest(rule, '<script src="x" integrity="sha256-abc123"></script>')).violations,
+		).toStrictEqual([]);
+	});
+});

--- a/packages/@markuplint/types/src/check.spec.ts
+++ b/packages/@markuplint/types/src/check.spec.ts
@@ -50,6 +50,16 @@ test('BCP47', () => {
 	expect(check('zh/cn', 'BCP47').matched).toBe(false);
 });
 
+test('SRIHash', () => {
+	expect(check('sha256-abc123', 'SRIHash').matched).toBe(true);
+	expect(check('sha384-abc123==', 'SRIHash').matched).toBe(true);
+	expect(check('sha512-abc+def/ghi=', 'SRIHash').matched).toBe(true);
+	expect(check('sha256-abc123 sha384-def456', 'SRIHash').matched).toBe(true);
+	expect(check('md5-abc123', 'SRIHash').matched).toBe(false);
+	expect(check('sha1-abc123', 'SRIHash').matched).toBe(false);
+	expect(check('', 'SRIHash').matched).toBe(false);
+});
+
 test('Srcset', () => {
 	expect(check('a/bb/ccc/dddd', 'Srcset').matched).toBe(true);
 	expect(check('a/bb/ccc/dddd 200w', 'Srcset').matched).toBe(true);

--- a/packages/@markuplint/types/src/defs.ts
+++ b/packages/@markuplint/types/src/defs.ts
@@ -288,6 +288,9 @@ export const defs: Defs = {
 	 * Subresource Integrity metadata: one or more space-separated
 	 * `hash-algo-base64` tokens where algo is sha256, sha384, or sha512.
 	 *
+	 * Note: The SRI spec also allows `?options` suffix (e.g., `sha256-abc?ct=...`)
+	 * but this is not widely used and not tested by nu-validator.
+	 *
 	 * @see https://w3c.github.io/webappsec-subresource-integrity/#integrity-metadata-description
 	 */
 	SRIHash: {

--- a/packages/@markuplint/types/src/defs.ts
+++ b/packages/@markuplint/types/src/defs.ts
@@ -284,6 +284,34 @@ export const defs: Defs = {
 		is: matches(isAbsURL()),
 	},
 
+	/**
+	 * Subresource Integrity metadata: one or more space-separated
+	 * `hash-algo-base64` tokens where algo is sha256, sha384, or sha512.
+	 *
+	 * @see https://w3c.github.io/webappsec-subresource-integrity/#integrity-metadata-description
+	 */
+	SRIHash: {
+		ref: 'https://w3c.github.io/webappsec-subresource-integrity/#integrity-metadata-description',
+		expects: [
+			{
+				type: 'format',
+				value: 'SRI hash',
+			},
+		],
+		is(value) {
+			const tokens = value.trim().split(/\s+/);
+			if (tokens.length === 0 || (tokens.length === 1 && tokens[0] === '')) {
+				return unmatched(value, 'empty-token');
+			}
+			for (const token of tokens) {
+				if (!/^sha(?:256|384|512)-[\w+/]+=*$/.test(token)) {
+					return unmatched(value, 'unexpected-token');
+				}
+			}
+			return matched();
+		},
+	},
+
 	HashName: {
 		ref: 'https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#valid-hash-name-reference',
 		expects: [


### PR DESCRIPTION
Closes #3626

## Summary

Add `SRIHash` type to `@markuplint/types` and assign it to the `integrity` attribute in `spec-common.attributes.jsonc`.

SRI hash must use `sha256-`, `sha384-`, or `sha512-` prefix followed by base64. `md5-` and `sha1-` are rejected.

## Changes

- `packages/@markuplint/types/src/defs.ts` — Add `SRIHash` type definition
- `packages/@markuplint/types/src/check.spec.ts` — 7 unit tests
- `packages/@markuplint/html-spec/src/spec-common.attributes.jsonc` — integrity type `Any` → `SRIHash`
- `packages/@markuplint/html-spec/index.json` — Regenerated
- `packages/@markuplint/rules/src/invalid-attr/index.spec.ts` — 2 integration tests (ID: issue-3626-001/002)

## Spec reference

- https://w3c.github.io/webappsec-subresource-integrity/#integrity-metadata-description

## Test plan

- [x] `yarn build` pass
- [x] `yarn test` pass (200 files, 3093 tests)
- [x] Idempotency verified