### PR TITLE
fix(rules): enforce descendantOf constraint in permitted-contents rule

### DIFF
--- a/packages/@markuplint/rules/src/permitted-contents/README.ja.md
+++ b/packages/@markuplint/rules/src/permitted-contents/README.ja.md
@@ -1,10 +1,10 @@
 ---
-description: 許可されていない要素もしくはテキストノードを子要素にもつ場合、または禁止された祖先要素の子孫として要素が出現した場合に警告します。
+description: 許可されていない要素もしくはテキストノードを子要素にもつ場合、禁止された祖先要素の子孫として要素が出現した場合、または必須の祖先要素が存在しない場合に警告します。
 ---
 
 # `permitted-contents`
 
-許可されていない要素もしくはテキストノードを子要素にもつ場合、または禁止された祖先要素の子孫として要素が出現した場合に警告します。
+許可されていない要素もしくはテキストノードを子要素にもつ場合、禁止された祖先要素の子孫として要素が出現した場合、または必須の祖先要素が存在しない場合に警告します。
 
 [HTML Living Standard](https://momdo.github.io/html/)を基準として[MDN Web docs](https://developer.mozilla.org/ja/docs/Web/HTML)から最新情報を確認しています。 [`@markuplint/html-spec`](https://github.com/markuplint/markuplint/tree/main/packages/%40markuplint/html-spec/src)に設定値を持っています。
 

--- a/packages/@markuplint/rules/src/permitted-contents/README.md
+++ b/packages/@markuplint/rules/src/permitted-contents/README.md
@@ -1,11 +1,11 @@
 ---
 id: permitted-contents
-description: Warn if a child element has a not allowed element or text node, or if an element appears as a descendant of a forbidden ancestor.
+description: Warn if a child element has a not allowed element or text node, if an element appears as a descendant of a forbidden ancestor, or if a required ancestor is missing.
 ---
 
 # `permitted-contents`
 
-Warn if a child element has a not allowed element or text node, or if an element appears as a descendant of a forbidden ancestor.
+Warn if a child element has a not allowed element or text node, if an element appears as a descendant of a forbidden ancestor, or if a required ancestor is missing.
 
 This rule refer [HTML Living Standard](https://html.spec.whatwg.org/) based [MDN Web docs](https://developer.mozilla.org/en/docs/Web/HTML). It has settings in [`@markuplint/html-spec`](https://github.com/markuplint/markuplint/tree/main/packages/%40markuplint/html-spec/src).
 

--- a/packages/@markuplint/rules/src/permitted-contents/index.spec.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/index.spec.ts
@@ -1983,6 +1983,29 @@ describe('Issues', () => {
 		);
 	});
 
+	test('[permitted-contents-issue-3670-001] area outside map is invalid', async () => {
+		const { violations } = await mlRuleTest(rule, '<div><area alt="x" href="#"></div>');
+		const descendantViolations = violations.filter(v => v.message?.includes('must appear as a descendant'));
+		expect(descendantViolations).toStrictEqual([
+			expect.objectContaining({
+				severity: 'error',
+				message: 'The "area" element must appear as a descendant of the "map" element',
+			}),
+		]);
+	});
+
+	test('[permitted-contents-issue-3670-002] area inside map is valid', async () => {
+		const { violations } = await mlRuleTest(rule, '<map name="m"><area alt="x" href="#"></map>');
+		const descendantViolations = violations.filter(v => v.message?.includes('descendant'));
+		expect(descendantViolations).toStrictEqual([]);
+	});
+
+	test('[permitted-contents-issue-3670-003] area inside deeply nested map has no descendantOf violation', async () => {
+		const { violations } = await mlRuleTest(rule, '<map name="m"><div><p><area alt="x" href="#"></p></div></map>');
+		const descendantViolations = violations.filter(v => v.message?.includes('descendant'));
+		expect(descendantViolations).toStrictEqual([]);
+	});
+
 	test('[permitted-contents-issue-3632-004] footer in header', async () => {
 		const { violations } = await mlRuleTest(rule, '<header><footer>x</footer></header>');
 		expect(violations).toContainEqual(

--- a/packages/@markuplint/rules/src/permitted-contents/index.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/index.ts
@@ -20,6 +20,8 @@ import { transparentMode } from './represent-transparent-nodes.js';
  * disallowed content through transparent models. It also checks forbidden ancestor
  * constraints — elements like `<header>`, `<footer>`, `<main>`, and `<address>` must
  * not appear as descendants of certain other elements as defined by the HTML spec.
+ * Additionally, it enforces required ancestor constraints (`descendantOf`) — certain
+ * elements must appear as descendants of specific other elements.
  */
 export default createRule<TagRule[], Options>({
 	meta: meta,
@@ -48,6 +50,30 @@ export default createRule<TagRule[], Options>({
 						break;
 					}
 					ancestor = ancestor.parentElement;
+				}
+			}
+
+			// Check required ancestor (descendantOf)
+			const descendantOf = elSpec?.contentModel?.descendantOf;
+			if (descendantOf) {
+				let ancestor = el.parentElement;
+				let found = false;
+				while (ancestor) {
+					if (ancestor.matches(descendantOf)) {
+						found = true;
+						break;
+					}
+					ancestor = ancestor.parentElement;
+				}
+				if (!found) {
+					report({
+						scope: el,
+						message: t(
+							'{0} must appear as a descendant of {1}',
+							t('the "{0}" {1}', el.localName, 'element'),
+							t('the "{0}" {1}', descendantOf, 'element'),
+						),
+					});
 				}
 			}
 


### PR DESCRIPTION
## Summary

Closes #3670

The `descendantOf` field was defined in the `ContentModel` type and used in spec data (`spec.area.jsonc`: `"descendantOf": "map"`), but the `permitted-contents` rule never checked it. This PR adds the missing enforcement logic.

- Walk up the ancestor chain from the element
- If the required ancestor is not found, report a violation
- Follows the same pattern as the existing `forbiddenAncestors` check
- Update documentation (README.md, README.ja.md, JSDoc)

## Test plan

- [x] `<area>` outside `<map>` reports violation
- [x] `<area>` directly inside `<map>` — no violation
- [x] `<area>` deeply nested inside `<map>` — no violation
- [x] `yarn build` passes
- [x] `yarn test` passes (200 files, 3102 tests)
- [x] `yarn lint-check` passes (0 errors, 0 warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)