### PR TITLE
feat(rules): disallow multiple track elements with default attribute

### DIFF
--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -55488,7 +55488,8 @@
 			"description": "The <track> HTML element is used as a child of the media elements, <audio> and <video>. Each track element lets you specify a timed text track (or time-based data) that can be displayed in parallel with the media element, for example to overlay subtitles or closed captions on top of a video or alongside audio tracks. Multiple tracks can be specified for a media element, containing different kinds of timed text data, or timed text data that has been translated for different locales. The data that is used will either be the track that has been set to be the default, or a kind and translation based on user preferences. The tracks are formatted in WebVTT format (.vtt files) — Web Video Text Tracks.",
 			"categories": [],
 			"contentModel": {
-				"contents": false
+				"contents": false,
+				"uniqueAttrs": ["default"]
 			},
 			"aria": {
 				"implicitRole": false,

--- a/packages/@markuplint/html-spec/src/spec.track.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.track.jsonc
@@ -3,7 +3,11 @@
 // https://w3c.github.io/html-aria/#el-track
 {
 	"contentModel": {
-		"contents": false
+		"contents": false,
+		// https://html.spec.whatwg.org/multipage/media.html#attr-track-default
+		// "There must not be more than one track element with the same parent node
+		//  with the default attribute specified."
+		"uniqueAttrs": ["default"]
 	},
 	"globalAttrs": {
 		"#HTMLGlobalAttrs": true,

--- a/packages/@markuplint/ml-spec/src/types/permitted-structures.ts
+++ b/packages/@markuplint/ml-spec/src/types/permitted-structures.ts
@@ -61,6 +61,15 @@ export interface ContentModel {
 	 * @see https://html.spec.whatwg.org/multipage/ (per-element "Contexts" sections)
 	 */
 	forbiddenAncestors?: string[];
+	/**
+	 * Attributes that must be unique among sibling elements of the same type.
+	 * If this element has one of these attributes, no other sibling element
+	 * of the same type may also have it.
+	 *
+	 * @example ["default"] for <track> — only one <track> per parent may have `default`
+	 * @see https://html.spec.whatwg.org/multipage/media.html#attr-track-default
+	 */
+	uniqueAttrs?: string[];
 	conditional?: {
 		condition: string;
 		contents: PermittedContentPattern[] | boolean;

--- a/packages/@markuplint/rules/src/permitted-contents/README.ja.md
+++ b/packages/@markuplint/rules/src/permitted-contents/README.ja.md
@@ -1,12 +1,17 @@
 ---
-description: 許可されていない要素もしくはテキストノードを子要素にもつ場合、禁止された祖先要素の子孫として要素が出現した場合、または必須の祖先要素が存在しない場合に警告します。
+description: HTML要素のコンテンツモデルと構造的な制約を検証します。
 ---
 
 # `permitted-contents`
 
-許可されていない要素もしくはテキストノードを子要素にもつ場合、禁止された祖先要素の子孫として要素が出現した場合、または必須の祖先要素が存在しない場合に警告します。
+[HTML Living Standard](https://momdo.github.io/html/)に基づき、HTML要素のコンテンツモデルと構造的な制約を検証します。[`@markuplint/html-spec`](https://github.com/markuplint/markuplint/tree/main/packages/%40markuplint/html-spec/src)に設定値を持っています。
 
-[HTML Living Standard](https://momdo.github.io/html/)を基準として[MDN Web docs](https://developer.mozilla.org/ja/docs/Web/HTML)から最新情報を確認しています。 [`@markuplint/html-spec`](https://github.com/markuplint/markuplint/tree/main/packages/%40markuplint/html-spec/src)に設定値を持っています。
+以下の場合に警告します:
+
+- 親要素のコンテンツモデルで許可されていない子要素やテキストノードが存在する
+- 禁止された祖先要素の子孫として要素が出現している（例: `<header>`内の`<header>`）
+- 必須の祖先要素が存在しない（例: `<map>`外の`<area>`）
+- 兄弟要素間でユニークであるべき属性が重複している（例: 複数の`<track default>`）
 
 オプションに独自のルールを設けることができます。カスタム要素やVueなどのテンプレートエンジン上での要素関係を設定することで、構造を堅牢にできます。
 

--- a/packages/@markuplint/rules/src/permitted-contents/README.md
+++ b/packages/@markuplint/rules/src/permitted-contents/README.md
@@ -1,13 +1,18 @@
 ---
 id: permitted-contents
-description: Warn if a child element has a not allowed element or text node, if an element appears as a descendant of a forbidden ancestor, or if a required ancestor is missing.
+description: Validate the content model and structural constraints of HTML elements.
 ---
 
 # `permitted-contents`
 
-Warn if a child element has a not allowed element or text node, if an element appears as a descendant of a forbidden ancestor, or if a required ancestor is missing.
+Validate the content model and structural constraints of HTML elements according to the [HTML Living Standard](https://html.spec.whatwg.org/). It has settings in [`@markuplint/html-spec`](https://github.com/markuplint/markuplint/tree/main/packages/%40markuplint/html-spec/src).
 
-This rule refer [HTML Living Standard](https://html.spec.whatwg.org/) based [MDN Web docs](https://developer.mozilla.org/en/docs/Web/HTML). It has settings in [`@markuplint/html-spec`](https://github.com/markuplint/markuplint/tree/main/packages/%40markuplint/html-spec/src).
+This rule warns when:
+
+- A child element or text node is not allowed by the parent's content model
+- An element appears as a descendant of a forbidden ancestor (e.g., `<header>` inside `<header>`)
+- A required ancestor is missing (e.g., `<area>` outside `<map>`)
+- A sibling-unique attribute appears on multiple elements of the same type (e.g., multiple `<track default>`)
 
 It is possible to make the structure robust by setting element relationships on template engines such as custom elements and Vue.
 

--- a/packages/@markuplint/rules/src/permitted-contents/index.spec.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/index.spec.ts
@@ -2006,6 +2006,47 @@ describe('Issues', () => {
 		expect(descendantViolations).toStrictEqual([]);
 	});
 
+	test('[permitted-contents-issue-3640-001] multiple track default is invalid', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<video><track kind="subtitles" src="a.vtt" default><track kind="captions" src="b.vtt" default></video>',
+		);
+		const uniqueViolations = violations.filter(v => v.message?.includes('"default" attribute'));
+		expect(uniqueViolations).toStrictEqual([
+			expect.objectContaining({
+				severity: 'error',
+				raw: '<track kind="captions" src="b.vtt" default>',
+				message:
+					'The "default" attribute must not appear on more than one "track" element within the same parent',
+			}),
+		]);
+	});
+
+	test('[permitted-contents-issue-3640-002] single track default is valid', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<video><track kind="subtitles" src="a.vtt" default><track kind="captions" src="b.vtt"></video>',
+		);
+		const uniqueViolations = violations.filter(v => v.message?.includes('"default" attribute'));
+		expect(uniqueViolations).toStrictEqual([]);
+	});
+
+	test('[permitted-contents-issue-3640-003] multiple track default in audio is invalid', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<audio><track kind="subtitles" src="a.vtt" default><track kind="captions" src="b.vtt" default></audio>',
+		);
+		const uniqueViolations = violations.filter(v => v.message?.includes('"default" attribute'));
+		expect(uniqueViolations).toStrictEqual([
+			expect.objectContaining({
+				severity: 'error',
+				raw: '<track kind="captions" src="b.vtt" default>',
+				message:
+					'The "default" attribute must not appear on more than one "track" element within the same parent',
+			}),
+		]);
+	});
+
 	test('[permitted-contents-issue-3632-004] footer in header', async () => {
 		const { violations } = await mlRuleTest(rule, '<header><footer>x</footer></header>');
 		expect(violations).toContainEqual(

--- a/packages/@markuplint/rules/src/permitted-contents/index.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/index.ts
@@ -21,7 +21,9 @@ import { transparentMode } from './represent-transparent-nodes.js';
  * constraints — elements like `<header>`, `<footer>`, `<main>`, and `<address>` must
  * not appear as descendants of certain other elements as defined by the HTML spec.
  * Additionally, it enforces required ancestor constraints (`descendantOf`) — certain
- * elements must appear as descendants of specific other elements.
+ * elements must appear as descendants of specific other elements. It also validates
+ * sibling-unique attribute constraints (`uniqueAttrs`) — certain attributes must not
+ * appear on more than one element of the same type within the same parent.
  */
 export default createRule<TagRule[], Options>({
 	meta: meta,
@@ -74,6 +76,36 @@ export default createRule<TagRule[], Options>({
 							t('the "{0}" {1}', descendantOf, 'element'),
 						),
 					});
+				}
+			}
+
+			// Check unique attributes among siblings of the same type
+			const uniqueAttrs = elSpec?.contentModel?.uniqueAttrs;
+			if (uniqueAttrs && uniqueAttrs.length > 0) {
+				for (const attrName of uniqueAttrs) {
+					if (!el.hasAttribute(attrName)) {
+						continue;
+					}
+					const parent = el.parentElement;
+					if (!parent) {
+						continue;
+					}
+					// Only report on the second (and subsequent) element that has the attribute
+					const precedingSiblings = [...parent.children];
+					const elIndex = precedingSiblings.indexOf(el);
+					const hasPrecedingDuplicate = precedingSiblings
+						.slice(0, elIndex)
+						.some(child => child.localName === el.localName && child.hasAttribute(attrName));
+					if (hasPrecedingDuplicate) {
+						report({
+							scope: el,
+							message: t(
+								'The "{0}" attribute must not appear on more than one "{1}" element within the same parent',
+								attrName,
+								el.localName,
+							),
+						});
+					}
 				}
 			}
 


### PR DESCRIPTION
## Summary

Closes #3640

Per the HTML Living Standard, there must not be more than one `<track>` element with the same parent node with the `default` attribute specified.

- Add `uniqueAttrs` field to `ContentModel` type in `@markuplint/ml-spec`
- Add `"uniqueAttrs": ["default"]` to `spec.track.jsonc` in `@markuplint/html-spec`
- Implement sibling-unique attribute checking in the `permitted-contents` rule — only reports on the second (and subsequent) duplicate element
- Update documentation (README.md, README.ja.md, JSDoc)

### Spec reference

- https://html.spec.whatwg.org/multipage/media.html#attr-track-default

## Test plan

- [x] Multiple `<track default>` in `<video>` reports violation on the second element
- [x] Single `<track default>` in `<video>` — no violation
- [x] Multiple `<track default>` in `<audio>` reports violation
- [x] `yarn build` passes
- [x] `yarn test` passes (200 files, 3105 tests)
- [x] `yarn lint-check` passes (0 errors, 0 warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)