### PR TITLE
feat(rules): add document uniqueness rules (autofocus, visible-main, charset)

### DIFF
--- a/packages/@markuplint/config-presets/README.md
+++ b/packages/@markuplint/config-presets/README.md
@@ -53,6 +53,9 @@ No use deprecated attr|Authors must not use deprecated attributes from the viewp
 No use deprecated element|Authors must not use deprecated elements from the viewpoint of compatibility.|✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
 [Require `doctype`](https://html.spec.whatwg.org/multipage/syntax.html#syntax-doctype)|It has the effect of avoiding quirks mode.|✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
 Must not skip heading levels| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
+[No duplicate autofocus](https://html.spec.whatwg.org/multipage/interaction.html#the-autofocus-attribute)| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
+[No duplicate visible main](https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element)| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
+[No duplicate charset](https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-charset)| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
 No use ineffective attr| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
 [No duplicate names in `<dl>`](https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element:~:text=Within%20a%20single%20dl%20element%2C%20there%20should%20not%20be%20more%20than%20one%20dt%20element%20for%20each%20name)|Within a single dl element, there should not be more than one dt element for each name.|✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
 No use **orphaned end tag**| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|

--- a/packages/@markuplint/config-presets/src/preset.html-standard.jsonc
+++ b/packages/@markuplint/config-presets/src/preset.html-standard.jsonc
@@ -75,6 +75,50 @@
 		},
 
 		/**
+		 * No duplicate autofocus
+		 *
+		 * There must not be two elements with the autofocus attribute specified
+		 * in the same document.
+		 *
+		 * @see https://html.spec.whatwg.org/multipage/interaction.html#the-autofocus-attribute
+		 */
+		"html-standard/no-duplicate-autofocus": {
+			"specConformance": "normative",
+			"rules": {
+				"no-duplicate-autofocus": true
+			}
+		},
+
+		/**
+		 * No duplicate visible main
+		 *
+		 * There must not be more than one visible main element in a document.
+		 *
+		 * @see https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element
+		 */
+		"html-standard/no-duplicate-visible-main": {
+			"specConformance": "normative",
+			"rules": {
+				"no-duplicate-visible-main": true
+			}
+		},
+
+		/**
+		 * No duplicate charset
+		 *
+		 * There must not be more than one meta element with a charset attribute
+		 * per document.
+		 *
+		 * @see https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-charset
+		 */
+		"html-standard/no-duplicate-charset": {
+			"specConformance": "normative",
+			"rules": {
+				"no-duplicate-charset": true
+			}
+		},
+
+		/**
 		 * No use ineffective attr
 		 *
 		 */

--- a/packages/@markuplint/rules/schema.json
+++ b/packages/@markuplint/rules/schema.json
@@ -84,8 +84,17 @@
 				"no-default-value": {
 					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/no-default-value/schema.json"
 				},
+				"no-duplicate-autofocus": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/no-duplicate-autofocus/schema.json"
+				},
+				"no-duplicate-charset": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/no-duplicate-charset/schema.json"
+				},
 				"no-duplicate-dt": {
 					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/no-duplicate-dt/schema.json"
+				},
+				"no-duplicate-visible-main": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/no-duplicate-visible-main/schema.json"
 				},
 				"no-empty-palpable-content": {
 					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/no-empty-palpable-content/schema.json"

--- a/packages/@markuplint/rules/src/index.ts
+++ b/packages/@markuplint/rules/src/index.ts
@@ -35,7 +35,10 @@ import NoAmbiguousNavigableTargetNames from './no-ambiguous-navigable-target-nam
 import NoBooleanAttrValue from './no-boolean-attr-value/index.js';
 import NoConsecutiveBr from './no-consecutive-br/index.js';
 import NoDefaultValue from './no-default-value/index.js';
+import NoDuplicateAutofocus from './no-duplicate-autofocus/index.js';
+import NoDuplicateCharset from './no-duplicate-charset/index.js';
 import NoDuplicateDt from './no-duplicate-dt/index.js';
+import NoDuplicateVisibleMain from './no-duplicate-visible-main/index.js';
 import NoEmptyPalpableContent from './no-empty-palpable-content/index.js';
 import NoHardCodeId from './no-hard-code-id/index.js';
 import NoOrphanedEndTag from './no-orphaned-end-tag/index.js';
@@ -87,7 +90,10 @@ const rules = {
 	'no-boolean-attr-value': NoBooleanAttrValue,
 	'no-consecutive-br': NoConsecutiveBr,
 	'no-default-value': NoDefaultValue,
+	'no-duplicate-autofocus': NoDuplicateAutofocus,
+	'no-duplicate-charset': NoDuplicateCharset,
 	'no-duplicate-dt': NoDuplicateDt,
+	'no-duplicate-visible-main': NoDuplicateVisibleMain,
 	'no-empty-palpable-content': NoEmptyPalpableContent,
 	'no-hard-code-id': NoHardCodeId,
 	'no-orphaned-end-tag': NoOrphanedEndTag,

--- a/packages/@markuplint/rules/src/no-duplicate-autofocus/README.ja.md
+++ b/packages/@markuplint/rules/src/no-duplicate-autofocus/README.ja.md
@@ -1,0 +1,19 @@
+---
+description: ドキュメント内で複数の要素にautofocus属性を指定することを禁止します。
+---
+
+# `no-duplicate-autofocus`
+
+ドキュメント内で複数の要素に`autofocus`属性を指定することを禁止します。[HTML Living Standard](https://html.spec.whatwg.org/multipage/interaction.html#the-autofocus-attribute)により、同一ドキュメント内で2つ以上の要素に`autofocus`属性を指定してはなりません。
+
+❌ 間違ったコード例
+
+```html
+<input autofocus /> <button autofocus>送信</button>
+```
+
+✅ 正しいコード例
+
+```html
+<input autofocus /> <button>送信</button>
+```

--- a/packages/@markuplint/rules/src/no-duplicate-autofocus/README.md
+++ b/packages/@markuplint/rules/src/no-duplicate-autofocus/README.md
@@ -1,0 +1,20 @@
+---
+id: no-duplicate-autofocus
+description: Disallow multiple elements with the autofocus attribute in a document.
+---
+
+# `no-duplicate-autofocus`
+
+Disallow multiple elements with the `autofocus` attribute in a document. Per the [HTML Living Standard](https://html.spec.whatwg.org/multipage/interaction.html#the-autofocus-attribute), there must not be two elements with the `autofocus` attribute specified in the same document.
+
+❌ Examples of **incorrect** code for this rule
+
+```html
+<input autofocus /> <button autofocus>Submit</button>
+```
+
+✅ Examples of **correct** code for this rule
+
+```html
+<input autofocus /> <button>Submit</button>
+```

--- a/packages/@markuplint/rules/src/no-duplicate-autofocus/index.spec.ts
+++ b/packages/@markuplint/rules/src/no-duplicate-autofocus/index.spec.ts
@@ -1,0 +1,46 @@
+import { mlRuleTest } from 'markuplint';
+import { test, expect } from 'vitest';
+
+import rule from './index.js';
+
+test('[no-duplicate-autofocus-valid-001] single autofocus', async () => {
+	const { violations } = await mlRuleTest(rule, '<div><input autofocus><input></div>');
+	expect(violations).toStrictEqual([]);
+});
+
+test('[no-duplicate-autofocus-valid-002] no autofocus', async () => {
+	const { violations } = await mlRuleTest(rule, '<div><input><input></div>');
+	expect(violations).toStrictEqual([]);
+});
+
+test('[no-duplicate-autofocus-invalid-001] two autofocus', async () => {
+	const { violations } = await mlRuleTest(rule, '<div><input autofocus><input autofocus></div>');
+	expect(violations).toStrictEqual([
+		expect.objectContaining({
+			severity: 'error',
+			raw: '<input autofocus>',
+			line: 1,
+			col: 23,
+			message: 'The "autofocus" attribute must be unique in the document',
+		}),
+	]);
+});
+
+test('[no-duplicate-autofocus-invalid-002] three autofocus', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		'<div><input autofocus><button autofocus>x</button><textarea autofocus></textarea></div>',
+	);
+	expect(violations).toStrictEqual([
+		expect.objectContaining({
+			severity: 'error',
+			raw: '<button autofocus>',
+			message: 'The "autofocus" attribute must be unique in the document',
+		}),
+		expect.objectContaining({
+			severity: 'error',
+			raw: '<textarea autofocus>',
+			message: 'The "autofocus" attribute must be unique in the document',
+		}),
+	]);
+});

--- a/packages/@markuplint/rules/src/no-duplicate-autofocus/index.ts
+++ b/packages/@markuplint/rules/src/no-duplicate-autofocus/index.ts
@@ -1,0 +1,33 @@
+import type { Element } from '@markuplint/ml-core';
+
+import { createRule } from '@markuplint/ml-core';
+
+import meta from './meta.js';
+
+/**
+ * Ensures no more than one element in a document has the `autofocus` attribute.
+ *
+ * @see https://html.spec.whatwg.org/multipage/interaction.html#the-autofocus-attribute
+ */
+export default createRule<boolean, null>({
+	meta: meta,
+	defaultValue: true,
+	defaultOptions: null,
+	async verify({ document, report, t }) {
+		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+		const autofocusElements: Element<boolean, null>[] = [];
+
+		await document.walkOn('Element', el => {
+			if (el.hasAttribute('autofocus')) {
+				autofocusElements.push(el);
+			}
+		});
+
+		for (const el of autofocusElements.slice(1)) {
+			report({
+				scope: el,
+				message: t('The "{0}" attribute must be unique in the document', 'autofocus'),
+			});
+		}
+	},
+});

--- a/packages/@markuplint/rules/src/no-duplicate-autofocus/meta.ts
+++ b/packages/@markuplint/rules/src/no-duplicate-autofocus/meta.ts
@@ -1,0 +1,3 @@
+export default {
+	category: 'validation',
+} as const;

--- a/packages/@markuplint/rules/src/no-duplicate-autofocus/schema.json
+++ b/packages/@markuplint/rules/src/no-duplicate-autofocus/schema.json
@@ -1,0 +1,29 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"value": {
+			"type": "boolean",
+			"description": "Disallow multiple elements with the autofocus attribute in a document.",
+			"description:ja": "ドキュメント内で複数の要素にautofocus属性を指定することを禁止します。"
+		}
+	},
+	"oneOf": [
+		{
+			"$ref": "#/definitions/value"
+		},
+		{
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"value": { "$ref": "#/definitions/value" },
+				"severity": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/ml-config/schema.json#/definitions/severity",
+					"default": "error"
+				},
+				"reason": {
+					"type": "string"
+				}
+			}
+		}
+	]
+}

--- a/packages/@markuplint/rules/src/no-duplicate-charset/README.ja.md
+++ b/packages/@markuplint/rules/src/no-duplicate-charset/README.ja.md
@@ -1,0 +1,24 @@
+---
+description: ドキュメント内にcharset属性をもつmeta要素が複数存在することを禁止します。
+---
+
+# `no-duplicate-charset`
+
+ドキュメント内に`charset`属性をもつ`<meta>`要素が複数存在することを禁止します。[HTML Living Standard](https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-charset)により、ドキュメント内に`charset`属性を持つ`meta`要素は1つまでです。
+
+❌ 間違ったコード例
+
+```html
+<head>
+  <meta charset="UTF-8" />
+  <meta charset="UTF-8" />
+</head>
+```
+
+✅ 正しいコード例
+
+```html
+<head>
+  <meta charset="UTF-8" />
+</head>
+```

--- a/packages/@markuplint/rules/src/no-duplicate-charset/README.md
+++ b/packages/@markuplint/rules/src/no-duplicate-charset/README.md
@@ -1,0 +1,25 @@
+---
+id: no-duplicate-charset
+description: Disallow more than one meta element with a charset attribute in a document.
+---
+
+# `no-duplicate-charset`
+
+Disallow more than one `<meta>` element with a `charset` attribute in a document. Per the [HTML Living Standard](https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-charset), there must not be more than one `meta` element with a `charset` attribute per document.
+
+❌ Examples of **incorrect** code for this rule
+
+```html
+<head>
+  <meta charset="UTF-8" />
+  <meta charset="UTF-8" />
+</head>
+```
+
+✅ Examples of **correct** code for this rule
+
+```html
+<head>
+  <meta charset="UTF-8" />
+</head>
+```

--- a/packages/@markuplint/rules/src/no-duplicate-charset/index.spec.ts
+++ b/packages/@markuplint/rules/src/no-duplicate-charset/index.spec.ts
@@ -1,0 +1,36 @@
+import { mlRuleTest } from 'markuplint';
+import { test, expect } from 'vitest';
+
+import rule from './index.js';
+
+test('[no-duplicate-charset-valid-001] single meta charset', async () => {
+	const { violations } = await mlRuleTest(rule, '<head><meta charset="UTF-8"></head>');
+	expect(violations).toStrictEqual([]);
+});
+
+test('[no-duplicate-charset-valid-002] no meta charset', async () => {
+	const { violations } = await mlRuleTest(rule, '<head><title>test</title></head>');
+	expect(violations).toStrictEqual([]);
+});
+
+test('[no-duplicate-charset-invalid-001] two meta charset', async () => {
+	const { violations } = await mlRuleTest(rule, '<head><meta charset="UTF-8"><meta charset="UTF-8"></head>');
+	expect(violations).toStrictEqual([
+		expect.objectContaining({
+			severity: 'error',
+			raw: '<meta charset="UTF-8">',
+			message: 'There must not be more than one "meta" element with the "charset" attribute in a document',
+		}),
+	]);
+});
+
+test('[no-duplicate-charset-invalid-002] two meta charset with different values', async () => {
+	const { violations } = await mlRuleTest(rule, '<head><meta charset="UTF-8"><meta charset="Shift_JIS"></head>');
+	expect(violations).toStrictEqual([
+		expect.objectContaining({
+			severity: 'error',
+			raw: '<meta charset="Shift_JIS">',
+			message: 'There must not be more than one "meta" element with the "charset" attribute in a document',
+		}),
+	]);
+});

--- a/packages/@markuplint/rules/src/no-duplicate-charset/index.ts
+++ b/packages/@markuplint/rules/src/no-duplicate-charset/index.ts
@@ -1,0 +1,37 @@
+import type { Element } from '@markuplint/ml-core';
+
+import { createRule } from '@markuplint/ml-core';
+
+import meta from './meta.js';
+
+/**
+ * Ensures no more than one `<meta>` element with a `charset` attribute exists in a document.
+ *
+ * @see https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-charset
+ */
+export default createRule<boolean, null>({
+	meta: meta,
+	defaultValue: true,
+	defaultOptions: null,
+	async verify({ document, report, t }) {
+		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+		const charsetMetaElements: Element<boolean, null>[] = [];
+
+		await document.walkOn('Element', el => {
+			if (el.localName === 'meta' && el.hasAttribute('charset')) {
+				charsetMetaElements.push(el);
+			}
+		});
+
+		for (const el of charsetMetaElements.slice(1)) {
+			report({
+				scope: el,
+				message: t(
+					'There must not be more than one "{0}" element with the "{1}" attribute in a document',
+					'meta',
+					'charset',
+				),
+			});
+		}
+	},
+});

--- a/packages/@markuplint/rules/src/no-duplicate-charset/meta.ts
+++ b/packages/@markuplint/rules/src/no-duplicate-charset/meta.ts
@@ -1,0 +1,3 @@
+export default {
+	category: 'validation',
+} as const;

--- a/packages/@markuplint/rules/src/no-duplicate-charset/schema.json
+++ b/packages/@markuplint/rules/src/no-duplicate-charset/schema.json
@@ -1,0 +1,29 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"value": {
+			"type": "boolean",
+			"description": "Disallow more than one meta element with a charset attribute in a document.",
+			"description:ja": "ドキュメント内にcharset属性をもつmeta要素が複数存在することを禁止します。"
+		}
+	},
+	"oneOf": [
+		{
+			"$ref": "#/definitions/value"
+		},
+		{
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"value": { "$ref": "#/definitions/value" },
+				"severity": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/ml-config/schema.json#/definitions/severity",
+					"default": "error"
+				},
+				"reason": {
+					"type": "string"
+				}
+			}
+		}
+	]
+}

--- a/packages/@markuplint/rules/src/no-duplicate-visible-main/README.ja.md
+++ b/packages/@markuplint/rules/src/no-duplicate-visible-main/README.ja.md
@@ -1,0 +1,25 @@
+---
+description: ドキュメント内に表示状態のmain要素が複数存在することを禁止します。
+---
+
+# `no-duplicate-visible-main`
+
+ドキュメント内に表示状態の`<main>`要素が複数存在することを禁止します。[HTML Living Standard](https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element)により、ドキュメント内に表示状態の`main`要素は1つまでです。`hidden`属性を持つ`<main>`要素は表示状態とみなされません。
+
+❌ 間違ったコード例
+
+```html
+<body>
+  <main>最初のコンテンツ</main>
+  <main>2番目のコンテンツ</main>
+</body>
+```
+
+✅ 正しいコード例
+
+```html
+<body>
+  <main>表示コンテンツ</main>
+  <main hidden>非表示コンテンツ</main>
+</body>
+```

--- a/packages/@markuplint/rules/src/no-duplicate-visible-main/README.md
+++ b/packages/@markuplint/rules/src/no-duplicate-visible-main/README.md
@@ -1,0 +1,26 @@
+---
+id: no-duplicate-visible-main
+description: Disallow more than one visible main element in a document.
+---
+
+# `no-duplicate-visible-main`
+
+Disallow more than one visible `<main>` element in a document. Per the [HTML Living Standard](https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element), there must not be more than one visible `main` element in a document. A `<main>` element with the `hidden` attribute is not considered visible.
+
+❌ Examples of **incorrect** code for this rule
+
+```html
+<body>
+  <main>First content</main>
+  <main>Second content</main>
+</body>
+```
+
+✅ Examples of **correct** code for this rule
+
+```html
+<body>
+  <main>Visible content</main>
+  <main hidden>Hidden content</main>
+</body>
+```

--- a/packages/@markuplint/rules/src/no-duplicate-visible-main/index.spec.ts
+++ b/packages/@markuplint/rules/src/no-duplicate-visible-main/index.spec.ts
@@ -1,0 +1,48 @@
+import { mlRuleTest } from 'markuplint';
+import { test, expect } from 'vitest';
+
+import rule from './index.js';
+
+test('[no-duplicate-visible-main-valid-001] single main', async () => {
+	const { violations } = await mlRuleTest(rule, '<body><main>content</main></body>');
+	expect(violations).toStrictEqual([]);
+});
+
+test('[no-duplicate-visible-main-valid-002] main with hidden main', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		'<body><main>content</main><main hidden>hidden content</main></body>',
+	);
+	expect(violations).toStrictEqual([]);
+});
+
+test('[no-duplicate-visible-main-valid-003] no main', async () => {
+	const { violations } = await mlRuleTest(rule, '<body><div>content</div></body>');
+	expect(violations).toStrictEqual([]);
+});
+
+test('[no-duplicate-visible-main-invalid-001] two visible mains', async () => {
+	const { violations } = await mlRuleTest(rule, '<body><main>first</main><main>second</main></body>');
+	expect(violations).toStrictEqual([
+		expect.objectContaining({
+			severity: 'error',
+			raw: '<main>',
+			message: 'There must not be more than one visible "main" element in a document',
+		}),
+	]);
+});
+
+test('[no-duplicate-visible-main-invalid-002] three mains one hidden', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		'<body><main>first</main><main hidden>hidden</main><main>third</main></body>',
+	);
+	expect(violations).toStrictEqual([
+		expect.objectContaining({
+			severity: 'error',
+			raw: '<main>',
+			col: 51,
+			message: 'There must not be more than one visible "main" element in a document',
+		}),
+	]);
+});

--- a/packages/@markuplint/rules/src/no-duplicate-visible-main/index.ts
+++ b/packages/@markuplint/rules/src/no-duplicate-visible-main/index.ts
@@ -1,0 +1,34 @@
+import type { Element } from '@markuplint/ml-core';
+
+import { createRule } from '@markuplint/ml-core';
+
+import meta from './meta.js';
+
+/**
+ * Ensures no more than one visible `<main>` element exists in a document.
+ * A `<main>` element with the `hidden` attribute is not considered visible.
+ *
+ * @see https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element
+ */
+export default createRule<boolean, null>({
+	meta: meta,
+	defaultValue: true,
+	defaultOptions: null,
+	async verify({ document, report, t }) {
+		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+		const visibleMains: Element<boolean, null>[] = [];
+
+		await document.walkOn('Element', el => {
+			if (el.localName === 'main' && !el.hasAttribute('hidden')) {
+				visibleMains.push(el);
+			}
+		});
+
+		for (const el of visibleMains.slice(1)) {
+			report({
+				scope: el,
+				message: t('There must not be more than one visible "{0}" element in a document', 'main'),
+			});
+		}
+	},
+});

--- a/packages/@markuplint/rules/src/no-duplicate-visible-main/meta.ts
+++ b/packages/@markuplint/rules/src/no-duplicate-visible-main/meta.ts
@@ -1,0 +1,3 @@
+export default {
+	category: 'validation',
+} as const;

--- a/packages/@markuplint/rules/src/no-duplicate-visible-main/schema.json
+++ b/packages/@markuplint/rules/src/no-duplicate-visible-main/schema.json
@@ -1,0 +1,29 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"value": {
+			"type": "boolean",
+			"description": "Disallow more than one visible main element in a document.",
+			"description:ja": "ドキュメント内に表示状態のmain要素が複数存在することを禁止します。"
+		}
+	},
+	"oneOf": [
+		{
+			"$ref": "#/definitions/value"
+		},
+		{
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"value": { "$ref": "#/definitions/value" },
+				"severity": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/ml-config/schema.json#/definitions/severity",
+					"default": "error"
+				},
+				"reason": {
+					"type": "string"
+				}
+			}
+		}
+	]
+}

--- a/packages/markuplint/src/cli/init/get-default-rules.spec.ts
+++ b/packages/markuplint/src/cli/init/get-default-rules.spec.ts
@@ -109,7 +109,19 @@ test('default-rules', () => {
 			category: 'style',
 			defaultValue: false,
 		},
+		'no-duplicate-autofocus': {
+			category: 'validation',
+			defaultValue: true,
+		},
+		'no-duplicate-charset': {
+			category: 'validation',
+			defaultValue: true,
+		},
 		'no-duplicate-dt': {
+			category: 'validation',
+			defaultValue: true,
+		},
+		'no-duplicate-visible-main': {
 			category: 'validation',
 			defaultValue: true,
 		},


### PR DESCRIPTION
## Summary

Closes #3638
Partially addresses #3634

Add three new rules that enforce document-level uniqueness constraints from the HTML Living Standard:

### `no-duplicate-autofocus`
- There must not be two elements with the `autofocus` attribute in the same document
- [Spec](https://html.spec.whatwg.org/multipage/interaction.html#the-autofocus-attribute)

### `no-duplicate-visible-main`
- There must not be more than one **visible** `<main>` element in a document
- `<main hidden>` is excluded from the count
- [Spec](https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element)

### `no-duplicate-charset`
- There must not be more than one `<meta charset>` element per document
- Regardless of the charset value
- [Spec](https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-charset)

All three rules are registered as normative in the `markuplint:html-standard` preset.

## Test plan

- [x] 13 tests across 3 rule spec files (4 + 5 + 4)
- [x] `get-default-rules.spec.ts` updated for new rules
- [x] `yarn build` passes
- [x] `yarn test` passes (203 files, 3117 tests)
- [x] `yarn lint-check` passes (0 errors, 0 warnings)
- [x] `node .claude/commands/scripts/list-rule-test.mjs --no-id` — empty output

🤖 Generated with [Claude Code](https://claude.com/claude-code)