### PR TITLE
feat(rules): disallow is attribute on autonomous custom elements

### DIFF
--- a/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
@@ -2156,4 +2156,27 @@ describe('integrity SRI hash validation (#3626)', () => {
 			(await mlRuleTest(rule, '<script src="x" integrity="sha256-abc123"></script>')).violations,
 		).toStrictEqual([]);
 	});
+
+	test('[invalid-attr-issue-3639-001] is attribute on autonomous custom element is disallowed', async () => {
+		const { violations } = await mlRuleTest(rule, '<my-element is="my-other"></my-element>');
+		expect(violations).toStrictEqual([
+			expect.objectContaining({
+				severity: 'error',
+				raw: 'is',
+				message: 'The "is" attribute must not be specified on an autonomous custom element',
+			}),
+		]);
+	});
+
+	test('[invalid-attr-issue-3639-002] is attribute on built-in element is valid', async () => {
+		const { violations } = await mlRuleTest(rule, '<button is="fancy-button">Click</button>');
+		const isViolations = violations.filter(v => v.message?.includes('"is"'));
+		expect(isViolations).toStrictEqual([]);
+	});
+
+	test('[invalid-attr-issue-3639-003] autonomous custom element without is attribute is valid', async () => {
+		const { violations } = await mlRuleTest(rule, '<my-element data-foo="bar"></my-element>');
+		const isViolations = violations.filter(v => v.message?.includes('"is"'));
+		expect(isViolations).toStrictEqual([]);
+	});
 });

--- a/packages/@markuplint/rules/src/invalid-attr/index.ts
+++ b/packages/@markuplint/rules/src/invalid-attr/index.ts
@@ -70,6 +70,19 @@ export default createRule<boolean, Option>({
 				return;
 			}
 
+			// https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is
+			// "The is attribute must not be specified on an autonomous custom element"
+			if (attr.name === 'is' && attr.ownerElement.elementType === 'web-component') {
+				report({
+					scope: attr,
+					line: attr.nameNode?.startLine,
+					col: attr.nameNode?.startCol,
+					raw: attr.nameNode?.raw,
+					message: t('The "{0}" attribute must not be specified on an autonomous custom element', 'is'),
+				});
+				return;
+			}
+
 			const attrSpecs = getAttrSpecs(attr.ownerElement, document.specs);
 
 			const attrName = attr.nameNode;


### PR DESCRIPTION
## Summary

Closes #3639

The `is` attribute must not be specified on autonomous custom elements (elements with a hyphen in the tag name). It is only valid on built-in elements to create customized built-in elements.

> "The exception is the `is` attribute, which must not be specified on an autonomous custom element (and which will have no effect if it is)."

### Spec reference

- https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is

### Implementation

Added an early check in `invalid-attr` rule: if `attr.name === 'is'` and `attr.ownerElement.elementType === 'web-component'`, report a violation.

## Test plan

- [x] `<my-element is="my-other">` — violation reported
- [x] `<button is="fancy-button">` — no violation (built-in element)
- [x] `<my-element data-foo="bar">` — no violation (no `is` attribute)
- [x] `yarn build` passes
- [x] `yarn test` passes (202 files, 3131 tests)
- [x] `yarn lint-check` passes (0 errors, 0 warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)