### PR TITLE
feat(rules): split wai-aria into granular sub-rules

### DIFF
--- a/packages/@markuplint/config-presets/src/preset.a11y.jsonc
+++ b/packages/@markuplint/config-presets/src/preset.a11y.jsonc
@@ -161,13 +161,78 @@
 
 		/**
 		 * Conform to **WAI-ARIA**
-		 *
 		 */
-		"a11y/wai-aria": {
+		"a11y/wai-aria/non-existent-role": {
 			"specConformance": "normative",
-			"rules": {
-				"wai-aria": true
-			}
+			"rules": { "wai-aria-non-existent-role": true }
+		},
+		"a11y/wai-aria/abstract-role": {
+			"specConformance": "normative",
+			"rules": { "wai-aria-abstract-role": true }
+		},
+		"a11y/wai-aria/permitted-roles": {
+			"specConformance": "normative",
+			"rules": { "wai-aria-permitted-roles": true }
+		},
+		"a11y/wai-aria/implicit-role": {
+			"specConformance": "non-normative",
+			"severity": "warning",
+			"rules": { "wai-aria-implicit-role": true }
+		},
+		"a11y/wai-aria/implicit-props": {
+			"specConformance": "non-normative",
+			"severity": "warning",
+			"rules": { "wai-aria-implicit-props": true }
+		},
+		"a11y/wai-aria/required-props": {
+			"specConformance": "normative",
+			"rules": { "wai-aria-required-props": true }
+		},
+		"a11y/wai-aria/disallowed-props": {
+			"specConformance": "normative",
+			"rules": { "wai-aria-disallowed-props": true }
+		},
+		"a11y/wai-aria/deprecated-role": {
+			"specConformance": "non-normative",
+			"severity": "warning",
+			"rules": { "wai-aria-deprecated-role": true }
+		},
+		"a11y/wai-aria/deprecated-props": {
+			"specConformance": "non-normative",
+			"severity": "warning",
+			"rules": { "wai-aria-deprecated-props": true }
+		},
+		"a11y/wai-aria/value": {
+			"specConformance": "normative",
+			"rules": { "wai-aria-value": true }
+		},
+		"a11y/wai-aria/required-owned-elements": {
+			"specConformance": "normative",
+			"severity": "warning",
+			"rules": { "wai-aria-required-owned-elements": true }
+		},
+		"a11y/wai-aria/required-parent-role": {
+			"specConformance": "normative",
+			"rules": { "wai-aria-required-parent-role": true }
+		},
+		"a11y/wai-aria/presentational-children": {
+			"specConformance": "non-normative",
+			"severity": "warning",
+			"rules": { "wai-aria-presentational-children": true }
+		},
+		"a11y/wai-aria/no-global-prop": {
+			"specConformance": "normative",
+			"rules": { "wai-aria-no-global-prop": true }
+		},
+		"a11y/wai-aria/default-value": {
+			"specConformance": "non-normative",
+			"severity": "warning",
+			"rules": { "wai-aria-default-value": true }
+		},
+		"a11y/wai-aria/interaction-in-hidden": {
+			"specConformance": "non-normative",
+			"severity": "warning",
+			"rules": { "wai-aria-interaction-in-hidden": true }
 		}
 	},
 	"nodeRules": [

--- a/packages/@markuplint/file-resolver/src/config-provider.spec.ts
+++ b/packages/@markuplint/file-resolver/src/config-provider.spec.ts
@@ -230,9 +230,9 @@ test('Config Presets', async () => {
 	const key = path.resolve(testDir, '007', '.markuplintrc');
 	const file = getFile(path.resolve(testDir, '007', 'target.html'));
 	const configSet = await configProvider.resolve(file, [key]);
-	expect(configSet.config.rules?.['a11y/wai-aria']).toStrictEqual({
+	expect(configSet.config.rules?.['a11y/wai-aria/non-existent-role']).toStrictEqual({
 		specConformance: 'normative',
-		rules: { 'wai-aria': true },
+		rules: { 'wai-aria-non-existent-role': true },
 	});
 });
 

--- a/packages/@markuplint/rules/schema.json
+++ b/packages/@markuplint/rules/schema.json
@@ -149,6 +149,54 @@
 				},
 				"wai-aria": {
 					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/wai-aria/schema.json"
+				},
+				"wai-aria-abstract-role": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/wai-aria-abstract-role/schema.json"
+				},
+				"wai-aria-default-value": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/wai-aria-default-value/schema.json"
+				},
+				"wai-aria-deprecated-props": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/wai-aria-deprecated-props/schema.json"
+				},
+				"wai-aria-deprecated-role": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/wai-aria-deprecated-role/schema.json"
+				},
+				"wai-aria-disallowed-props": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/wai-aria-disallowed-props/schema.json"
+				},
+				"wai-aria-implicit-props": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/wai-aria-implicit-props/schema.json"
+				},
+				"wai-aria-implicit-role": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/wai-aria-implicit-role/schema.json"
+				},
+				"wai-aria-interaction-in-hidden": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/wai-aria-interaction-in-hidden/schema.json"
+				},
+				"wai-aria-no-global-prop": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/wai-aria-no-global-prop/schema.json"
+				},
+				"wai-aria-non-existent-role": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/wai-aria-non-existent-role/schema.json"
+				},
+				"wai-aria-permitted-roles": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/wai-aria-permitted-roles/schema.json"
+				},
+				"wai-aria-presentational-children": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/wai-aria-presentational-children/schema.json"
+				},
+				"wai-aria-required-owned-elements": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/wai-aria-required-owned-elements/schema.json"
+				},
+				"wai-aria-required-parent-role": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/wai-aria-required-parent-role/schema.json"
+				},
+				"wai-aria-required-props": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/wai-aria-required-props/schema.json"
+				},
+				"wai-aria-value": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/wai-aria-value/schema.json"
 				}
 			}
 		}

--- a/packages/@markuplint/rules/src/index.ts
+++ b/packages/@markuplint/rules/src/index.ts
@@ -57,6 +57,22 @@ import RequiredH1 from './required-h1/index.js';
 import TableRowColumnAlignment from './table-row-column-alignment/index.js';
 import UseList from './use-list/index.js';
 import WaiAria from './wai-aria/index.js';
+import WaiAriaAbstractRole from './wai-aria-abstract-role/index.js';
+import WaiAriaDefaultValue from './wai-aria-default-value/index.js';
+import WaiAriaDeprecatedProps from './wai-aria-deprecated-props/index.js';
+import WaiAriaDeprecatedRole from './wai-aria-deprecated-role/index.js';
+import WaiAriaDisallowedProps from './wai-aria-disallowed-props/index.js';
+import WaiAriaImplicitProps from './wai-aria-implicit-props/index.js';
+import WaiAriaImplicitRole from './wai-aria-implicit-role/index.js';
+import WaiAriaInteractionInHidden from './wai-aria-interaction-in-hidden/index.js';
+import WaiAriaNoGlobalProp from './wai-aria-no-global-prop/index.js';
+import WaiAriaNonExistentRole from './wai-aria-non-existent-role/index.js';
+import WaiAriaPermittedRoles from './wai-aria-permitted-roles/index.js';
+import WaiAriaPresentationalChildren from './wai-aria-presentational-children/index.js';
+import WaiAriaRequiredOwnedElements from './wai-aria-required-owned-elements/index.js';
+import WaiAriaRequiredParentRole from './wai-aria-required-parent-role/index.js';
+import WaiAriaRequiredProps from './wai-aria-required-props/index.js';
+import WaiAriaValue from './wai-aria-value/index.js';
 
 /**
  * Registry of all built-in markuplint rules, mapping rule names to their seed definitions.
@@ -111,6 +127,22 @@ const rules = {
 	'table-row-column-alignment': TableRowColumnAlignment,
 	'use-list': UseList,
 	'wai-aria': WaiAria,
+	'wai-aria-abstract-role': WaiAriaAbstractRole,
+	'wai-aria-default-value': WaiAriaDefaultValue,
+	'wai-aria-deprecated-props': WaiAriaDeprecatedProps,
+	'wai-aria-deprecated-role': WaiAriaDeprecatedRole,
+	'wai-aria-disallowed-props': WaiAriaDisallowedProps,
+	'wai-aria-implicit-props': WaiAriaImplicitProps,
+	'wai-aria-implicit-role': WaiAriaImplicitRole,
+	'wai-aria-interaction-in-hidden': WaiAriaInteractionInHidden,
+	'wai-aria-no-global-prop': WaiAriaNoGlobalProp,
+	'wai-aria-non-existent-role': WaiAriaNonExistentRole,
+	'wai-aria-permitted-roles': WaiAriaPermittedRoles,
+	'wai-aria-presentational-children': WaiAriaPresentationalChildren,
+	'wai-aria-required-owned-elements': WaiAriaRequiredOwnedElements,
+	'wai-aria-required-parent-role': WaiAriaRequiredParentRole,
+	'wai-aria-required-props': WaiAriaRequiredProps,
+	'wai-aria-value': WaiAriaValue,
 } as const satisfies Record<string, AnyRuleSeed<any, any>>;
 
 export default rules;

--- a/packages/@markuplint/rules/src/wai-aria-abstract-role/README.ja.md
+++ b/packages/@markuplint/rules/src/wai-aria-abstract-role/README.ja.md
@@ -1,0 +1,25 @@
+---
+description: 抽象ロールが使用された場合に警告します。
+---
+
+# `wai-aria-abstract-role`
+
+抽象ロールが使用された場合に警告します。
+
+このルールは[`wai-aria`](../wai-aria/)ルールファミリーの一部で、きめ細かなseverity制御のために分割されたものです。
+
+<!-- textlint-disable ja-technical-writing/ja-no-mixed-period -->
+
+❌ 間違ったコード例
+
+```html
+<div role="roletype"></div>
+```
+
+✅ 正しいコード例
+
+```html
+<div role="button"></div>
+```
+
+<!-- textlint-enable ja-technical-writing/ja-no-mixed-period -->

--- a/packages/@markuplint/rules/src/wai-aria-abstract-role/README.md
+++ b/packages/@markuplint/rules/src/wai-aria-abstract-role/README.md
@@ -1,0 +1,22 @@
+---
+id: wai-aria-abstract-role
+description: Warns when an abstract WAI-ARIA role is used.
+---
+
+# `wai-aria-abstract-role`
+
+Warns when an abstract WAI-ARIA role is used.
+
+This rule is part of the [`wai-aria`](../wai-aria/) rule family, split for granular severity control.
+
+❌ Examples of **incorrect** code for this rule
+
+```html
+<div role="roletype"></div>
+```
+
+✅ Examples of **correct** code for this rule
+
+```html
+<div role="button"></div>
+```

--- a/packages/@markuplint/rules/src/wai-aria-abstract-role/index.spec.ts
+++ b/packages/@markuplint/rules/src/wai-aria-abstract-role/index.spec.ts
@@ -1,0 +1,20 @@
+import { mlRuleTest } from 'markuplint';
+import { test, expect } from 'vitest';
+
+import rule from './index.js';
+
+test('[wai-aria-abstract-role-valid-001] concrete role', async () => {
+	expect((await mlRuleTest(rule, '<div role="button"></div>')).violations).toStrictEqual([]);
+});
+
+test('[wai-aria-abstract-role-invalid-001] abstract role', async () => {
+	expect((await mlRuleTest(rule, '<div role="roletype"></div>')).violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 12,
+			message: 'The "roletype" role is the abstract role',
+			raw: 'roletype',
+		},
+	]);
+});

--- a/packages/@markuplint/rules/src/wai-aria-abstract-role/index.ts
+++ b/packages/@markuplint/rules/src/wai-aria-abstract-role/index.ts
@@ -1,0 +1,23 @@
+import type { Options } from '../wai-aria/types.js';
+
+import { createRule, getSpec } from '@markuplint/ml-core';
+
+import { checkingAbstractRole } from '../wai-aria/checkings/abstract-role.js';
+import { defaultOptions } from '../wai-aria/default-options.js';
+import meta from './meta.js';
+
+/** Warns when an abstract WAI-ARIA role is used directly in content. */
+export default createRule<boolean, Options>({
+	meta,
+	defaultOptions,
+	async verify({ document, report }) {
+		await document.walkOn('Element', el => {
+			const roleAttr = el.getAttributeNode('role');
+			if (!roleAttr) return;
+			const elSpec = getSpec(el, document.specs.specs);
+			if (!elSpec) return;
+			if (!elSpec.globalAttrs['#ARIAAttrs']) return;
+			report(checkingAbstractRole({ attr: roleAttr }));
+		});
+	},
+});

--- a/packages/@markuplint/rules/src/wai-aria-abstract-role/meta.ts
+++ b/packages/@markuplint/rules/src/wai-aria-abstract-role/meta.ts
@@ -1,0 +1,3 @@
+export default {
+	category: 'a11y',
+} as const;

--- a/packages/@markuplint/rules/src/wai-aria-abstract-role/schema.json
+++ b/packages/@markuplint/rules/src/wai-aria-abstract-role/schema.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"value": {
+			"type": "boolean"
+		}
+	},
+	"oneOf": [
+		{
+			"$ref": "#/definitions/value"
+		},
+		{
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"value": { "$ref": "#/definitions/value" },
+				"severity": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/ml-config/schema.json#/definitions/severity",
+					"default": "error"
+				},
+				"reason": {
+					"type": "string"
+				}
+			}
+		}
+	]
+}

--- a/packages/@markuplint/rules/src/wai-aria-default-value/README.ja.md
+++ b/packages/@markuplint/rules/src/wai-aria-default-value/README.ja.md
@@ -1,0 +1,25 @@
+---
+description: ARIAプロパティにスペックで定義されたデフォルト値が明示的に指定された場合に警告します。
+---
+
+# `wai-aria-default-value`
+
+ARIAプロパティにスペックで定義されたデフォルト値が明示的に指定された場合に警告します。
+
+このルールは[`wai-aria`](../wai-aria/)ルールファミリーの一部で、きめ細かなseverity制御のために分割されたものです。
+
+<!-- textlint-disable ja-technical-writing/ja-no-mixed-period -->
+
+❌ 間違ったコード例
+
+```html
+<div role="button" aria-expanded="undefined"></div>
+```
+
+✅ 正しいコード例
+
+```html
+<div role="button" aria-expanded="true"></div>
+```
+
+<!-- textlint-enable ja-technical-writing/ja-no-mixed-period -->

--- a/packages/@markuplint/rules/src/wai-aria-default-value/README.md
+++ b/packages/@markuplint/rules/src/wai-aria-default-value/README.md
@@ -1,0 +1,22 @@
+---
+id: wai-aria-default-value
+description: Warns when an ARIA property is explicitly set to its spec-defined default value.
+---
+
+# `wai-aria-default-value`
+
+Warns when an ARIA property is explicitly set to its spec-defined default value.
+
+This rule is part of the [`wai-aria`](../wai-aria/) rule family, split for granular severity control.
+
+❌ Examples of **incorrect** code for this rule
+
+```html
+<div role="button" aria-expanded="undefined"></div>
+```
+
+✅ Examples of **correct** code for this rule
+
+```html
+<div role="button" aria-expanded="true"></div>
+```

--- a/packages/@markuplint/rules/src/wai-aria-default-value/index.spec.ts
+++ b/packages/@markuplint/rules/src/wai-aria-default-value/index.spec.ts
@@ -1,0 +1,12 @@
+import { mlRuleTest } from 'markuplint';
+import { test, expect } from 'vitest';
+
+import rule from './index.js';
+
+test('[wai-aria-default-value-valid-001] no aria props', async () => {
+	expect((await mlRuleTest(rule, '<div></div>')).violations).toStrictEqual([]);
+});
+
+test('[wai-aria-default-value-valid-002] non-default value', async () => {
+	expect((await mlRuleTest(rule, '<div role="button" aria-pressed="true"></div>')).violations).toStrictEqual([]);
+});

--- a/packages/@markuplint/rules/src/wai-aria-default-value/index.ts
+++ b/packages/@markuplint/rules/src/wai-aria-default-value/index.ts
@@ -1,0 +1,30 @@
+import type { Options } from '../wai-aria/types.js';
+
+import { createRule, ariaSpecs, getSpec } from '@markuplint/ml-core';
+import { ARIA_RECOMMENDED_VERSION } from '@markuplint/ml-spec';
+
+import { checkingDefaultValue } from '../wai-aria/checkings/default-value.js';
+import { defaultOptions } from '../wai-aria/default-options.js';
+import meta from './meta.js';
+
+/** Warns when an ARIA property is explicitly set to its spec-defined default value. */
+export default createRule<boolean, Options>({
+	meta,
+	defaultSeverity: 'warning',
+	defaultOptions,
+	async verify({ document, report }) {
+		await document.walkOn('Element', el => {
+			const elSpec = getSpec(el, document.specs.specs);
+			if (!elSpec) return;
+			if (!elSpec.globalAttrs['#ARIAAttrs']) return;
+			const propAttrs = el.attributes.filter(attr => /^aria-/i.test(attr.name));
+			if (propAttrs.length === 0) return;
+			const ariaVersion =
+				el.rule.options?.version ?? document.ruleCommonSettings?.ariaVersion ?? ARIA_RECOMMENDED_VERSION;
+			const { props: propSpecs } = ariaSpecs(document.specs, ariaVersion);
+			for (const attr of propAttrs) {
+				report(checkingDefaultValue({ attr, propSpecs }));
+			}
+		});
+	},
+});

--- a/packages/@markuplint/rules/src/wai-aria-default-value/meta.ts
+++ b/packages/@markuplint/rules/src/wai-aria-default-value/meta.ts
@@ -1,0 +1,4 @@
+/** Rule metadata for the `wai-aria-default-value` rule, categorized under accessibility. */
+export default {
+	category: 'a11y',
+} as const;

--- a/packages/@markuplint/rules/src/wai-aria-default-value/schema.json
+++ b/packages/@markuplint/rules/src/wai-aria-default-value/schema.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"value": {
+			"type": "boolean"
+		}
+	},
+	"oneOf": [
+		{
+			"$ref": "#/definitions/value"
+		},
+		{
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"value": { "$ref": "#/definitions/value" },
+				"severity": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/ml-config/schema.json#/definitions/severity",
+					"default": "warning"
+				},
+				"reason": {
+					"type": "string"
+				}
+			}
+		}
+	]
+}

--- a/packages/@markuplint/rules/src/wai-aria-deprecated-props/README.ja.md
+++ b/packages/@markuplint/rules/src/wai-aria-deprecated-props/README.ja.md
@@ -1,0 +1,25 @@
+---
+description: ロールにおいて非推奨のARIAプロパティ/ステートが使用された場合に警告します。
+---
+
+# `wai-aria-deprecated-props`
+
+ロールにおいて非推奨のARIAプロパティ/ステートが使用された場合に警告します。
+
+このルールは[`wai-aria`](../wai-aria/)ルールファミリーの一部で、きめ細かなseverity制御のために分割されたものです。
+
+<!-- textlint-disable ja-technical-writing/ja-no-mixed-period -->
+
+❌ 間違ったコード例
+
+```html
+<div role="img" aria-disabled="true"></div>
+```
+
+✅ 正しいコード例
+
+```html
+<div role="button" aria-pressed="true"></div>
+```
+
+<!-- textlint-enable ja-technical-writing/ja-no-mixed-period -->

--- a/packages/@markuplint/rules/src/wai-aria-deprecated-props/README.md
+++ b/packages/@markuplint/rules/src/wai-aria-deprecated-props/README.md
@@ -1,0 +1,22 @@
+---
+id: wai-aria-deprecated-props
+description: Warns when a deprecated ARIA property or state is used on a role.
+---
+
+# `wai-aria-deprecated-props`
+
+Warns when a deprecated ARIA property or state is used on a role.
+
+This rule is part of the [`wai-aria`](../wai-aria/) rule family, split for granular severity control.
+
+❌ Examples of **incorrect** code for this rule
+
+```html
+<div role="img" aria-disabled="true"></div>
+```
+
+✅ Examples of **correct** code for this rule
+
+```html
+<div role="button" aria-pressed="true"></div>
+```

--- a/packages/@markuplint/rules/src/wai-aria-deprecated-props/index.spec.ts
+++ b/packages/@markuplint/rules/src/wai-aria-deprecated-props/index.spec.ts
@@ -1,0 +1,12 @@
+import { mlRuleTest } from 'markuplint';
+import { test, expect } from 'vitest';
+
+import rule from './index.js';
+
+test('[wai-aria-deprecated-props-valid-001] non-deprecated prop', async () => {
+	expect((await mlRuleTest(rule, '<div role="button" aria-pressed="true"></div>')).violations).toStrictEqual([]);
+});
+
+test('[wai-aria-deprecated-props-valid-002] no aria props', async () => {
+	expect((await mlRuleTest(rule, '<div></div>')).violations).toStrictEqual([]);
+});

--- a/packages/@markuplint/rules/src/wai-aria-deprecated-props/index.ts
+++ b/packages/@markuplint/rules/src/wai-aria-deprecated-props/index.ts
@@ -1,0 +1,31 @@
+import type { Options } from '../wai-aria/types.js';
+
+import { createRule, getComputedRole, ariaSpecs, getSpec } from '@markuplint/ml-core';
+import { ARIA_RECOMMENDED_VERSION } from '@markuplint/ml-spec';
+
+import { checkingDeprecatedProps } from '../wai-aria/checkings/deprecated-props.js';
+import { defaultOptions } from '../wai-aria/default-options.js';
+import meta from './meta.js';
+
+/** Warns when a deprecated ARIA property or state is used on a role. */
+export default createRule<boolean, Options>({
+	meta,
+	defaultSeverity: 'warning',
+	defaultOptions,
+	async verify({ document, report }) {
+		await document.walkOn('Element', el => {
+			const elSpec = getSpec(el, document.specs.specs);
+			if (!elSpec) return;
+			if (!elSpec.globalAttrs['#ARIAAttrs']) return;
+			const propAttrs = el.attributes.filter(attr => /^aria-/i.test(attr.name));
+			if (propAttrs.length === 0) return;
+			const ariaVersion =
+				el.rule.options?.version ?? document.ruleCommonSettings?.ariaVersion ?? ARIA_RECOMMENDED_VERSION;
+			const computed = getComputedRole(document.specs, el, ariaVersion);
+			const { props: propSpecs } = ariaSpecs(document.specs, ariaVersion);
+			for (const attr of propAttrs) {
+				report(checkingDeprecatedProps({ attr, role: computed.role, propSpecs }));
+			}
+		});
+	},
+});

--- a/packages/@markuplint/rules/src/wai-aria-deprecated-props/meta.ts
+++ b/packages/@markuplint/rules/src/wai-aria-deprecated-props/meta.ts
@@ -1,0 +1,4 @@
+/** Rule metadata for the `wai-aria-deprecated-props` rule, categorized under accessibility. */
+export default {
+	category: 'a11y',
+} as const;

--- a/packages/@markuplint/rules/src/wai-aria-deprecated-props/schema.json
+++ b/packages/@markuplint/rules/src/wai-aria-deprecated-props/schema.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"value": {
+			"type": "boolean"
+		}
+	},
+	"oneOf": [
+		{
+			"$ref": "#/definitions/value"
+		},
+		{
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"value": { "$ref": "#/definitions/value" },
+				"severity": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/ml-config/schema.json#/definitions/severity",
+					"default": "warning"
+				},
+				"reason": {
+					"type": "string"
+				}
+			}
+		}
+	]
+}

--- a/packages/@markuplint/rules/src/wai-aria-deprecated-role/README.ja.md
+++ b/packages/@markuplint/rules/src/wai-aria-deprecated-role/README.ja.md
@@ -1,0 +1,25 @@
+---
+description: 非推奨（廃止予定）のロールが使用された場合に警告します。
+---
+
+# `wai-aria-deprecated-role`
+
+非推奨（廃止予定）のロールが使用された場合に警告します。
+
+このルールは[`wai-aria`](../wai-aria/)ルールファミリーの一部で、きめ細かなseverity制御のために分割されたものです。
+
+<!-- textlint-disable ja-technical-writing/ja-no-mixed-period -->
+
+❌ 間違ったコード例
+
+```html
+<div role="directory"></div>
+```
+
+✅ 正しいコード例
+
+```html
+<div role="list"></div>
+```
+
+<!-- textlint-enable ja-technical-writing/ja-no-mixed-period -->

--- a/packages/@markuplint/rules/src/wai-aria-deprecated-role/README.md
+++ b/packages/@markuplint/rules/src/wai-aria-deprecated-role/README.md
@@ -1,0 +1,22 @@
+---
+id: wai-aria-deprecated-role
+description: Warns when a deprecated WAI-ARIA role is used.
+---
+
+# `wai-aria-deprecated-role`
+
+Warns when a deprecated WAI-ARIA role is used.
+
+This rule is part of the [`wai-aria`](../wai-aria/) rule family, split for granular severity control.
+
+❌ Examples of **incorrect** code for this rule
+
+```html
+<div role="directory"></div>
+```
+
+✅ Examples of **correct** code for this rule
+
+```html
+<div role="list"></div>
+```

--- a/packages/@markuplint/rules/src/wai-aria-deprecated-role/index.spec.ts
+++ b/packages/@markuplint/rules/src/wai-aria-deprecated-role/index.spec.ts
@@ -1,0 +1,20 @@
+import { mlRuleTest } from 'markuplint';
+import { test, expect } from 'vitest';
+
+import rule from './index.js';
+
+test('[wai-aria-deprecated-role-valid-001] non-deprecated role', async () => {
+	expect((await mlRuleTest(rule, '<div role="button"></div>')).violations).toStrictEqual([]);
+});
+
+test('[wai-aria-deprecated-role-invalid-001] deprecated role', async () => {
+	expect((await mlRuleTest(rule, '<div role="directory"></div>')).violations).toStrictEqual([
+		{
+			severity: 'warning',
+			line: 1,
+			col: 6,
+			message: 'The "directory" role is deprecated',
+			raw: 'role="directory"',
+		},
+	]);
+});

--- a/packages/@markuplint/rules/src/wai-aria-deprecated-role/index.ts
+++ b/packages/@markuplint/rules/src/wai-aria-deprecated-role/index.ts
@@ -1,0 +1,28 @@
+import type { Options } from '../wai-aria/types.js';
+
+import { createRule, getComputedRole, getSpec } from '@markuplint/ml-core';
+import { ARIA_RECOMMENDED_VERSION } from '@markuplint/ml-spec';
+
+import { checkingDeprecatedRole } from '../wai-aria/checkings/deprecated-role.js';
+import { defaultOptions } from '../wai-aria/default-options.js';
+import meta from './meta.js';
+
+/** Warns when a deprecated WAI-ARIA role is used. */
+export default createRule<boolean, Options>({
+	meta,
+	defaultSeverity: 'warning',
+	defaultOptions,
+	async verify({ document, report }) {
+		await document.walkOn('Element', el => {
+			const roleAttr = el.getAttributeNode('role');
+			if (!roleAttr) return;
+			const elSpec = getSpec(el, document.specs.specs);
+			if (!elSpec) return;
+			if (!elSpec.globalAttrs['#ARIAAttrs']) return;
+			const ariaVersion =
+				el.rule.options?.version ?? document.ruleCommonSettings?.ariaVersion ?? ARIA_RECOMMENDED_VERSION;
+			const computed = getComputedRole(document.specs, el, ariaVersion);
+			report(checkingDeprecatedRole({ attr: roleAttr, role: computed.role }));
+		});
+	},
+});

--- a/packages/@markuplint/rules/src/wai-aria-deprecated-role/meta.ts
+++ b/packages/@markuplint/rules/src/wai-aria-deprecated-role/meta.ts
@@ -1,0 +1,3 @@
+export default {
+	category: 'a11y',
+} as const;

--- a/packages/@markuplint/rules/src/wai-aria-deprecated-role/schema.json
+++ b/packages/@markuplint/rules/src/wai-aria-deprecated-role/schema.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"value": {
+			"type": "boolean"
+		}
+	},
+	"oneOf": [
+		{
+			"$ref": "#/definitions/value"
+		},
+		{
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"value": { "$ref": "#/definitions/value" },
+				"severity": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/ml-config/schema.json#/definitions/severity",
+					"default": "warning"
+				},
+				"reason": {
+					"type": "string"
+				}
+			}
+		}
+	]
+}

--- a/packages/@markuplint/rules/src/wai-aria-disallowed-props/README.ja.md
+++ b/packages/@markuplint/rules/src/wai-aria-disallowed-props/README.ja.md
@@ -1,0 +1,25 @@
+---
+description: 要素のロールで許可されていないARIAプロパティ/ステートが指定された場合に警告します。
+---
+
+# `wai-aria-disallowed-props`
+
+要素のロールで許可されていないARIAプロパティ/ステートが指定された場合に警告します。
+
+このルールは[`wai-aria`](../wai-aria/)ルールファミリーの一部で、きめ細かなseverity制御のために分割されたものです。
+
+<!-- textlint-disable ja-technical-writing/ja-no-mixed-period -->
+
+❌ 間違ったコード例
+
+```html
+<div role="heading" aria-pressed="true"></div>
+```
+
+✅ 正しいコード例
+
+```html
+<div role="button" aria-pressed="true"></div>
+```
+
+<!-- textlint-enable ja-technical-writing/ja-no-mixed-period -->

--- a/packages/@markuplint/rules/src/wai-aria-disallowed-props/README.md
+++ b/packages/@markuplint/rules/src/wai-aria-disallowed-props/README.md
@@ -1,0 +1,22 @@
+---
+id: wai-aria-disallowed-props
+description: Warns when an ARIA property or state is not allowed on the element's computed role.
+---
+
+# `wai-aria-disallowed-props`
+
+Warns when an ARIA property or state is not allowed on the element's computed role.
+
+This rule is part of the [`wai-aria`](../wai-aria/) rule family, split for granular severity control.
+
+❌ Examples of **incorrect** code for this rule
+
+```html
+<div role="heading" aria-pressed="true"></div>
+```
+
+✅ Examples of **correct** code for this rule
+
+```html
+<div role="button" aria-pressed="true"></div>
+```

--- a/packages/@markuplint/rules/src/wai-aria-disallowed-props/index.spec.ts
+++ b/packages/@markuplint/rules/src/wai-aria-disallowed-props/index.spec.ts
@@ -1,0 +1,14 @@
+import { mlRuleTest } from 'markuplint';
+import { test, expect } from 'vitest';
+
+import rule from './index.js';
+
+test('[wai-aria-disallowed-props-valid-001] allowed prop on role', async () => {
+	expect((await mlRuleTest(rule, '<div role="button" aria-pressed="true"></div>')).violations).toStrictEqual([]);
+});
+
+test('[wai-aria-disallowed-props-invalid-001] disallowed prop on role', async () => {
+	const { violations } = await mlRuleTest(rule, '<div role="heading" aria-pressed="true"></div>');
+	expect(violations.length).toBe(1);
+	expect(violations[0]!.severity).toBe('error');
+});

--- a/packages/@markuplint/rules/src/wai-aria-disallowed-props/index.ts
+++ b/packages/@markuplint/rules/src/wai-aria-disallowed-props/index.ts
@@ -1,0 +1,37 @@
+import type { Options } from '../wai-aria/types.js';
+
+import { createRule, getComputedRole, ariaSpecs, getSpec } from '@markuplint/ml-core';
+import { ARIA_RECOMMENDED_VERSION } from '@markuplint/ml-spec';
+
+import { checkingDisallowedProp } from '../wai-aria/checkings/disallowed-prop.js';
+import { defaultOptions } from '../wai-aria/default-options.js';
+import meta from './meta.js';
+
+/** Warns when an ARIA property or state is not allowed on the element's computed role. */
+export default createRule<boolean, Options>({
+	meta,
+	defaultOptions,
+	async verify({ document, report }) {
+		await document.walkOn('Element', el => {
+			const elSpec = getSpec(el, document.specs.specs);
+			if (!elSpec) return;
+			if (!elSpec.globalAttrs['#ARIAAttrs']) return;
+			const propAttrs = el.attributes.filter(attr => /^aria-/i.test(attr.name));
+			if (propAttrs.length === 0) return;
+			const ariaVersion =
+				el.rule.options?.version ?? document.ruleCommonSettings?.ariaVersion ?? ARIA_RECOMMENDED_VERSION;
+			const computed = getComputedRole(document.specs, el, ariaVersion);
+			const { props: propSpecs } = ariaSpecs(document.specs, ariaVersion);
+			for (const attr of propAttrs) {
+				report(
+					checkingDisallowedProp({
+						attr,
+						role: computed.role,
+						propSpecs,
+						disallowSetImplicitProps: true,
+					}),
+				);
+			}
+		});
+	},
+});

--- a/packages/@markuplint/rules/src/wai-aria-disallowed-props/meta.ts
+++ b/packages/@markuplint/rules/src/wai-aria-disallowed-props/meta.ts
@@ -1,0 +1,4 @@
+/** Rule metadata for the `wai-aria-disallowed-props` rule, categorized under accessibility. */
+export default {
+	category: 'a11y',
+} as const;

--- a/packages/@markuplint/rules/src/wai-aria-disallowed-props/schema.json
+++ b/packages/@markuplint/rules/src/wai-aria-disallowed-props/schema.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"value": {
+			"type": "boolean"
+		}
+	},
+	"oneOf": [
+		{
+			"$ref": "#/definitions/value"
+		},
+		{
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"value": { "$ref": "#/definitions/value" },
+				"severity": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/ml-config/schema.json#/definitions/severity",
+					"default": "error"
+				},
+				"reason": {
+					"type": "string"
+				}
+			}
+		}
+	]
+}

--- a/packages/@markuplint/rules/src/wai-aria-implicit-props/README.ja.md
+++ b/packages/@markuplint/rules/src/wai-aria-implicit-props/README.ja.md
@@ -1,0 +1,25 @@
+---
+description: ネイティブHTML属性と同等のセマンティクスを持つARIAプロパティが指定された場合に警告します。
+---
+
+# `wai-aria-implicit-props`
+
+ネイティブHTML属性と同等のセマンティクスを持つARIAプロパティが指定された場合に警告します。
+
+このルールは[`wai-aria`](../wai-aria/)ルールファミリーの一部で、きめ細かなseverity制御のために分割されたものです。
+
+<!-- textlint-disable ja-technical-writing/ja-no-mixed-period -->
+
+❌ 間違ったコード例
+
+```html
+<input type="checkbox" aria-checked="true" checked />
+```
+
+✅ 正しいコード例
+
+```html
+<input type="checkbox" checked />
+```
+
+<!-- textlint-enable ja-technical-writing/ja-no-mixed-period -->

--- a/packages/@markuplint/rules/src/wai-aria-implicit-props/README.md
+++ b/packages/@markuplint/rules/src/wai-aria-implicit-props/README.md
@@ -1,0 +1,22 @@
+---
+id: wai-aria-implicit-props
+description: Warns when an ARIA property duplicates or contradicts semantics provided by a native HTML attribute.
+---
+
+# `wai-aria-implicit-props`
+
+Warns when an ARIA property duplicates or contradicts semantics provided by a native HTML attribute.
+
+This rule is part of the [`wai-aria`](../wai-aria/) rule family, split for granular severity control.
+
+❌ Examples of **incorrect** code for this rule
+
+```html
+<input type="checkbox" aria-checked="true" checked />
+```
+
+✅ Examples of **correct** code for this rule
+
+```html
+<input type="checkbox" checked />
+```

--- a/packages/@markuplint/rules/src/wai-aria-implicit-props/index.spec.ts
+++ b/packages/@markuplint/rules/src/wai-aria-implicit-props/index.spec.ts
@@ -1,0 +1,14 @@
+import { mlRuleTest } from 'markuplint';
+import { test, expect } from 'vitest';
+
+import rule from './index.js';
+
+test('[wai-aria-implicit-props-valid-001] no implicit prop conflict', async () => {
+	expect((await mlRuleTest(rule, '<div role="button" aria-pressed="true"></div>')).violations).toStrictEqual([]);
+});
+
+test('[wai-aria-implicit-props-invalid-001] implicit prop same as native attr', async () => {
+	const { violations } = await mlRuleTest(rule, '<input type="checkbox" aria-checked="true" checked />');
+	expect(violations.length).toBeGreaterThanOrEqual(1);
+	expect(violations[0]!.severity).toBe('warning');
+});

--- a/packages/@markuplint/rules/src/wai-aria-implicit-props/index.ts
+++ b/packages/@markuplint/rules/src/wai-aria-implicit-props/index.ts
@@ -1,0 +1,31 @@
+import type { Options } from '../wai-aria/types.js';
+
+import { createRule, ariaSpecs, getAttrSpecs, getSpec } from '@markuplint/ml-core';
+import { ARIA_RECOMMENDED_VERSION } from '@markuplint/ml-spec';
+
+import { checkingImplicitProps } from '../wai-aria/checkings/implicit-props.js';
+import { defaultOptions } from '../wai-aria/default-options.js';
+import meta from './meta.js';
+
+/** Warns when an ARIA property duplicates or contradicts semantics provided by a native HTML attribute. */
+export default createRule<boolean, Options>({
+	meta,
+	defaultSeverity: 'warning',
+	defaultOptions,
+	async verify({ document, report }) {
+		await document.walkOn('Element', el => {
+			const elSpec = getSpec(el, document.specs.specs);
+			if (!elSpec) return;
+			if (!elSpec.globalAttrs['#ARIAAttrs']) return;
+			const propAttrs = el.attributes.filter(attr => /^aria-/i.test(attr.name));
+			if (propAttrs.length === 0) return;
+			const ariaVersion =
+				el.rule.options?.version ?? document.ruleCommonSettings?.ariaVersion ?? ARIA_RECOMMENDED_VERSION;
+			const { props: propSpecs } = ariaSpecs(document.specs, ariaVersion);
+			const attrSpecs = getAttrSpecs(el, document.specs);
+			for (const attr of propAttrs) {
+				report(checkingImplicitProps({ attr, propSpecs, attrSpecs }));
+			}
+		});
+	},
+});

--- a/packages/@markuplint/rules/src/wai-aria-implicit-props/meta.ts
+++ b/packages/@markuplint/rules/src/wai-aria-implicit-props/meta.ts
@@ -1,0 +1,4 @@
+/** Rule metadata for the `wai-aria-implicit-props` rule, categorized under accessibility. */
+export default {
+	category: 'a11y',
+} as const;

--- a/packages/@markuplint/rules/src/wai-aria-implicit-props/schema.json
+++ b/packages/@markuplint/rules/src/wai-aria-implicit-props/schema.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"value": {
+			"type": "boolean"
+		}
+	},
+	"oneOf": [
+		{
+			"$ref": "#/definitions/value"
+		},
+		{
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"value": { "$ref": "#/definitions/value" },
+				"severity": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/ml-config/schema.json#/definitions/severity",
+					"default": "warning"
+				},
+				"reason": {
+					"type": "string"
+				}
+			}
+		}
+	]
+}

--- a/packages/@markuplint/rules/src/wai-aria-implicit-role/README.ja.md
+++ b/packages/@markuplint/rules/src/wai-aria-implicit-role/README.ja.md
@@ -1,0 +1,25 @@
+---
+description: 要素の暗黙のロールと同じロールが明示的に指定された場合に警告します。
+---
+
+# `wai-aria-implicit-role`
+
+要素の暗黙のロールと同じロールが明示的に指定された場合に警告します。
+
+このルールは[`wai-aria`](../wai-aria/)ルールファミリーの一部で、きめ細かなseverity制御のために分割されたものです。
+
+<!-- textlint-disable ja-technical-writing/ja-no-mixed-period -->
+
+❌ 間違ったコード例
+
+```html
+<nav role="navigation"></nav>
+```
+
+✅ 正しいコード例
+
+```html
+<nav role="menu"></nav>
+```
+
+<!-- textlint-enable ja-technical-writing/ja-no-mixed-period -->

--- a/packages/@markuplint/rules/src/wai-aria-implicit-role/README.md
+++ b/packages/@markuplint/rules/src/wai-aria-implicit-role/README.md
@@ -1,0 +1,22 @@
+---
+id: wai-aria-implicit-role
+description: Warns when the explicit role attribute duplicates the element's implicit role.
+---
+
+# `wai-aria-implicit-role`
+
+Warns when the explicit role attribute duplicates the element's implicit role.
+
+This rule is part of the [`wai-aria`](../wai-aria/) rule family, split for granular severity control.
+
+❌ Examples of **incorrect** code for this rule
+
+```html
+<nav role="navigation"></nav>
+```
+
+✅ Examples of **correct** code for this rule
+
+```html
+<nav role="menu"></nav>
+```

--- a/packages/@markuplint/rules/src/wai-aria-implicit-role/index.spec.ts
+++ b/packages/@markuplint/rules/src/wai-aria-implicit-role/index.spec.ts
@@ -1,0 +1,20 @@
+import { mlRuleTest } from 'markuplint';
+import { test, expect } from 'vitest';
+
+import rule from './index.js';
+
+test('[wai-aria-implicit-role-valid-001] different from implicit role', async () => {
+	expect((await mlRuleTest(rule, '<nav role="menu"></nav>')).violations).toStrictEqual([]);
+});
+
+test('[wai-aria-implicit-role-invalid-001] same as implicit role', async () => {
+	expect((await mlRuleTest(rule, '<nav role="navigation"></nav>')).violations).toStrictEqual([
+		{
+			severity: 'warning',
+			line: 1,
+			col: 12,
+			message: 'The "navigation" role is the implicit role of the "nav" element',
+			raw: 'navigation',
+		},
+	]);
+});

--- a/packages/@markuplint/rules/src/wai-aria-implicit-role/index.ts
+++ b/packages/@markuplint/rules/src/wai-aria-implicit-role/index.ts
@@ -1,0 +1,24 @@
+import type { Options } from '../wai-aria/types.js';
+
+import { createRule, getSpec } from '@markuplint/ml-core';
+
+import { checkingImplicitRole } from '../wai-aria/checkings/implicit-role.js';
+import { defaultOptions } from '../wai-aria/default-options.js';
+import meta from './meta.js';
+
+/** Warns when the explicit role attribute duplicates the element's implicit role. */
+export default createRule<boolean, Options>({
+	meta,
+	defaultSeverity: 'warning',
+	defaultOptions,
+	async verify({ document, report }) {
+		await document.walkOn('Element', el => {
+			const roleAttr = el.getAttributeNode('role');
+			if (!roleAttr) return;
+			const elSpec = getSpec(el, document.specs.specs);
+			if (!elSpec) return;
+			if (!elSpec.globalAttrs['#ARIAAttrs']) return;
+			report(checkingImplicitRole({ attr: roleAttr }));
+		});
+	},
+});

--- a/packages/@markuplint/rules/src/wai-aria-implicit-role/meta.ts
+++ b/packages/@markuplint/rules/src/wai-aria-implicit-role/meta.ts
@@ -1,0 +1,3 @@
+export default {
+	category: 'a11y',
+} as const;

--- a/packages/@markuplint/rules/src/wai-aria-implicit-role/schema.json
+++ b/packages/@markuplint/rules/src/wai-aria-implicit-role/schema.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"value": {
+			"type": "boolean"
+		}
+	},
+	"oneOf": [
+		{
+			"$ref": "#/definitions/value"
+		},
+		{
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"value": { "$ref": "#/definitions/value" },
+				"severity": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/ml-config/schema.json#/definitions/severity",
+					"default": "warning"
+				},
+				"reason": {
+					"type": "string"
+				}
+			}
+		}
+	]
+}

--- a/packages/@markuplint/rules/src/wai-aria-interaction-in-hidden/README.ja.md
+++ b/packages/@markuplint/rules/src/wai-aria-interaction-in-hidden/README.ja.md
@@ -1,0 +1,25 @@
+---
+description: aria-hiddenで非表示にされたサブツリー内にフォーカス可能なインタラクティブ要素がある場合に警告します。
+---
+
+# `wai-aria-interaction-in-hidden`
+
+aria-hiddenで非表示にされたサブツリー内にフォーカス可能なインタラクティブ要素がある場合に警告します。
+
+このルールは[`wai-aria`](../wai-aria/)ルールファミリーの一部で、きめ細かなseverity制御のために分割されたものです。
+
+<!-- textlint-disable ja-technical-writing/ja-no-mixed-period -->
+
+❌ 間違ったコード例
+
+```html
+<div aria-hidden="true"><button>click</button></div>
+```
+
+✅ 正しいコード例
+
+```html
+<div aria-hidden="true"><span>text</span></div>
+```
+
+<!-- textlint-enable ja-technical-writing/ja-no-mixed-period -->

--- a/packages/@markuplint/rules/src/wai-aria-interaction-in-hidden/README.md
+++ b/packages/@markuplint/rules/src/wai-aria-interaction-in-hidden/README.md
@@ -1,0 +1,22 @@
+---
+id: wai-aria-interaction-in-hidden
+description: Warns when focusable interactive elements are placed inside an aria-hidden subtree.
+---
+
+# `wai-aria-interaction-in-hidden`
+
+Warns when focusable interactive elements are placed inside an aria-hidden subtree.
+
+This rule is part of the [`wai-aria`](../wai-aria/) rule family, split for granular severity control.
+
+❌ Examples of **incorrect** code for this rule
+
+```html
+<div aria-hidden="true"><button>click</button></div>
+```
+
+✅ Examples of **correct** code for this rule
+
+```html
+<div aria-hidden="true"><span>text</span></div>
+```

--- a/packages/@markuplint/rules/src/wai-aria-interaction-in-hidden/index.spec.ts
+++ b/packages/@markuplint/rules/src/wai-aria-interaction-in-hidden/index.spec.ts
@@ -1,0 +1,18 @@
+import { mlRuleTest } from 'markuplint';
+import { test, expect } from 'vitest';
+
+import rule from './index.js';
+
+test('[wai-aria-interaction-in-hidden-valid-001] no aria-hidden', async () => {
+	expect((await mlRuleTest(rule, '<button>click</button>')).violations).toStrictEqual([]);
+});
+
+test('[wai-aria-interaction-in-hidden-valid-002] non-interactive in hidden', async () => {
+	expect((await mlRuleTest(rule, '<div aria-hidden="true"><span>text</span></div>')).violations).toStrictEqual([]);
+});
+
+test('[wai-aria-interaction-in-hidden-invalid-001] focusable in hidden', async () => {
+	const { violations } = await mlRuleTest(rule, '<div aria-hidden="true"><button>click</button></div>');
+	expect(violations.length).toBe(1);
+	expect(violations[0]!.severity).toBe('warning');
+});

--- a/packages/@markuplint/rules/src/wai-aria-interaction-in-hidden/index.ts
+++ b/packages/@markuplint/rules/src/wai-aria-interaction-in-hidden/index.ts
@@ -1,0 +1,22 @@
+import type { Options } from '../wai-aria/types.js';
+
+import { createRule, getSpec } from '@markuplint/ml-core';
+
+import { checkingInteractionInHidden } from '../wai-aria/checkings/interaction-in-hidden.js';
+import { defaultOptions } from '../wai-aria/default-options.js';
+import meta from './meta.js';
+
+/** Warns when focusable interactive elements are placed inside an aria-hidden subtree. */
+export default createRule<boolean, Options>({
+	meta,
+	defaultSeverity: 'warning',
+	defaultOptions,
+	async verify({ document, report }) {
+		await document.walkOn('Element', el => {
+			const elSpec = getSpec(el, document.specs.specs);
+			if (!elSpec) return;
+			if (!elSpec.globalAttrs['#ARIAAttrs']) return;
+			report(checkingInteractionInHidden({ el }));
+		});
+	},
+});

--- a/packages/@markuplint/rules/src/wai-aria-interaction-in-hidden/meta.ts
+++ b/packages/@markuplint/rules/src/wai-aria-interaction-in-hidden/meta.ts
@@ -1,0 +1,4 @@
+/** Rule metadata for the `wai-aria-interaction-in-hidden` rule, categorized under accessibility. */
+export default {
+	category: 'a11y',
+} as const;

--- a/packages/@markuplint/rules/src/wai-aria-interaction-in-hidden/schema.json
+++ b/packages/@markuplint/rules/src/wai-aria-interaction-in-hidden/schema.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"value": {
+			"type": "boolean"
+		}
+	},
+	"oneOf": [
+		{
+			"$ref": "#/definitions/value"
+		},
+		{
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"value": { "$ref": "#/definitions/value" },
+				"severity": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/ml-config/schema.json#/definitions/severity",
+					"default": "warning"
+				},
+				"reason": {
+					"type": "string"
+				}
+			}
+		}
+	]
+}

--- a/packages/@markuplint/rules/src/wai-aria-no-global-prop/README.ja.md
+++ b/packages/@markuplint/rules/src/wai-aria-no-global-prop/README.ja.md
@@ -1,0 +1,25 @@
+---
+description: 明示的なロールを持たない要素にグローバルでないARIAプロパティが指定された場合に警告します。
+---
+
+# `wai-aria-no-global-prop`
+
+明示的なロールを持たない要素にグローバルでないARIAプロパティが指定された場合に警告します。
+
+このルールは[`wai-aria`](../wai-aria/)ルールファミリーの一部で、きめ細かなseverity制御のために分割されたものです。
+
+<!-- textlint-disable ja-technical-writing/ja-no-mixed-period -->
+
+❌ 間違ったコード例
+
+```html
+<div aria-pressed="true"></div>
+```
+
+✅ 正しいコード例
+
+```html
+<div aria-label="text"></div>
+```
+
+<!-- textlint-enable ja-technical-writing/ja-no-mixed-period -->

--- a/packages/@markuplint/rules/src/wai-aria-no-global-prop/README.md
+++ b/packages/@markuplint/rules/src/wai-aria-no-global-prop/README.md
@@ -1,0 +1,22 @@
+---
+id: wai-aria-no-global-prop
+description: Warns when a non-global ARIA property is used on an element without an explicit role.
+---
+
+# `wai-aria-no-global-prop`
+
+Warns when a non-global ARIA property is used on an element without an explicit role.
+
+This rule is part of the [`wai-aria`](../wai-aria/) rule family, split for granular severity control.
+
+❌ Examples of **incorrect** code for this rule
+
+```html
+<div aria-pressed="true"></div>
+```
+
+✅ Examples of **correct** code for this rule
+
+```html
+<div aria-label="text"></div>
+```

--- a/packages/@markuplint/rules/src/wai-aria-no-global-prop/index.spec.ts
+++ b/packages/@markuplint/rules/src/wai-aria-no-global-prop/index.spec.ts
@@ -1,0 +1,12 @@
+import { mlRuleTest } from 'markuplint';
+import { test, expect } from 'vitest';
+
+import rule from './index.js';
+
+test('[wai-aria-no-global-prop-valid-001] global prop without role', async () => {
+	expect((await mlRuleTest(rule, '<div aria-label="text"></div>')).violations).toStrictEqual([]);
+});
+
+test('[wai-aria-no-global-prop-valid-002] any prop with role', async () => {
+	expect((await mlRuleTest(rule, '<div role="button" aria-pressed="true"></div>')).violations).toStrictEqual([]);
+});

--- a/packages/@markuplint/rules/src/wai-aria-no-global-prop/index.ts
+++ b/packages/@markuplint/rules/src/wai-aria-no-global-prop/index.ts
@@ -1,0 +1,31 @@
+import type { Options } from '../wai-aria/types.js';
+
+import { createRule, getComputedRole, ariaSpecs, getSpec } from '@markuplint/ml-core';
+import { ARIA_RECOMMENDED_VERSION } from '@markuplint/ml-spec';
+
+import { checkingNoGlobalProp } from '../wai-aria/checkings/no-global-prop.js';
+import { defaultOptions } from '../wai-aria/default-options.js';
+import meta from './meta.js';
+
+/** Warns when a non-global ARIA property is used on an element without an explicit role. */
+export default createRule<boolean, Options>({
+	meta,
+	defaultOptions,
+	async verify({ document, report }) {
+		await document.walkOn('Element', el => {
+			const elSpec = getSpec(el, document.specs.specs);
+			if (!elSpec) return;
+			if (!elSpec.globalAttrs['#ARIAAttrs']) return;
+			const propAttrs = el.attributes.filter(attr => /^aria-/i.test(attr.name));
+			if (propAttrs.length === 0) return;
+			const ariaVersion =
+				el.rule.options?.version ?? document.ruleCommonSettings?.ariaVersion ?? ARIA_RECOMMENDED_VERSION;
+			const computed = getComputedRole(document.specs, el, ariaVersion);
+			if (computed.role) return;
+			const { props: propSpecs } = ariaSpecs(document.specs, ariaVersion);
+			for (const attr of propAttrs) {
+				report(checkingNoGlobalProp({ attr, propSpecs }));
+			}
+		});
+	},
+});

--- a/packages/@markuplint/rules/src/wai-aria-no-global-prop/meta.ts
+++ b/packages/@markuplint/rules/src/wai-aria-no-global-prop/meta.ts
@@ -1,0 +1,4 @@
+/** Rule metadata for the `wai-aria-no-global-prop` rule, categorized under accessibility. */
+export default {
+	category: 'a11y',
+} as const;

--- a/packages/@markuplint/rules/src/wai-aria-no-global-prop/schema.json
+++ b/packages/@markuplint/rules/src/wai-aria-no-global-prop/schema.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"value": {
+			"type": "boolean"
+		}
+	},
+	"oneOf": [
+		{
+			"$ref": "#/definitions/value"
+		},
+		{
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"value": { "$ref": "#/definitions/value" },
+				"severity": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/ml-config/schema.json#/definitions/severity",
+					"default": "error"
+				},
+				"reason": {
+					"type": "string"
+				}
+			}
+		}
+	]
+}

--- a/packages/@markuplint/rules/src/wai-aria-non-existent-role/README.ja.md
+++ b/packages/@markuplint/rules/src/wai-aria-non-existent-role/README.ja.md
@@ -1,0 +1,25 @@
+---
+description: WAI-ARIA仕様に存在しないロールが指定された場合に警告します。
+---
+
+# `wai-aria-non-existent-role`
+
+WAI-ARIA仕様に存在しないロールが指定された場合に警告します。
+
+このルールは[`wai-aria`](../wai-aria/)ルールファミリーの一部で、きめ細かなseverity制御のために分割されたものです。
+
+<!-- textlint-disable ja-technical-writing/ja-no-mixed-period -->
+
+❌ 間違ったコード例
+
+```html
+<div role="hoge"></div>
+```
+
+✅ 正しいコード例
+
+```html
+<div role="button"></div>
+```
+
+<!-- textlint-enable ja-technical-writing/ja-no-mixed-period -->

--- a/packages/@markuplint/rules/src/wai-aria-non-existent-role/README.md
+++ b/packages/@markuplint/rules/src/wai-aria-non-existent-role/README.md
@@ -1,0 +1,22 @@
+---
+id: wai-aria-non-existent-role
+description: Warns when a role attribute value does not exist in the WAI-ARIA specification.
+---
+
+# `wai-aria-non-existent-role`
+
+Warns when a role attribute value does not exist in the WAI-ARIA specification.
+
+This rule is part of the [`wai-aria`](../wai-aria/) rule family, split for granular severity control.
+
+❌ Examples of **incorrect** code for this rule
+
+```html
+<div role="hoge"></div>
+```
+
+✅ Examples of **correct** code for this rule
+
+```html
+<div role="button"></div>
+```

--- a/packages/@markuplint/rules/src/wai-aria-non-existent-role/index.spec.ts
+++ b/packages/@markuplint/rules/src/wai-aria-non-existent-role/index.spec.ts
@@ -1,0 +1,24 @@
+import { mlRuleTest } from 'markuplint';
+import { test, expect } from 'vitest';
+
+import rule from './index.js';
+
+test('[wai-aria-non-existent-role-valid-001] valid role', async () => {
+	expect((await mlRuleTest(rule, '<div role="button"></div>')).violations).toStrictEqual([]);
+});
+
+test('[wai-aria-non-existent-role-valid-002] no role attr', async () => {
+	expect((await mlRuleTest(rule, '<div></div>')).violations).toStrictEqual([]);
+});
+
+test('[wai-aria-non-existent-role-invalid-001] non-existent role', async () => {
+	expect((await mlRuleTest(rule, '<div role="hoge"></div>')).violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 12,
+			message: 'The "hoge" role does not exist according to the WAI-ARIA specification.',
+			raw: 'hoge',
+		},
+	]);
+});

--- a/packages/@markuplint/rules/src/wai-aria-non-existent-role/index.ts
+++ b/packages/@markuplint/rules/src/wai-aria-non-existent-role/index.ts
@@ -1,0 +1,23 @@
+import type { Options } from '../wai-aria/types.js';
+
+import { createRule, getSpec } from '@markuplint/ml-core';
+
+import { checkingNonExistentRole } from '../wai-aria/checkings/non-existent-role.js';
+import { defaultOptions } from '../wai-aria/default-options.js';
+import meta from './meta.js';
+
+/** Warns when a role attribute value does not exist in the WAI-ARIA specification. */
+export default createRule<boolean, Options>({
+	meta,
+	defaultOptions,
+	async verify({ document, report }) {
+		await document.walkOn('Element', el => {
+			const roleAttr = el.getAttributeNode('role');
+			if (!roleAttr) return;
+			const elSpec = getSpec(el, document.specs.specs);
+			if (!elSpec) return;
+			if (!elSpec.globalAttrs['#ARIAAttrs']) return;
+			report(checkingNonExistentRole({ attr: roleAttr }));
+		});
+	},
+});

--- a/packages/@markuplint/rules/src/wai-aria-non-existent-role/meta.ts
+++ b/packages/@markuplint/rules/src/wai-aria-non-existent-role/meta.ts
@@ -1,0 +1,3 @@
+export default {
+	category: 'a11y',
+} as const;

--- a/packages/@markuplint/rules/src/wai-aria-non-existent-role/schema.json
+++ b/packages/@markuplint/rules/src/wai-aria-non-existent-role/schema.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"value": {
+			"type": "boolean"
+		}
+	},
+	"oneOf": [
+		{
+			"$ref": "#/definitions/value"
+		},
+		{
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"value": { "$ref": "#/definitions/value" },
+				"severity": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/ml-config/schema.json#/definitions/severity",
+					"default": "error"
+				},
+				"reason": {
+					"type": "string"
+				}
+			}
+		}
+	]
+}

--- a/packages/@markuplint/rules/src/wai-aria-permitted-roles/README.ja.md
+++ b/packages/@markuplint/rules/src/wai-aria-permitted-roles/README.ja.md
@@ -1,0 +1,25 @@
+---
+description: ARIA in HTMLの仕様において要素に許可されていないロールが指定された場合に警告します。
+---
+
+# `wai-aria-permitted-roles`
+
+ARIA in HTMLの仕様において要素に許可されていないロールが指定された場合に警告します。
+
+このルールは[`wai-aria`](../wai-aria/)ルールファミリーの一部で、きめ細かなseverity制御のために分割されたものです。
+
+<!-- textlint-disable ja-technical-writing/ja-no-mixed-period -->
+
+❌ 間違ったコード例
+
+```html
+<select role="textbox"></select>
+```
+
+✅ 正しいコード例
+
+```html
+<a href="path/to" role="button">text</a>
+```
+
+<!-- textlint-enable ja-technical-writing/ja-no-mixed-period -->

--- a/packages/@markuplint/rules/src/wai-aria-permitted-roles/README.md
+++ b/packages/@markuplint/rules/src/wai-aria-permitted-roles/README.md
@@ -1,0 +1,22 @@
+---
+id: wai-aria-permitted-roles
+description: Warns when a role is not permitted on the element according to ARIA in HTML.
+---
+
+# `wai-aria-permitted-roles`
+
+Warns when a role is not permitted on the element according to ARIA in HTML.
+
+This rule is part of the [`wai-aria`](../wai-aria/) rule family, split for granular severity control.
+
+❌ Examples of **incorrect** code for this rule
+
+```html
+<select role="textbox"></select>
+```
+
+✅ Examples of **correct** code for this rule
+
+```html
+<a href="path/to" role="button">text</a>
+```

--- a/packages/@markuplint/rules/src/wai-aria-permitted-roles/index.spec.ts
+++ b/packages/@markuplint/rules/src/wai-aria-permitted-roles/index.spec.ts
@@ -1,0 +1,21 @@
+import { mlRuleTest } from 'markuplint';
+import { test, expect } from 'vitest';
+
+import rule from './index.js';
+
+test('[wai-aria-permitted-roles-valid-001] permitted role', async () => {
+	expect((await mlRuleTest(rule, '<a href="path/to" role="button">text</a>')).violations).toStrictEqual([]);
+});
+
+test('[wai-aria-permitted-roles-invalid-001] non-permitted role on select', async () => {
+	expect((await mlRuleTest(rule, '<select role="textbox"></select>')).violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 15,
+			message:
+				'Cannot overwrite the "textbox" role to the "select" element according to ARIA in HTML specification',
+			raw: 'textbox',
+		},
+	]);
+});

--- a/packages/@markuplint/rules/src/wai-aria-permitted-roles/index.ts
+++ b/packages/@markuplint/rules/src/wai-aria-permitted-roles/index.ts
@@ -1,0 +1,23 @@
+import type { Options } from '../wai-aria/types.js';
+
+import { createRule, getSpec } from '@markuplint/ml-core';
+
+import { checkingPermittedRoles } from '../wai-aria/checkings/permitted-roles.js';
+import { defaultOptions } from '../wai-aria/default-options.js';
+import meta from './meta.js';
+
+/** Warns when a role is not permitted on the element according to ARIA in HTML. */
+export default createRule<boolean, Options>({
+	meta,
+	defaultOptions,
+	async verify({ document, report }) {
+		await document.walkOn('Element', el => {
+			const roleAttr = el.getAttributeNode('role');
+			if (!roleAttr) return;
+			const elSpec = getSpec(el, document.specs.specs);
+			if (!elSpec) return;
+			if (!elSpec.globalAttrs['#ARIAAttrs']) return;
+			report(checkingPermittedRoles({ attr: roleAttr }));
+		});
+	},
+});

--- a/packages/@markuplint/rules/src/wai-aria-permitted-roles/meta.ts
+++ b/packages/@markuplint/rules/src/wai-aria-permitted-roles/meta.ts
@@ -1,0 +1,3 @@
+export default {
+	category: 'a11y',
+} as const;

--- a/packages/@markuplint/rules/src/wai-aria-permitted-roles/schema.json
+++ b/packages/@markuplint/rules/src/wai-aria-permitted-roles/schema.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"value": {
+			"type": "boolean"
+		}
+	},
+	"oneOf": [
+		{
+			"$ref": "#/definitions/value"
+		},
+		{
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"value": { "$ref": "#/definitions/value" },
+				"severity": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/ml-config/schema.json#/definitions/severity",
+					"default": "error"
+				},
+				"reason": {
+					"type": "string"
+				}
+			}
+		}
+	]
+}

--- a/packages/@markuplint/rules/src/wai-aria-presentational-children/README.ja.md
+++ b/packages/@markuplint/rules/src/wai-aria-presentational-children/README.ja.md
@@ -1,0 +1,25 @@
+---
+description: childrenPresentationalを持つロールの子孫要素にARIA属性が指定された場合に警告します。
+---
+
+# `wai-aria-presentational-children`
+
+childrenPresentationalを持つロールの子孫要素にARIA属性が指定された場合に警告します。
+
+このルールは[`wai-aria`](../wai-aria/)ルールファミリーの一部で、きめ細かなseverity制御のために分割されたものです。
+
+<!-- textlint-disable ja-technical-writing/ja-no-mixed-period -->
+
+❌ 間違ったコード例
+
+```html
+<div role="img"><span aria-label="text"></span></div>
+```
+
+✅ 正しいコード例
+
+```html
+<div role="img"><span>text</span></div>
+```
+
+<!-- textlint-enable ja-technical-writing/ja-no-mixed-period -->

--- a/packages/@markuplint/rules/src/wai-aria-presentational-children/README.md
+++ b/packages/@markuplint/rules/src/wai-aria-presentational-children/README.md
@@ -1,0 +1,22 @@
+---
+id: wai-aria-presentational-children
+description: Warns when ARIA attributes are set on descendants of roles with presentational children.
+---
+
+# `wai-aria-presentational-children`
+
+Warns when ARIA attributes are set on descendants of roles with presentational children.
+
+This rule is part of the [`wai-aria`](../wai-aria/) rule family, split for granular severity control.
+
+❌ Examples of **incorrect** code for this rule
+
+```html
+<div role="img"><span aria-label="text"></span></div>
+```
+
+✅ Examples of **correct** code for this rule
+
+```html
+<div role="img"><span>text</span></div>
+```

--- a/packages/@markuplint/rules/src/wai-aria-presentational-children/index.spec.ts
+++ b/packages/@markuplint/rules/src/wai-aria-presentational-children/index.spec.ts
@@ -1,0 +1,20 @@
+import { mlRuleTest } from 'markuplint';
+import { test, expect } from 'vitest';
+
+import rule from './index.js';
+
+test('[wai-aria-presentational-children-valid-001] no presentational role ancestor', async () => {
+	expect(
+		(await mlRuleTest(rule, '<div role="group"><span aria-label="text"></span></div>')).violations,
+	).toStrictEqual([]);
+});
+
+test('[wai-aria-presentational-children-invalid-001] aria attr on child of presentational children role', async () => {
+	const { violations } = await mlRuleTest(rule, '<div role="button"><span aria-label="text"></span></div>');
+	expect(violations.length).toBe(1);
+	expect(violations[0]!.severity).toBe('warning');
+});
+
+test('[wai-aria-presentational-children-valid-002] no aria on children', async () => {
+	expect((await mlRuleTest(rule, '<div role="img"><span>text</span></div>')).violations).toStrictEqual([]);
+});

--- a/packages/@markuplint/rules/src/wai-aria-presentational-children/index.ts
+++ b/packages/@markuplint/rules/src/wai-aria-presentational-children/index.ts
@@ -1,0 +1,22 @@
+import type { Options } from '../wai-aria/types.js';
+
+import { createRule, getSpec } from '@markuplint/ml-core';
+
+import { checkingPresentationalChildren } from '../wai-aria/checkings/presentational-children.js';
+import { defaultOptions } from '../wai-aria/default-options.js';
+import meta from './meta.js';
+
+/** Warns when ARIA attributes are set on descendants of roles with presentational children. */
+export default createRule<boolean, Options>({
+	meta,
+	defaultSeverity: 'warning',
+	defaultOptions,
+	async verify({ document, report }) {
+		await document.walkOn('Element', el => {
+			const elSpec = getSpec(el, document.specs.specs);
+			if (!elSpec) return;
+			if (!elSpec.globalAttrs['#ARIAAttrs']) return;
+			report(checkingPresentationalChildren({ el }));
+		});
+	},
+});

--- a/packages/@markuplint/rules/src/wai-aria-presentational-children/meta.ts
+++ b/packages/@markuplint/rules/src/wai-aria-presentational-children/meta.ts
@@ -1,0 +1,4 @@
+/** Rule metadata for the `wai-aria-presentational-children` rule, categorized under accessibility. */
+export default {
+	category: 'a11y',
+} as const;

--- a/packages/@markuplint/rules/src/wai-aria-presentational-children/schema.json
+++ b/packages/@markuplint/rules/src/wai-aria-presentational-children/schema.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"value": {
+			"type": "boolean"
+		}
+	},
+	"oneOf": [
+		{
+			"$ref": "#/definitions/value"
+		},
+		{
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"value": { "$ref": "#/definitions/value" },
+				"severity": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/ml-config/schema.json#/definitions/severity",
+					"default": "warning"
+				},
+				"reason": {
+					"type": "string"
+				}
+			}
+		}
+	]
+}

--- a/packages/@markuplint/rules/src/wai-aria-required-owned-elements/README.ja.md
+++ b/packages/@markuplint/rules/src/wai-aria-required-owned-elements/README.ja.md
@@ -1,0 +1,25 @@
+---
+description: ロールが必要とする子ロールを含んでいない場合に警告します。
+---
+
+# `wai-aria-required-owned-elements`
+
+ロールが必要とする子ロールを含んでいない場合に警告します。
+
+このルールは[`wai-aria`](../wai-aria/)ルールファミリーの一部で、きめ細かなseverity制御のために分割されたものです。
+
+<!-- textlint-disable ja-technical-writing/ja-no-mixed-period -->
+
+❌ 間違ったコード例
+
+```html
+<div role="list"><div>not a listitem</div></div>
+```
+
+✅ 正しいコード例
+
+```html
+<div role="list"><div role="listitem">item</div></div>
+```
+
+<!-- textlint-enable ja-technical-writing/ja-no-mixed-period -->

--- a/packages/@markuplint/rules/src/wai-aria-required-owned-elements/README.md
+++ b/packages/@markuplint/rules/src/wai-aria-required-owned-elements/README.md
@@ -1,0 +1,22 @@
+---
+id: wai-aria-required-owned-elements
+description: Warns when a role does not contain its required child roles.
+---
+
+# `wai-aria-required-owned-elements`
+
+Warns when a role does not contain its required child roles.
+
+This rule is part of the [`wai-aria`](../wai-aria/) rule family, split for granular severity control.
+
+❌ Examples of **incorrect** code for this rule
+
+```html
+<div role="list"><div>not a listitem</div></div>
+```
+
+✅ Examples of **correct** code for this rule
+
+```html
+<div role="list"><div role="listitem">item</div></div>
+```

--- a/packages/@markuplint/rules/src/wai-aria-required-owned-elements/index.spec.ts
+++ b/packages/@markuplint/rules/src/wai-aria-required-owned-elements/index.spec.ts
@@ -1,0 +1,20 @@
+import { mlRuleTest } from 'markuplint';
+import { test, expect } from 'vitest';
+
+import rule from './index.js';
+
+test('[wai-aria-required-owned-elements-valid-001] list with listitem', async () => {
+	expect((await mlRuleTest(rule, '<div role="list"><div role="listitem">item</div></div>')).violations).toStrictEqual(
+		[],
+	);
+});
+
+test('[wai-aria-required-owned-elements-valid-002] no role', async () => {
+	expect((await mlRuleTest(rule, '<div></div>')).violations).toStrictEqual([]);
+});
+
+test('[wai-aria-required-owned-elements-invalid-001] list without listitem', async () => {
+	const { violations } = await mlRuleTest(rule, '<div role="list"><div>not a listitem</div></div>');
+	expect(violations.length).toBe(1);
+	expect(violations[0]!.severity).toBe('warning');
+});

--- a/packages/@markuplint/rules/src/wai-aria-required-owned-elements/index.ts
+++ b/packages/@markuplint/rules/src/wai-aria-required-owned-elements/index.ts
@@ -1,0 +1,26 @@
+import type { Options } from '../wai-aria/types.js';
+
+import { createRule, getComputedRole, getSpec } from '@markuplint/ml-core';
+import { ARIA_RECOMMENDED_VERSION } from '@markuplint/ml-spec';
+
+import { checkingRequiredOwnedElements } from '../wai-aria/checkings/required-owned-elements.js';
+import { defaultOptions } from '../wai-aria/default-options.js';
+import meta from './meta.js';
+
+/** Warns when a role does not contain its required child roles. */
+export default createRule<boolean, Options>({
+	meta,
+	defaultSeverity: 'warning',
+	defaultOptions,
+	async verify({ document, report }) {
+		await document.walkOn('Element', el => {
+			const elSpec = getSpec(el, document.specs.specs);
+			if (!elSpec) return;
+			if (!elSpec.globalAttrs['#ARIAAttrs']) return;
+			const ariaVersion =
+				el.rule.options?.version ?? document.ruleCommonSettings?.ariaVersion ?? ARIA_RECOMMENDED_VERSION;
+			const computed = getComputedRole(document.specs, el, ariaVersion);
+			report(checkingRequiredOwnedElements({ el, role: computed.role }));
+		});
+	},
+});

--- a/packages/@markuplint/rules/src/wai-aria-required-owned-elements/meta.ts
+++ b/packages/@markuplint/rules/src/wai-aria-required-owned-elements/meta.ts
@@ -1,0 +1,3 @@
+export default {
+	category: 'a11y',
+} as const;

--- a/packages/@markuplint/rules/src/wai-aria-required-owned-elements/schema.json
+++ b/packages/@markuplint/rules/src/wai-aria-required-owned-elements/schema.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"value": {
+			"type": "boolean"
+		}
+	},
+	"oneOf": [
+		{
+			"$ref": "#/definitions/value"
+		},
+		{
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"value": { "$ref": "#/definitions/value" },
+				"severity": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/ml-config/schema.json#/definitions/severity",
+					"default": "warning"
+				},
+				"reason": {
+					"type": "string"
+				}
+			}
+		}
+	]
+}

--- a/packages/@markuplint/rules/src/wai-aria-required-parent-role/README.ja.md
+++ b/packages/@markuplint/rules/src/wai-aria-required-parent-role/README.ja.md
@@ -1,0 +1,25 @@
+---
+description: 明示的なロールを持つ要素が必須の親コンテキストの外に配置された場合に警告します。
+---
+
+# `wai-aria-required-parent-role`
+
+明示的なロールを持つ要素が必須の親コンテキストの外に配置された場合に警告します。
+
+このルールは[`wai-aria`](../wai-aria/)ルールファミリーの一部で、きめ細かなseverity制御のために分割されたものです。
+
+<!-- textlint-disable ja-technical-writing/ja-no-mixed-period -->
+
+❌ 間違ったコード例
+
+```html
+<div role="option">item</div>
+```
+
+✅ 正しいコード例
+
+```html
+<div role="listbox"><div role="option">item</div></div>
+```
+
+<!-- textlint-enable ja-technical-writing/ja-no-mixed-period -->

--- a/packages/@markuplint/rules/src/wai-aria-required-parent-role/README.md
+++ b/packages/@markuplint/rules/src/wai-aria-required-parent-role/README.md
@@ -1,0 +1,22 @@
+---
+id: wai-aria-required-parent-role
+description: Warns when an element with an explicit role is placed outside its required parent context.
+---
+
+# `wai-aria-required-parent-role`
+
+Warns when an element with an explicit role is placed outside its required parent context.
+
+This rule is part of the [`wai-aria`](../wai-aria/) rule family, split for granular severity control.
+
+❌ Examples of **incorrect** code for this rule
+
+```html
+<div role="option">item</div>
+```
+
+✅ Examples of **correct** code for this rule
+
+```html
+<div role="listbox"><div role="option">item</div></div>
+```

--- a/packages/@markuplint/rules/src/wai-aria-required-parent-role/index.spec.ts
+++ b/packages/@markuplint/rules/src/wai-aria-required-parent-role/index.spec.ts
@@ -1,0 +1,14 @@
+import { mlRuleTest } from 'markuplint';
+import { test, expect } from 'vitest';
+
+import rule from './index.js';
+
+test('[wai-aria-required-parent-role-valid-001] correct parent context', async () => {
+	expect((await mlRuleTest(rule, '<div role="listbox"><div role="option"></div></div>')).violations).toStrictEqual(
+		[],
+	);
+});
+
+test('[wai-aria-required-parent-role-valid-002] no role attr', async () => {
+	expect((await mlRuleTest(rule, '<div></div>')).violations).toStrictEqual([]);
+});

--- a/packages/@markuplint/rules/src/wai-aria-required-parent-role/index.ts
+++ b/packages/@markuplint/rules/src/wai-aria-required-parent-role/index.ts
@@ -1,0 +1,27 @@
+import type { Options } from '../wai-aria/types.js';
+
+import { createRule, getComputedRole, getSpec } from '@markuplint/ml-core';
+import { ARIA_RECOMMENDED_VERSION } from '@markuplint/ml-spec';
+
+import { checkingRequiredAccessibilityParentRole } from '../wai-aria/checkings/required-accessibility-parent-role.js';
+import { defaultOptions } from '../wai-aria/default-options.js';
+import meta from './meta.js';
+
+/** Warns when an element with an explicit role is placed outside its required parent context. */
+export default createRule<boolean, Options>({
+	meta,
+	defaultOptions,
+	async verify({ document, report }) {
+		await document.walkOn('Element', el => {
+			const roleAttr = el.getAttributeNode('role');
+			if (!roleAttr) return;
+			const elSpec = getSpec(el, document.specs.specs);
+			if (!elSpec) return;
+			if (!elSpec.globalAttrs['#ARIAAttrs']) return;
+			const ariaVersion =
+				el.rule.options?.version ?? document.ruleCommonSettings?.ariaVersion ?? ARIA_RECOMMENDED_VERSION;
+			const computed = getComputedRole(document.specs, el, ariaVersion);
+			report(checkingRequiredAccessibilityParentRole({ el, computed }));
+		});
+	},
+});

--- a/packages/@markuplint/rules/src/wai-aria-required-parent-role/meta.ts
+++ b/packages/@markuplint/rules/src/wai-aria-required-parent-role/meta.ts
@@ -1,0 +1,3 @@
+export default {
+	category: 'a11y',
+} as const;

--- a/packages/@markuplint/rules/src/wai-aria-required-parent-role/schema.json
+++ b/packages/@markuplint/rules/src/wai-aria-required-parent-role/schema.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"value": {
+			"type": "boolean"
+		}
+	},
+	"oneOf": [
+		{
+			"$ref": "#/definitions/value"
+		},
+		{
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"value": { "$ref": "#/definitions/value" },
+				"severity": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/ml-config/schema.json#/definitions/severity",
+					"default": "error"
+				},
+				"reason": {
+					"type": "string"
+				}
+			}
+		}
+	]
+}

--- a/packages/@markuplint/rules/src/wai-aria-required-props/README.ja.md
+++ b/packages/@markuplint/rules/src/wai-aria-required-props/README.ja.md
@@ -1,0 +1,25 @@
+---
+description: ロールに必須のARIAプロパティが指定されていない場合に警告します。
+---
+
+# `wai-aria-required-props`
+
+ロールに必須のARIAプロパティが指定されていない場合に警告します。
+
+このルールは[`wai-aria`](../wai-aria/)ルールファミリーの一部で、きめ細かなseverity制御のために分割されたものです。
+
+<!-- textlint-disable ja-technical-writing/ja-no-mixed-period -->
+
+❌ 間違ったコード例
+
+```html
+<div role="slider"></div>
+```
+
+✅ 正しいコード例
+
+```html
+<div role="slider" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100"></div>
+```
+
+<!-- textlint-enable ja-technical-writing/ja-no-mixed-period -->

--- a/packages/@markuplint/rules/src/wai-aria-required-props/README.md
+++ b/packages/@markuplint/rules/src/wai-aria-required-props/README.md
@@ -1,0 +1,22 @@
+---
+id: wai-aria-required-props
+description: Warns when required ARIA properties for a role are missing.
+---
+
+# `wai-aria-required-props`
+
+Warns when required ARIA properties for a role are missing.
+
+This rule is part of the [`wai-aria`](../wai-aria/) rule family, split for granular severity control.
+
+❌ Examples of **incorrect** code for this rule
+
+```html
+<div role="slider"></div>
+```
+
+✅ Examples of **correct** code for this rule
+
+```html
+<div role="slider" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100"></div>
+```

--- a/packages/@markuplint/rules/src/wai-aria-required-props/index.spec.ts
+++ b/packages/@markuplint/rules/src/wai-aria-required-props/index.spec.ts
@@ -1,0 +1,21 @@
+import { mlRuleTest } from 'markuplint';
+import { test, expect } from 'vitest';
+
+import rule from './index.js';
+
+test('[wai-aria-required-props-valid-001] no role, no required props', async () => {
+	expect((await mlRuleTest(rule, '<div></div>')).violations).toStrictEqual([]);
+});
+
+test('[wai-aria-required-props-valid-002] role with required props present', async () => {
+	expect(
+		(await mlRuleTest(rule, '<div role="slider" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100"></div>'))
+			.violations,
+	).toStrictEqual([]);
+});
+
+test('[wai-aria-required-props-invalid-001] role missing required prop', async () => {
+	const { violations } = await mlRuleTest(rule, '<div role="slider"></div>');
+	expect(violations.length).toBeGreaterThanOrEqual(1);
+	expect(violations[0]!.severity).toBe('error');
+});

--- a/packages/@markuplint/rules/src/wai-aria-required-props/index.ts
+++ b/packages/@markuplint/rules/src/wai-aria-required-props/index.ts
@@ -1,0 +1,28 @@
+import type { Options } from '../wai-aria/types.js';
+
+import { ariaSpecs, createRule, getComputedRole, getSpec } from '@markuplint/ml-core';
+import { ARIA_RECOMMENDED_VERSION } from '@markuplint/ml-spec';
+
+import { checkingRequiredProp } from '../wai-aria/checkings/required-prop.js';
+import { defaultOptions } from '../wai-aria/default-options.js';
+import meta from './meta.js';
+
+/** Warns when required ARIA properties for a role are missing. */
+export default createRule<boolean, Options>({
+	meta,
+	defaultOptions,
+	async verify({ document, report }) {
+		await document.walkOn('Element', el => {
+			const roleAttr = el.getAttributeNode('role');
+			if (!roleAttr) return;
+			const elSpec = getSpec(el, document.specs.specs);
+			if (!elSpec) return;
+			if (!elSpec.globalAttrs['#ARIAAttrs']) return;
+			const ariaVersion =
+				el.rule.options?.version ?? document.ruleCommonSettings?.ariaVersion ?? ARIA_RECOMMENDED_VERSION;
+			const computed = getComputedRole(document.specs, el, ariaVersion);
+			const { props: propSpecs } = ariaSpecs(document.specs, ariaVersion);
+			report(checkingRequiredProp({ el, role: computed.role, propSpecs }));
+		});
+	},
+});

--- a/packages/@markuplint/rules/src/wai-aria-required-props/meta.ts
+++ b/packages/@markuplint/rules/src/wai-aria-required-props/meta.ts
@@ -1,0 +1,3 @@
+export default {
+	category: 'a11y',
+} as const;

--- a/packages/@markuplint/rules/src/wai-aria-required-props/schema.json
+++ b/packages/@markuplint/rules/src/wai-aria-required-props/schema.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"value": {
+			"type": "boolean"
+		}
+	},
+	"oneOf": [
+		{
+			"$ref": "#/definitions/value"
+		},
+		{
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"value": { "$ref": "#/definitions/value" },
+				"severity": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/ml-config/schema.json#/definitions/severity",
+					"default": "error"
+				},
+				"reason": {
+					"type": "string"
+				}
+			}
+		}
+	]
+}

--- a/packages/@markuplint/rules/src/wai-aria-value/README.ja.md
+++ b/packages/@markuplint/rules/src/wai-aria-value/README.ja.md
@@ -1,0 +1,25 @@
+---
+description: ARIAプロパティ/ステートの値が期待される型に適合しない場合に警告します。
+---
+
+# `wai-aria-value`
+
+ARIAプロパティ/ステートの値が期待される型に適合しない場合に警告します。
+
+このルールは[`wai-aria`](../wai-aria/)ルールファミリーの一部で、きめ細かなseverity制御のために分割されたものです。
+
+<!-- textlint-disable ja-technical-writing/ja-no-mixed-period -->
+
+❌ 間違ったコード例
+
+```html
+<div role="button" aria-pressed="hoge"></div>
+```
+
+✅ 正しいコード例
+
+```html
+<div role="button" aria-pressed="true"></div>
+```
+
+<!-- textlint-enable ja-technical-writing/ja-no-mixed-period -->

--- a/packages/@markuplint/rules/src/wai-aria-value/README.md
+++ b/packages/@markuplint/rules/src/wai-aria-value/README.md
@@ -1,0 +1,22 @@
+---
+id: wai-aria-value
+description: Warns when an ARIA property or state value does not conform to its expected type.
+---
+
+# `wai-aria-value`
+
+Warns when an ARIA property or state value does not conform to its expected type.
+
+This rule is part of the [`wai-aria`](../wai-aria/) rule family, split for granular severity control.
+
+❌ Examples of **incorrect** code for this rule
+
+```html
+<div role="button" aria-pressed="hoge"></div>
+```
+
+✅ Examples of **correct** code for this rule
+
+```html
+<div role="button" aria-pressed="true"></div>
+```

--- a/packages/@markuplint/rules/src/wai-aria-value/index.spec.ts
+++ b/packages/@markuplint/rules/src/wai-aria-value/index.spec.ts
@@ -1,0 +1,14 @@
+import { mlRuleTest } from 'markuplint';
+import { test, expect } from 'vitest';
+
+import rule from './index.js';
+
+test('[wai-aria-value-valid-001] valid aria value', async () => {
+	expect((await mlRuleTest(rule, '<div role="button" aria-pressed="true"></div>')).violations).toStrictEqual([]);
+});
+
+test('[wai-aria-value-invalid-001] invalid aria value', async () => {
+	const { violations } = await mlRuleTest(rule, '<div role="button" aria-pressed="hoge"></div>');
+	expect(violations.length).toBe(1);
+	expect(violations[0]!.severity).toBe('error');
+});

--- a/packages/@markuplint/rules/src/wai-aria-value/index.ts
+++ b/packages/@markuplint/rules/src/wai-aria-value/index.ts
@@ -1,0 +1,30 @@
+import type { Options } from '../wai-aria/types.js';
+
+import { createRule, getComputedRole, ariaSpecs, getSpec } from '@markuplint/ml-core';
+import { ARIA_RECOMMENDED_VERSION } from '@markuplint/ml-spec';
+
+import { checkingValue } from '../wai-aria/checkings/value.js';
+import { defaultOptions } from '../wai-aria/default-options.js';
+import meta from './meta.js';
+
+/** Warns when an ARIA property or state value does not conform to its expected type. */
+export default createRule<boolean, Options>({
+	meta,
+	defaultOptions,
+	async verify({ document, report }) {
+		await document.walkOn('Element', el => {
+			const elSpec = getSpec(el, document.specs.specs);
+			if (!elSpec) return;
+			if (!elSpec.globalAttrs['#ARIAAttrs']) return;
+			const propAttrs = el.attributes.filter(attr => /^aria-/i.test(attr.name));
+			if (propAttrs.length === 0) return;
+			const ariaVersion =
+				el.rule.options?.version ?? document.ruleCommonSettings?.ariaVersion ?? ARIA_RECOMMENDED_VERSION;
+			const computed = getComputedRole(document.specs, el, ariaVersion);
+			const { props: propSpecs } = ariaSpecs(document.specs, ariaVersion);
+			for (const attr of propAttrs) {
+				report(checkingValue({ attr, role: computed.role, propSpecs, booleanish: document.booleanish }));
+			}
+		});
+	},
+});

--- a/packages/@markuplint/rules/src/wai-aria-value/meta.ts
+++ b/packages/@markuplint/rules/src/wai-aria-value/meta.ts
@@ -1,0 +1,4 @@
+/** Rule metadata for the `wai-aria-value` rule, categorized under accessibility. */
+export default {
+	category: 'a11y',
+} as const;

--- a/packages/@markuplint/rules/src/wai-aria-value/schema.json
+++ b/packages/@markuplint/rules/src/wai-aria-value/schema.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"value": {
+			"type": "boolean"
+		}
+	},
+	"oneOf": [
+		{
+			"$ref": "#/definitions/value"
+		},
+		{
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"value": { "$ref": "#/definitions/value" },
+				"severity": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/ml-config/schema.json#/definitions/severity",
+					"default": "error"
+				},
+				"reason": {
+					"type": "string"
+				}
+			}
+		}
+	]
+}

--- a/packages/@markuplint/rules/src/wai-aria/README.ja.md
+++ b/packages/@markuplint/rules/src/wai-aria/README.ja.md
@@ -30,6 +30,12 @@ description: WAI-ARIAおよびARIA in HTMLの仕様のとおりrole属性また�
 
 <!-- textlint-disable ja-technical-writing/ja-no-mixed-period -->
 
+> [!TIP]
+> このルールは、きめ細かなseverity制御のために個別のサブルールに分割されました。
+> `markuplint:a11y`プリセットを使用すると、各チェックが独立したルール
+> （例: `wai-aria-non-existent-role`、`wai-aria-implicit-role`）として実行されます。
+> `wai-aria: true`を使用すれば、従来通り全てのチェックをまとめて有効化できます。
+
 ❌ 間違ったコード例
 
 ```html

--- a/packages/@markuplint/rules/src/wai-aria/README.md
+++ b/packages/@markuplint/rules/src/wai-aria/README.md
@@ -29,6 +29,12 @@ Warn if:
   - Set ARIA attributes on descendants of roles whose children are presentational.
   - Use focusable interactive elements hidden via `aria-hidden`.
 
+> [!TIP]
+> This rule has been split into individual sub-rules for granular severity control.
+> When using the `markuplint:a11y` preset, each check runs as an independent rule
+> (e.g., `wai-aria-non-existent-role`, `wai-aria-implicit-role`).
+> You can still use `wai-aria: true` to enable all checks at once.
+
 ❌ Examples of **incorrect** code for this rule
 
 ```html

--- a/packages/@markuplint/rules/src/wai-aria/default-options.ts
+++ b/packages/@markuplint/rules/src/wai-aria/default-options.ts
@@ -1,0 +1,21 @@
+import type { Options } from './types.js';
+import type { ARIAVersion } from '@markuplint/ml-spec';
+
+/**
+ * Default options shared by the `wai-aria` rule and all `wai-aria-*` sub-rules.
+ */
+export const defaultOptions: Options = {
+	checkingValue: true,
+	checkingDeprecatedRole: true,
+	checkingDeprecatedProps: true,
+	permittedAriaRoles: true,
+	checkingAllowedAccessibilityChildRoles: true,
+	checkingRequiredOwnedElements: true,
+	checkingRequiredAccessibilityParentRole: true,
+	checkingPresentationalChildren: false,
+	checkingInteractionInHidden: false,
+	disallowSetImplicitRole: true,
+	disallowSetImplicitProps: true,
+	disallowDefaultValue: false,
+	version: undefined as ARIAVersion | undefined,
+};

--- a/packages/@markuplint/rules/src/wai-aria/index.ts
+++ b/packages/@markuplint/rules/src/wai-aria/index.ts
@@ -1,10 +1,10 @@
 import type { Options } from './types.js';
 
 import { createRule, getAttrSpecs, getComputedRole, ariaSpecs, getSpec } from '@markuplint/ml-core';
-import type { ARIAVersion } from '@markuplint/ml-spec';
 import { ARIA_RECOMMENDED_VERSION } from '@markuplint/ml-spec';
 
 import { Collection } from '../helpers.js';
+import { defaultOptions } from './default-options.js';
 
 import { checkingAbstractRole } from './checkings/abstract-role.js';
 import { checkingDefaultValue } from './checkings/default-value.js';
@@ -36,21 +36,7 @@ import meta from './meta.js';
  */
 export default createRule<boolean, Options>({
 	meta: meta,
-	defaultOptions: {
-		checkingValue: true,
-		checkingDeprecatedRole: true,
-		checkingDeprecatedProps: true,
-		permittedAriaRoles: true,
-		checkingAllowedAccessibilityChildRoles: true,
-		checkingRequiredOwnedElements: true,
-		checkingRequiredAccessibilityParentRole: true,
-		checkingPresentationalChildren: false,
-		checkingInteractionInHidden: false,
-		disallowSetImplicitRole: true,
-		disallowSetImplicitProps: true,
-		disallowDefaultValue: false,
-		version: undefined as ARIAVersion | undefined,
-	},
+	defaultOptions,
 	async verify({ document, report, t }) {
 		await document.walkOn('Element', el => {
 			const roleAttr = el.getAttributeNode('role');

--- a/packages/markuplint/src/api/ml-engine.spec.ts
+++ b/packages/markuplint/src/api/ml-engine.spec.ts
@@ -130,9 +130,9 @@ describe('Config Priority', () => {
 		// @ts-ignore
 		expect(configSet?.config.rules?.__hoge).toBe(true);
 		// @ts-ignore
-		expect(configSet?.config.rules?.['a11y/wai-aria']).toStrictEqual({
+		expect(configSet?.config.rules?.['a11y/wai-aria/non-existent-role']).toStrictEqual({
 			specConformance: 'normative',
-			rules: { 'wai-aria': true },
+			rules: { 'wai-aria-non-existent-role': true },
 		});
 	});
 
@@ -155,9 +155,9 @@ describe('Config Priority', () => {
 		// @ts-ignore
 		expect(configSet?.config.rules?.__hoge).toBe(undefined);
 		// @ts-ignore
-		expect(configSet?.config.rules?.['a11y/wai-aria']).toStrictEqual({
+		expect(configSet?.config.rules?.['a11y/wai-aria/non-existent-role']).toStrictEqual({
 			specConformance: 'normative',
-			rules: { 'wai-aria': true },
+			rules: { 'wai-aria-non-existent-role': true },
 		});
 	});
 

--- a/packages/markuplint/src/cli/init/get-default-rules.spec.ts
+++ b/packages/markuplint/src/cli/init/get-default-rules.spec.ts
@@ -197,5 +197,69 @@ test('default-rules', () => {
 			category: 'a11y',
 			defaultValue: true,
 		},
+		'wai-aria-abstract-role': {
+			category: 'a11y',
+			defaultValue: true,
+		},
+		'wai-aria-default-value': {
+			category: 'a11y',
+			defaultValue: false,
+		},
+		'wai-aria-deprecated-props': {
+			category: 'a11y',
+			defaultValue: false,
+		},
+		'wai-aria-deprecated-role': {
+			category: 'a11y',
+			defaultValue: false,
+		},
+		'wai-aria-disallowed-props': {
+			category: 'a11y',
+			defaultValue: true,
+		},
+		'wai-aria-implicit-props': {
+			category: 'a11y',
+			defaultValue: false,
+		},
+		'wai-aria-implicit-role': {
+			category: 'a11y',
+			defaultValue: false,
+		},
+		'wai-aria-interaction-in-hidden': {
+			category: 'a11y',
+			defaultValue: false,
+		},
+		'wai-aria-no-global-prop': {
+			category: 'a11y',
+			defaultValue: true,
+		},
+		'wai-aria-non-existent-role': {
+			category: 'a11y',
+			defaultValue: true,
+		},
+		'wai-aria-permitted-roles': {
+			category: 'a11y',
+			defaultValue: true,
+		},
+		'wai-aria-presentational-children': {
+			category: 'a11y',
+			defaultValue: false,
+		},
+		'wai-aria-required-owned-elements': {
+			category: 'a11y',
+			defaultValue: false,
+		},
+		'wai-aria-required-parent-role': {
+			category: 'a11y',
+			defaultValue: true,
+		},
+		'wai-aria-required-props': {
+			category: 'a11y',
+			defaultValue: true,
+		},
+		'wai-aria-value': {
+			category: 'a11y',
+			defaultValue: true,
+		},
 	});
 });

--- a/packages/markuplint/src/index.spec.ts
+++ b/packages/markuplint/src/index.spec.ts
@@ -174,39 +174,51 @@ describe('basic test', () => {
 			'require-accessible-name',
 			'require-accessible-name',
 			'require-accessible-name',
-			'wai-aria',
-			'wai-aria',
-			'wai-aria',
-			'wai-aria',
-			'wai-aria',
-			'wai-aria',
-			'wai-aria',
-			'wai-aria',
-			'wai-aria',
-			'wai-aria',
-			'wai-aria',
-			'wai-aria',
-			'wai-aria',
-			'wai-aria',
-			'wai-aria',
-			'wai-aria',
-			'wai-aria',
-			'wai-aria',
-			'wai-aria',
-			'wai-aria',
-			'wai-aria',
-			'wai-aria',
-			'wai-aria',
-			'wai-aria',
-			'wai-aria',
-			'wai-aria',
-			'wai-aria',
-			'wai-aria',
-			'wai-aria',
-			'wai-aria',
-			'wai-aria',
-			'wai-aria',
-			'wai-aria',
+			'wai-aria-non-existent-role',
+			'wai-aria-non-existent-role',
+			'wai-aria-abstract-role',
+			'wai-aria-abstract-role',
+			'wai-aria-permitted-roles',
+			'wai-aria-permitted-roles',
+			'wai-aria-permitted-roles',
+			'wai-aria-permitted-roles',
+			'wai-aria-permitted-roles',
+			'wai-aria-permitted-roles',
+			'wai-aria-permitted-roles',
+			'wai-aria-implicit-role',
+			'wai-aria-implicit-role',
+			'wai-aria-implicit-role',
+			'wai-aria-implicit-role',
+			'wai-aria-implicit-role',
+			'wai-aria-implicit-role',
+			'wai-aria-implicit-role',
+			'wai-aria-implicit-props',
+			'wai-aria-implicit-props',
+			'wai-aria-implicit-props',
+			'wai-aria-implicit-props',
+			'wai-aria-implicit-props',
+			'wai-aria-implicit-props',
+			'wai-aria-required-props',
+			'wai-aria-required-props',
+			'wai-aria-disallowed-props',
+			'wai-aria-disallowed-props',
+			'wai-aria-disallowed-props',
+			'wai-aria-disallowed-props',
+			'wai-aria-disallowed-props',
+			'wai-aria-disallowed-props',
+			'wai-aria-disallowed-props',
+			'wai-aria-disallowed-props',
+			'wai-aria-disallowed-props',
+			'wai-aria-disallowed-props',
+			'wai-aria-disallowed-props',
+			'wai-aria-disallowed-props',
+			'wai-aria-disallowed-props',
+			'wai-aria-value',
+			'wai-aria-value',
+			'wai-aria-value',
+			'wai-aria-value',
+			'wai-aria-value',
+			'wai-aria-value',
 			'required-element',
 			'required-attr',
 			'required-attr',
@@ -239,6 +251,26 @@ describe('basic test', () => {
 	it('is ignoring 008.html', async () => {
 		const { violations } = await mlTestFile('test/fixture/008.html');
 		expect(violations).toStrictEqual([]);
+	});
+});
+
+describe('wai-aria sub-rule severity via preset', () => {
+	test('normative sub-rule reports as error', async () => {
+		const { violations } = await mlTest('<div role="hoge"></div>', {
+			extends: ['markuplint:a11y'],
+		});
+		const nonExistentRole = violations.find(v => v.ruleId === 'wai-aria-non-existent-role');
+		expect(nonExistentRole).toBeDefined();
+		expect(nonExistentRole!.severity).toBe('error');
+	});
+
+	test('non-normative sub-rule reports as warning', async () => {
+		const { violations } = await mlTest('<nav role="navigation"></nav>', {
+			extends: ['markuplint:a11y'],
+		});
+		const implicitRole = violations.find(v => v.ruleId === 'wai-aria-implicit-role');
+		expect(implicitRole).toBeDefined();
+		expect(implicitRole!.severity).toBe('warning');
 	});
 });
 

--- a/packages/markuplint/src/named-noderules.spec.ts
+++ b/packages/markuplint/src/named-noderules.spec.ts
@@ -939,13 +939,13 @@ describe('Named nodeRules integration', () => {
 							selector: '.ignore',
 							inheritance: true,
 							rules: {
-								'wai-aria': false,
+								'wai-aria-non-existent-role': false,
 							},
 						},
 					],
 				},
 			);
-			const waiAriaViolations = violations.filter(v => v.ruleId === 'wai-aria');
+			const waiAriaViolations = violations.filter(v => v.ruleId === 'wai-aria-non-existent-role');
 			expect(waiAriaViolations).toHaveLength(0);
 		});
 
@@ -959,13 +959,13 @@ describe('Named nodeRules integration', () => {
 							selector: '.ignore',
 							inheritance: true,
 							rules: {
-								'wai-aria': false,
+								'wai-aria-non-existent-role': false,
 							},
 						},
 					],
 				},
 			);
-			const waiAriaViolations = violations.filter(v => v.ruleId === 'wai-aria');
+			const waiAriaViolations = violations.filter(v => v.ruleId === 'wai-aria-non-existent-role');
 			// role="foo" outside .ignore is still reported; role="bar" inside .ignore is suppressed
 			expect(waiAriaViolations).toHaveLength(1);
 			expect(waiAriaViolations[0]!.message).toContain('foo');
@@ -980,13 +980,13 @@ describe('Named nodeRules integration', () => {
 						{
 							selector: 'div',
 							rules: {
-								'wai-aria': false,
+								'wai-aria-non-existent-role': false,
 							},
 						},
 					],
 				},
 			);
-			const waiAriaViolations = violations.filter(v => v.ruleId === 'wai-aria');
+			const waiAriaViolations = violations.filter(v => v.ruleId === 'wai-aria-non-existent-role');
 			expect(waiAriaViolations).toHaveLength(0);
 		});
 
@@ -1033,7 +1033,7 @@ describe('Named nodeRules integration', () => {
 			expect(a11yViolations).toHaveLength(0);
 		});
 
-		it('propagates option override from base rule name to virtual rules', async () => {
+		it('propagates disable from base rule name to virtual rules via nodeRules', async () => {
 			const { violations } = await mlTest(
 				'<!doctype html><html lang="en"><head><meta charset="UTF-8"></head><body><img src="icon.svg" alt="icon" role="img" /></body></html>',
 				{
@@ -1042,22 +1042,20 @@ describe('Named nodeRules integration', () => {
 						{
 							selector: 'img[src$=".svg"]',
 							rules: {
-								'wai-aria': {
-									options: {
-										disallowSetImplicitRole: false,
-									},
-								},
+								'wai-aria-implicit-role': false,
 							},
 						},
 					],
 				},
 			);
-			// Base rule name option override propagates to a11y/wai-aria virtual rule
-			const implicitRoleViolations = violations.filter(v => v.ruleId === 'wai-aria' && v.message.includes('img'));
+			// Base rule name disable propagates to a11y/wai-aria/implicit-role virtual rule
+			const implicitRoleViolations = violations.filter(
+				v => v.ruleId === 'wai-aria-implicit-role' && v.message.includes('img'),
+			);
 			expect(implicitRoleViolations).toHaveLength(0);
 		});
 
-		it('propagates option override via childNodeRules to virtual rules', async () => {
+		it('propagates disable via childNodeRules to virtual rules', async () => {
 			const { violations } = await mlTest(
 				'<!doctype html><html lang="en"><head><meta charset="UTF-8"></head><body><div class="svg-section"><img src="icon.svg" alt="icon" role="img" /></div></body></html>',
 				{
@@ -1067,17 +1065,15 @@ describe('Named nodeRules integration', () => {
 							selector: '.svg-section',
 							inheritance: true,
 							rules: {
-								'wai-aria': {
-									options: {
-										disallowSetImplicitRole: false,
-									},
-								},
+								'wai-aria-implicit-role': false,
 							},
 						},
 					],
 				},
 			);
-			const implicitRoleViolations = violations.filter(v => v.ruleId === 'wai-aria' && v.message.includes('img'));
+			const implicitRoleViolations = violations.filter(
+				v => v.ruleId === 'wai-aria-implicit-role' && v.message.includes('img'),
+			);
 			expect(implicitRoleViolations).toHaveLength(0);
 		});
 


### PR DESCRIPTION
## Summary

- Split the monolithic `wai-aria` rule into 16 independent sub-rules for granular severity control (#3645)
- Update `preset.a11y.jsonc` to use individual `namedRuleGroup` entries (`a11y/wai-aria/non-existent-role`, etc.)
- The original `wai-aria` rule is preserved for backward compatibility

## Sub-rules

| Sub-rule | Default Severity | Spec Conformance |
|----------|-----------------|-----------------|
| `wai-aria-non-existent-role` | error | normative |
| `wai-aria-abstract-role` | error | normative |
| `wai-aria-permitted-roles` | error | normative |
| `wai-aria-implicit-role` | warning | non-normative |
| `wai-aria-implicit-props` | warning | non-normative |
| `wai-aria-required-props` | error | normative |
| `wai-aria-disallowed-props` | error | normative |
| `wai-aria-deprecated-role` | warning | non-normative |
| `wai-aria-deprecated-props` | warning | non-normative |
| `wai-aria-value` | error | normative |
| `wai-aria-required-owned-elements` | warning | normative |
| `wai-aria-required-parent-role` | error | normative |
| `wai-aria-presentational-children` | warning | non-normative |
| `wai-aria-no-global-prop` | error | normative |
| `wai-aria-default-value` | warning | non-normative |
| `wai-aria-interaction-in-hidden` | warning | non-normative |

## Test plan

- [x] Existing `wai-aria` tests pass (160 tests)
- [x] Each sub-rule has its own `.spec.ts` with valid/invalid tests (37 new tests)
- [x] Integration tests verify preset severity (error vs warning)
- [x] Full test suite passes (218 files, 3167 tests)

Closes #3645

🤖 Generated with [Claude Code](https://claude.com/claude-code)