### PR TITLE
fix(html-spec): override MDN incorrect experimental flag on video loading attribute

### DIFF
--- a/packages/@markuplint/html-spec/src/spec.video.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.video.jsonc
@@ -45,6 +45,11 @@
 		]
 	},
 	"attributes": {
+		"loading": {
+			// MDN incorrectly marks this as experimental, but it is defined in the HTML Living Standard.
+			// https://html.spec.whatwg.org/multipage/media.html#the-video-element
+			"experimental": false
+		},
 		// https://html.spec.whatwg.org/multipage/media.html#attr-video-poster
 		"poster": {
 			"type": "URL"


### PR DESCRIPTION
## Summary
- MDN incorrectly marks `video` element's `loading` attribute as experimental
- The `loading` attribute is defined in the [HTML Living Standard](https://html.spec.whatwg.org/multipage/media.html#the-video-element) as a standard attribute
- Added `"experimental": false` override in `spec.video.jsonc` to prevent the auto-generated spec from inheriting MDN's incorrect classification

Closes #3697

## Test plan
- [x] `yarn build` passes
- [x] `yarn test` passes (218 files, 3170 tests)
- [x] `yarn up:gen` generates correct output with `"experimental": false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)