### PR TITLE
fix(html-spec): restore ARIA 1.3 role name extraction

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -85,7 +85,7 @@ Specs:
     - changed-files:
           - any-glob-to-any-file:
                 - packages/@markuplint/*-spec/src/**/*
-                - packages/@markuplint/spec-generator/src/**/*
+                - packages/@markuplint/html-spec/generator/**/*
 
 VS Code Extension:
     - changed-files:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,6 @@ Each package has a `SKILL.md` with package-specific maintenance guidance.
 | `@markuplint/parser-utils`    | Maintenance tasks for parser-utils                                    | [SKILL.md](packages/@markuplint/parser-utils/SKILL.md)    |
 | `@markuplint/html-parser`     | Maintenance tasks for html-parser                                     | [SKILL.md](packages/@markuplint/html-parser/SKILL.md)     |
 | `@markuplint/html-spec`       | Maintenance tasks for html-spec                                       | [SKILL.md](packages/@markuplint/html-spec/SKILL.md)       |
-| `@markuplint/spec-generator`  | Maintenance tasks for spec-generator                                  | [SKILL.md](packages/@markuplint/spec-generator/SKILL.md)  |
 | `@markuplint/i18n`            | Maintenance tasks for i18n (internationalization)                     | [SKILL.md](packages/@markuplint/i18n/SKILL.md)            |
 | `@markuplint/create-rule`     | Maintenance tasks for create-rule (CLI scaffolding tool)              | [SKILL.md](packages/@markuplint/create-rule/SKILL.md)     |
 | `@markuplint/react-spec`      | Maintenance tasks for react-spec                                      | [SKILL.md](packages/@markuplint/react-spec/SKILL.md)      |

--- a/docs/architectures/ARCHITECTURE.md
+++ b/docs/architectures/ARCHITECTURE.md
@@ -218,7 +218,7 @@ The data generation process is a key architectural decision that influences the 
 
 ```
 Individual JSONC Sources (spec.table.jsonc, spec.tr.jsonc...)
-    ↓ @markuplint/spec-generator processing
+    ↓ generator/ scripts processing
 External Data Enrichment (MDN, W3C ARIA, HTML Standard)
     ↓ Consolidation and validation
 Single JSON Output (index.json, 48K+ lines)
@@ -413,14 +413,14 @@ The ml-spec package follows a taxonomy-based organization that improves code cla
   ↓
 @markuplint/ml-spec (gen/gen.ts) → schemas/*.json
   ↓
-@markuplint/html-spec (build.mjs + @markuplint/spec-generator) → index.json
+@markuplint/html-spec (build.ts + generator/) → index.json
   ↓
 Framework-specific specs (extend base data)
 ```
 
 **Responsibility Boundaries**:
 
-- **@markuplint/spec-generator**: External data fetching and enrichment (MDN scraping, W3C ARIA downloading)
+- **@markuplint/html-spec/generator/**: External data fetching and enrichment (MDN scraping, W3C ARIA downloading)
 - **@markuplint/ml-spec/gen/**: Schema structure generation and type-to-schema transformations
 - **Package build scripts**: Local data processing and file operations
 
@@ -438,7 +438,7 @@ Framework-specific specs (extend base data)
 1. **Package Separation**: Would create artificial boundaries and reduce performance
 2. **Algorithm Extraction to Separate Package**: Would break specification coupling and reduce maintainability
 3. **Data Structure Changes**: Would require extensive migration with minimal benefits
-4. **Generator Responsibility Mixing**: Moving schema operations to spec-generator would muddy architectural boundaries
+4. **Generator Responsibility Mixing**: Moving schema operations to the generator would muddy architectural boundaries
 
 ## Package Operation Order
 

--- a/packages/@markuplint/html-spec/ARCHITECTURE.ja.md
+++ b/packages/@markuplint/html-spec/ARCHITECTURE.ja.md
@@ -4,7 +4,7 @@
 
 `@markuplint/html-spec` は HTML Living Standard のデータセットプロバイダです。TypeScript ソースコードを含まない純粋なデータパッケージであり、208 個の要素 JSON 仕様ファイル（HTML、SVG、MathML）と 2 個の共通定義ファイルから構成されます。
 
-ビルド時に `@markuplint/spec-generator` が外部ソース（MDN、W3C ARIA 1.1/1.2/1.3、HTML Living Standard、SVG 仕様、MathML 仕様）からデータをフェッチし、手動で管理されたローカル仕様とマージして、統合された `index.json`（48,000 行以上、約 1.4MB）を生成します。手動データは常に外部データより優先され、仕様の正確性を保証します。
+ビルド時に `generator/` のスクリプトが外部ソース（MDN、W3C ARIA 1.1/1.2/1.3、HTML Living Standard、SVG 仕様、MathML 仕様）からデータをフェッチし、手動で管理されたローカル仕様とマージして、統合された `index.json`（48,000 行以上、約 1.4MB）を生成します。手動データは常に外部データより優先され、仕様の正確性を保証します。
 
 ## ディレクトリ構成
 
@@ -18,7 +18,7 @@ src/
 ├── spec-common.attributes.jsonc      # 20 個のグローバル属性カテゴリ定義
 └── spec-common.contents.jsonc        # HTML 10 + SVG 19 + MathML 3 のコンテンツモデルカテゴリ定義
 
-build.mjs                             # @markuplint/spec-generator を呼び出すビルドスクリプト
+build.ts                              # generator/ モジュールを呼び出すビルドスクリプト
 index.json                            # 生成出力（48K 行以上、編集不可）
 index.js                              # CommonJS エントリーポイント
 index.d.ts                            # TypeScript 型宣言
@@ -38,7 +38,7 @@ flowchart TD
 
     subgraph build ["ビルドパイプライン"]
         buildMjs["build.mjs"]
-        specGen["@markuplint/spec-generator\nmain()"]
+        specGen["generator/\nmain()"]
     end
 
     subgraph external ["外部データソース"]
@@ -119,7 +119,7 @@ export = json;
 | -------------- | --------------------------------------- | ------------------------------------------------------------- |
 | ソース仕様     | `src/spec.*.jsonc`（208 ファイル）      | 要素ごとの仕様定義（コンテンツモデル、属性、ARIA マッピング） |
 | 共通定義       | `src/spec-common.*.jsonc`（2 ファイル） | グローバル属性カテゴリとコンテンツモデルマクロの共有定義      |
-| ビルドシステム | `build.mjs`                             | `@markuplint/spec-generator` の `main()` を呼び出すエントリー |
+| ビルドシステム | `build.ts`                              | `generator/` の `main()` を呼び出すエントリー                 |
 | 生成出力       | `index.json`                            | 統合データセット（48K 行以上、直接編集不可）                  |
 | 型宣言         | `index.d.ts`                            | `@markuplint/ml-spec` からの型を再エクスポート                |
 | スキーマ検証   | `test/structure.spec.mjs`               | Ajv ベースの JSON スキーマ検証テスト                          |
@@ -186,19 +186,7 @@ export = json;
 
 ## ビルドパイプライン
 
-ビルドは `build.mjs` を通じて `@markuplint/spec-generator` の `main()` 関数を呼び出します。
-
-```javascript
-import path from 'node:path';
-import { main } from '@markuplint/spec-generator';
-
-await main({
-  outputFilePath: path.resolve(import.meta.dirname, 'index.json'),
-  htmlFilePattern: path.resolve(import.meta.dirname, 'src', 'spec.*.jsonc'),
-  commonAttrsFilePath: path.resolve(import.meta.dirname, 'src', 'spec-common.attributes.jsonc'),
-  commonContentsFilePath: path.resolve(import.meta.dirname, 'src', 'spec-common.contents.jsonc'),
-});
-```
+ビルドは `build.ts` を通じて `generator/` の `main()` 関数を呼び出します。
 
 ビルドプロセスの流れ:
 
@@ -231,18 +219,17 @@ yarn gen:prettier
 
 ## 外部依存パッケージ
 
-| パッケージ                   | 種別 | 用途                                         |
-| ---------------------------- | ---- | -------------------------------------------- |
-| `@markuplint/ml-spec`        | 本番 | 型定義（`Cites`, `ElementSpec`, `SpecDefs`） |
-| `@markuplint/spec-generator` | 開発 | ビルドパイプライン                           |
-| `@markuplint/test-tools`     | 開発 | テストユーティリティ（`glob` 等）            |
+| パッケージ               | 種別 | 用途                                         |
+| ------------------------ | ---- | -------------------------------------------- |
+| `@markuplint/ml-spec`    | 本番 | 型定義（`Cites`, `ElementSpec`, `SpecDefs`） |
+| `@markuplint/test-tools` | 開発 | テストユーティリティ（`glob` 等）            |
 
 ## 他パッケージとの連携
 
 ```mermaid
 flowchart LR
     subgraph upstream ["上流パッケージ"]
-        specGen["@markuplint/spec-generator\n(ビルドパイプライン)"]
+        specGen["generator/\n(ビルドパイプライン)"]
         mlSpecTypes["@markuplint/ml-spec\n(型定義)"]
     end
 
@@ -273,7 +260,7 @@ flowchart LR
 ### 上流
 
 - **`@markuplint/ml-spec`** は `index.d.ts` で使用される型定義（`Cites`, `ElementSpec`, `SpecDefs`）を提供します。
-- **`@markuplint/spec-generator`** はビルド時に外部仕様のフェッチとデータ統合を担当します。
+- **`generator/`** はビルド時に外部仕様のフェッチとデータ統合を担当します。
 
 ### 下流
 
@@ -285,5 +272,5 @@ flowchart LR
 ## ドキュメントマップ
 
 - [要素仕様フォーマット](docs/element-spec-format.ja.md) -- 要素 JSON の構造、フィールド定義、条件分岐パターン
-- [ビルドパイプライン](docs/build-pipeline.ja.md) -- spec-generator の動作、外部データフェッチ、マージ戦略
+- [ビルドパイプライン](docs/build-pipeline.ja.md) -- generator の動作、外部データフェッチ、マージ戦略
 - [メンテナンスガイド](docs/maintenance.ja.md) -- 新規要素の追加、属性更新、外部仕様の変更対応

--- a/packages/@markuplint/html-spec/ARCHITECTURE.md
+++ b/packages/@markuplint/html-spec/ARCHITECTURE.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-`@markuplint/html-spec` is the canonical HTML Living Standard dataset provider for markuplint. It is a pure data package with no TypeScript source code. It contains 208 per-element JSON specification files (HTML, SVG, and MathML) and 2 common definition files that are processed by `@markuplint/spec-generator` to produce a single consolidated `index.json` (48K+ lines, 1.4MB).
+`@markuplint/html-spec` is the canonical HTML Living Standard dataset provider for markuplint. It is a pure data package with no TypeScript source code. It contains 208 per-element JSON specification files (HTML, SVG, and MathML) and 2 common definition files that are processed by `generator/` scripts to produce a single consolidated `index.json` (48K+ lines, 1.4MB).
 
-During the build, `@markuplint/spec-generator` fetches live data from MDN, W3C ARIA specifications (1.1, 1.2, 1.3), Graphics ARIA, DPub ARIA, HTML-ARIA mappings, the HTML Living Standard, SVG specifications, and MathML specifications, then merges that external data with the hand-authored JSON files. Manual specifications always take precedence over fetched data, ensuring stable, curated definitions while still benefiting from automated enrichment.
+During the build, `generator/` fetches live data from MDN, W3C ARIA specifications (1.1, 1.2, 1.3), Graphics ARIA, DPub ARIA, HTML-ARIA mappings, the HTML Living Standard, SVG specifications, and MathML specifications, then merges that external data with the hand-authored JSON files. Manual specifications always take precedence over fetched data, ensuring stable, curated definitions while still benefiting from automated enrichment.
 
 ## Directory Structure
 
@@ -18,7 +18,7 @@ src/
 ├── spec-common.attributes.jsonc      # 20 global attribute category definitions
 └── spec-common.contents.jsonc        # 10 HTML + 19 SVG + 3 MathML content model category definitions
 
-build.mjs                             # Build script invoking @markuplint/spec-generator
+build.ts                              # Build script invoking generator/ modules
 index.json                            # Generated output (48K+ lines, DO NOT EDIT)
 index.js                              # CommonJS entry point (re-exports index.json)
 index.d.ts                            # TypeScript type declarations
@@ -38,7 +38,7 @@ flowchart TD
 
     subgraph build ["Build Pipeline"]
         buildScript["build.mjs"]
-        specGen["@markuplint/spec-generator\nmain()"]
+        specGen["generator/\nmain()"]
     end
 
     subgraph external ["External Data Sources"]
@@ -142,18 +142,17 @@ An array of element specifications. Each entry defines a single HTML, SVG, or Ma
 | --------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------ |
 | Source Specifications | 208 `src/spec.*.jsonc` files                                 | Per-element definitions: content models, attributes, ARIA mappings             |
 | Common Definitions    | `spec-common.attributes.jsonc`, `spec-common.contents.jsonc` | Shared global attribute categories and content model category macros           |
-| Build System          | `build.mjs`                                                  | Invokes `@markuplint/spec-generator` to merge sources with external data       |
+| Build System          | `build.ts`                                                   | Invokes `generator/` to merge sources with external data                       |
 | Generated Output      | `index.json`                                                 | Single consolidated dataset consumed by downstream packages                    |
 | Type Declarations     | `index.d.ts`                                                 | Re-exports `Cites`, `ElementSpec`, `SpecDefs` from `@markuplint/ml-spec`       |
 | Schema Validation     | `test/structure.spec.mjs`                                    | Ajv-based validation of generated output against `@markuplint/ml-spec` schemas |
 
 ## External Dependencies
 
-| Dependency                   | Type       | Purpose                                                      |
-| ---------------------------- | ---------- | ------------------------------------------------------------ |
-| `@markuplint/ml-spec`        | Production | Type definitions (`Cites`, `ElementSpec`, `SpecDefs`)        |
-| `@markuplint/spec-generator` | Dev        | Build pipeline: merges manual specs with MDN/W3C/WHATWG data |
-| `@markuplint/test-tools`     | Dev        | Test utilities (`glob` for file discovery)                   |
+| Dependency               | Type       | Purpose                                               |
+| ------------------------ | ---------- | ----------------------------------------------------- |
+| `@markuplint/ml-spec`    | Production | Type definitions (`Cites`, `ElementSpec`, `SpecDefs`) |
+| `@markuplint/test-tools` | Dev        | Test utilities (`glob` for file discovery)            |
 
 ## Integration Points
 
@@ -161,7 +160,7 @@ An array of element specifications. Each entry defines a single HTML, SVG, or Ma
 flowchart LR
     subgraph upstream ["Upstream"]
         mlSpec["@markuplint/ml-spec\n(types + schemas)"]
-        specGen["@markuplint/spec-generator\n(build tool)"]
+        specGen["generator/\n(build scripts)"]
     end
 
     subgraph pkg ["@markuplint/html-spec"]
@@ -192,7 +191,7 @@ flowchart LR
 ### Upstream
 
 - **`@markuplint/ml-spec`** provides the TypeScript type definitions (`MLMLSpec`, `ElementSpec`, `SpecDefs`) and JSON schemas used to validate the generated output. The `index.d.ts` re-exports these types.
-- **`@markuplint/spec-generator`** is the build tool invoked by `build.mjs`. It reads the source JSON files, fetches live data from MDN Web Docs, W3C ARIA specifications (versions 1.1, 1.2, 1.3), Graphics ARIA, DPub ARIA, HTML-ARIA mappings, the HTML Living Standard, SVG specifications, and MathML specifications, then merges everything into `index.json`.
+- **`generator/`** is the build module invoked by `build.ts`. It reads the source JSON files, fetches live data from MDN Web Docs, W3C ARIA specifications (versions 1.1, 1.2, 1.3), Graphics ARIA, DPub ARIA, HTML-ARIA mappings, the HTML Living Standard, SVG specifications, and MathML specifications, then merges everything into `index.json`.
 
 ### Downstream
 
@@ -203,5 +202,5 @@ flowchart LR
 ## Documentation Map
 
 - [Element Specification Format](docs/element-spec-format.md) -- Structure and fields of per-element JSON files
-- [Build Pipeline](docs/build-pipeline.md) -- How build.mjs and spec-generator produce index.json
+- [Build Pipeline](docs/build-pipeline.md) -- How build.ts and generator/ produce index.json
 - [Maintenance Guide](docs/maintenance.md) -- Adding elements, updating external sources, troubleshooting

--- a/packages/@markuplint/html-spec/README.md
+++ b/packages/@markuplint/html-spec/README.md
@@ -41,7 +41,7 @@ Core packages (Application Layer)
 
 ### Build System
 
-- **`build.mjs`** - Generation script that invokes `@markuplint/spec-generator`
+- **`build.ts`** - Generation script that invokes `generator/` modules
 - Fetches live data from MDN, W3C ARIA specs, Graphics ARIA, DPub ARIA, HTML-ARIA mappings, HTML Living Standard, SVG specs, and MathML specs
 
 ## Relationship to @markuplint/ml-spec
@@ -79,7 +79,7 @@ For detailed documentation, see:
 
 - [Architecture](ARCHITECTURE.md) -- Package structure, data flow, and integration points
 - [Element Specification Format](docs/element-spec-format.md) -- JSON spec file reference, content models, ARIA integration
-- [Build Pipeline](docs/build-pipeline.md) -- Build process, external data sources, spec-generator modules
+- [Build Pipeline](docs/build-pipeline.md) -- Build process, external data sources, generator modules
 - [Maintenance Guide](docs/maintenance.md) -- Common recipes, testing, troubleshooting
 
 ## License

--- a/packages/@markuplint/html-spec/SKILL.md
+++ b/packages/@markuplint/html-spec/SKILL.md
@@ -46,7 +46,7 @@ and review what has changed.
 yarn up:gen
 ```
 
-This runs `@markuplint/spec-generator`, which scrapes live MDN data and merges it with
+This runs the generator scripts in `generator/`, which scrape live MDN data and merge it with
 the manual spec files in `src/`. The result is written to `index.json`.
 
 ### Step 2: Review the diff
@@ -191,9 +191,9 @@ Mark an element as obsolete. Follow recipe #8 in `docs/maintenance.md`.
 
 There are two approaches:
 
-- **Via spec-generator's hardcoded list** (preferred for standard obsolete elements):
+- **Via generator's hardcoded list** (preferred for standard obsolete elements):
   Add the element name to the `obsoleteList` array in
-  `packages/@markuplint/spec-generator/src/html-elements.ts`
+  `packages/@markuplint/html-spec/generator/html-elements.ts`
 - **Via manual spec file**: Set `"obsolete": true` in the element's
   `src/spec.<element>.jsonc`
 

--- a/packages/@markuplint/html-spec/docs/build-pipeline.ja.md
+++ b/packages/@markuplint/html-spec/docs/build-pipeline.ja.md
@@ -4,7 +4,7 @@
 
 ## 概要
 
-`@markuplint/html-spec` は `@markuplint/spec-generator` を使用して、単一の統合 `index.json` ファイルを生成します。ビルドプロセス:
+`@markuplint/html-spec` は `generator/` のスクリプトを使用して、単一の統合 `index.json` ファイルを生成します。ビルドプロセス:
 
 1. `src/` から 208 個の要素 JSON 仕様ファイル（HTML、SVG、MathML）と 2 個の共通定義ファイルを読み込む
 2. MDN Web Docs、W3C ARIA 仕様、HTML Living Standard から外部データをフェッチ
@@ -24,8 +24,8 @@ flowchart TD
     end
 
     subgraph build ["ビルド"]
-        buildScript["build.mjs"]
-        specGen["@markuplint/spec-generator"]
+        buildScript["build.ts"]
+        specGen["generator/"]
     end
 
     subgraph external ["外部データソース"]
@@ -54,30 +54,11 @@ flowchart TD
 
 ## ビルドエントリポイント
 
-`build.mjs` が `@markuplint/spec-generator` の `main()` を呼び出します。
-
-```javascript
-import path from 'node:path';
-import { main } from '@markuplint/spec-generator';
-
-await main({
-  outputFilePath: path.resolve(import.meta.dirname, 'index.json'),
-  htmlFilePattern: path.resolve(import.meta.dirname, 'src', 'spec.*.jsonc'),
-  commonAttrsFilePath: path.resolve(import.meta.dirname, 'src', 'spec-common.attributes.jsonc'),
-  commonContentsFilePath: path.resolve(import.meta.dirname, 'src', 'spec-common.contents.jsonc'),
-});
-```
-
-| オプション               | 説明                                       |
-| ------------------------ | ------------------------------------------ |
-| `outputFilePath`         | `index.json` の出力先パス                  |
-| `htmlFilePattern`        | 要素仕様ファイルにマッチする glob パターン |
-| `commonAttrsFilePath`    | グローバル属性定義ファイルのパス           |
-| `commonContentsFilePath` | コンテンツモデルマクロ定義ファイルのパス   |
+`build.ts` が `generator/` の `main()` を呼び出します。
 
 ## 外部データソース
 
-spec-generator はビルド時に以下の外部ソースからデータをフェッチします。
+generator はビルド時に以下の外部ソースからデータをフェッチします。
 
 | ソース                                    | 提供データ                                                   |
 | ----------------------------------------- | ------------------------------------------------------------ |
@@ -90,7 +71,7 @@ spec-generator はビルド時に以下の外部ソースからデータをフ�
 | Graphics ARIA                             | グラフィックス固有 ARIA ロール                               |
 | HTML-ARIA（`w3.org/TR/html-aria/`）       | HTML 属性から ARIA プロパティへのマッピング                  |
 
-spec-generator の内部アーキテクチャ（スクレイピング、キャッシュ、モジュール構成）の詳細は `@markuplint/spec-generator` 自身のドキュメントを参照してください。
+generator の内部アーキテクチャ（スクレイピング、キャッシュ、モジュール構成）の詳細は `generator/` ディレクトリを参照してください。
 
 ## データ優先順位ルール
 

--- a/packages/@markuplint/html-spec/docs/build-pipeline.md
+++ b/packages/@markuplint/html-spec/docs/build-pipeline.md
@@ -4,7 +4,7 @@ This document describes how `index.json` is generated from the source files and 
 
 ## Overview
 
-The `@markuplint/html-spec` package uses `@markuplint/spec-generator` to produce a single consolidated `index.json` file. The build process:
+The `@markuplint/html-spec` package uses `generator/` scripts to produce a single consolidated `index.json` file. The build process:
 
 1. Reads 208 per-element JSON spec files (HTML, SVG, MathML) and 2 common definition files from `src/`
 2. Fetches external data from MDN Web Docs, W3C ARIA specifications, and the HTML Living Standard
@@ -24,8 +24,8 @@ flowchart TD
     end
 
     subgraph build ["Build"]
-        buildScript["build.mjs"]
-        specGen["@markuplint/spec-generator"]
+        buildScript["build.ts"]
+        specGen["generator/"]
     end
 
     subgraph external ["External Data Sources"]
@@ -54,30 +54,11 @@ flowchart TD
 
 ## Build Entry Point
 
-The build is triggered via `build.mjs`:
-
-```javascript
-import path from 'node:path';
-import { main } from '@markuplint/spec-generator';
-
-await main({
-  outputFilePath: path.resolve(import.meta.dirname, 'index.json'),
-  htmlFilePattern: path.resolve(import.meta.dirname, 'src', 'spec.*.jsonc'),
-  commonAttrsFilePath: path.resolve(import.meta.dirname, 'src', 'spec-common.attributes.jsonc'),
-  commonContentsFilePath: path.resolve(import.meta.dirname, 'src', 'spec-common.contents.jsonc'),
-});
-```
-
-| Option                   | Description                                      |
-| ------------------------ | ------------------------------------------------ |
-| `outputFilePath`         | Absolute path where `index.json` will be written |
-| `htmlFilePattern`        | Glob pattern matching per-element spec files     |
-| `commonAttrsFilePath`    | Path to global attribute definitions             |
-| `commonContentsFilePath` | Path to content model macro definitions          |
+The build is triggered via `build.ts`, which calls the `main()` function from `generator/index.ts`.
 
 ## External Data Sources
 
-The spec-generator fetches live data from the following sources during the build:
+The generator fetches live data from the following sources during the build:
 
 | Source                                   | Data Provided                                                                     |
 | ---------------------------------------- | --------------------------------------------------------------------------------- |
@@ -90,7 +71,7 @@ The spec-generator fetches live data from the following sources during the build
 | Graphics ARIA                            | Graphics-specific ARIA roles                                                      |
 | HTML-ARIA (`w3.org/TR/html-aria/`)       | HTML attribute to ARIA property mappings                                          |
 
-For details on the spec-generator's internal architecture (scraping, caching, module structure), see `@markuplint/spec-generator`'s own documentation.
+For details on the generator's internal architecture (scraping, caching, module structure), see the `generator/` directory.
 
 ## Data Precedence Rules
 

--- a/packages/@markuplint/html-spec/docs/maintenance.ja.md
+++ b/packages/@markuplint/html-spec/docs/maintenance.ja.md
@@ -216,7 +216,7 @@ description の表現変更などの表面的な変更は、更新された `ind
 
 要素を非推奨にする方法は2つある:
 
-- **ハードコードリスト経由**: `packages/@markuplint/spec-generator/src/html-elements.ts` の `obsoleteList` 配列に要素名を追加
+- **ハードコードリスト経由**: `packages/@markuplint/html-spec/generator/html-elements.ts` の `obsoleteList` 配列に要素名を追加
 - **手動仕様経由**: 要素の仕様ファイルに `"obsolete": true` を設定
 
 非推奨要素には自動的に以下が設定される:
@@ -285,12 +285,11 @@ yarn workspace @markuplint/html-spec run test
 
 ### 開発依存
 
-- **`@markuplint/spec-generator`**: ビルドツール。外部データのスクレイピングとマージを担当
 - **`@markuplint/test-tools`**: テストユーティリティ。`glob` 関数などを提供
 
 ### 依存関係更新時の注意
 
-1. `@markuplint/spec-generator` 更新後は必ず再生成を実行
+1. `generator/` 更新後は必ず再生成を実行
 2. `index.json` の差分を注意深くレビュー（外部データソースの変更により予期しない差分が出る場合がある）
 3. テストを実行してスキーマ検証が通ることを確認
 4. `@markuplint/ml-spec` のスキーマが変更された場合、ソースJSONファイルの更新が必要になることがある

--- a/packages/@markuplint/html-spec/docs/maintenance.md
+++ b/packages/@markuplint/html-spec/docs/maintenance.md
@@ -15,14 +15,14 @@ This is a practical operations and maintenance guide for contributors working on
 
 The generation process (`gen`) performs two steps in sequence via `npm-run-all`:
 
-1. **`gen:build`** -- Executes `build.mjs`, which calls the `main()` function from
-   `@markuplint/spec-generator`. This reads all `src/spec.*.jsonc` files, merges them
+1. **`gen:build`** -- Executes `build.ts`, which calls the `main()` function from
+   `generator/`. This reads all `src/spec.*.jsonc` files, merges them
    with scraped MDN data and the common attribute/content files, appends obsolete
    element stubs, and writes the consolidated output to `index.json`.
 2. **`gen:prettier`** -- Runs Prettier on `index.json` to ensure consistent formatting
    across regenerations.
 
-The build is network-dependent because `@markuplint/spec-generator` fetches live data
+The build is network-dependent because `generator/` fetches live data
 from MDN for each element (descriptions, compatibility flags, attribute metadata).
 Expect the build to take several minutes on a clean run.
 
@@ -275,7 +275,7 @@ what has changed in web standards and ensuring the spec data remains accurate.
 
 Elements can be marked obsolete in two ways:
 
-- **Via the hardcoded list**: Add the element name to the `obsoleteList` array in `packages/@markuplint/spec-generator/src/html-elements.ts`
+- **Via the hardcoded list**: Add the element name to the `obsoleteList` array in `packages/@markuplint/html-spec/generator/html-elements.ts`
 - **Via manual spec**: Set `"obsolete": true` in the element's spec file
 
 Obsolete elements automatically get:
@@ -358,15 +358,11 @@ grep -A5 '"accept"' index.json
 
 ### Dev Dependencies
 
-- **`@markuplint/spec-generator`**: The build tool. Updates may change:
-  - How MDN pages are scraped (if MDN layout changes)
-  - Which ARIA spec versions are fetched
-  - The output format of `index.json`
 - **`@markuplint/test-tools`**: Test utilities. Updates are generally safe.
 
 ### When Updating Dependencies
 
-1. Always regenerate after updating `@markuplint/spec-generator`: `yarn workspace @markuplint/html-spec run gen`
+1. Always regenerate after updating `generator/`: `yarn up:gen`
 2. Review `index.json` diff carefully for unexpected changes
 3. Run tests to ensure schema validation passes
 
@@ -380,7 +376,7 @@ grep -A5 '"accept"' index.json
 
 - Check network connectivity
 - Failed fetches are cached as empty strings; the build will continue but affected elements will have missing metadata
-- If MDN page structure changed, `@markuplint/spec-generator` scraping selectors may need updating
+- If MDN page structure changed, `generator/` scraping selectors may need updating
 
 ### Schema Validation Error
 

--- a/packages/@markuplint/html-spec/generator/aria.ts
+++ b/packages/@markuplint/html-spec/generator/aria.ts
@@ -64,7 +64,11 @@ async function getDpubRoles() {
 
 	$roleList.each((_, el) => {
 		const $el = $(el);
-		const name = $el.find('.role-name').attr('title')?.trim() ?? '';
+		// ARIA 1.2 uses `<h4 class="role-name" title="...">`, but ARIA 1.3 dropped that
+		// structure in favor of `<h4><code>name</code> role</h4>`. The `section.role` wrapper
+		// always carries the role name as its `id`, so fall back to that when the legacy
+		// selector yields nothing.
+		const name = $el.find('.role-name').attr('title')?.trim() || $el.attr('id')?.trim() || '';
 		const description = $el
 			.find('.role-description p')
 			.toArray()
@@ -185,7 +189,11 @@ async function getRoles(version: ARIAVersion, graphicsAria = false) {
 
 	$roleList.each((_, el) => {
 		const $el = $(el);
-		const name = $el.find('.role-name').attr('title')?.trim() ?? '';
+		// ARIA 1.2 uses `<h4 class="role-name" title="...">`, but ARIA 1.3 dropped that
+		// structure in favor of `<h4><code>name</code> role</h4>`. The `section.role` wrapper
+		// always carries the role name as its `id`, so fall back to that when the legacy
+		// selector yields nothing.
+		const name = $el.find('.role-name').attr('title')?.trim() || $el.attr('id')?.trim() || '';
 		const description = $el
 			.find('.role-description p')
 			.toArray()

--- a/packages/@markuplint/html-spec/generator/fetch.ts
+++ b/packages/@markuplint/html-spec/generator/fetch.ts
@@ -19,7 +19,7 @@ const RETRY_BASE_DELAY_MS = 1000;
 /**
  * User-Agent header sent with all fetch requests.
  */
-const USER_AGENT = 'markuplint-spec-generator (https://github.com/markuplint/markuplint)';
+const USER_AGENT = 'markuplint-html-spec-generator (https://github.com/markuplint/markuplint)';
 
 /**
  * In-memory cache mapping URLs to their raw HTML text responses.

--- a/packages/@markuplint/html-spec/generator/index.ts
+++ b/packages/@markuplint/html-spec/generator/index.ts
@@ -1,5 +1,5 @@
 /**
- * @module @markuplint/spec-generator
+ * @module @markuplint/html-spec/generator
  *
  * Generates the markuplint extended specification JSON file by scraping W3C and MDN web standards
  * documentation. Aggregates HTML/SVG element specs, global attributes, ARIA roles and properties,

--- a/packages/@markuplint/ml-spec/README.md
+++ b/packages/@markuplint/ml-spec/README.md
@@ -96,7 +96,7 @@ Generated TypeScript types (do not edit directly):
 
 - **Built output**: `index.json` (48K+ lines, consolidated specification data)
 - **Sources**: `src/spec-*.json` (individual element specifications)
-- **Build process**: `build.mjs` → `@markuplint/spec-generator` → enriched with MDN/W3C data
+- **Build process**: `build.ts` → `generator/` scripts → enriched with MDN/W3C data
 
 **@markuplint/ml-spec** (this package) provides:
 

--- a/packages/@markuplint/rules/src/wai-aria/checkings/required-accessibility-parent-role.ts
+++ b/packages/@markuplint/rules/src/wai-aria/checkings/required-accessibility-parent-role.ts
@@ -60,7 +60,7 @@ export const checkingRequiredAccessibilityParentRole: ElementChecker<
 			// `ariaSpecs().roles` returns raw spec data where the field is always
 			// `requiredContextRole` for all versions. The fallback to
 			// `requiredAccessibilityParentRole` is a defensive guard in case
-			// the spec-generator changes the field name in the future.
+			// the generator changes the field name in the future.
 			const parentRoles = roleSpec.requiredContextRole ?? roleSpec.requiredAccessibilityParentRole;
 			if (parentRoles && parentRoles.length > 0) {
 				return {

--- a/website/docs/api/index.md
+++ b/website/docs/api/index.md
@@ -83,8 +83,7 @@ console.log(result.violations);
 
 ### Utilities
 
-| Package                                                                                                                | NPM                                                                                                                                    |
-| ---------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| [`@markuplint/pretenders`](https://github.com/markuplint/markuplint/tree/main/packages/@markuplint/pretenders)         | [![npm version](https://badge.fury.io/js/%40markuplint%2Fpretenders.svg)](https://badge.fury.io/js/%40markuplint%2Fpretenders)         |
-| [`@markuplint/create-rule`](https://github.com/markuplint/markuplint/tree/main/packages/@markuplint/create-rule)       | [![npm version](https://badge.fury.io/js/%40markuplint%2Fcreate-rule.svg)](https://badge.fury.io/js/%40markuplint%2Fcreate-rule)       |
-| [`@markuplint/spec-generator`](https://github.com/markuplint/markuplint/tree/main/packages/@markuplint/spec-generator) | [![npm version](https://badge.fury.io/js/%40markuplint%2Fspec-generator.svg)](https://badge.fury.io/js/%40markuplint%2Fspec-generator) |
+| Package                                                                                                          | NPM                                                                                                                              |
+| ---------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| [`@markuplint/pretenders`](https://github.com/markuplint/markuplint/tree/main/packages/@markuplint/pretenders)   | [![npm version](https://badge.fury.io/js/%40markuplint%2Fpretenders.svg)](https://badge.fury.io/js/%40markuplint%2Fpretenders)   |
+| [`@markuplint/create-rule`](https://github.com/markuplint/markuplint/tree/main/packages/@markuplint/create-rule) | [![npm version](https://badge.fury.io/js/%40markuplint%2Fcreate-rule.svg)](https://badge.fury.io/js/%40markuplint%2Fcreate-rule) |

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/api/index.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/api/index.md
@@ -83,8 +83,7 @@ console.log(result.violations);
 
 ### ユーティリティ
 
-| パッケージ                                                                                                             | NPM                                                                                                                                    |
-| ---------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| [`@markuplint/pretenders`](https://github.com/markuplint/markuplint/tree/main/packages/@markuplint/pretenders)         | [![npm version](https://badge.fury.io/js/%40markuplint%2Fpretenders.svg)](https://badge.fury.io/js/%40markuplint%2Fpretenders)         |
-| [`@markuplint/create-rule`](https://github.com/markuplint/markuplint/tree/main/packages/@markuplint/create-rule)       | [![npm version](https://badge.fury.io/js/%40markuplint%2Fcreate-rule.svg)](https://badge.fury.io/js/%40markuplint%2Fcreate-rule)       |
-| [`@markuplint/spec-generator`](https://github.com/markuplint/markuplint/tree/main/packages/@markuplint/spec-generator) | [![npm version](https://badge.fury.io/js/%40markuplint%2Fspec-generator.svg)](https://badge.fury.io/js/%40markuplint%2Fspec-generator) |
+| パッケージ                                                                                                       | NPM                                                                                                                              |
+| ---------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| [`@markuplint/pretenders`](https://github.com/markuplint/markuplint/tree/main/packages/@markuplint/pretenders)   | [![npm version](https://badge.fury.io/js/%40markuplint%2Fpretenders.svg)](https://badge.fury.io/js/%40markuplint%2Fpretenders)   |
+| [`@markuplint/create-rule`](https://github.com/markuplint/markuplint/tree/main/packages/@markuplint/create-rule) | [![npm version](https://badge.fury.io/js/%40markuplint%2Fcreate-rule.svg)](https://badge.fury.io/js/%40markuplint%2Fcreate-rule) |


### PR DESCRIPTION
## Summary

- ARIA 1.3 の仕様ページが `<h4 class="role-name" title="...">` を廃止し `<h4><code>name</code> role</h4>` に変更したため、既存の `.role-name[title]` セレクタが 1.3 の全ロールで空文字を返していた。1.2/1.3 両方に存在する `section.role` の `id` 属性にフォールバックすることで修正。
- 併せて、以前 `@markuplint/spec-generator` パッケージを `@markuplint/html-spec/generator/` に統合した際に取り残されていたドキュメント・labeler 設定・コード内コメントの参照を更新。

## Test plan

- [x] `yarn lint-check` — 0 errors, 0 warnings
- [x] `yarn build` — 39 projects succeeded
- [x] `yarn test` — 3170 passed
- [x] `yarn up:gen` 実行後の `index.json` 差分が 427 行 → 20 行に縮小し、残差分は ARIA 1.3 の `tooltip` ロール仕様変更（本物の差分）のみであることを確認

> [!NOTE]
> 実際の `index.json` の再生成 (`yarn up:gen`) は本 PR には含めていません。別 PR で取り込む想定です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)