### PR TITLE
feat(ml-spec): add ConditionalAttributeType to Attribute.type union (#3685)

### DIFF
--- a/packages/@markuplint/ml-spec/ARCHITECTURE.ja.md
+++ b/packages/@markuplint/ml-spec/ARCHITECTURE.ja.md
@@ -146,12 +146,12 @@ flowchart TD
 
 型システムは、マークアップ言語仕様・要素仕様・ARIA ロール・属性の構造を定義します。
 
-| ファイル                        | 役割                                                                                                  |
-| ------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `types/index.ts`                | 手書き型: `MLMLSpec`, `ElementSpec`, `ExtendedSpec`, `ARIARole`, `ComputedRole` 等                    |
-| `types/aria.ts`                 | 生成型: `ARIA`, `PermittedRoles`, `ImplicitRole`, `PermittedARIAProperties`, `ImplicitProperties`     |
-| `types/attributes.ts`           | 生成型: `AttributeType`, `GlobalAttributes`, `AttributeJSON`, `List`, `Enum`, `Number`                |
-| `types/permitted-structures.ts` | 生成型: `PermittedContentPattern`, `ContentModel`, `Category`（HTML 13 + SVG 19 + MathML 3 カテゴリ） |
+| ファイル                        | 役割                                                                                                                            |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `types/index.ts`                | 手書き型: `MLMLSpec`, `ElementSpec`, `ExtendedSpec`, `ARIARole`, `ComputedRole` 等                                              |
+| `types/aria.ts`                 | 生成型: `ARIA`, `PermittedRoles`, `ImplicitRole`, `PermittedARIAProperties`, `ImplicitProperties`                               |
+| `types/attributes.ts`           | 生成型: `AttributeType`, `ConditionalAttributeType`, `GlobalAttributes`, `AttributeJSON`, `List`, `Enum`, `Number`, `Directive` |
+| `types/permitted-structures.ts` | 生成型: `PermittedContentPattern`, `ContentModel`, `Category`（HTML 13 + SVG 19 + MathML 3 カテゴリ）                           |
 
 ### 2. ARIA アルゴリズム
 

--- a/packages/@markuplint/ml-spec/ARCHITECTURE.md
+++ b/packages/@markuplint/ml-spec/ARCHITECTURE.md
@@ -146,12 +146,12 @@ flowchart TD
 
 The type system defines the structure of markup language specifications, element specs, ARIA roles, and attributes.
 
-| File                            | Purpose                                                                                                   |
-| ------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| `types/index.ts`                | Hand-written types: `MLMLSpec`, `ElementSpec`, `ExtendedSpec`, `ARIARole`, `ComputedRole`, etc.           |
-| `types/aria.ts`                 | Generated: `ARIA`, `PermittedRoles`, `ImplicitRole`, `PermittedARIAProperties`, `ImplicitProperties`      |
-| `types/attributes.ts`           | Generated: `AttributeType`, `GlobalAttributes`, `AttributeJSON`, `List`, `Enum`, `Number`                 |
-| `types/permitted-structures.ts` | Generated: `PermittedContentPattern`, `ContentModel`, `Category` (HTML 13 + SVG 19 + MathML 3 categories) |
+| File                            | Purpose                                                                                                                            |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `types/index.ts`                | Hand-written types: `MLMLSpec`, `ElementSpec`, `ExtendedSpec`, `ARIARole`, `ComputedRole`, etc.                                    |
+| `types/aria.ts`                 | Generated: `ARIA`, `PermittedRoles`, `ImplicitRole`, `PermittedARIAProperties`, `ImplicitProperties`                               |
+| `types/attributes.ts`           | Generated: `AttributeType`, `ConditionalAttributeType`, `GlobalAttributes`, `AttributeJSON`, `List`, `Enum`, `Number`, `Directive` |
+| `types/permitted-structures.ts` | Generated: `PermittedContentPattern`, `ContentModel`, `Category` (HTML 13 + SVG 19 + MathML 3 categories)                          |
 
 ### 2. ARIA Algorithms
 

--- a/packages/@markuplint/ml-spec/docs/maintenance.ja.md
+++ b/packages/@markuplint/ml-spec/docs/maintenance.ja.md
@@ -230,6 +230,34 @@ AttributeJSON: {
 
 再生成すると、新しいフィールドが `src/types/attributes.ts` にオプショナルプロパティとして反映されます。
 
+> **警告:** `schemas/attributes.schema.json` と `schemas/global-attributes.schema.json` は `gen/gen.ts` によって _上書き_ されます。**これらのファイルを直接編集してはいけません** — 次に `schema:json`（または `yarn up:schema`）が走った瞬間に変更が消えます。すべての編集は `gen/gen.ts` に対して行ってください。
+
+### 3b. `attributes.schema.json` に新しい definition を追加する（新しいスキーマ型）
+
+`AttributeJSON` のフィールドではなく、まったく新しい definition を追加したい場合 — 例えば #3685 の `ConditionalAttributeType` のような新しい構造化型バリアント — は、`gen/gen.ts` の 2 つめの `fs.writeFileSync` 呼び出し内の `definitions` オブジェクトに、`AttributeJSON` の隣に配置してください。
+
+```ts
+fs.writeFileSync(
+  path.resolve(import.meta.dirname, '..', 'schemas', 'attributes.schema.json'),
+  JSON.stringify({
+    definitions: {
+      // ...既存の definitions...
+      NewType: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['foo'],
+        properties: { foo: { type: 'string' } },
+      },
+      AttributeJSON: {
+        /* ... */
+      },
+    },
+  }),
+);
+```
+
+再生成すると、新しい definition は TypeScript の `interface` として `src/types/attributes.ts` から export されます。下流パッケージ（例: `@markuplint/rules`）で narrowing が必要な場合は、`src/utils/` に型ガードを追加し `src/index.ts` から再 export してください — #3685 で確立したパターンは `is-conditional-attribute-type.ts` を参照してください。
+
 ### 4. ARIA ロール/プロパティスキーマを変更する
 
 `schemas/aria.schema.json` を直接編集します。例えば、ロール定義に新しいフィールドを追加する場合:

--- a/packages/@markuplint/ml-spec/docs/maintenance.md
+++ b/packages/@markuplint/ml-spec/docs/maintenance.md
@@ -230,6 +230,34 @@ AttributeJSON: {
 
 Then regenerate. The new field will appear in `src/types/attributes.ts` as an optional property.
 
+> **Warning:** `schemas/attributes.schema.json` and `schemas/global-attributes.schema.json` are both _overwritten_ by `gen/gen.ts`. **Never hand-edit those files** — your changes will be blown away the next time `schema:json` (or `yarn up:schema`) runs. All edits must live in `gen/gen.ts`.
+
+### 3b. Add a new definition to `attributes.schema.json` (new schema type)
+
+When you need to add a brand-new definition (not just a field on `AttributeJSON`) — for example, adding a new structured type variant like `ConditionalAttributeType` (#3685) — edit `gen/gen.ts` and place the new definition alongside `AttributeJSON` inside the `definitions` object of the second `fs.writeFileSync` call.
+
+```ts
+fs.writeFileSync(
+  path.resolve(import.meta.dirname, '..', 'schemas', 'attributes.schema.json'),
+  JSON.stringify({
+    definitions: {
+      // ...existing definitions...
+      NewType: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['foo'],
+        properties: { foo: { type: 'string' } },
+      },
+      AttributeJSON: {
+        /* ... */
+      },
+    },
+  }),
+);
+```
+
+After regeneration, the new definition is exported from `src/types/attributes.ts` as a TypeScript `interface`. If downstream packages (e.g. `@markuplint/rules`) need to narrow against it, add a type guard in `src/utils/` and re-export from `src/index.ts` — see `is-conditional-attribute-type.ts` for the pattern established by #3685.
+
 ### 4. Modify ARIA role/property schema
 
 Edit `schemas/aria.schema.json` directly. For example, to add a new field to the role definition:

--- a/packages/@markuplint/ml-spec/docs/type-definitions.ja.md
+++ b/packages/@markuplint/ml-spec/docs/type-definitions.ja.md
@@ -113,7 +113,10 @@ type ElementSpec = {
 ```ts
 type Attribute = {
   readonly name: string;
-  readonly type: ReadonlyDeep<AttributeType> | readonly ReadonlyDeep<AttributeType>[];
+  readonly type:
+    | ReadonlyDeep<AttributeType>
+    | readonly ReadonlyDeep<AttributeType>[]
+    | readonly ReadonlyDeep<ConditionalAttributeType>[];
   readonly description?: string;
   readonly caseSensitive?: true;
   readonly experimental?: boolean;
@@ -124,6 +127,8 @@ type Attribute = {
 ```
 
 `& ExtendableAttributeSpec` の交差型により、生成された `AttributeJSON` 型のフィールド（`type` を除く。`ReadonlyDeep` ラッパーでオーバーライドされるため）が追加されます: `defaultValue`、`required`、`requiredEither`、`noUse`、`condition`、`ineffective`、`animatable`。
+
+`type` の共用体には、別の属性の値によって値型が切り替わる属性のために `readonly ReadonlyDeep<ConditionalAttributeType>[]` が含まれます（下記 [`ConditionalAttributeType`](#attributesschemajson-から----srctypesattributests) を参照）。このバリアントは v5.0 では型定義のみで先行投入されており（#3685）、実ロジックは follow-up Issue #3598 / #3189 で実装されます。
 
 ## ARIA 型
 
@@ -419,7 +424,10 @@ interface GlobalAttributes {
 
 ```ts
 interface AttributeJSON {
-  type?: AttributeType | [AttributeType, ...AttributeType[]];
+  type?:
+    | AttributeType
+    | [AttributeType, ...AttributeType[]]
+    | [ConditionalAttributeType, ...ConditionalAttributeType[]];
   defaultValue?: string;
   deprecated?: boolean;
   required?: boolean | AttributeCondition;
@@ -431,6 +439,17 @@ interface AttributeJSON {
   experimental?: boolean;
 }
 ```
+
+**`ConditionalAttributeType`** -- 条件付き型切り替え: ある属性の期待する値型が、同じ要素上の _別の_ 属性の値によって切り替わることを宣言します。例えば `<input value>` は `type=color` のとき `<'color'>`、`type=url` のとき `URL` となる、といった仕様表現に使われます。
+
+```ts
+interface ConditionalAttributeType {
+  condition: AttributeCondition; // 所属要素に対する CSS セレクター
+  type: AttributeType | [AttributeType, ...AttributeType[]];
+}
+```
+
+> **ステータス (#3685 / v5.0):** 型定義は v5.0 で先行投入されていますが、条件付き型を実際に解決するバリデーションロジックは follow-up Issue に先送りされています: [#3598](https://github.com/markuplint/markuplint/issues/3598)（`type` による `input[value]`）と [#3189](https://github.com/markuplint/markuplint/issues/3189)（`rel` による `link[as]`）。それらが着地するまでは、`invalid-attr` は `ConditionalAttributeType[]` が宣言されている属性を短絡的に有効扱いにし、違反として報告しません。詳細は `packages/@markuplint/rules/src/attr-check.ts` および `@markuplint/ml-spec` の `isConditionalAttributeTypeArray` ヘルパーを参照してください。
 
 **`List`** -- スペース区切りまたはカンマ区切りのトークンリスト用の構造化型です。
 

--- a/packages/@markuplint/ml-spec/docs/type-definitions.md
+++ b/packages/@markuplint/ml-spec/docs/type-definitions.md
@@ -113,7 +113,10 @@ Describes a single HTML/SVG attribute with its type, description, and status fla
 ```ts
 type Attribute = {
   readonly name: string;
-  readonly type: ReadonlyDeep<AttributeType> | readonly ReadonlyDeep<AttributeType>[];
+  readonly type:
+    | ReadonlyDeep<AttributeType>
+    | readonly ReadonlyDeep<AttributeType>[]
+    | readonly ReadonlyDeep<ConditionalAttributeType>[];
   readonly description?: string;
   readonly caseSensitive?: true;
   readonly experimental?: boolean;
@@ -124,6 +127,8 @@ type Attribute = {
 ```
 
 The `& ExtendableAttributeSpec` intersection adds fields from the generated `AttributeJSON` type (excluding `type`, which is overridden with the `ReadonlyDeep` wrapper): `defaultValue`, `required`, `requiredEither`, `noUse`, `condition`, `ineffective`, `animatable`.
+
+The `type` union includes `readonly ReadonlyDeep<ConditionalAttributeType>[]` for attributes whose value type depends on another attribute's value (see [`ConditionalAttributeType`](#from-attributesschemajson----srctypesattributests) below). This variant is shipped type-only in v5.0 (#3685); follow-ups #3598 and #3189 implement the runtime resolution.
 
 ## ARIA Types
 
@@ -419,7 +424,10 @@ interface GlobalAttributes {
 
 ```ts
 interface AttributeJSON {
-  type?: AttributeType | [AttributeType, ...AttributeType[]];
+  type?:
+    | AttributeType
+    | [AttributeType, ...AttributeType[]]
+    | [ConditionalAttributeType, ...ConditionalAttributeType[]];
   defaultValue?: string;
   deprecated?: boolean;
   required?: boolean | AttributeCondition;
@@ -431,6 +439,17 @@ interface AttributeJSON {
   experimental?: boolean;
 }
 ```
+
+**`ConditionalAttributeType`** -- Conditional type switching: declares that an attribute's expected value type depends on the value of _another_ attribute on the same element. Used when the spec states, for example, that `<input value>` is `<'color'>` when `type=color` but a `URL` when `type=url`.
+
+```ts
+interface ConditionalAttributeType {
+  condition: AttributeCondition; // CSS selector against the owning element
+  type: AttributeType | [AttributeType, ...AttributeType[]];
+}
+```
+
+> **Status (#3685 / v5.0):** The type definition ships in v5.0, but the validation logic that actually resolves conditional types is deferred to follow-up issues: [#3598](https://github.com/markuplint/markuplint/issues/3598) (`input[value]` by `type`) and [#3189](https://github.com/markuplint/markuplint/issues/3189) (`link[as]` by `rel`). Until those land, `invalid-attr` short-circuits any attribute whose spec declares a `ConditionalAttributeType[]` — it is treated as valid, never as a violation. See `packages/@markuplint/rules/src/attr-check.ts` and the `isConditionalAttributeTypeArray` helper in `@markuplint/ml-spec`.
 
 **`List`** -- Structured type for space-separated or comma-separated token lists.
 

--- a/packages/@markuplint/ml-spec/gen/gen.ts
+++ b/packages/@markuplint/ml-spec/gen/gen.ts
@@ -115,6 +115,37 @@ fs.writeFileSync(
 			AttributeType: {
 				$ref: '../../types/types.schema.json#/definitions/type',
 			},
+			// #3685: ConditionalAttributeType lets an attribute declare different
+			// value types depending on another attribute's value (e.g. `input[value]`
+			// is a color when `type=color`, a URL when `type=url`). v5.0 ships the
+			// type only; validation logic lands in follow-up issues #3598 / #3189.
+			ConditionalAttributeType: {
+				description:
+					"Declares that an attribute value type depends on a condition (a CSS selector) matched against the owning element. Used when an attribute's valid values differ based on the value of another attribute — for example, `<input value>` is `<'color'>` when `type=color`, or a `URL` when `type=url`. Shipped type-only in v5.0 (#3685); validation logic is deferred to #3598 and #3189.",
+				type: 'object',
+				additionalProperties: false,
+				required: ['condition', 'type'],
+				properties: {
+					condition: {
+						$ref: '#/definitions/AttributeCondition',
+					},
+					type: {
+						oneOf: [
+							{
+								$ref: '#/definitions/AttributeType',
+							},
+							{
+								type: 'array',
+								minItems: 1,
+								uniqueItems: true,
+								items: {
+									$ref: '#/definitions/AttributeType',
+								},
+							},
+						],
+					},
+				},
+			},
 			AttributeJSON: {
 				type: 'object',
 				additionalProperties: false,
@@ -131,6 +162,14 @@ fs.writeFileSync(
 								uniqueItems: true,
 								items: {
 									$ref: '#/definitions/AttributeType',
+								},
+							},
+							{
+								type: 'array',
+								minItems: 1,
+								uniqueItems: true,
+								items: {
+									$ref: '#/definitions/ConditionalAttributeType',
 								},
 							},
 						],

--- a/packages/@markuplint/ml-spec/schemas/attributes.schema.json
+++ b/packages/@markuplint/ml-spec/schemas/attributes.schema.json
@@ -6,6 +6,26 @@
 			"oneOf": [{ "type": "string" }, { "type": "array", "minItems": 2, "items": { "type": "string" } }]
 		},
 		"AttributeType": { "$ref": "../../types/types.schema.json#/definitions/type" },
+		"ConditionalAttributeType": {
+			"description": "Declares that an attribute value type depends on a condition (a CSS selector) matched against the owning element. Used when an attribute's valid values differ based on the value of another attribute — for example, `<input value>` is `<'color'>` when `type=color`, or a `URL` when `type=url`. Shipped type-only in v5.0 (#3685); validation logic is deferred to #3598 and #3189.",
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["condition", "type"],
+			"properties": {
+				"condition": { "$ref": "#/definitions/AttributeCondition" },
+				"type": {
+					"oneOf": [
+						{ "$ref": "#/definitions/AttributeType" },
+						{
+							"type": "array",
+							"minItems": 1,
+							"uniqueItems": true,
+							"items": { "$ref": "#/definitions/AttributeType" }
+						}
+					]
+				}
+			}
+		},
 		"AttributeJSON": {
 			"type": "object",
 			"additionalProperties": false,
@@ -19,6 +39,12 @@
 							"minItems": 1,
 							"uniqueItems": true,
 							"items": { "$ref": "#/definitions/AttributeType" }
+						},
+						{
+							"type": "array",
+							"minItems": 1,
+							"uniqueItems": true,
+							"items": { "$ref": "#/definitions/ConditionalAttributeType" }
 						}
 					]
 				},

--- a/packages/@markuplint/ml-spec/src/index.ts
+++ b/packages/@markuplint/ml-spec/src/index.ts
@@ -35,6 +35,7 @@ export * from './utils/schema-to-spec.js';
 export * from './utils/resolve-namespace.js';
 export * from './utils/validate-aria-version.js';
 export * from './utils/directive-resolver.js';
+export * from './utils/is-conditional-attribute-type.js';
 
 // Type definitions
 export * from './types/index.js';

--- a/packages/@markuplint/ml-spec/src/types/attributes.ts
+++ b/packages/@markuplint/ml-spec/src/types/attributes.ts
@@ -1640,7 +1640,10 @@ export interface Attributes {
  * via the `patternProperty` ".*".
  */
 export interface AttributeJSON {
-  type?: AttributeType | [AttributeType, ...AttributeType[]];
+  type?:
+    | AttributeType
+    | [AttributeType, ...AttributeType[]]
+    | [ConditionalAttributeType, ...ConditionalAttributeType[]];
   defaultValue?: string;
   deprecated?: boolean;
   required?: boolean | AttributeCondition;
@@ -1786,4 +1789,11 @@ export interface Directive {
  */
 export interface Pattern {
   pattern: string;
+}
+/**
+ * Declares that an attribute value type depends on a condition (a CSS selector) matched against the owning element. Used when an attribute's valid values differ based on the value of another attribute — for example, `<input value>` is `<'color'>` when `type=color`, or a `URL` when `type=url`. Shipped type-only in v5.0 (#3685); validation logic is deferred to #3598 and #3189.
+ */
+export interface ConditionalAttributeType {
+  condition: AttributeCondition;
+  type: AttributeType | [AttributeType, ...AttributeType[]];
 }

--- a/packages/@markuplint/ml-spec/src/types/conditional-attribute-type.spec.ts
+++ b/packages/@markuplint/ml-spec/src/types/conditional-attribute-type.spec.ts
@@ -1,0 +1,100 @@
+import type { AttributeJSON, ConditionalAttributeType } from './attributes.js';
+import type { Attribute } from './index.js';
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, test, expect } from 'vitest';
+
+/**
+ * Tests for the `ConditionalAttributeType` type (#3685).
+ *
+ * v5.0 ships the type-only extension — validation logic lands in follow-up
+ * issues (#3598, #3189). The authoritative contract is the TypeScript types
+ * generated from `attributes.schema.json`; downstream packages consume those
+ * types, not the schema file itself.
+ *
+ * - The schema-level check below is a smoke test only, to guard against the
+ *   single source of truth dropping the definition.
+ * - The shape tests exercise the real contract: if `json2ts` ever produces
+ *   drifted output, these tests fail at build time (TypeScript compile error)
+ *   rather than passing silently.
+ */
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const schemaPath = resolve(__dirname, '../../schemas/attributes.schema.json');
+const schema = JSON.parse(readFileSync(schemaPath, 'utf8')) as {
+	readonly definitions: Record<string, unknown>;
+};
+
+describe('attributes.schema.json — schema-level smoke test (#3685)', () => {
+	test('declares ConditionalAttributeType under #/definitions', () => {
+		expect(schema.definitions).toHaveProperty('ConditionalAttributeType');
+	});
+});
+
+describe('generated types — ConditionalAttributeType shape (#3685)', () => {
+	test('ConditionalAttributeType accepts a single AttributeType', () => {
+		const entry: ConditionalAttributeType = {
+			condition: "[type='color' i]",
+			type: "<'color'>",
+		};
+		expect(entry.condition).toBe("[type='color' i]");
+		expect(entry.type).toBe("<'color'>");
+	});
+
+	test('ConditionalAttributeType accepts a non-empty tuple of AttributeTypes', () => {
+		const entry: ConditionalAttributeType = {
+			condition: "[type='number' i]",
+			type: ['Number', 'Any'],
+		};
+		expect(Array.isArray(entry.type)).toBe(true);
+		expect((entry.type as readonly string[]).length).toBe(2);
+	});
+
+	test('ConditionalAttributeType.condition accepts an array of selectors', () => {
+		const entry: ConditionalAttributeType = {
+			condition: ["[type='url' i]", "[type='email' i]"],
+			type: 'URL',
+		};
+		expect(Array.isArray(entry.condition)).toBe(true);
+	});
+
+	test('AttributeJSON.type accepts a ConditionalAttributeType[] variant', () => {
+		const spec: AttributeJSON = {
+			type: [
+				{ condition: "[type='color' i]", type: "<'color'>" },
+				{ condition: "[type='url' i]", type: 'URL' },
+				{ condition: "[type='number' i]", type: [{ type: 'integer' }] },
+			],
+		};
+		expect(Array.isArray(spec.type)).toBe(true);
+		expect((spec.type as readonly ConditionalAttributeType[])[0]?.condition).toBe("[type='color' i]");
+	});
+
+	test('AttributeJSON.type still accepts a single AttributeType (backward compatible)', () => {
+		const spec: AttributeJSON = { type: 'URL' };
+		expect(spec.type).toBe('URL');
+	});
+
+	test('AttributeJSON.type still accepts an AttributeType tuple (backward compatible)', () => {
+		const spec: AttributeJSON = { type: ['URL', 'Any'] };
+		expect(Array.isArray(spec.type)).toBe(true);
+		expect((spec.type as readonly string[])[0]).toBe('URL');
+	});
+
+	test('merged Attribute.type accepts a ConditionalAttributeType[] variant', () => {
+		const attr: Attribute = {
+			name: 'value',
+			type: [{ condition: "[type='color' i]", type: "<'color'>" }],
+		};
+		expect(attr.name).toBe('value');
+		expect(Array.isArray(attr.type)).toBe(true);
+	});
+
+	test('merged Attribute.type still accepts a scalar AttributeType', () => {
+		const attr: Attribute = { name: 'href', type: 'URL' };
+		expect(attr.type).toBe('URL');
+	});
+});

--- a/packages/@markuplint/ml-spec/src/types/index.ts
+++ b/packages/@markuplint/ml-spec/src/types/index.ts
@@ -1,5 +1,5 @@
 import type { ARIA } from './aria.js';
-import type { AttributeJSON, AttributeType, GlobalAttributes } from './attributes.js';
+import type { AttributeJSON, AttributeType, ConditionalAttributeType, GlobalAttributes } from './attributes.js';
 import type { ContentModel, Category } from './permitted-structures.js';
 import type { ariaVersions } from '../utils/aria-version.js';
 import type { NamespaceURI } from '@markuplint/ml-ast';
@@ -229,7 +229,10 @@ type ElementCondition = {
  */
 export type Attribute = {
 	readonly name: string;
-	readonly type: ReadonlyDeep<AttributeType> | readonly ReadonlyDeep<AttributeType>[];
+	readonly type:
+		| ReadonlyDeep<AttributeType>
+		| readonly ReadonlyDeep<AttributeType>[]
+		| readonly ReadonlyDeep<ConditionalAttributeType>[];
 	readonly description?: string;
 	readonly caseSensitive?: true;
 	readonly experimental?: boolean;

--- a/packages/@markuplint/ml-spec/src/utils/is-conditional-attribute-type.spec.ts
+++ b/packages/@markuplint/ml-spec/src/utils/is-conditional-attribute-type.spec.ts
@@ -1,0 +1,79 @@
+import type { Attribute } from '../types/index.js';
+
+import { describe, test, expect } from 'vitest';
+
+import { isConditionalAttributeTypeArray } from './is-conditional-attribute-type.js';
+
+describe('isConditionalAttributeTypeArray (#3685)', () => {
+	describe('positive cases', () => {
+		test('returns true for a single ConditionalAttributeType entry', () => {
+			const type: Attribute['type'] = [{ condition: "[type='color' i]", type: "<'color'>" }];
+			expect(isConditionalAttributeTypeArray(type)).toBe(true);
+		});
+
+		test('returns true for multiple ConditionalAttributeType entries', () => {
+			const type: Attribute['type'] = [
+				{ condition: "[type='color' i]", type: "<'color'>" },
+				{ condition: "[type='url' i]", type: 'URL' },
+				{ condition: "[type='number' i]", type: [{ type: 'integer' }] },
+			];
+			expect(isConditionalAttributeTypeArray(type)).toBe(true);
+		});
+
+		test('narrows the type parameter to ConditionalAttributeType[] (compile-time check)', () => {
+			const type: Attribute['type'] = [{ condition: "[type='color' i]", type: "<'color'>" }];
+			if (isConditionalAttributeTypeArray(type)) {
+				// If narrowing is correct, accessing `.condition` without extra guards compiles.
+				expect(type[0]?.condition).toBe("[type='color' i]");
+			} else {
+				throw new Error('Expected narrowing to succeed');
+			}
+		});
+	});
+
+	describe('negative cases — scalar AttributeType', () => {
+		test('returns false for a single string AttributeType', () => {
+			expect(isConditionalAttributeTypeArray('URL')).toBe(false);
+		});
+
+		test('returns false for a Boolean AttributeType', () => {
+			expect(isConditionalAttributeTypeArray('Boolean')).toBe(false);
+		});
+	});
+
+	describe('negative cases — AttributeType array', () => {
+		test('returns false for a tuple of string AttributeTypes', () => {
+			expect(isConditionalAttributeTypeArray(['URL', 'Any'])).toBe(false);
+		});
+
+		test('returns false for a single-element string-only array', () => {
+			expect(isConditionalAttributeTypeArray(['Any'])).toBe(false);
+		});
+
+		test('returns false for an array containing an Enum object', () => {
+			const type: Attribute['type'] = [{ enum: ['on', 'off'] }];
+			expect(isConditionalAttributeTypeArray(type)).toBe(false);
+		});
+
+		test('returns false for an array containing a Number object', () => {
+			const type: Attribute['type'] = [{ type: 'integer', gte: 0 }];
+			expect(isConditionalAttributeTypeArray(type)).toBe(false);
+		});
+
+		test('returns false for an array containing a List object', () => {
+			const type: Attribute['type'] = [{ token: 'Any', separator: 'space' }];
+			expect(isConditionalAttributeTypeArray(type)).toBe(false);
+		});
+
+		test('returns false for an array containing a Directive object', () => {
+			const type: Attribute['type'] = [{ directive: ['find '], token: '<complex-selector-list>' }];
+			expect(isConditionalAttributeTypeArray(type)).toBe(false);
+		});
+	});
+
+	describe('edge cases', () => {
+		test('returns false for an empty array', () => {
+			expect(isConditionalAttributeTypeArray([])).toBe(false);
+		});
+	});
+});

--- a/packages/@markuplint/ml-spec/src/utils/is-conditional-attribute-type.ts
+++ b/packages/@markuplint/ml-spec/src/utils/is-conditional-attribute-type.ts
@@ -1,0 +1,35 @@
+import type { ConditionalAttributeType } from '../types/attributes.js';
+import type { Attribute } from '../types/index.js';
+import type { ReadonlyDeep } from 'type-fest';
+
+/**
+ * Narrows an `Attribute['type']` value to `readonly ConditionalAttributeType[]` (#3685).
+ *
+ * `Attribute['type']` is the union `AttributeType | readonly AttributeType[] | readonly ConditionalAttributeType[]`.
+ * The three variants are mutually exclusive at the spec author level: an attribute
+ * either declares a single/tuple of `AttributeType` values, or it declares conditional
+ * types that depend on another attribute's value — never a mix.
+ *
+ * Discrimination: every non-conditional `AttributeType` object variant (`List`, `Enum`,
+ * `Number`, `Directive`) lacks a `condition` key, whereas `ConditionalAttributeType`
+ * requires it. Checking the first array element is sufficient because the schema
+ * forbids mixing the two shapes within a single `type` value.
+ *
+ * @example
+ * ```ts
+ * isConditionalAttributeTypeArray('URL') // false — single AttributeType
+ * isConditionalAttributeTypeArray(['URL', 'Any']) // false — AttributeType tuple
+ * isConditionalAttributeTypeArray([{ enum: ['on', 'off'] }]) // false — Enum
+ * isConditionalAttributeTypeArray([{ condition: "[type='color' i]", type: "<'color'>" }]) // true
+ * ```
+ *
+ * @param type - The `Attribute['type']` value to test; may be a scalar `AttributeType`,
+ *   an array of `AttributeType`, or an array of `ConditionalAttributeType`
+ * @returns `true` if `type` is a non-empty array whose first entry is a
+ *   `ConditionalAttributeType` (has a `condition` key); `false` otherwise
+ */
+export function isConditionalAttributeTypeArray(
+	type: Attribute['type'],
+): type is readonly ReadonlyDeep<ConditionalAttributeType>[] {
+	return Array.isArray(type) && type.length > 0 && typeof type[0] === 'object' && 'condition' in type[0];
+}

--- a/packages/@markuplint/rules/src/attr-check.spec.ts
+++ b/packages/@markuplint/rules/src/attr-check.spec.ts
@@ -1,10 +1,11 @@
 import type { Translator } from '@markuplint/i18n';
+import type { Attribute as AttrSpec } from '@markuplint/ml-spec';
 
 import { translator } from '@markuplint/i18n';
 import { i18n } from 'markuplint';
 import { test, expect, beforeAll } from 'vitest';
 
-import { valueCheck } from './attr-check.js';
+import { attrCheck, valueCheck } from './attr-check.js';
 
 let t: Translator;
 
@@ -89,4 +90,55 @@ test('[attr-check-invalid-005] Directive', () => {
 			raw: 'fin #id',
 		},
 	]);
+});
+
+/*
+ * #3685 — ConditionalAttributeType[] ships as a type-only extension in v5.0.
+ * Until follow-ups #3598 / #3189 implement value-conditional validation,
+ * attrCheck must short-circuit to "valid" when a spec declares such a type.
+ * These tests lock the guard in place so a regression cannot silently remove it.
+ */
+test('[attr-check-issue-3685-001] ConditionalAttributeType[] short-circuits to valid', () => {
+	const spec: AttrSpec = {
+		name: 'value',
+		type: [
+			{ condition: "[type='color' i]", type: "<'color'>" },
+			{ condition: "[type='url' i]", type: 'URL' },
+		],
+	};
+	// Any value must pass because validation is deferred to follow-up issues.
+	expect(attrCheck(t, 'value', 'not-a-url-or-color', true, spec)).toBe(false);
+	expect(attrCheck(t, 'value', '', true, spec)).toBe(false);
+});
+
+test('[attr-check-issue-3685-002] array of Enum is NOT treated as conditional (falls through)', () => {
+	const spec: AttrSpec = {
+		name: 'autocomplete',
+		type: [{ enum: ['on', 'off'] }],
+	};
+	// 'on' matches the enum → normal path → early-return `false` (valid).
+	expect(attrCheck(t, 'autocomplete', 'on', true, spec)).toBe(false);
+	// 'bogus' matches no enum member → real violation reported (proves guard did NOT fire).
+	const invalid = attrCheck(t, 'autocomplete', 'bogus', true, spec);
+	expect(Array.isArray(invalid)).toBe(true);
+	expect((invalid as readonly unknown[]).length).toBeGreaterThan(0);
+});
+
+test('[attr-check-issue-3685-003] empty type array falls through to normal path', () => {
+	const spec: AttrSpec = { name: 'x-attr', type: [] };
+	// Empty types array → guard returns false (length 0) → normal loop doesn't run → empty violations.
+	expect(attrCheck(t, 'x-attr', 'anything', true, spec)).toStrictEqual([]);
+});
+
+test('[attr-check-issue-3685-004] array of Number is NOT treated as conditional', () => {
+	const spec: AttrSpec = {
+		name: 'count',
+		type: [{ type: 'integer', gte: 0 }],
+	};
+	// '42' is a valid non-negative integer → early-return `false` (valid).
+	expect(attrCheck(t, 'count', '42', true, spec)).toBe(false);
+	// '-1' violates `gte: 0` → real violation reported (proves guard did NOT fire).
+	const invalid = attrCheck(t, 'count', '-1', true, spec);
+	expect(Array.isArray(invalid)).toBe(true);
+	expect((invalid as readonly unknown[]).length).toBeGreaterThan(0);
 });

--- a/packages/@markuplint/rules/src/attr-check.ts
+++ b/packages/@markuplint/rules/src/attr-check.ts
@@ -3,6 +3,7 @@ import type { Attribute as AttrSpec, AttributeType } from '@markuplint/ml-spec';
 import type { Type } from '@markuplint/types';
 import type { ReadonlyDeep } from 'type-fest';
 
+import { isConditionalAttributeTypeArray } from '@markuplint/ml-spec';
 import { toNonNullableArrayFromItemOrArray } from '@markuplint/shared';
 import { check, getCandidate } from '@markuplint/types';
 
@@ -44,7 +45,9 @@ type Loc = {
  * 2. Verifies the attribute exists in the spec
  * 3. Checks case-sensitive name matching
  * 4. Checks whether the attribute is marked as `noUse` (disallowed)
- * 5. Validates the attribute value against all declared types
+ * 5. Short-circuits to valid when the spec declares a `ConditionalAttributeType[]`
+ *    (#3685); conditional value validation is deferred to follow-up issues #3598 and #3189
+ * 6. Validates the attribute value against all declared types
  *
  * @param t - The i18n translator for generating localized error messages
  * @param name - The attribute name to check
@@ -117,6 +120,14 @@ export function attrCheck(
 			invalidType: 'disallowed-attr',
 			message: t('{0} is {1:c}', t('the "{0*}" {1}', name, 'attribute'), 'disallowed'),
 		};
+	}
+
+	// TODO(#3598, #3189): `ConditionalAttributeType[]` ships as a type-only extension
+	// in v5.0 (#3685). Value-conditional validation (`input[type=color]` value, etc.)
+	// will be implemented in follow-up issues. Until then, short-circuit to "valid".
+	if (isConditionalAttributeTypeArray(spec.type)) {
+		log('The "%s" attribute uses ConditionalAttributeType[] — skipping (v5.0 type-only, #3685)', name);
+		return false;
 	}
 
 	const types = toNonNullableArrayFromItemOrArray(spec.type);

--- a/packages/@markuplint/rules/src/helpers.spec.ts
+++ b/packages/@markuplint/rules/src/helpers.spec.ts
@@ -1,0 +1,70 @@
+import type { Translator } from '@markuplint/i18n';
+import type { Attribute } from '@markuplint/ml-spec';
+
+import { translator } from '@markuplint/i18n';
+import { createTestElement } from '@markuplint/ml-core';
+import { i18n } from 'markuplint';
+import { test, expect, beforeAll } from 'vitest';
+
+import { isValidAttr } from './helpers.js';
+
+let t: Translator;
+
+beforeAll(() => {
+	const locale = i18n('en');
+	t = translator(locale);
+});
+
+/*
+ * #3685 — Integration tests for `isValidAttr`.
+ *
+ * These exercise the boundary where the `invalid-attr` rule meets the
+ * attribute spec data. `ConditionalAttributeType[]` is a v5.0 type-only
+ * extension (validation logic lands in #3598 / #3189). Until then, an
+ * attribute whose spec uses `ConditionalAttributeType[]` must be treated
+ * as valid — no crash, no false positive reported through the rule pipeline.
+ */
+test('[helpers-issue-3685-001] isValidAttr passes through ConditionalAttributeType[] without false positives', () => {
+	const el = createTestElement('<custom-el value="not-a-url-or-color"></custom-el>');
+	const attrSpecs: readonly Attribute[] = [
+		{
+			name: 'value',
+			type: [
+				{ condition: "[type='color' i]", type: "<'color'>" },
+				{ condition: "[type='url' i]", type: 'URL' },
+			],
+		},
+	];
+	const result = isValidAttr(t, 'value', 'not-a-url-or-color', false, el, attrSpecs);
+	// v5.0: short-circuits to valid — follow-up #3598/#3189 implements logic.
+	expect(result).toBe(false);
+});
+
+test('[helpers-issue-3685-002] isValidAttr still reports violations for regular AttributeType[] specs', () => {
+	const el = createTestElement('<custom-el autocomplete="bogus"></custom-el>');
+	const attrSpecs: readonly Attribute[] = [
+		{
+			name: 'autocomplete',
+			type: [{ enum: ['on', 'off'] }],
+		},
+	];
+	const result = isValidAttr(t, 'autocomplete', 'bogus', false, el, attrSpecs);
+	// Enum[] is not a ConditionalAttributeType[] → normal path → violation reported.
+	expect(result).not.toBe(false);
+});
+
+test('[helpers-issue-3685-003] isValidAttr does not crash when attribute is absent from a conditional spec', () => {
+	const el = createTestElement('<custom-el></custom-el>');
+	const attrSpecs: readonly Attribute[] = [
+		{
+			name: 'value',
+			type: [{ condition: "[type='color' i]", type: "<'color'>" }],
+		},
+	];
+	// Missing attribute: "unknown-attr" is not in the spec → existence error,
+	// but crucially the surrounding spec with ConditionalAttributeType[] must
+	// not poison iteration over attrSpecs.
+	const result = isValidAttr(t, 'unknown-attr', 'x', false, el, attrSpecs);
+	expect(result).not.toBe(false);
+	expect(result).toHaveProperty('invalidType', 'non-existent');
+});


### PR DESCRIPTION
## Summary

Add `ConditionalAttributeType` to the `Attribute` interface's `type` union in `@markuplint/ml-spec`, enabling future support for attributes whose value type depends on another attribute's value.

- **v5.0 ships the type definition only.** Validation logic and spec data updates will follow in #3598 and #3189.
- Adds `isConditionalAttributeTypeArray` type guard helper exported from `@markuplint/ml-spec`
- `invalid-attr` rule short-circuits to "valid" for `ConditionalAttributeType[]` specs (no false positives)

## Use cases

- **#3598**: `input[type=color]` value should be `#rrggbb`, `input[type=url]` value should be a URL — the `value` type depends on the `type` attribute (~97 missed errors)
- **#3189**: `link[rel=preload]` `as` and `link[rel=modulepreload]` `as` allow different enum values

## Changes

### `@markuplint/ml-spec`
- `gen/gen.ts`: `ConditionalAttributeType` definition with JSDoc description
- `schemas/attributes.schema.json`: Regenerated
- `src/types/attributes.ts`: Regenerated (new `ConditionalAttributeType` interface)
- `src/types/index.ts`: `Attribute.type` union extended
- `src/utils/is-conditional-attribute-type.ts`: Type guard + `@param`/`@returns` JSDoc
- `src/index.ts`: Re-export helper
- Docs: type-definitions, maintenance, ARCHITECTURE (EN + JA)

### `@markuplint/rules`
- `src/attr-check.ts`: Import helper, short-circuit + debug log
- `src/attr-check.spec.ts`: 4 unit tests
- `src/helpers.spec.ts`: 3 integration tests

## Test plan

- [x] `yarn build` succeeds for all 39 packages
- [x] `yarn test` passes all 221 test files (3199 tests)
- [x] `yarn lint-check` passes with 0 warnings / 0 errors
- [x] New tests: 9 shape tests + 12 type guard tests + 4 unit tests + 3 integration tests = 28 new tests
- [x] Ghost code check: deleting `isConditionalAttributeTypeArray` breaks 7+ tests

Closes #3685

🤖 Generated with [Claude Code](https://claude.com/claude-code)