### PR TITLE
feat(html-spec): split link[as] enum by rel condition

### DIFF
--- a/packages/@markuplint/html-spec/docs/maintenance.ja.md
+++ b/packages/@markuplint/html-spec/docs/maintenance.ja.md
@@ -88,6 +88,26 @@
 
 **使用タイミング:** HTML仕様が「属性 Y が Z のとき、値は X でなければならない」と規定している場合 — 例: `type=color` のとき `<input value>` は valid simple color でなければならない。
 
+**例2** -- `link[as]` の有効な値は `rel` に依存:
+
+```jsonc
+"as": {
+    "type": [
+        {
+            "condition": "[rel~='preload' i]",
+            "type": { "enum": ["fetch", "font", "image", "script", "style", "track"] }
+        },
+        {
+            "condition": "[rel~='modulepreload' i]",
+            "type": { "enum": ["audioworklet", "json", "paintworklet", "script", "serviceworker", "sharedworker", "style", "worker"] }
+        }
+    ],
+    "condition": ["[rel~='preload' i]", "[rel~='modulepreload' i]"]
+}
+```
+
+注: 属性レベルの `condition` は `as` 属性自体が有効かどうか（`rel=preload` または `rel=modulepreload` の場合のみ）を制御し、型レベルの `ConditionalAttributeType[]` は各 `rel` 値に対してどの enum 値が有効かを制御します。
+
 **参照:** `@markuplint/ml-spec` ドキュメント（`docs/type-definitions.md`）の `ConditionalAttributeType` セクション。
 
 ### 3. SVG要素の追加

--- a/packages/@markuplint/html-spec/docs/maintenance.md
+++ b/packages/@markuplint/html-spec/docs/maintenance.md
@@ -106,6 +106,26 @@ This is different from the attribute-level `condition` field (Recipe 2), which c
 
 **When to use:** When the HTML spec says "the value must be X when attribute Y is Z" — e.g., `<input value>` must be a valid simple color when `type=color`.
 
+**Example 2** -- `link[as]` valid values depend on `rel`:
+
+```jsonc
+"as": {
+    "type": [
+        {
+            "condition": "[rel~='preload' i]",
+            "type": { "enum": ["fetch", "font", "image", "script", "style", "track"] }
+        },
+        {
+            "condition": "[rel~='modulepreload' i]",
+            "type": { "enum": ["audioworklet", "json", "paintworklet", "script", "serviceworker", "sharedworker", "style", "worker"] }
+        }
+    ],
+    "condition": ["[rel~='preload' i]", "[rel~='modulepreload' i]"]
+}
+```
+
+Note: The attribute-level `condition` controls whether the `as` attribute is valid at all (only with `rel=preload` or `rel=modulepreload`), while the type-level `ConditionalAttributeType[]` controls which enum values are valid for each `rel` value.
+
 **See also:** `ConditionalAttributeType` in `@markuplint/ml-spec` docs (`docs/type-definitions.md`).
 
 ### 3. Adding an SVG Element

--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -52782,23 +52782,30 @@
 			"attributes": {
 				"as": {
 					"description": "This attribute is required when rel=\"preload\" has been set on the <link> element, optional when rel=\"modulepreload\" has been set, and otherwise should not be used. It specifies the type of content being loaded by the <link>, which is necessary for request matching, application of correct content security policy, and setting of correct Accept request header. Furthermore, rel=\"preload\" uses this as a signal for request prioritization. The table below lists the valid values for this attribute and the elements or resources they apply to. Value Applies To audio <audio> elements document <iframe> and <frame> elements embed <embed> elements fetch fetch, XHR Note: This value also requires <link> to contain the crossorigin attribute, see CORS-enabled fetches. font CSS @font-face Note: This value also requires <link> to contain the crossorigin attribute, see CORS-enabled fetches. image <img> and <picture> elements with srcset or imageset attributes, SVG <image> elements, CSS *-image rules json modulepreload destinations. object <object> elements script <script> elements, Worker importScripts, and modulepreload destinations. style <link rel=stylesheet> elements, CSS @import and modulepreload destinations. track <track> elements video <video> elements worker Worker, SharedWorker",
-					"type": {
-						"enum": [
-							"audioworklet",
-							"fetch",
-							"font",
-							"image",
-							"json",
-							"paintworklet",
-							"script",
-							"serviceworker",
-							"sharedworker",
-							"style",
-							"track",
-							"worker"
-						]
-					},
-					"condition": ["[rel='preload' i]", "[rel='modulepreload' i]"]
+					"type": [
+						{
+							"condition": "[rel~='preload' i]",
+							"type": {
+								"enum": ["fetch", "font", "image", "script", "style", "track"]
+							}
+						},
+						{
+							"condition": "[rel~='modulepreload' i]",
+							"type": {
+								"enum": [
+									"audioworklet",
+									"json",
+									"paintworklet",
+									"script",
+									"serviceworker",
+									"sharedworker",
+									"style",
+									"worker"
+								]
+							}
+						}
+					],
+					"condition": ["[rel~='preload' i]", "[rel~='modulepreload' i]"]
 				},
 				"blocking": {
 					"description": "This attribute explicitly indicates that certain operations should be blocked until specific conditions are met. It must only be used when the rel attribute contains the expect or stylesheet keywords. With rel=\"expect\", it indicates that operations should be blocked until a specific DOM node has been parsed. With rel=\"stylesheet\", it indicates that operations should be blocked until an external stylesheet and its critical subresources have been fetched and applied to the document. The operations that are to be blocked must be a space-separated list of blocking tokens listed below. Currently there is only one token: render: The rendering of content on the screen is blocked. Note: Only link elements in the document's <head> can possibly block rendering. By default, a link element with rel=\"stylesheet\" in the <head> blocks rendering when the browser discovers it during parsing. If such a link element is added dynamically via script, you must additionally set blocking = \"render\" for it to block rendering.",

--- a/packages/@markuplint/html-spec/src/spec.link.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.link.jsonc
@@ -68,27 +68,26 @@
 		// https://html.spec.whatwg.org/multipage/semantics.html#attr-link-as
 		// https://html.spec.whatwg.org/multipage/links.html#link-type-preload
 		// https://html.spec.whatwg.org/multipage/links.html#link-type-modulepreload
-		// The enumerated values are the union of preload destinations and module preload destinations.
-		// Preload destinations: fetch, font, image, script, style, track
-		// Module preload destinations: json, style, and script-like destinations (audioworklet, paintworklet, script, serviceworker, sharedworker, worker)
+		// The valid values differ per link type:
+		// - Preload destinations: fetch, font, image, script, style, track
+		// - Module preload destinations: json, style, and script-like destinations
+		//   (audioworklet, paintworklet, script, serviceworker, sharedworker, worker)
 		"as": {
-			"type": {
-				"enum": [
-					"audioworklet",
-					"fetch",
-					"font",
-					"image",
-					"json",
-					"paintworklet",
-					"script",
-					"serviceworker",
-					"sharedworker",
-					"style",
-					"track",
-					"worker"
-				]
-			},
-			"condition": ["[rel='preload' i]", "[rel='modulepreload' i]"]
+			"type": [
+				{
+					"condition": "[rel~='preload' i]",
+					"type": {
+						"enum": ["fetch", "font", "image", "script", "style", "track"]
+					}
+				},
+				{
+					"condition": "[rel~='modulepreload' i]",
+					"type": {
+						"enum": ["audioworklet", "json", "paintworklet", "script", "serviceworker", "sharedworker", "style", "worker"]
+					}
+				}
+			],
+			"condition": ["[rel~='preload' i]", "[rel~='modulepreload' i]"]
 		},
 		// https://html.spec.whatwg.org/multipage/urls-and-fetching.html#blocking-attributes
 		"blocking": {

--- a/packages/@markuplint/ml-spec/docs/type-definitions.ja.md
+++ b/packages/@markuplint/ml-spec/docs/type-definitions.ja.md
@@ -449,7 +449,7 @@ interface ConditionalAttributeType {
 }
 ```
 
-> **ステータス:** 型定義は v5.0 で投入済み (#3685)。`type` による `input[value]` の条件解決は [#3598](https://github.com/markuplint/markuplint/issues/3598) で実装済み — `helpers.ts` の `isValidAttr()` が要素を各条件にマッチさせ、解決された型でバリデーションを行います。条件に一致しない場合は `Any` にフォールバックします。`rel` による `link[as]` の解決 ([#3189](https://github.com/markuplint/markuplint/issues/3189)) は未実装 — `attrCheck()` に安全ネットガードが残っており、未解決の `ConditionalAttributeType[]` は有効として扱います。
+> **ステータス:** 型定義は v5.0 で投入済み (#3685)。条件解決は完全に実装済み: `type` による `input[value]` は [#3598](https://github.com/markuplint/markuplint/issues/3598)、`rel` による `link[as]` は [#3189](https://github.com/markuplint/markuplint/issues/3189)。`helpers.ts` の `isValidAttr()` が要素を各条件にマッチさせ、解決された型でバリデーションを行います。条件に一致しない場合は `Any` にフォールバックします。直接呼び出し元向けに、`attrCheck()` に安全ネットガードが残っており、未解決の `ConditionalAttributeType[]` は有効として扱います。
 
 **`List`** -- スペース区切りまたはカンマ区切りのトークンリスト用の構造化型です。
 

--- a/packages/@markuplint/ml-spec/docs/type-definitions.ja.md
+++ b/packages/@markuplint/ml-spec/docs/type-definitions.ja.md
@@ -440,7 +440,7 @@ interface AttributeJSON {
 }
 ```
 
-**`ConditionalAttributeType`** -- 条件付き型切り替え: ある属性の期待する値型が、同じ要素上の _別の_ 属性の値によって切り替わることを宣言します。例えば `<input value>` は `type=color` のとき `<'color'>`、`type=url` のとき `URL` となる、といった仕様表現に使われます。
+**`ConditionalAttributeType`** -- 条件付き型切り替え: ある属性の期待する値型が、同じ要素上の _別の_ 属性の値によって切り替わることを宣言します。例えば `<input value>` は `type=color` のとき valid simple color、`type=url` のとき valid URL でなければならない、あるいは `<link as>` は `rel` が `preload` か `modulepreload` かによって異なる destination キーワードを受け入れる、といった仕様表現に使われます。
 
 ```ts
 interface ConditionalAttributeType {

--- a/packages/@markuplint/ml-spec/docs/type-definitions.md
+++ b/packages/@markuplint/ml-spec/docs/type-definitions.md
@@ -449,7 +449,7 @@ interface ConditionalAttributeType {
 }
 ```
 
-> **Status:** The type definition shipped in v5.0 (#3685). Conditional resolution for `input[value]` by `type` is implemented in [#3598](https://github.com/markuplint/markuplint/issues/3598) — `isValidAttr()` in `helpers.ts` matches the element against each condition and validates against the resolved type; unmatched conditions fall back to `Any`. Resolution for `link[as]` by `rel` ([#3189](https://github.com/markuplint/markuplint/issues/3189)) is not yet implemented — `attrCheck()` retains a safety-net guard that treats unresolved `ConditionalAttributeType[]` as valid.
+> **Status:** The type definition shipped in v5.0 (#3685). Conditional resolution is fully implemented: `input[value]` by `type` in [#3598](https://github.com/markuplint/markuplint/issues/3598), `link[as]` by `rel` in [#3189](https://github.com/markuplint/markuplint/issues/3189). `isValidAttr()` in `helpers.ts` matches the element against each condition and validates against the resolved type; unmatched conditions fall back to `Any`. A safety-net guard in `attrCheck()` treats any remaining unresolved `ConditionalAttributeType[]` as valid for direct callers.
 
 **`List`** -- Structured type for space-separated or comma-separated token lists.
 

--- a/packages/@markuplint/ml-spec/docs/type-definitions.md
+++ b/packages/@markuplint/ml-spec/docs/type-definitions.md
@@ -440,7 +440,7 @@ interface AttributeJSON {
 }
 ```
 
-**`ConditionalAttributeType`** -- Conditional type switching: declares that an attribute's expected value type depends on the value of _another_ attribute on the same element. Used when the spec states, for example, that `<input value>` is `<'color'>` when `type=color` but a `URL` when `type=url`.
+**`ConditionalAttributeType`** -- Conditional type switching: declares that an attribute's expected value type depends on the value of _another_ attribute on the same element. Used when the spec states, for example, that `<input value>` must be a valid simple color when `type=color` but a valid URL when `type=url`, or that `<link as>` accepts different destination keywords depending on whether `rel` is `preload` or `modulepreload`.
 
 ```ts
 interface ConditionalAttributeType {

--- a/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
@@ -2361,8 +2361,24 @@ describe('#3189 link[as] conditional enum', () => {
 
 	test('[invalid-attr-issue-3189-009] no rel: as attribute is disallowed (condition check)', async () => {
 		const { violations } = await mlRuleTest(rule, '<link href="/a.css" as="style">');
-		// `as` has condition=["[rel='preload' i]","[rel='modulepreload' i]"],
+		// `as` has condition=["[rel~='preload' i]","[rel~='modulepreload' i]"],
 		// so without rel=preload/modulepreload, the attribute itself is disallowed.
 		expect(violations.some(v => v.message.includes('"as"'))).toBe(true);
+	});
+
+	test('[invalid-attr-issue-3189-010] rel with multiple tokens: preload + stylesheet', async () => {
+		// condition uses ~= (space-separated token match), so "preload stylesheet" must match
+		const { violations } = await mlRuleTest(rule, '<link rel="preload stylesheet" href="/a.css" as="style">');
+		expect(violations.some(v => v.raw === 'style')).toBe(false);
+	});
+
+	test('[invalid-attr-issue-3189-011] rel=modulepreload as=fetch is invalid (fetch is preload-only)', async () => {
+		const { violations } = await mlRuleTest(rule, '<link rel="modulepreload" href="/a" as="fetch">');
+		expect(violations.some(v => v.raw === 'fetch')).toBe(true);
+	});
+
+	test('[invalid-attr-issue-3189-012] case-insensitive rel matching: rel=PRELOAD', async () => {
+		const { violations } = await mlRuleTest(rule, '<link rel="PRELOAD" href="/a.js" as="script">');
+		expect(violations.some(v => v.raw === 'script')).toBe(false);
 	});
 });

--- a/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
@@ -1545,7 +1545,7 @@ describe('Issues', () => {
 			(await mlRuleTest(rule, '<link rel="modulepreload" as="audioworklet" href="/audio.js" />')).violations,
 		).toStrictEqual([]);
 
-		// Invalid: values removed from the spec (no longer valid for either preload or modulepreload)
+		// Invalid: values not valid for preload (condition-specific enum after #3189)
 		expect(
 			(await mlRuleTest(rule, '<link rel="preload" as="audio" href="/audio.mp3" />')).violations,
 		).toStrictEqual([
@@ -1553,8 +1553,7 @@ describe('Issues', () => {
 				severity: 'error',
 				line: 1,
 				col: 25,
-				message:
-					'The "as" attribute expects either "audioworklet", "fetch", "font", "image", "json", "paintworklet", "script", "serviceworker", "sharedworker", "style", "track", "worker"',
+				message: 'The "as" attribute expects either "fetch", "font", "image", "script", "style", "track"',
 				raw: 'audio',
 			},
 		]);
@@ -1565,8 +1564,7 @@ describe('Issues', () => {
 				severity: 'error',
 				line: 1,
 				col: 25,
-				message:
-					'The "as" attribute expects either "audioworklet", "fetch", "font", "image", "json", "paintworklet", "script", "serviceworker", "sharedworker", "style", "track", "worker"',
+				message: 'The "as" attribute expects either "fetch", "font", "image", "script", "style", "track"',
 				raw: 'video',
 			},
 		]);
@@ -1575,8 +1573,7 @@ describe('Issues', () => {
 				severity: 'error',
 				line: 1,
 				col: 25,
-				message:
-					'The "as" attribute expects either "audioworklet", "fetch", "font", "image", "json", "paintworklet", "script", "serviceworker", "sharedworker", "style", "track", "worker"',
+				message: 'The "as" attribute expects either "fetch", "font", "image", "script", "style", "track"',
 				raw: 'document',
 			},
 		]);
@@ -2298,5 +2295,74 @@ describe('#3598 input value validation', () => {
 	test('[invalid-attr-issue-3598-022] input[type=datetime-local] with invalid value', async () => {
 		const { violations } = await mlRuleTest(rule, '<input type="datetime-local" value="2024-01-15">');
 		expect(violations.some(v => v.message.includes('"value"'))).toBe(true);
+	});
+});
+
+/*
+ * #3189 — link[as] condition-specific enum values.
+ * The `as` attribute has different valid values depending on `rel`:
+ * - rel=preload → fetch, font, image, script, style, track
+ * - rel=modulepreload → json, style, audioworklet, paintworklet, script,
+ *   serviceworker, sharedworker, worker
+ */
+describe('#3189 link[as] conditional enum', () => {
+	test('[invalid-attr-issue-3189-001] rel=preload with valid as value', async () => {
+		const { violations } = await mlRuleTest(rule, '<link rel="preload" href="/a.js" as="script">');
+		expect(violations.some(v => v.raw === 'script')).toBe(false);
+	});
+
+	test('[invalid-attr-issue-3189-002] rel=preload with invalid as value (json is modulepreload-only)', async () => {
+		const { violations } = await mlRuleTest(rule, '<link rel="preload" href="/a.json" as="json">');
+		expect(violations.some(v => v.raw === 'json')).toBe(true);
+	});
+
+	test('[invalid-attr-issue-3189-003] rel=modulepreload with valid as value', async () => {
+		const { violations } = await mlRuleTest(rule, '<link rel="modulepreload" href="/a.js" as="script">');
+		expect(violations.some(v => v.raw === 'script')).toBe(false);
+	});
+
+	test('[invalid-attr-issue-3189-004] rel=modulepreload with valid as=json', async () => {
+		const { violations } = await mlRuleTest(rule, '<link rel="modulepreload" href="/a.json" as="json">');
+		expect(violations.some(v => v.raw === 'json')).toBe(false);
+	});
+
+	test('[invalid-attr-issue-3189-005] rel=modulepreload with invalid as value (track is preload-only)', async () => {
+		const { violations } = await mlRuleTest(rule, '<link rel="modulepreload" href="/a.vtt" as="track">');
+		expect(violations.some(v => v.raw === 'track')).toBe(true);
+	});
+
+	test('[invalid-attr-issue-3189-006] rel=preload with all valid preload destinations', async () => {
+		for (const dest of ['fetch', 'font', 'image', 'script', 'style', 'track']) {
+			const { violations } = await mlRuleTest(rule, `<link rel="preload" href="/a" as="${dest}">`);
+			expect(violations.some(v => v.raw === dest)).toBe(false);
+		}
+	});
+
+	test('[invalid-attr-issue-3189-007] rel=modulepreload with all valid module destinations', async () => {
+		for (const dest of [
+			'json',
+			'style',
+			'audioworklet',
+			'paintworklet',
+			'script',
+			'serviceworker',
+			'sharedworker',
+			'worker',
+		]) {
+			const { violations } = await mlRuleTest(rule, `<link rel="modulepreload" href="/a" as="${dest}">`);
+			expect(violations.some(v => v.raw === dest)).toBe(false);
+		}
+	});
+
+	test('[invalid-attr-issue-3189-008] rel=preload with completely bogus as value', async () => {
+		const { violations } = await mlRuleTest(rule, '<link rel="preload" href="/a" as="bogus">');
+		expect(violations.some(v => v.raw === 'bogus')).toBe(true);
+	});
+
+	test('[invalid-attr-issue-3189-009] no rel: as attribute is disallowed (condition check)', async () => {
+		const { violations } = await mlRuleTest(rule, '<link href="/a.css" as="style">');
+		// `as` has condition=["[rel='preload' i]","[rel='modulepreload' i]"],
+		// so without rel=preload/modulepreload, the attribute itself is disallowed.
+		expect(violations.some(v => v.message.includes('"as"'))).toBe(true);
 	});
 });


### PR DESCRIPTION
## Summary

Closes #3189

Split the `link[as]` attribute's single union enum into condition-specific enums using `ConditionalAttributeType[]` (infrastructure from #3598):

- `rel=preload` -> `fetch`, `font`, `image`, `script`, `style`, `track`
- `rel=modulepreload` -> `audioworklet`, `json`, `paintworklet`, `script`, `serviceworker`, `sharedworker`, `style`, `worker`

Previously, all 12 values were accepted for both link types. Now `as="json"` with `rel="preload"` correctly reports a violation (json is a modulepreload-only destination), and `as="track"` with `rel="modulepreload"` is likewise rejected.

No production code changes — only spec data and documentation. The conditional resolution logic from #3598 handles this automatically.

## Test plan

- [x] 12 integration tests covering valid/invalid for each rel type
- [x] Multi-token rel (`rel="preload stylesheet"`) with `~=` matching
- [x] Cross-condition rejection (modulepreload + fetch, preload + json)
- [x] Case-insensitive rel matching (`rel="PRELOAD"`)
- [x] Existing #1987 test updated to expect condition-resolved error messages
- [x] Full test suite: 3291 passed, 0 errors, 0 type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)