### PR TITLE
fix(html-spec): correct permittedRoles for input[type=button/image/reset/submit]

### DIFF
--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -51568,14 +51568,18 @@
 						"permittedRoles": [
 							"checkbox",
 							"combobox",
+							"gridcell",
 							"link",
 							"menuitem",
 							"menuitemcheckbox",
 							"menuitemradio",
 							"option",
 							"radio",
+							"separator",
+							"slider",
 							"switch",
-							"tab"
+							"tab",
+							"treeitem"
 						]
 					},
 					"[type='checkbox' i]": {
@@ -51658,7 +51662,21 @@
 					},
 					"[type='image' i]": {
 						"implicitRole": "button",
-						"permittedRoles": ["link", "menuitem", "menuitemcheckbox", "menuitemradio", "radio", "switch"]
+						"permittedRoles": [
+							"checkbox",
+							"gridcell",
+							"link",
+							"menuitem",
+							"menuitemcheckbox",
+							"menuitemradio",
+							"option",
+							"radio",
+							"separator",
+							"slider",
+							"switch",
+							"tab",
+							"treeitem"
+						]
 					},
 					"[type='month' i]": {
 						"implicitRole": false,
@@ -51764,11 +51782,22 @@
 					},
 					"[type='reset' i]": {
 						"implicitRole": "button",
-						"permittedRoles": false,
-						"properties": {
-							"global": true,
-							"role": "button"
-						}
+						"permittedRoles": [
+							"checkbox",
+							"combobox",
+							"gridcell",
+							"link",
+							"menuitem",
+							"menuitemcheckbox",
+							"menuitemradio",
+							"option",
+							"radio",
+							"separator",
+							"slider",
+							"switch",
+							"tab",
+							"treeitem"
+						]
 					},
 					"[type='search' i]:not([list])": {
 						"implicitRole": "searchbox",
@@ -51780,11 +51809,22 @@
 					},
 					"[type='submit' i]": {
 						"implicitRole": "button",
-						"permittedRoles": false,
-						"properties": {
-							"global": true,
-							"role": "button"
-						}
+						"permittedRoles": [
+							"checkbox",
+							"combobox",
+							"gridcell",
+							"link",
+							"menuitem",
+							"menuitemcheckbox",
+							"menuitemradio",
+							"option",
+							"radio",
+							"separator",
+							"slider",
+							"switch",
+							"tab",
+							"treeitem"
+						]
 					},
 					"[type='tel' i]:not([list])": {
 						"implicitRole": "textbox",
@@ -51840,6 +51880,7 @@
 						"[type='button' i]": {
 							"implicitRole": "button",
 							"permittedRoles": [
+								"checkbox",
 								"link",
 								"menuitem",
 								"menuitemcheckbox",
@@ -51927,12 +51968,15 @@
 						"[type='image' i]": {
 							"implicitRole": "button",
 							"permittedRoles": [
+								"checkbox",
 								"link",
 								"menuitem",
 								"menuitemcheckbox",
 								"menuitemradio",
+								"option",
 								"radio",
-								"switch"
+								"switch",
+								"tab"
 							]
 						},
 						"[type='month' i]": {
@@ -52039,11 +52083,17 @@
 						},
 						"[type='reset' i]": {
 							"implicitRole": "button",
-							"permittedRoles": false,
-							"properties": {
-								"global": true,
-								"role": "button"
-							}
+							"permittedRoles": [
+								"checkbox",
+								"link",
+								"menuitem",
+								"menuitemcheckbox",
+								"menuitemradio",
+								"option",
+								"radio",
+								"switch",
+								"tab"
+							]
 						},
 						"[type='search' i]:not([list])": {
 							"implicitRole": "searchbox",
@@ -52055,11 +52105,17 @@
 						},
 						"[type='submit' i]": {
 							"implicitRole": "button",
-							"permittedRoles": false,
-							"properties": {
-								"global": true,
-								"role": "button"
-							}
+							"permittedRoles": [
+								"checkbox",
+								"link",
+								"menuitem",
+								"menuitemcheckbox",
+								"menuitemradio",
+								"option",
+								"radio",
+								"switch",
+								"tab"
+							]
 						},
 						"[type='tel' i]:not([list])": {
 							"implicitRole": "textbox",
@@ -57513,7 +57569,7 @@
 			},
 			"attributes": {
 				"keyPoints": {
-					"description": "This attribute indicate, in the range [0,1], how far is the object along the path for each keyTimes associated values. Value type: <number>*; Default value: none; Animatable: no",
+					"description": "This attribute indicates, in the range [0,1], how far the object is along the path for each associated value in keyTimes. Value type: <number>*; Default value: none; Animatable: no",
 					"type": "<key-points>"
 				},
 				"origin": {

--- a/packages/@markuplint/html-spec/src/spec.input.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.input.jsonc
@@ -366,17 +366,22 @@
 		"conditions": {
 			"[type='button' i]": {
 				"implicitRole": "button",
+				// @see https://w3c.github.io/html-aria/#el-input-button
 				"permittedRoles": [
 					"checkbox",
 					"combobox",
+					"gridcell",
 					"link",
 					"menuitem",
 					"menuitemcheckbox",
 					"menuitemradio",
 					"option",
 					"radio",
+					"separator",
+					"slider",
 					"switch",
-					"tab"
+					"tab",
+					"treeitem"
 				]
 			},
 			"[type='checkbox' i]": {
@@ -467,7 +472,23 @@
 			},
 			"[type='image' i]": {
 				"implicitRole": "button",
-				"permittedRoles": ["link", "menuitem", "menuitemcheckbox", "menuitemradio", "radio", "switch"]
+				// @see https://w3c.github.io/html-aria/#el-input-image
+				// Same as button element but WITHOUT combobox
+				"permittedRoles": [
+					"checkbox",
+					"gridcell",
+					"link",
+					"menuitem",
+					"menuitemcheckbox",
+					"menuitemradio",
+					"option",
+					"radio",
+					"separator",
+					"slider",
+					"switch",
+					"tab",
+					"treeitem"
+				]
 			},
 			"[type='month' i]": {
 				"implicitRole": false,
@@ -577,11 +598,24 @@
 			},
 			"[type='reset' i]": {
 				"implicitRole": "button",
-				"permittedRoles": false,
-				"properties": {
-					"global": true,
-					"role": "button"
-				}
+				// @see https://w3c.github.io/html-aria/#el-input-reset
+				// Same permitted roles as button element
+				"permittedRoles": [
+					"checkbox",
+					"combobox",
+					"gridcell",
+					"link",
+					"menuitem",
+					"menuitemcheckbox",
+					"menuitemradio",
+					"option",
+					"radio",
+					"separator",
+					"slider",
+					"switch",
+					"tab",
+					"treeitem"
+				]
 			},
 			"[type='search' i]:not([list])": {
 				"implicitRole": "searchbox",
@@ -593,11 +627,24 @@
 			},
 			"[type='submit' i]": {
 				"implicitRole": "button",
-				"permittedRoles": false,
-				"properties": {
-					"global": true,
-					"role": "button"
-				}
+				// @see https://w3c.github.io/html-aria/#el-input-submit
+				// Same permitted roles as button element
+				"permittedRoles": [
+					"checkbox",
+					"combobox",
+					"gridcell",
+					"link",
+					"menuitem",
+					"menuitemcheckbox",
+					"menuitemradio",
+					"option",
+					"radio",
+					"separator",
+					"slider",
+					"switch",
+					"tab",
+					"treeitem"
+				]
 			},
 			"[type='tel' i]:not([list])": {
 				"implicitRole": "textbox",
@@ -648,6 +695,8 @@
 			}
 		},
 		"1.1": {
+			// Frozen snapshot — ARIA 1.1 is a finalized W3C Recommendation.
+			// Do NOT add roles that were introduced in ARIA 1.2 or later.
 			// No condition:
 			// > input type=text or with a missing or invalid type, with no list attribute
 			// https://www.w3.org/TR/html-aria/#el-input-text
@@ -657,6 +706,7 @@
 				"[type='button' i]": {
 					"implicitRole": "button",
 					"permittedRoles": [
+						"checkbox",
 						"link",
 						"menuitem",
 						"menuitemcheckbox",
@@ -749,7 +799,17 @@
 				},
 				"[type='image' i]": {
 					"implicitRole": "button",
-					"permittedRoles": ["link", "menuitem", "menuitemcheckbox", "menuitemradio", "radio", "switch"]
+					"permittedRoles": [
+						"checkbox",
+						"link",
+						"menuitem",
+						"menuitemcheckbox",
+						"menuitemradio",
+						"option",
+						"radio",
+						"switch",
+						"tab"
+					]
 				},
 				"[type='month' i]": {
 					"implicitRole": false,
@@ -859,11 +919,17 @@
 				},
 				"[type='reset' i]": {
 					"implicitRole": "button",
-					"permittedRoles": false,
-					"properties": {
-						"global": true,
-						"role": "button"
-					}
+					"permittedRoles": [
+						"checkbox",
+						"link",
+						"menuitem",
+						"menuitemcheckbox",
+						"menuitemradio",
+						"option",
+						"radio",
+						"switch",
+						"tab"
+					]
 				},
 				"[type='search' i]:not([list])": {
 					"implicitRole": "searchbox",
@@ -875,11 +941,17 @@
 				},
 				"[type='submit' i]": {
 					"implicitRole": "button",
-					"permittedRoles": false,
-					"properties": {
-						"global": true,
-						"role": "button"
-					}
+					"permittedRoles": [
+						"checkbox",
+						"link",
+						"menuitem",
+						"menuitemcheckbox",
+						"menuitemradio",
+						"option",
+						"radio",
+						"switch",
+						"tab"
+					]
 				},
 				"[type='tel' i]:not([list])": {
 					"implicitRole": "textbox",

--- a/packages/@markuplint/ml-spec/src/algorithm/aria/get-permitted-roles-spec.spec.ts
+++ b/packages/@markuplint/ml-spec/src/algorithm/aria/get-permitted-roles-spec.spec.ts
@@ -231,17 +231,22 @@ describe('getPermittedRoles', () => {
 			'button',
 			'checkbox',
 			'combobox',
+			'gridcell',
 			'link',
 			'menuitem',
 			'menuitemcheckbox',
 			'menuitemradio',
 			'option',
 			'radio',
+			'separator',
+			'slider',
 			'switch',
 			'tab',
+			'treeitem',
 		]);
 		expect(c('<input type="button">', '1.1')).toStrictEqual([
 			'button',
+			'checkbox',
 			'link',
 			'menuitem',
 			'menuitemcheckbox',
@@ -252,6 +257,100 @@ describe('getPermittedRoles', () => {
 			'tab',
 		]);
 		expect(c('<input type="checkbox" aria-pressed="true">', '1.2')).toStrictEqual(['checkbox', 'button']);
+	});
+
+	test('the input element — reset, submit, image (#3588)', () => {
+		// input[type=reset] — same permitted roles as button element
+		expect(c('<input type="reset">', '1.2')).toStrictEqual([
+			'button',
+			'checkbox',
+			'combobox',
+			'gridcell',
+			'link',
+			'menuitem',
+			'menuitemcheckbox',
+			'menuitemradio',
+			'option',
+			'radio',
+			'separator',
+			'slider',
+			'switch',
+			'tab',
+			'treeitem',
+		]);
+		expect(c('<input type="reset">', '1.1')).toStrictEqual([
+			'button',
+			'checkbox',
+			'link',
+			'menuitem',
+			'menuitemcheckbox',
+			'menuitemradio',
+			'option',
+			'radio',
+			'switch',
+			'tab',
+		]);
+
+		// input[type=submit] — same permitted roles as button element
+		expect(c('<input type="submit">', '1.2')).toStrictEqual([
+			'button',
+			'checkbox',
+			'combobox',
+			'gridcell',
+			'link',
+			'menuitem',
+			'menuitemcheckbox',
+			'menuitemradio',
+			'option',
+			'radio',
+			'separator',
+			'slider',
+			'switch',
+			'tab',
+			'treeitem',
+		]);
+		expect(c('<input type="submit">', '1.1')).toStrictEqual([
+			'button',
+			'checkbox',
+			'link',
+			'menuitem',
+			'menuitemcheckbox',
+			'menuitemradio',
+			'option',
+			'radio',
+			'switch',
+			'tab',
+		]);
+
+		// input[type=image] — same as button but WITHOUT combobox
+		expect(c('<input type="image">', '1.2')).toStrictEqual([
+			'button',
+			'checkbox',
+			'gridcell',
+			'link',
+			'menuitem',
+			'menuitemcheckbox',
+			'menuitemradio',
+			'option',
+			'radio',
+			'separator',
+			'slider',
+			'switch',
+			'tab',
+			'treeitem',
+		]);
+		expect(c('<input type="image">', '1.1')).toStrictEqual([
+			'button',
+			'checkbox',
+			'link',
+			'menuitem',
+			'menuitemcheckbox',
+			'menuitemradio',
+			'option',
+			'radio',
+			'switch',
+			'tab',
+		]);
 	});
 
 	test('the img element', () => {

--- a/packages/@markuplint/rules/src/wai-aria/index.spec.ts
+++ b/packages/@markuplint/rules/src/wai-aria/index.spec.ts
@@ -2473,3 +2473,184 @@ describe('Issue #970 — Required Accessibility Parent Role check', () => {
 		expect(violations).toStrictEqual([]);
 	});
 });
+
+// #3588: input element permitted roles false positives
+describe('Issue #3588 — input element permitted roles', () => {
+	// input[type=reset] should allow same roles as button element
+	test('[wai-aria-issue-3588-001] input[type=reset] with role="link" is valid', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="reset" role="link">');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('[wai-aria-issue-3588-002] input[type=reset] with role="switch" — no permitted-roles violation', async () => {
+		// switch requires aria-checked, so a required-state violation is expected,
+		// but there must be NO "Cannot overwrite" permitted-roles violation.
+		const { violations } = await mlRuleTest(rule, '<input type="reset" role="switch">');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 1,
+				message: 'Require the "aria-checked" ARIA state on the "switch" role',
+				raw: '<input type="reset" role="switch">',
+			},
+		]);
+	});
+
+	test('[wai-aria-issue-3588-003] input[type=reset] with role="switch" and aria-checked is fully valid', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="reset" role="switch" aria-checked="true">');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('[wai-aria-issue-3588-004] input[type=reset] with role="tab" is valid', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="reset" role="tab">');
+		expect(violations).toStrictEqual([]);
+	});
+
+	// input[type=submit] should allow same roles as button element
+	test('[wai-aria-issue-3588-005] input[type=submit] with role="menuitem" is valid', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="submit" role="menuitem">');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('[wai-aria-issue-3588-006] input[type=submit] with role="checkbox" — no permitted-roles violation', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="submit" role="checkbox">');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 1,
+				message: 'Require the "aria-checked" ARIA state on the "checkbox" role',
+				raw: '<input type="submit" role="checkbox">',
+			},
+		]);
+	});
+
+	test('[wai-aria-issue-3588-007] input[type=submit] with role="checkbox" and aria-checked is fully valid', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="submit" role="checkbox" aria-checked="false">');
+		expect(violations).toStrictEqual([]);
+	});
+
+	// input[type=image] should allow button-like roles (except combobox)
+	test('[wai-aria-issue-3588-008] input[type=image] with role="checkbox" — no permitted-roles violation', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="image" role="checkbox" alt="Toggle">');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 1,
+				message: 'Require the "aria-checked" ARIA state on the "checkbox" role',
+				raw: '<input type="image" role="checkbox" alt="Toggle">',
+			},
+		]);
+	});
+
+	test('[wai-aria-issue-3588-009] input[type=image] with role="checkbox" and aria-checked is fully valid', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<input type="image" role="checkbox" aria-checked="false" alt="Toggle">',
+		);
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('[wai-aria-issue-3588-010] input[type=image] with role="tab" is valid', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="image" role="tab" alt="Tab">');
+		expect(violations).toStrictEqual([]);
+	});
+
+	// input[type=button] with new 1.2 roles
+	test('[wai-aria-issue-3588-011] input[type=button] with role="gridcell" is valid', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="button" role="gridcell" value="Cell">');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('[wai-aria-issue-3588-012] input[type=button] with role="treeitem" is valid', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="button" role="treeitem" value="Item">');
+		expect(violations).toStrictEqual([]);
+	});
+
+	// Invalid cases — should still report violations after fix
+	test('[wai-aria-issue-3588-013] input[type=reset] with role="navigation" is not permitted', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="reset" role="navigation">');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 27,
+				message:
+					'Cannot overwrite the "navigation" role to the "input" element according to ARIA in HTML specification',
+				raw: 'navigation',
+			},
+		]);
+	});
+
+	test('[wai-aria-issue-3588-014] input[type=image] with role="combobox" is not permitted', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="image" role="combobox" alt="Combo">');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 27,
+				message:
+					'Cannot overwrite the "combobox" role to the "input" element according to ARIA in HTML specification',
+				raw: 'combobox',
+			},
+		]);
+	});
+
+	// Cascading fix: permitted role → correct computed role → props valid
+	test('[wai-aria-issue-3588-015] input[type=submit] role=switch aria-checked — no cascade violation', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="submit" role="switch" aria-checked="true">');
+		expect(violations).toStrictEqual([]);
+	});
+
+	// Default behavior preserved after properties removal
+	test('[wai-aria-issue-3588-016] input[type=reset] without role — default behavior preserved', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="reset">');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('[wai-aria-issue-3588-017] input[type=submit] without role — default behavior preserved', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="submit">');
+		expect(violations).toStrictEqual([]);
+	});
+
+	// ARIA 1.1 boundary: roles added in 1.2 must be rejected in 1.1
+	test('[wai-aria-issue-3588-018] input[type=reset] with role="gridcell" is NOT permitted in 1.1', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="reset" role="gridcell">', {
+			rule: { options: { version: '1.1' } },
+		});
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 27,
+				message:
+					'Cannot overwrite the "gridcell" role to the "input" element according to ARIA in HTML specification',
+				raw: 'gridcell',
+			},
+		]);
+	});
+
+	test('[wai-aria-issue-3588-019] input[type=image] with role="treeitem" is NOT permitted in 1.1', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="image" role="treeitem" alt="Item">', {
+			rule: { options: { version: '1.1' } },
+		});
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 27,
+				message:
+					'Cannot overwrite the "treeitem" role to the "input" element according to ARIA in HTML specification',
+				raw: 'treeitem',
+			},
+		]);
+	});
+
+	// Focusable separator with required aria-valuenow
+	test('[wai-aria-issue-3588-020] input[type=submit] with role="separator" and aria-valuenow is valid', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="submit" role="separator" aria-valuenow="50">');
+		expect(violations).toStrictEqual([]);
+	});
+});


### PR DESCRIPTION
## Summary

- Fix false positive `wai-aria` violations on `input[type=reset]`, `input[type=submit]`, `input[type=image]`, and `input[type=button]` by aligning `permittedRoles` with the [ARIA in HTML](https://w3c.github.io/html-aria/) specification
- `input[type=reset/submit]`: `permittedRoles: false` → button-equivalent role array (14 roles)
- `input[type=button]`: add `gridcell`, `separator`, `slider`, `treeitem`
- `input[type=image]`: add `checkbox`, `gridcell`, `option`, `separator`, `slider`, `tab`, `treeitem` (no `combobox` per spec)
- Also fix ARIA 1.1 section for the same four types, and add frozen-snapshot comment
- Resolves ~113 nu-validator false positives (72 permitted-roles + 41 cascading disallowed-props)

## Test plan

- [x] `get-permitted-roles-spec.spec.ts`: updated expectations for `input[type=button]` (1.2 + 1.1), added new test block for reset/submit/image (1.2 + 1.1)
- [x] `wai-aria/index.spec.ts`: 20 regression tests covering valid roles, invalid roles, required-state vs permitted-roles, ARIA 1.1 boundary, cascading fix, properties removal, focusable separator
- [x] Full test suite: 3312 passed, 0 failed
- [x] Lint: 0 warnings, 0 errors
- [x] Idempotent `yarn up:gen` verified

Closes #3588

🤖 Generated with [Claude Code](https://claude.com/claude-code)