### PR TITLE
fix(ml-spec): apply optimizePermittedRoles to condition-specific overrides

### DIFF
--- a/packages/@markuplint/ml-spec/docs/aria-algorithms.ja.md
+++ b/packages/@markuplint/ml-spec/docs/aria-algorithms.ja.md
@@ -325,7 +325,6 @@ if (result.role) {
 1. `getVersionResolvedARIA()` を呼び出します。この関数は：
    - タグ名と名前空間で要素仕様を検索します。
    - `resolveVersion()` を適用して、ベース ARIA 仕様の上にバージョン固有のオーバーライドをマージします。
-   - 許可ロールの最適化：許可ロール配列に `"presentation"` がある場合は `"none"` を追加し、逆も同様です（WAI-ARIA 1.2 の `none` ロールに関する注記に準拠）。ARIA 1.3 では、`"image"` がある場合は `"img"` を追加し、逆も同様です（ARIA 1.3 の `image`/`img` シノニムに準拠）。
    - 結果を `localName + namespace + version` をキーとしてキャッシュします。
 
 2. 条件付きオーバーライド（ARIA 仕様の `conditions` ブロック）を評価します：
@@ -333,7 +332,9 @@ if (result.role) {
    - マッチする条件ごとに、`implicitRole`、`permittedRoles`、`implicitProperties`、`properties`、`namingProhibited` を上書きします。
    - 後の条件は前の条件よりも優先されます。
 
-3. 最終的に解決された ARIA 仕様を返します。要素の仕様が存在しない場合は `null` を返します。
+3. 許可ロールの最適化（ベース値と条件オーバーライド値の両方に適用）：許可ロール配列に `"presentation"` がある場合は `"none"` を追加し、逆も同様です（WAI-ARIA 1.2 の `none` ロールに関する注記に準拠）。ARIA 1.3 では、`"image"` がある場合は `"img"` を追加し、逆も同様です（ARIA 1.3 の `image`/`img` シノニムに準拠）。
+
+4. 最終的に解決された ARIA 仕様を返します。要素の仕様が存在しない場合は `null` を返します。
 
 **例:** `<input>` の場合、ベース仕様は汎用的な暗黙のロールを定義しますが、条件 `[type=checkbox]` がそれを `"checkbox"` ロールに上書きします。
 

--- a/packages/@markuplint/ml-spec/docs/aria-algorithms.md
+++ b/packages/@markuplint/ml-spec/docs/aria-algorithms.md
@@ -325,7 +325,6 @@ Gets the version-resolved ARIA specification for an element, evaluating conditio
 1. Calls `getVersionResolvedARIA()` which:
    - Looks up the element spec by tag name and namespace.
    - Applies `resolveVersion()` to merge version-specific overrides on top of the base ARIA spec.
-   - Optimizes permitted roles: if `"presentation"` is in the permitted roles array, `"none"` is added, and vice versa (per WAI-ARIA 1.2 note on the `none` role). In ARIA 1.3, if `"image"` is present, `"img"` is added, and vice versa (per the ARIA 1.3 `image`/`img` synonym).
    - Caches results by `localName + namespace + version`.
 
 2. Evaluates conditional overrides (the `conditions` block in the ARIA spec):
@@ -333,7 +332,9 @@ Gets the version-resolved ARIA specification for an element, evaluating conditio
    - For each matching condition, overrides `implicitRole`, `permittedRoles`, `implicitProperties`, `properties`, and `namingProhibited`.
    - Later conditions take precedence over earlier ones.
 
-3. Returns the final resolved ARIA spec, or `null` if no spec exists for the element.
+3. Optimizes permitted roles (applied to both base and condition-overridden values): if `"presentation"` is in the permitted roles array, `"none"` is added, and vice versa (per WAI-ARIA 1.2 note on the `none` role). In ARIA 1.3, if `"image"` is present, `"img"` is added, and vice versa (per the ARIA 1.3 `image`/`img` synonym).
+
+4. Returns the final resolved ARIA spec, or `null` if no spec exists for the element.
 
 **Example:** For `<input>`, the base spec may define a generic implicit role, but the condition `[type=checkbox]` overrides it to `"checkbox"`.
 

--- a/packages/@markuplint/ml-spec/src/algorithm/aria/get-aria.spec.ts
+++ b/packages/@markuplint/ml-spec/src/algorithm/aria/get-aria.spec.ts
@@ -1,0 +1,79 @@
+import specs from '@markuplint/html-spec';
+import { createSelector } from '@markuplint/selector';
+import { createJSDOMElement } from '@markuplint/test-tools';
+import { describe, test, expect } from 'vitest';
+
+import { getARIA } from './get-aria.js';
+
+function a(html: string, version: '1.1' | '1.2' | '1.3', selector?: string) {
+	const el = createJSDOMElement(html, selector);
+	return getARIA(
+		specs,
+		el.localName,
+		el.namespaceURI,
+		version,
+		selector => createSelector(selector, specs).match(el) !== false,
+	);
+}
+
+describe('getARIA — optimizePermittedRoles on conditions (#3724)', () => {
+	test('base permittedRoles includes none/presentation synonyms', () => {
+		// form base permittedRoles includes both "none" and "presentation"
+		const aria = a('<form></form>', '1.2');
+		expect(aria?.permittedRoles).toStrictEqual(expect.arrayContaining(['none', 'presentation']));
+	});
+
+	test('condition-specific permittedRoles sorted with synonyms applied', () => {
+		// dl > div condition has permittedRoles: ["presentation", "none"]
+		// optimizePermittedRoles should sort them → ["none", "presentation"]
+		const aria = a('<dl><div></div></dl>', '1.2', 'div');
+		expect(aria?.permittedRoles).toStrictEqual(['none', 'presentation']);
+	});
+
+	test('condition-specific permittedRoles sorted alphabetically', () => {
+		// input[type=button] condition permittedRoles should be sorted
+		const aria = a('<input type="button">', '1.2');
+		expect(aria?.permittedRoles).toStrictEqual([
+			'checkbox',
+			'combobox',
+			'gridcell',
+			'link',
+			'menuitem',
+			'menuitemcheckbox',
+			'menuitemradio',
+			'option',
+			'radio',
+			'separator',
+			'slider',
+			'switch',
+			'tab',
+			'treeitem',
+		]);
+	});
+
+	test('ARIA 1.3 image/img synonym applied to base permittedRoles', () => {
+		// embed element base permittedRoles includes "img"
+		// In 1.3, "image" should also appear (no-conditions early return path)
+		// Note: no spec data currently has "img" in a condition-specific
+		// permittedRoles, so only the base spec path is verified here.
+		const aria = a('<embed>', '1.3');
+		expect(aria?.permittedRoles).toStrictEqual(expect.arrayContaining(['img', 'image']));
+
+		// In 1.2, "image" synonym should NOT be added
+		const aria12 = a('<embed>', '1.2');
+		expect(aria12?.permittedRoles).toContain('img');
+		expect(aria12?.permittedRoles).not.toContain('image');
+	});
+
+	test('permittedRoles: false is passed through without optimization', () => {
+		// input[type=color] condition sets permittedRoles: false
+		const aria = a('<input type="color">', '1.2');
+		expect(aria?.permittedRoles).toBe(false);
+	});
+
+	test('permittedRoles: true is passed through without optimization', () => {
+		// div base permittedRoles is true (any role allowed)
+		const aria = a('<div></div>', '1.2');
+		expect(aria?.permittedRoles).toBe(true);
+	});
+});

--- a/packages/@markuplint/ml-spec/src/algorithm/aria/get-aria.ts
+++ b/packages/@markuplint/ml-spec/src/algorithm/aria/get-aria.ts
@@ -32,7 +32,10 @@ export function getARIA(
 	}
 	const conditions = aria.conditions;
 	if (!conditions) {
-		return aria;
+		return {
+			...aria,
+			permittedRoles: optimizePermittedRoles(aria.permittedRoles, version),
+		};
 	}
 	const conditionKeys = Object.keys(conditions);
 	let { implicitRole, permittedRoles, implicitProperties, properties, namingProhibited } = aria;
@@ -67,13 +70,17 @@ export function getARIA(
 	}
 	return {
 		implicitRole,
-		permittedRoles,
+		permittedRoles: optimizePermittedRoles(permittedRoles, version),
 		implicitProperties,
 		properties,
 		namingProhibited,
 	};
 }
 
+/**
+ * Returns raw ARIA spec without permittedRoles optimization.
+ * Callers must apply optimizePermittedRoles() to the result.
+ */
 function getVersionResolvedARIA(specs: MLMLSpec, localName: string, namespace: string | null, version: ARIAVersion) {
 	const key = localName + namespace + version;
 	let aria = cache.get(key);
@@ -86,12 +93,6 @@ function getVersionResolvedARIA(specs: MLMLSpec, localName: string, namespace: s
 		return null;
 	}
 	aria = resolveVersion(spec, version);
-	if (aria.permittedRoles !== false) {
-		aria = {
-			...aria,
-			permittedRoles: optimizePermittedRoles(aria.permittedRoles, version),
-		};
-	}
 	cache.set(key, aria);
 	return aria;
 }


### PR DESCRIPTION
## Summary

- Move `optimizePermittedRoles()` from `getVersionResolvedARIA()` (cached, base-spec only) to `getARIA()` (both return paths), ensuring role synonyms (`none`↔`presentation`, ARIA 1.3 `image`↔`img`) and alphabetical sorting are applied to condition-specific `permittedRoles` overrides as well
- Add internal contract comment to `getVersionResolvedARIA` noting it returns raw (un-optimized) data
- Update `aria-algorithms.md` / `aria-algorithms.ja.md` to reflect the moved optimization step

## Test plan

- [x] 6 new `getARIA` unit tests: base synonyms, condition-specific sort/synonyms, ARIA 1.3 image/img, `false`/`true` pass-through
- [x] Full test suite: 3318 passed, 0 failed
- [x] Lint: 0 warnings, 0 errors

Closes #3724

🤖 Generated with [Claude Code](https://claude.com/claude-code)