### PR TITLE
test(rules): document empty container behavior for wai-aria-required-owned-elements

### DIFF
--- a/packages/@markuplint/rules/src/wai-aria-required-owned-elements/index.spec.ts
+++ b/packages/@markuplint/rules/src/wai-aria-required-owned-elements/index.spec.ts
@@ -18,3 +18,29 @@ test('[wai-aria-required-owned-elements-invalid-001] list without listitem', asy
 	expect(violations.length).toBe(1);
 	expect(violations[0]!.severity).toBe('warning');
 });
+
+// #3589: empty containers warn with busy suggestion (not error)
+test('[wai-aria-required-owned-elements-issue-3589-001] empty ul warns with busy suggestion', async () => {
+	const { violations } = await mlRuleTest(rule, '<ul></ul>');
+	expect(violations.length).toBe(1);
+	expect(violations[0]!.severity).toBe('warning');
+	expect(violations[0]!.message).toContain('aria-busy');
+});
+
+test('[wai-aria-required-owned-elements-issue-3589-002] empty div[role=list] warns with busy suggestion', async () => {
+	const { violations } = await mlRuleTest(rule, '<div role="list"></div>');
+	expect(violations.length).toBe(1);
+	expect(violations[0]!.severity).toBe('warning');
+	expect(violations[0]!.message).toContain('aria-busy');
+});
+
+test('[wai-aria-required-owned-elements-issue-3589-003] empty menu warns with busy suggestion', async () => {
+	const { violations } = await mlRuleTest(rule, '<menu></menu>');
+	expect(violations.length).toBe(1);
+	expect(violations[0]!.severity).toBe('warning');
+	expect(violations[0]!.message).toContain('aria-busy');
+});
+
+test('[wai-aria-required-owned-elements-issue-3589-004] ul with aria-busy="true" is valid', async () => {
+	expect((await mlRuleTest(rule, '<ul aria-busy="true"></ul>')).violations).toStrictEqual([]);
+});

--- a/packages/@markuplint/rules/src/wai-aria-required-owned-elements/index.spec.ts
+++ b/packages/@markuplint/rules/src/wai-aria-required-owned-elements/index.spec.ts
@@ -22,23 +22,41 @@ test('[wai-aria-required-owned-elements-invalid-001] list without listitem', asy
 // #3589: empty containers warn with busy suggestion (not error)
 test('[wai-aria-required-owned-elements-issue-3589-001] empty ul warns with busy suggestion', async () => {
 	const { violations } = await mlRuleTest(rule, '<ul></ul>');
-	expect(violations.length).toBe(1);
-	expect(violations[0]!.severity).toBe('warning');
-	expect(violations[0]!.message).toContain('aria-busy');
+	expect(violations).toStrictEqual([
+		{
+			severity: 'warning',
+			line: 1,
+			col: 1,
+			message: 'The child element requires the "listitem" role. Or, require aria-busy="true"',
+			raw: '<ul>',
+		},
+	]);
 });
 
 test('[wai-aria-required-owned-elements-issue-3589-002] empty div[role=list] warns with busy suggestion', async () => {
 	const { violations } = await mlRuleTest(rule, '<div role="list"></div>');
-	expect(violations.length).toBe(1);
-	expect(violations[0]!.severity).toBe('warning');
-	expect(violations[0]!.message).toContain('aria-busy');
+	expect(violations).toStrictEqual([
+		{
+			severity: 'warning',
+			line: 1,
+			col: 1,
+			message: 'The child element requires the "listitem" role. Or, require aria-busy="true"',
+			raw: '<div role="list">',
+		},
+	]);
 });
 
 test('[wai-aria-required-owned-elements-issue-3589-003] empty menu warns with busy suggestion', async () => {
 	const { violations } = await mlRuleTest(rule, '<menu></menu>');
-	expect(violations.length).toBe(1);
-	expect(violations[0]!.severity).toBe('warning');
-	expect(violations[0]!.message).toContain('aria-busy');
+	expect(violations).toStrictEqual([
+		{
+			severity: 'warning',
+			line: 1,
+			col: 1,
+			message: 'The child element requires the "listitem" role. Or, require aria-busy="true"',
+			raw: '<menu>',
+		},
+	]);
 });
 
 test('[wai-aria-required-owned-elements-issue-3589-004] ul with aria-busy="true" is valid', async () => {


### PR DESCRIPTION
## Summary

- Add 4 tests documenting that `wai-aria-required-owned-elements` correctly handles empty containers as **warnings** (not errors) with an `aria-busy` suggestion
- The false positive reported in #3589 was resolved by the wai-aria rule split (#3680), which moved this check to a standalone rule with `defaultSeverity: 'warning'`
- No production code changes — tests only

## Test plan

- [x] Empty `<ul>`, `<div role="list">`, `<menu>` → warning with exact message assertion
- [x] `<ul aria-busy="true">` → no violation
- [x] Full test suite: 3322 passed, 0 failed

Closes #3589

🤖 Generated with [Claude Code](https://claude.com/claude-code)