### PR TITLE
fix(html-spec,rules): allow empty dl element (zero or more dt+dd groups)

### DIFF
--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -50370,7 +50370,7 @@
 						"choice": [
 							[
 								{
-									"oneOrMore": [
+									"zeroOrMore": [
 										{
 											"zeroOrMore": ":model(script-supporting)"
 										},

--- a/packages/@markuplint/html-spec/src/spec.dl.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.dl.jsonc
@@ -8,7 +8,10 @@
 				"choice": [
 					[
 						{
-							"oneOrMore": [
+							// HTML spec: "Zero or more groups each consisting of
+							// one or more dt elements followed by one or more dd elements"
+							// @see https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element
+							"zeroOrMore": [
 								{
 									"zeroOrMore": ":model(script-supporting)"
 								},

--- a/packages/@markuplint/rules/src/permitted-contents/choice.spec.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/choice.spec.ts
@@ -133,6 +133,34 @@ test('[permitted-contents-invalid-004] the dl element', () => {
 	expect(c(models, '<dt></dt><dd></dd><dt></dt>').type).toBe('MISSING_NODE_ONE_OR_MORE');
 });
 
+test('[permitted-contents-issue-3592-001] dl with zeroOrMore groups — empty is valid', () => {
+	const models = {
+		choice: [
+			[
+				{
+					zeroOrMore: [
+						{ zeroOrMore: ':model(script-supporting)' },
+						{ oneOrMore: 'dt' },
+						{ zeroOrMore: ':model(script-supporting)' },
+						{ oneOrMore: 'dd' },
+						{ zeroOrMore: ':model(script-supporting)' },
+					],
+				},
+			],
+			[
+				{ zeroOrMore: ':model(script-supporting)' },
+				{ oneOrMore: 'div' },
+				{ zeroOrMore: ':model(script-supporting)' },
+			],
+		],
+	};
+
+	expect(c(models, '').type).toBe('MATCHED_ZERO');
+	expect(c(models, '<dt></dt><dd></dd>').type).toBe('MATCHED');
+	expect(c(models, '<div></div>').type).toBe('MATCHED');
+	expect(c(models, '<dt></dt>').type).toBe('MISSING_NODE_ONE_OR_MORE');
+});
+
 test('[permitted-contents-invalid-005] part of the ruby element', () => {
 	const models = {
 		// 2. One or the other of the following:

--- a/packages/@markuplint/rules/src/permitted-contents/count-pattern.spec.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/count-pattern.spec.ts
@@ -310,6 +310,38 @@ test('[permitted-contents-invalid-014] part of the ruby element #3', () => {
 });
 
 describe('Issues', () => {
+	// #3592: verify min=0 guard doesn't break optional with nested require
+	test('[permitted-contents-issue-3592-001] optional with nested require — empty is valid', () => {
+		expect(c({ optional: [{ require: 'dt' }, { require: 'dd' }] }, '').type).toBe('MATCHED_ZERO');
+	});
+
+	test('[permitted-contents-issue-3592-002] optional with nested require — partial is invalid', () => {
+		expect(c({ optional: [{ require: 'dt' }, { require: 'dd' }] }, '<dt></dt>').type).toBe('MISSING_NODE_REQUIRED');
+	});
+
+	test('[permitted-contents-issue-3592-003] zeroOrMore with nested sequence — empty is valid', () => {
+		// This is the actual pattern used by the dl element fix
+		expect(
+			c(
+				{
+					zeroOrMore: [{ oneOrMore: 'dt' }, { oneOrMore: 'dd' }],
+				},
+				'',
+			).type,
+		).toBe('MATCHED_ZERO');
+	});
+
+	test('[permitted-contents-issue-3592-004] zeroOrMore with nested sequence — match is valid', () => {
+		expect(
+			c(
+				{
+					zeroOrMore: [{ oneOrMore: 'dt' }, { oneOrMore: 'dd' }],
+				},
+				'<dt></dt><dd></dd>',
+			).type,
+		).toBe('MATCHED');
+	});
+
 	test('[permitted-contents-issue-1146-001] #1146 1/2', () => {
 		const models = {
 			oneOrMore: [

--- a/packages/@markuplint/rules/src/permitted-contents/count-pattern.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/count-pattern.ts
@@ -202,10 +202,15 @@ export function countPattern(
 			matchedCount,
 		);
 
+		// When min=0 and no elements were consumed, the pattern legitimately
+		// matched zero times — don't propagate the inner sequence's failure.
+		// This enables zeroOrMore([oneOrMore dt, oneOrMore dd]) to accept
+		// empty content (e.g., <dl></dl>). See #3592.
 		if (
-			result.type === 'MISSING_NODE_REQUIRED' ||
-			result.type === 'MISSING_NODE_ONE_OR_MORE' ||
-			result.type === 'TRANSPARENT_MODEL_DISALLOWS'
+			(collection.matchedCount > 0 || min > 0) &&
+			(result.type === 'MISSING_NODE_REQUIRED' ||
+				result.type === 'MISSING_NODE_ONE_OR_MORE' ||
+				result.type === 'TRANSPARENT_MODEL_DISALLOWS')
 		) {
 			return compereResult(
 				{

--- a/packages/@markuplint/rules/src/permitted-contents/index.spec.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/index.spec.ts
@@ -2120,4 +2120,49 @@ describe('Issues', () => {
 			}),
 		);
 	});
+
+	// #3592: empty dl is valid (zero or more groups)
+	test('[permitted-contents-issue-3592-001] empty dl is valid', async () => {
+		expect((await mlRuleTest(rule, '<dl></dl>')).violations).toStrictEqual([]);
+	});
+
+	test('[permitted-contents-issue-3592-002] dl with dt+dd is still valid', async () => {
+		expect((await mlRuleTest(rule, '<dl><dt>term</dt><dd>def</dd></dl>')).violations).toStrictEqual([]);
+	});
+
+	test('[permitted-contents-issue-3592-003] dl with div is still valid', async () => {
+		expect((await mlRuleTest(rule, '<dl><div><dt>term</dt><dd>def</dd></div></dl>')).violations).toStrictEqual([]);
+	});
+
+	test('[permitted-contents-issue-3592-004] dl with only dt is still invalid', async () => {
+		const { violations } = await mlRuleTest(rule, '<dl><dt>term</dt></dl>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 1,
+				message: 'Require one or more elements. (Need "dd")',
+				raw: '<dl>',
+			},
+		]);
+	});
+
+	test('[permitted-contents-issue-3592-005] dl with only dd is still invalid', async () => {
+		const { violations } = await mlRuleTest(rule, '<dl><dd>def</dd></dl>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 1,
+				message: 'Require one or more elements. (Need "dt")',
+				raw: '<dl>',
+			},
+		]);
+	});
+
+	test('[permitted-contents-issue-3592-006] dl with multiple dt+dd groups is valid', async () => {
+		expect((await mlRuleTest(rule, '<dl><dt>a</dt><dd>b</dd><dt>c</dt><dd>d</dd></dl>')).violations).toStrictEqual(
+			[],
+		);
+	});
 });


### PR DESCRIPTION
## Summary

- Fix `<dl></dl>` false positive: the HTML spec says "zero or more groups" but the spec data used `oneOrMore`
- Two changes required:
  1. **html-spec**: `spec.dl.jsonc` — `oneOrMore` → `zeroOrMore` for the dt+dd group repetition
  2. **rules**: `count-pattern.ts` — when `min=0` and no elements consumed, don't propagate the inner sequence's `MISSING_NODE` error (return `MATCHED_ZERO` instead)
- Spec data fix alone was insufficient because the `permitted-contents` engine's `countPattern` function incorrectly forwarded internal `MISSING_NODE_ONE_OR_MORE` results even when the outer pattern allowed zero matches

## Test plan

- [x] `count-pattern.spec.ts`: 4 tests — `optional` empty/partial, `zeroOrMore` nested sequence empty/match
- [x] `choice.spec.ts`: 1 test — dl-like model with `zeroOrMore` groups (empty + valid + invalid)
- [x] `index.spec.ts`: 6 integration tests — empty dl, dt+dd, div wrapper, dt-only, dd-only, multiple groups
- [x] Full test suite: 3333 passed, 0 failed
- [x] Lint: 0 warnings, 0 errors

Closes #3592

🤖 Generated with [Claude Code](https://claude.com/claude-code)