### PR TITLE
fix(parser-utils)!: align unquoted attribute value tokenizer with HTML spec

### DIFF
--- a/packages/@markuplint/html-parser/src/index.spec.ts
+++ b/packages/@markuplint/html-parser/src/index.spec.ts
@@ -1215,6 +1215,45 @@ describe('Issues', () => {
 			'[11:2]>[12:2](60,67)body: <body⏎>',
 		]);
 	});
+
+	// https://html.spec.whatwg.org/multipage/syntax.html#attributes-2
+	// `/` is a valid character in an unquoted attribute value. The parser must not throw.
+	test('#3594 unquoted attribute value containing "/"', () => {
+		expect(() => parse('<picture><source srcset=x type=image/gif><img src=x alt=x></picture>')).not.toThrow();
+
+		const doc = parse('<picture><source srcset=x type=image/gif><img src=x alt=x></picture>');
+		const source = doc.nodeList.find(n => n.nodeName === 'source') as MLASTElement;
+		expect(source).toBeDefined();
+		const typeAttr = source.attributes.find(a => a.type === 'attr' && a.name.raw === 'type')!;
+		expect(typeAttr.type).toBe('attr');
+		expect((typeAttr as Extract<typeof typeAttr, { type: 'attr' }>).value.raw).toBe('image/gif');
+
+		expect(() => parse('<script src=/foo.js></script>')).not.toThrow();
+		expect(() => parse('<img src=/a/b alt=x>')).not.toThrow();
+	});
+
+	// https://html.spec.whatwg.org/multipage/parsing.html#attribute-value-(unquoted)-state
+	// Per the HTML spec, `/` in the attribute value (unquoted) state is NOT a terminator.
+	// Self-closing `/>` only applies in the before/after attribute name state.
+	// Therefore `<input type=text/>` is parsed as `type="text/"`, not self-closing with type="text".
+	test('#3594 spec: "/" before ">" is part of the unquoted value', () => {
+		const doc = parse('<input type=text/>');
+		const input = doc.nodeList.find(n => n.nodeName === 'input') as MLASTElement;
+		expect(input).toBeDefined();
+		const typeAttr = input.attributes.find(a => a.type === 'attr' && a.name.raw === 'type')!;
+		expect(typeAttr.type).toBe('attr');
+		expect((typeAttr as Extract<typeof typeAttr, { type: 'attr' }>).value.raw).toBe('text/');
+	});
+
+	// Ensure the outer tag tokenizer still handles self-closing slashes in the
+	// "before attribute name" state (i.e., with no preceding unquoted value).
+	test('#3594 spec: "<br/>" remains a well-formed void-element tag', () => {
+		expect(() => parse('<br/>')).not.toThrow();
+		const doc = parse('<br/>');
+		const br = doc.nodeList.find(n => n.nodeName === 'br') as MLASTElement | undefined;
+		expect(br).toBeDefined();
+		expect(br?.type).toBe('starttag');
+	});
 });
 
 describe('Circular reference removal', () => {

--- a/packages/@markuplint/jsx-parser/src/index.spec.ts
+++ b/packages/@markuplint/jsx-parser/src/index.spec.ts
@@ -644,6 +644,19 @@ const C = () => {
 		expect(nodeListToDebugMaps(doc.nodeList, true)).toStrictEqual(['[9:10]>[9:17](148,155)div: <div␣/>']);
 	});
 
+	// Pins the cross-package impact of Issue #3594's default change.
+	// JSX does not allow unquoted string attribute values at the language level
+	// (typescript-estree rejects them), so the default change is behaviorally
+	// inert for JSX. This test pins that fact: `/` in curly-brace expressions
+	// stays untouched because the tokenizer switches to `script` quote type
+	// before `endOfUnquotedValueChars` is consulted.
+	test('#3594 JSX curly-brace expressions still parse paths containing "/"', () => {
+		const doc = parse('const C = () => <img src={"/foo/bar.png"} alt="x" />;');
+		const img = doc.nodeList.find(n => n.nodeName === 'img');
+		const srcAttr = img.attributes.find(a => a.name?.raw === 'src');
+		expect(srcAttr.value.raw).toBe('"/foo/bar.png"');
+	});
+
 	test('#1451', () => {
 		expect(parse('<div></div>').nodeList[0].elementType).toBe('html');
 		expect(parse('<x-div></x-div>').nodeList[0].elementType).toBe('web-component');

--- a/packages/@markuplint/parser-utils/SKILL.md
+++ b/packages/@markuplint/parser-utils/SKILL.md
@@ -101,6 +101,7 @@ Customize attribute parsing behavior for a specific parser. Follow recipe #4 in 
    - `quoteSet` -- custom quote delimiters (e.g., `{` `}` for JSX)
    - `startState` -- initial AttrState (usually `BeforeName`)
    - `noQuoteValueType` -- value type for unquoted values
+   - `endOfUnquotedValueChars` -- characters that terminate an unquoted value (default: whitespace and `>`, matching the WHATWG HTML spec)
 
 ### Step 2: Post-process
 

--- a/packages/@markuplint/parser-utils/docs/maintenance.ja.md
+++ b/packages/@markuplint/parser-utils/docs/maintenance.ja.md
@@ -120,6 +120,27 @@ visitAttr(token: Token) {
 }
 ```
 
+#### 引用符なし属性値の終端文字のカスタマイズ
+
+`endOfUnquotedValueChars` のデフォルトは WHATWG HTML の "attribute value (unquoted) state" に準拠し、空白類と `>` のみが値を終端する。`/` は値の一部として扱われる。
+
+ホスト言語が異なる規則を要求する場合はカスタムリストを渡す:
+
+```ts
+// Pug: 文字による終端を無効化 — Pug レクサが属性境界を既に区切っている
+super.visitAttr(token, {
+  quoteSet: [],
+  endOfUnquotedValueChars: [],
+});
+```
+
+```ts
+// `/` を終端文字として扱う（例: `a=x/>` を属性 `a="x"` + 自己閉じ `/>` として読む）
+super.visitAttr(token, {
+  endOfUnquotedValueChars: ['\t', '\n', '\f', '\r', ' ', '/', '>'],
+});
+```
+
 ### 5. IDL属性マッピングの追加
 
 IDL属性マップは `src/idl-attributes.ts` で定義されています。新しいマッピングを追加するには:

--- a/packages/@markuplint/parser-utils/docs/maintenance.md
+++ b/packages/@markuplint/parser-utils/docs/maintenance.md
@@ -120,6 +120,27 @@ visitAttr(token: Token) {
 }
 ```
 
+#### Customizing Unquoted Value Terminators
+
+The default `endOfUnquotedValueChars` follows the WHATWG HTML "attribute value (unquoted) state": only whitespace and `>` terminate the value. `/` is part of the value.
+
+Pass a custom list when the host language requires different rules:
+
+```ts
+// Pug: never terminate by character — the Pug lexer already delimits attrs
+super.visitAttr(token, {
+  quoteSet: [],
+  endOfUnquotedValueChars: [],
+});
+```
+
+```ts
+// Treat `/` as a terminator (e.g., to read `a=x/>` as attribute `a="x"` + self-closing `/>`)
+super.visitAttr(token, {
+  endOfUnquotedValueChars: ['\t', '\n', '\f', '\r', ' ', '/', '>'],
+});
+```
+
 ### 5. Adding an IDL Attribute Mapping
 
 The IDL attribute map is defined in `src/idl-attributes.ts`. To add a new mapping:

--- a/packages/@markuplint/parser-utils/docs/parser-class.ja.md
+++ b/packages/@markuplint/parser-utils/docs/parser-class.ja.md
@@ -282,6 +282,17 @@ visitAttr(
 
 また、`visitSpreadAttr()` を通じてスプレッド属性の検出も試みます。
 
+#### オプション
+
+| オプション                | デフォルト                                                                             | 説明                                                                                                                                                                                                                                                                                |
+| ------------------------- | -------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `quoteSet`                | `[{ start: '"', end: '"', type: 'string' }, { start: "'", end: "'", type: 'string' }]` | 属性値として認識される引用符のセット。JSX / Vue / Svelte / Astro / MDX では `{` `}` を `type: 'script'` として追加する。                                                                                                                                                            |
+| `noQuoteValueType`        | `'string'`                                                                             | 引用符で囲まれていない値に割り当てられる値の型。                                                                                                                                                                                                                                    |
+| `endOfUnquotedValueChars` | `['\t', '\n', '\f', '\r', ' ', '>']`                                                   | 引用符なし属性値を終端する文字。WHATWG HTML の "attribute value (unquoted) state" に準拠し、空白類と `>` のみ。`/` は終端ではなく値に含まれる（自己閉じの `/` は前段の before/after attribute name state で処理される）。終端判定を完全に無効化するには `[]` を渡す（Pug で利用）。 |
+| `startState`              | `AttrState.BeforeName`                                                                 | 属性トークナイザの初期状態。JSX の `{...spread}` のような式のみの属性を扱う場合は `AttrState.BeforeValue` を指定する。                                                                                                                                                              |
+
+> 参照: [WHATWG HTML — attribute value (unquoted) state](<https://html.spec.whatwg.org/multipage/parsing.html#attribute-value-(unquoted)-state>)
+
 ### visitSpreadAttr()
 
 ```ts

--- a/packages/@markuplint/parser-utils/docs/parser-class.md
+++ b/packages/@markuplint/parser-utils/docs/parser-class.md
@@ -282,6 +282,17 @@ If the raw string contains multiple attributes, only the first is parsed and the
 
 Also attempts to detect spread attributes via `visitSpreadAttr()`.
 
+#### Options
+
+| Option                    | Default                                                                                | Description                                                                                                                                                                                                                                                                                                                                 |
+| ------------------------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `quoteSet`                | `[{ start: '"', end: '"', type: 'string' }, { start: "'", end: "'", type: 'string' }]` | Quote delimiters recognized for the attribute value. Override to add expression delimiters such as `{` `}` (JSX / Vue / Svelte / Astro / MDX) with `type: 'script'`.                                                                                                                                                                        |
+| `noQuoteValueType`        | `'string'`                                                                             | Value type assigned when the value is unquoted.                                                                                                                                                                                                                                                                                             |
+| `endOfUnquotedValueChars` | `['\t', '\n', '\f', '\r', ' ', '>']`                                                   | Characters that terminate an unquoted attribute value. Matches the WHATWG HTML "attribute value (unquoted) state" — whitespace and `>` only. `/` is NOT a terminator and is included in the value (self-closing `/` is handled earlier, in the before/after attribute name state). Pass `[]` to disable termination entirely (used by Pug). |
+| `startState`              | `AttrState.BeforeName`                                                                 | Initial state of the attribute tokenizer. Use `AttrState.BeforeValue` to start directly at the value (e.g., for bare expression attributes like JSX `{...spread}`).                                                                                                                                                                         |
+
+> See: [WHATWG HTML — attribute value (unquoted) state](<https://html.spec.whatwg.org/multipage/parsing.html#attribute-value-(unquoted)-state>)
+
 ### visitSpreadAttr()
 
 ```ts

--- a/packages/@markuplint/parser-utils/src/attr-tokenizer.spec.ts
+++ b/packages/@markuplint/parser-utils/src/attr-tokenizer.spec.ts
@@ -366,9 +366,9 @@ test('a=/>', () => {
 		equal: '=',
 		spacesAfterEqual: '',
 		quoteStart: '',
-		attrValue: '',
+		attrValue: '/',
 		quoteEnd: '',
-		leftover: '/>',
+		leftover: '>',
 	});
 });
 
@@ -380,9 +380,9 @@ test('a=a/>', () => {
 		equal: '=',
 		spacesAfterEqual: '',
 		quoteStart: '',
-		attrValue: 'a',
+		attrValue: 'a/',
 		quoteEnd: '',
-		leftover: '/>',
+		leftover: '>',
 	});
 });
 
@@ -485,6 +485,59 @@ describe('Issues', () => {
 			attrValue: "...register('x', options)",
 			quoteEnd: '}',
 			leftover: '',
+		});
+	});
+
+	// https://html.spec.whatwg.org/multipage/parsing.html#attribute-value-(unquoted)-state
+	// Per WHATWG HTML, `<`, `"`, `'`, `=`, `` ` `` in an unquoted attribute value
+	// are parse errors but the character itself is STILL appended to the attribute value.
+	// The tokenizer must not terminate the value on these characters.
+	test('#3594 spec: parse-error characters are included in the unquoted value', () => {
+		expect(attrTokenizer('a=x"y')).toMatchObject({ attrName: 'a', attrValue: 'x"y', leftover: '' });
+		expect(attrTokenizer("a=x'y")).toMatchObject({ attrName: 'a', attrValue: "x'y", leftover: '' });
+		expect(attrTokenizer('a=x=y')).toMatchObject({ attrName: 'a', attrValue: 'x=y', leftover: '' });
+		expect(attrTokenizer('a=x`y')).toMatchObject({ attrName: 'a', attrValue: 'x`y', leftover: '' });
+		expect(attrTokenizer('a=x<y')).toMatchObject({ attrName: 'a', attrValue: 'x<y', leftover: '' });
+	});
+
+	// https://html.spec.whatwg.org/multipage/syntax.html#attributes-2
+	// Unquoted attribute values may contain any character except whitespace, `"`, `'`, `=`, `<`, `>`, and `` ` ``.
+	// The solidus `/` is explicitly permitted.
+	test('#3594 unquoted value containing "/"', () => {
+		expect(attrTokenizer('type=image/gif')).toStrictEqual({
+			spacesBeforeAttrName: '',
+			attrName: 'type',
+			spacesBeforeEqual: '',
+			equal: '=',
+			spacesAfterEqual: '',
+			quoteStart: '',
+			attrValue: 'image/gif',
+			quoteEnd: '',
+			leftover: '',
+		});
+
+		expect(attrTokenizer('src=/foo.js>')).toStrictEqual({
+			spacesBeforeAttrName: '',
+			attrName: 'src',
+			spacesBeforeEqual: '',
+			equal: '=',
+			spacesAfterEqual: '',
+			quoteStart: '',
+			attrValue: '/foo.js',
+			quoteEnd: '',
+			leftover: '>',
+		});
+
+		expect(attrTokenizer('src=/a/b alt=x')).toStrictEqual({
+			spacesBeforeAttrName: '',
+			attrName: 'src',
+			spacesBeforeEqual: '',
+			equal: '=',
+			spacesAfterEqual: '',
+			quoteStart: '',
+			attrValue: '/a/b',
+			quoteEnd: '',
+			leftover: ' alt=x',
 		});
 	});
 });

--- a/packages/@markuplint/parser-utils/src/attr-tokenizer.ts
+++ b/packages/@markuplint/parser-utils/src/attr-tokenizer.ts
@@ -17,13 +17,17 @@ const EQUAL = '=';
  * @see https://html.spec.whatwg.org/multipage/parsing.html#tag-name-state
  * @see https://html.spec.whatwg.org/multipage/parsing.html#before-attribute-name-state
  * @see https://html.spec.whatwg.org/multipage/parsing.html#attribute-name-state
+ * @see https://html.spec.whatwg.org/multipage/parsing.html#attribute-value-(unquoted)-state
  */
 export function attrTokenizer(
 	raw: string,
 	quoteSet = defaultQuoteSet,
 	startState = AttrState.BeforeName,
 	noQuoteValueType: ValueType = 'string',
-	endOfUnquotedValueChars: ReadonlyArray<string> = [...defaultSpaces, '/', '>'],
+	// Default follows the spec referenced above: only whitespace and `>` terminate
+	// the value. `/` is handled by the outer tag tokenizer (before/after attribute
+	// name state), not here.
+	endOfUnquotedValueChars: ReadonlyArray<string> = [...defaultSpaces, '>'],
 ) {
 	let state: AttrState = startState;
 	let spacesBeforeAttrName = '';

--- a/packages/@markuplint/vue-parser/src/index.spec.ts
+++ b/packages/@markuplint/vue-parser/src/index.spec.ts
@@ -606,4 +606,16 @@ h3 {
 		expect(parse('<template><x-div></x-div></template>').nodeList[0].elementType).toBe('web-component');
 		expect(parse('<template><Div></Div></template>').nodeList[0].elementType).toBe('authored');
 	});
+
+	// Pins the cross-package impact of Issue #3594's default change.
+	// Vue parser relies on the default `endOfUnquotedValueChars` from parser-utils.
+	// After the fix, `/` is no longer a terminator, so unquoted values in Vue
+	// templates inherit the HTML-spec behavior: `/` is part of the value.
+	test('#3594 Vue inherits HTML-spec unquoted "/" handling', () => {
+		expect(() => parse('<template><img src=/a/b.png alt=x></template>')).not.toThrow();
+		const doc = parse('<template><img src=/a/b.png alt=x></template>');
+		const img = doc.nodeList.find(n => n.nodeName === 'img');
+		const srcAttr = img.attributes.find(a => a.name?.raw === 'src');
+		expect(srcAttr.value.raw).toBe('/a/b.png');
+	});
 });

--- a/packages/markuplint/src/index.spec.ts
+++ b/packages/markuplint/src/index.spec.ts
@@ -408,3 +408,52 @@ describe('fixSummary pipeline', () => {
 		expect(fixSummary).toBeUndefined();
 	});
 });
+
+// Regression guard for Issue #3594.
+//
+// Primary impact: markuplint's attr tokenizer used to reject `<source type=image/gif>`
+// as "Invalid tag syntax". That false-positive `ParserError` replaced the whole
+// document with a single `parse-error` violation, silencing every other rule.
+//
+// This test pins the END-TO-END contract: valid HTML (per the WHATWG spec's
+// "attribute value (unquoted) state") must NOT emit `parse-error`, and unrelated
+// rules must still run. A unit test on attr-tokenizer alone cannot catch this
+// because the collateral silencing happens in MLCore, not in the tokenizer.
+describe('Issue #3594 — unquoted "/" does not block the lint pipeline', () => {
+	const cases = [
+		{
+			label: '<source srcset=x type=image/gif>',
+			html: '<!doctype html>\n<html lang=en><head><meta charset=utf-8><title>t</title></head><body><picture><source srcset=x type=image/gif><img src=x alt=x></picture></body></html>',
+		},
+		{
+			label: '<script src=/foo.js>',
+			html: '<!doctype html>\n<html lang=en><head><meta charset=utf-8><title>t</title></head><body><script src=/foo.js></script></body></html>',
+		},
+		{
+			label: '<img src=/a/b alt=x>',
+			html: '<!doctype html>\n<html lang=en><head><meta charset=utf-8><title>t</title></head><body><img src=/a/b alt=x></body></html>',
+		},
+	];
+
+	for (const { label, html } of cases) {
+		it(`does not emit parse-error for ${label}`, async () => {
+			const { violations } = await mlTest(html, { extends: ['markuplint:recommended'] });
+			const parseErrors = violations.filter(v => v.ruleId === 'parse-error');
+			expect(parseErrors).toStrictEqual([]);
+		});
+	}
+
+	// Before the fix, the `parse-error` violation short-circuited the pipeline
+	// by replacing MLCore's #document with the ParserError, so no other rule
+	// ever ran. This case deliberately includes an `attr-value-quotes` target
+	// (`src=x` is unquoted) to prove the rest of the pipeline keeps executing.
+	it('other rules keep running on documents that previously threw', async () => {
+		const { violations } = await mlTest(
+			'<!doctype html>\n<html lang=en><head><meta charset=utf-8><title>t</title></head><body><picture><source srcset=x type=image/gif><img src=x alt=x></picture></body></html>',
+			{ rules: { 'attr-value-quotes': true } },
+		);
+		const unrelated = violations.filter(v => v.ruleId !== 'parse-error');
+		expect(unrelated.length).toBeGreaterThan(0);
+		expect(unrelated.some(v => v.ruleId === 'attr-value-quotes')).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

- Closes #3594.
- The `attrTokenizer` in `@markuplint/parser-utils` treated `/` as a terminator inside unquoted attribute values, so inputs like `<source type=image/gif>` were rejected with `SyntaxError: Invalid tag syntax` and surfaced as a single `parse-error` violation that short-circuited the pipeline and silenced every other rule.
- The default `endOfUnquotedValueChars` now matches the WHATWG HTML "attribute value (unquoted) state": only whitespace and `>` terminate an unquoted value. `/` is part of the value.
- This eliminates the false-positive rejection of spec-conforming HTML that parse5 already accepts, and restores downstream rule execution on affected documents.

## BREAKING CHANGE

The default `endOfUnquotedValueChars` of `attrTokenizer()` / `Parser.visitAttr()` changes from `['\t', '\n', '\f', '\r', ' ', '/', '>']` to `['\t', '\n', '\f', '\r', ' ', '>']`.

Consumers that relied on `/` as a terminator must opt in explicitly:

\`\`\`ts
super.visitAttr(token, {
  endOfUnquotedValueChars: ['\t', '\n', '\f', '\r', ' ', '/', '>'],
});
\`\`\`

## Test plan

- [x] \`yarn build\`: 39 projects pass
- [x] \`yarn lint-check\`: 0 warnings / 0 errors (CSpell reports 0 files — known worktree limitation)
- [x] \`yarn test\`: 225 files / 3354 passed / 1 skipped / 0 type errors
- [x] \`attr-tokenizer\` unit tests cover spec-compliant handling of parse-error characters (\`<\`, \`"\`, \`'\`, \`=\`, \`` \` ``\`) that must stay inside the value
- [x] \`html-parser\` regression tests cover the three inputs from the issue plus \`<input type=text/>\` → \`type=\"text/\"\` and \`<br/>\` as a well-formed void tag
- [x] \`jsx-parser\` / \`vue-parser\` pin the cross-package behavior under the new default
- [x] \`markuplint\` end-to-end tests assert no \`parse-error\` is emitted and that other rules keep running on documents that previously threw

🤖 Generated with [Claude Code](https://claude.com/claude-code)