### PR TITLE
fix(rules): apply permitted-contents user rule on pretended elements

### DIFF
--- a/packages/@markuplint/rules/src/permitted-contents/README.ja.md
+++ b/packages/@markuplint/rules/src/permitted-contents/README.ja.md
@@ -175,6 +175,45 @@ description: HTML要素のコンテンツモデルと構造的な制約を検証
 }
 ```
 
+### [`pretenders`](/docs/guides/beyond-html#pretenders)オプションと併用したタグルール
+
+[`pretenders`](/docs/guides/beyond-html#pretenders)設定によって要素がHTML要素にマッピングされている場合（たとえばJSXコンポーネント`<Breadcrumbs>`を`<nav>`として扱う場合）、このルールは要素を**2つの独立したパス**で検証します。
+
+1. **Pretendedパス** — pretender先のHTMLコンテンツモデル（例: `<nav>`）に基づいて検証します。他のルールが要素を見るのと同じ方法で、従来の動作に一致します。
+2. **Originパス** — コンポーネントの元の名前（ソースコードに現れる識別子）をキーにしたタグルールを宣言している場合、pretenderコンテキストを一時的に抑制した状態でそのルールを追加評価します。これにより子要素セレクターはコンポーネント名（例: `BreadcrumbList`）で一致し、pretender先の`<ol>`ではなく`<BreadcrumbList>`にマッチします。
+
+Originパスは以下の**両方**の条件を満たすときのみ実行されます。
+
+- 要素がpretenderマッピングを持つ（`pretenders`設定または`as`属性経由）**かつ**
+- `permitted-contents`設定に`tag`がコンポーネントのソースレベル名と一致するエントリが存在する
+
+ユーザーがコンポーネント名向けのタグルールを宣言していない場合、Originパスはスキップされ、ルールはこれまでと完全に同じ挙動を示します。既存の設定が影響を受けることはありません。
+
+```json class=config
+{
+  "pretenders": [
+    { "selector": "Breadcrumbs", "as": "nav" },
+    { "selector": "BreadcrumbsLabel", "as": "span" },
+    { "selector": "BreadcrumbList", "as": "ol" },
+    { "selector": "BreadcrumbItem", "as": "li" },
+    { "selector": "BreadcrumbLink", "as": "a" }
+  ],
+  "rules": {
+    "permitted-contents": [
+      {
+        "tag": "Breadcrumbs",
+        "contents": [{ "optional": "BreadcrumbsLabel" }, { "require": "BreadcrumbList" }]
+      },
+      { "tag": "BreadcrumbList", "contents": [{ "oneOrMore": "BreadcrumbItem" }] },
+      { "tag": "BreadcrumbItem", "contents": [{ "require": "BreadcrumbLink" }] },
+      { "tag": "BreadcrumbLink", "contents": [{ "require": "#text" }] }
+    ]
+  }
+}
+```
+
+この設定により、ルールはコンポーネントレベルの構造（Originパス）**と**pretend先のHTMLコンテンツモデル（`<nav>`/`<ol>`/…）を同時に強制します。2つのパスは独立に違反を報告するため、両方のビューに違反する子ノードには複数の診断が付く場合があります。これは各視点からのエラーを作者が確認できるよう意図されたものです。
+
 ### `ignoreHasMutableChildren`オプションの設定
 
 - 型: `boolean`

--- a/packages/@markuplint/rules/src/permitted-contents/README.md
+++ b/packages/@markuplint/rules/src/permitted-contents/README.md
@@ -166,6 +166,45 @@ The `choice` keyword has the following meanings for the specified array:
 }
 ```
 
+### Tag rules with the [`pretenders`](/docs/guides/beyond-html#pretenders) option
+
+When an element is mapped to an HTML element via [`pretenders`](/docs/guides/beyond-html#pretenders) (e.g., a JSX component `<Breadcrumbs>` pretending to be `<nav>`), this rule evaluates the element in **two independent passes**:
+
+1. **Pretended pass** — validates the element against the HTML content model of the pretender target (e.g., `<nav>`). This is how all other rules see the element and matches the historical behavior.
+2. **Origin pass** — if you have declared a tag rule keyed on the component's original name (the identifier that appears in the source code), that rule is additionally evaluated with the pretender context suppressed, so child selectors match the component identities (e.g., `BreadcrumbList` matches `<BreadcrumbList>`, not the pretended `<ol>`).
+
+The origin pass only runs when **both** conditions hold:
+
+- The element has a pretender mapping (from the `pretenders` config or an `as` attribute), **and**
+- The `permitted-contents` config contains an entry whose `tag` equals the component's source-level name
+
+If the user has not declared a tag rule for the component name, the origin pass is skipped and the rule behaves exactly as it did before — existing configurations are not affected.
+
+```json class=config
+{
+  "pretenders": [
+    { "selector": "Breadcrumbs", "as": "nav" },
+    { "selector": "BreadcrumbsLabel", "as": "span" },
+    { "selector": "BreadcrumbList", "as": "ol" },
+    { "selector": "BreadcrumbItem", "as": "li" },
+    { "selector": "BreadcrumbLink", "as": "a" }
+  ],
+  "rules": {
+    "permitted-contents": [
+      {
+        "tag": "Breadcrumbs",
+        "contents": [{ "optional": "BreadcrumbsLabel" }, { "require": "BreadcrumbList" }]
+      },
+      { "tag": "BreadcrumbList", "contents": [{ "oneOrMore": "BreadcrumbItem" }] },
+      { "tag": "BreadcrumbItem", "contents": [{ "require": "BreadcrumbLink" }] },
+      { "tag": "BreadcrumbLink", "contents": [{ "require": "#text" }] }
+    ]
+  }
+}
+```
+
+With this config, the rule enforces the component-level structure (origin pass) **and** the pretended HTML content model (`<nav>`/`<ol>`/…) simultaneously. Because the two passes report violations independently, a single child node may receive multiple diagnostics when it breaks both views — this is intentional so that the author can see each perspective.
+
 ### Setting `ignoreHasMutableChildren` option
 
 - Type: `boolean`

--- a/packages/@markuplint/rules/src/permitted-contents/choice.spec.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/choice.spec.ts
@@ -6,7 +6,7 @@ import { choice } from './choice.js';
 
 function c(models: any, innerHtml: string) {
 	const el = createTestElement(`<div>${innerHtml}</div>`);
-	return choice(models, [...el.childNodes], specs, { ignoreHasMutableChildren: true }, 0);
+	return choice(models, [...el.childNodes], [], specs, { ignoreHasMutableChildren: true }, 0, 'pretended');
 }
 
 test('[permitted-contents-invalid-001] ordered requires', () => {

--- a/packages/@markuplint/rules/src/permitted-contents/choice.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/choice.ts
@@ -24,9 +24,12 @@ const indexes = new WeakMap<Result<MatchedReason>, number>();
  *
  * @param pattern - The choice pattern containing multiple alternative content model branches.
  * @param childNodes - The child nodes to validate against the choice branches.
+ * @param rules - User-defined tag rules. Threaded through for transparent-model recursion;
+ *                not consulted here directly. See `order` for the rationale.
  * @param specs - The resolved spec data for content model lookups.
  * @param options - Validation behavior options.
  * @param depth - The current recursion depth, used for debug logging and nested evaluation.
+ * @param mode - Whether we are evaluating the element's `'origin'` or `'pretended'` identity.
  * @returns A result from the best-matching branch, or the branch that came closest to matching.
  */
 export function choice(

--- a/packages/@markuplint/rules/src/permitted-contents/choice.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/choice.ts
@@ -1,4 +1,4 @@
-import type { ChildNode, MatchedReason, Options, Result, Specs } from './types.js';
+import type { ChildNode, MatchedReason, Mode, Options, Result, Specs, TagRule } from './types.js';
 import type { PermittedContentChoice } from '@markuplint/ml-spec';
 import type { ReadonlyDeep } from 'type-fest';
 
@@ -33,9 +33,11 @@ export function choice(
 	pattern: ReadonlyDeep<PermittedContentChoice>,
 	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
 	childNodes: readonly ChildNode[],
+	rules: readonly TagRule[],
 	specs: Specs,
 	options: Options,
 	depth: number,
+	mode: Mode,
 ): Result {
 	const choiceLog = cmLog.extend(`choice#${depth}`);
 	const collection = new Collection(childNodes);
@@ -45,7 +47,7 @@ export function choice(
 	for (const some of pattern.choice) {
 		choiceLog('Patterns[%s]: %s', i, modelLog(some, ''));
 
-		const result = order(some, collection.unmatched, specs, options, depth + 1);
+		const result = order(some, collection.unmatched, rules, specs, options, depth + 1, mode);
 
 		if (
 			result.type === 'MATCHED' ||

--- a/packages/@markuplint/rules/src/permitted-contents/complex-branch.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/complex-branch.ts
@@ -1,4 +1,4 @@
-import type { ChildNode, Options, Result, Specs } from './types.js';
+import type { ChildNode, Mode, Options, Result, Specs, TagRule } from './types.js';
 import type { PermittedContentPattern } from '@markuplint/ml-spec';
 import type { ReadonlyDeep } from 'type-fest';
 
@@ -25,17 +25,19 @@ export function complexBranch(
 	pattern: ReadonlyDeep<PermittedContentPattern>,
 	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
 	childNodes: readonly ChildNode[],
+	rules: readonly TagRule[],
 	specs: Specs,
 	options: Options,
 	depth: number,
+	mode: Mode,
 ): Result {
 	if (isChoice(pattern)) {
-		return choice(pattern, childNodes, specs, options, depth);
+		return choice(pattern, childNodes, rules, specs, options, depth, mode);
 	}
 
 	if (isTransparent(pattern)) {
 		return transparent(childNodes);
 	}
 
-	return countPattern(pattern, childNodes, specs, options, depth);
+	return countPattern(pattern, childNodes, rules, specs, options, depth, mode);
 }

--- a/packages/@markuplint/rules/src/permitted-contents/complex-branch.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/complex-branch.ts
@@ -16,9 +16,12 @@ import { isChoice, isTransparent } from './utils.js';
  *
  * @param pattern - A single content model pattern to evaluate.
  * @param childNodes - The child nodes to validate against the pattern.
+ * @param rules - User-defined tag rules. Threaded through for transparent-model recursion;
+ *                not consulted here directly. See `order` for the rationale.
  * @param specs - The resolved spec data for content model lookups.
  * @param options - Validation behavior options.
  * @param depth - The current recursion depth, used for debug logging and nested evaluation.
+ * @param mode - Whether we are evaluating the element's `'origin'` or `'pretended'` identity.
  * @returns A result indicating whether the child nodes match the pattern.
  */
 export function complexBranch(

--- a/packages/@markuplint/rules/src/permitted-contents/content-model.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/content-model.ts
@@ -1,5 +1,6 @@
-import type { ContentModelResult, Element, Options, Specs, TagRule } from './types.js';
-import type { MLMLSpec } from '@markuplint/ml-spec';
+import type { ContentModelResult, Element, Mode, Options, Specs, TagRule } from './types.js';
+import type { ContentModel, MLMLSpec } from '@markuplint/ml-spec';
+import type { ReadonlyDeep } from 'type-fest';
 
 import { getContentModel } from '@markuplint/ml-spec';
 
@@ -14,6 +15,9 @@ import { start } from './start.js';
  * @param el - The element whose children are to be validated against its content model.
  * @param rules - User-defined tag rules that can override or extend built-in content models.
  * @param options - Validation behavior options (e.g., whether to ignore mutable children).
+ * @param mode - Which identity to evaluate the element as (`'origin'` consults user
+ *               rules keyed on the pre-pretender AST name; `'pretended'` uses the
+ *               HTML spec for the pretender target).
  * @returns An array of content model results, one per child node issue found (empty if all valid).
  */
 export function contentModel(
@@ -21,8 +25,9 @@ export function contentModel(
 	el: Element,
 	rules: readonly TagRule[],
 	options: Options,
+	mode: Mode,
 ): ContentModelResult[] {
-	const { model, specs } = createModel(el, rules);
+	const { model, specs } = createModel(el, rules, mode);
 	if (model == null) {
 		return [
 			{
@@ -33,7 +38,7 @@ export function contentModel(
 			},
 		];
 	}
-	const result = start(model, el, specs, options);
+	const result = start(model, el, rules, specs, options, mode);
 
 	return result;
 }
@@ -41,23 +46,52 @@ export function contentModel(
 /**
  * Builds the content model and merged specs for a given element.
  * Combines the element's document-level specs with any user-defined
- * tag rules, then looks up the content model for the element.
+ * tag rules, then resolves the content model for the current {@link Mode}.
  *
  * @param el - The element to look up the content model for.
  * @param rules - User-defined tag rules to merge into the spec.
+ * @param mode - Which identity to resolve against.
  * @returns An object containing the resolved content model and merged specs.
  */
 function createModel(
 	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
 	el: Element,
 	rules: readonly TagRule[],
+	mode: Mode,
 ) {
 	const specs = cachedSpecs(el.ownerMLDocument.specs, rules);
-	const model = getContentModel(el, specs.specs);
+	const model = resolveContentModel(el, rules, specs, mode);
 	return {
 		model,
 		specs,
 	};
+}
+
+/**
+ * Resolves the content model for an element while honoring the current
+ * {@link Mode}. In `'origin'` mode for a pretendered element, the lookup
+ * first consults user-defined tag rules keyed on the element's original AST
+ * name (`rawName`); if no such rule exists the returned model is `null`,
+ * which signals the caller to skip validation for this mode. In all other
+ * cases the standard spec lookup (`getContentModel`) is used, which keys on
+ * the visible `localName` — i.e. the pretender target when pretending is
+ * active.
+ *
+ * Exported so that {@link representTransparentNodes} can reuse the same
+ * resolution logic when recursing into child content models.
+ */
+export function resolveContentModel(
+	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+	el: Element,
+	rules: readonly TagRule[],
+	specs: Specs,
+	mode: Mode,
+): ReadonlyDeep<ContentModel['contents']> | null {
+	if (mode === 'origin' && el.pretenderContext?.type === 'pretender') {
+		const userRule = rules.find(r => r.tag === el.rawName);
+		return userRule?.contents ?? null;
+	}
+	return getContentModel(el, specs.specs);
 }
 
 /**

--- a/packages/@markuplint/rules/src/permitted-contents/count-pattern.spec.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/count-pattern.spec.ts
@@ -6,7 +6,7 @@ import { countPattern } from './count-pattern.js';
 
 function c(models: any, innerHtml: string) {
 	const el = createTestElement(`<div>${innerHtml}</div>`);
-	return countPattern(models, [...el.childNodes], specs, { ignoreHasMutableChildren: true }, 0);
+	return countPattern(models, [...el.childNodes], [], specs, { ignoreHasMutableChildren: true }, 0, 'pretended');
 }
 
 test('[permitted-contents-invalid-001] require: a', () => {

--- a/packages/@markuplint/rules/src/permitted-contents/count-pattern.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/count-pattern.ts
@@ -1,4 +1,4 @@
-import type { ChildNode, Options, Result, Specs } from './types.js';
+import type { ChildNode, Mode, Options, Result, Specs, TagRule } from './types.js';
 import type {
 	PermittedContentOneOrMore,
 	PermittedContentOptional,
@@ -37,9 +37,11 @@ export function countPattern(
 		| ReadonlyDeep<PermittedContentZeroOrMore>,
 	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
 	childNodes: readonly ChildNode[],
+	rules: readonly TagRule[],
 	specs: Specs,
 	options: Options,
 	depth: number,
+	mode: Mode,
 ): Result {
 	const ptLog = cmLog.extend(`countPattern#${depth}`);
 	const collection = new Collection(childNodes);
@@ -55,7 +57,7 @@ export function countPattern(
 	while (true) {
 		loopCount++;
 		ptLog('Check#%s: %s', loopCount, collection);
-		const result = recursiveBranch(model, collection.unmatched, specs, options, depth);
+		const result = recursiveBranch(model, collection.unmatched, rules, specs, options, depth, mode);
 		const added = collection.addMatched(result.matched);
 		const { matchedCount } = collection;
 

--- a/packages/@markuplint/rules/src/permitted-contents/count-pattern.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/count-pattern.ts
@@ -24,9 +24,12 @@ const cLog = cmLog.extend('countCompereResult');
  *
  * @param pattern - A quantified content model pattern (require, optional, oneOrMore, or zeroOrMore).
  * @param childNodes - The child nodes to validate against the repeated pattern.
+ * @param rules - User-defined tag rules. Threaded through for transparent-model recursion;
+ *                not consulted here directly. See `order` for the rationale.
  * @param specs - The resolved spec data for content model lookups.
  * @param options - Validation behavior options.
  * @param depth - The current recursion depth, used for debug logging and nested evaluation.
+ * @param mode - Whether we are evaluating the element's `'origin'` or `'pretended'` identity.
  * @returns A result indicating whether the required count of matches was achieved.
  */
 export function countPattern(

--- a/packages/@markuplint/rules/src/permitted-contents/index.spec.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/index.spec.ts
@@ -2355,4 +2355,39 @@ describe('#3739 (pretender + user tag rule)', () => {
 		});
 		expect(violations).toStrictEqual([]);
 	});
+
+	test('[permitted-contents-issue-3739-010] origin-mode rejects a native child that coincides with the pretender target name', async () => {
+		// The full Breadcrumbs family of pretenders AND user tag rules is
+		// wired up, matching the production-style config. Inside a
+		// `<BreadcrumbList>` (which pretends to `<ol>` and has a user rule
+		// requiring `<BreadcrumbItem>`) we drop a raw `<li>`. In the
+		// pretended pass `<ol>` happily accepts `<li>`; in the origin pass
+		// the user selector `BreadcrumbItem` must NOT match the native
+		// `<li>`. This pins that the `<li>`/`BreadcrumbItem` name collision
+		// does not leak across modes.
+		const source = '<BreadcrumbList><li>native</li></BreadcrumbList>';
+		const { violations } = await mlRuleTest(rule, source, breadcrumbsConfig);
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 1,
+				raw: '<BreadcrumbList>',
+				message: 'Require one or more elements. (Need "BreadcrumbItem")',
+			},
+		]);
+	});
+
+	test('[permitted-contents-issue-3739-011] native parent without a user rule passes even when pretendered children are present', async () => {
+		// Again the full Breadcrumbs family is configured, but the parent
+		// here is a raw `<ul>` for which no user tag rule exists. The
+		// `rules.some(r => r.tag === el.rawName)` guard must keep origin
+		// mode dormant on `<ul>`, so only the pretended pass runs: `<ul>`
+		// accepts the pretendered `<li>` (originally `<BreadcrumbItem>`)
+		// and the tree is valid. Pins that mode enablement is per-parent —
+		// a pretendered child does not drag origin mode onto its parent.
+		const source = '<ul><BreadcrumbItem><BreadcrumbLink>Home</BreadcrumbLink></BreadcrumbItem></ul>';
+		const { violations } = await mlRuleTest(rule, source, breadcrumbsConfig);
+		expect(violations).toStrictEqual([]);
+	});
 });

--- a/packages/@markuplint/rules/src/permitted-contents/index.spec.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/index.spec.ts
@@ -2166,3 +2166,105 @@ describe('Issues', () => {
 		);
 	});
 });
+
+describe('#3739 (pretender + user tag rule)', () => {
+	const breadcrumbsConfig = {
+		parser: {
+			'.*': '@markuplint/jsx-parser',
+		},
+		pretenders: [
+			{ selector: 'Breadcrumbs', as: 'nav' },
+			{ selector: 'BreadcrumbsLabel', as: 'span' },
+			{ selector: 'BreadcrumbList', as: 'ol' },
+			{ selector: 'BreadcrumbItem', as: 'li' },
+			{ selector: 'BreadcrumbLink', as: 'a' },
+		],
+		rule: [
+			{
+				tag: 'Breadcrumbs',
+				contents: [{ optional: 'BreadcrumbsLabel' }, { require: 'BreadcrumbList' }],
+			},
+			{
+				tag: 'BreadcrumbList',
+				contents: [{ oneOrMore: 'BreadcrumbItem' }],
+			},
+			{
+				tag: 'BreadcrumbItem',
+				contents: [{ require: 'BreadcrumbLink' }],
+			},
+			{
+				tag: 'BreadcrumbLink',
+				contents: [{ require: '#text' }],
+			},
+		],
+	};
+
+	test('[permitted-contents-issue-3739-001] origin-mode reports a violation for disallowed child between optional and require', async () => {
+		// The sequential content-model matcher consumes `<BreadcrumbsLabel>` for the
+		// `optional` slot and then expects `<BreadcrumbList>` next. `<div>` breaks
+		// the sequence so the violation is reported as a missing required element
+		// on `<Breadcrumbs>` — the same wording produced for the non-pretendered
+		// path. The critical regression guard is that *some* violation is now
+		// reported (previously the rule was silently bypassed).
+		const source =
+			'<Breadcrumbs>' +
+			'<BreadcrumbsLabel>Label</BreadcrumbsLabel>' +
+			'<div>UNEXPECTED</div>' +
+			'<BreadcrumbList>' +
+			'<BreadcrumbItem><BreadcrumbLink>Home</BreadcrumbLink></BreadcrumbItem>' +
+			'</BreadcrumbList>' +
+			'</Breadcrumbs>';
+		const { violations } = await mlRuleTest(rule, source, breadcrumbsConfig);
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 1,
+				raw: '<Breadcrumbs>',
+				message: 'Require an element. (Need "BreadcrumbList")',
+			},
+		]);
+	});
+
+	test('[permitted-contents-issue-3739-002] user-model satisfied produces no origin-mode violation', async () => {
+		const source =
+			'<Breadcrumbs>' +
+			'<BreadcrumbsLabel>Label</BreadcrumbsLabel>' +
+			'<BreadcrumbList>' +
+			'<BreadcrumbItem><BreadcrumbLink>Home</BreadcrumbLink></BreadcrumbItem>' +
+			'</BreadcrumbList>' +
+			'</Breadcrumbs>';
+		const { violations } = await mlRuleTest(rule, source, breadcrumbsConfig);
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('[permitted-contents-issue-3739-003] pretended-mode still detects HTML-spec violation', async () => {
+		// <Section> pretends to <section>, user declares it may contain only <BreadcrumbList>.
+		// In origin mode the child <Breadcrumbs> is disallowed; in pretended mode <section>
+		// permits flow content so pretended mode does not fire. Ensures the pretended path
+		// keeps working when the user rule restricts it further.
+		const source = '<Section><Nope/></Section>';
+		const { violations } = await mlRuleTest(rule, source, {
+			parser: { '.*': '@markuplint/jsx-parser' },
+			pretenders: [
+				{ selector: 'Section', as: 'section' },
+				{ selector: 'Nope', as: 'div' },
+			],
+			rule: [
+				{
+					tag: 'Section',
+					contents: [{ require: 'BreadcrumbList' }],
+				},
+			],
+		});
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 1,
+				raw: '<Section>',
+				message: 'Require an element. (Need "BreadcrumbList")',
+			},
+		]);
+	});
+});

--- a/packages/@markuplint/rules/src/permitted-contents/index.spec.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/index.spec.ts
@@ -2238,11 +2238,13 @@ describe('#3739 (pretender + user tag rule)', () => {
 		expect(violations).toStrictEqual([]);
 	});
 
-	test('[permitted-contents-issue-3739-003] pretended-mode still detects HTML-spec violation', async () => {
-		// <Section> pretends to <section>, user declares it may contain only <BreadcrumbList>.
-		// In origin mode the child <Breadcrumbs> is disallowed; in pretended mode <section>
-		// permits flow content so pretended mode does not fire. Ensures the pretended path
-		// keeps working when the user rule restricts it further.
+	test('[permitted-contents-issue-3739-003] origin-mode reports missing required child when the user model is stricter than the pretended spec', async () => {
+		// `<Section>` pretends to `<section>` (flow content, permissive); the
+		// pretended pass alone would happily accept `<Nope>/<div>`. The user
+		// tag rule is only consulted in origin mode, where it requires a
+		// `<BreadcrumbList>` child — which is absent — so origin mode reports
+		// the violation. This pins the fact that origin mode can report
+		// violations that pretended mode silently allows.
 		const source = '<Section><Nope/></Section>';
 		const { violations } = await mlRuleTest(rule, source, {
 			parser: { '.*': '@markuplint/jsx-parser' },
@@ -2266,5 +2268,91 @@ describe('#3739 (pretender + user tag rule)', () => {
 				message: 'Require an element. (Need "BreadcrumbList")',
 			},
 		]);
+	});
+
+	test('[permitted-contents-issue-3739-004] pretended-mode detects HTML-spec violation independently of origin user rule', async () => {
+		// `<Opt>` pretends to `<option>` whose content model is text-only.
+		// The user tag rule on `<Opt>` permits any combination of text and
+		// `<Span>`, so origin mode has no objection. Embedding `<Span>`
+		// (pretends to `<span>`) as a child must still be rejected by the
+		// pretended pass because HTML's `<option>` forbids element children.
+		// Ensures the historical pretended-mode path is not weakened by the
+		// new origin-mode plumbing.
+		const source = '<Opt>Label<Span>nope</Span></Opt>';
+		const { violations } = await mlRuleTest(rule, source, {
+			parser: { '.*': '@markuplint/jsx-parser' },
+			pretenders: [
+				{ selector: 'Opt', as: 'option' },
+				{ selector: 'Span', as: 'span' },
+			],
+			rule: [{ tag: 'Opt', contents: [{ zeroOrMore: ['#text', 'Span'] }] }],
+		});
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 11,
+				raw: '<Span>',
+				message: 'The "span" element is not allowed in the "option" element in this context',
+			},
+		]);
+	});
+
+	test('[permitted-contents-issue-3739-005] origin-mode handles transparent-model pretender children', async () => {
+		// `<MyLink>` pretends to `<a>`, whose content model is transparent.
+		// The surrounding `<p>`-pretending `<Para>` declares a user rule that
+		// allows an `<a>`. Origin mode must recurse into the transparent
+		// child's content model via `resolveContentModel` without losing the
+		// mode, and the user model on the ancestor must not be disrupted by
+		// the transparent recursion.
+		const source = '<Para><MyLink>text</MyLink></Para>';
+		const { violations } = await mlRuleTest(rule, source, {
+			parser: { '.*': '@markuplint/jsx-parser' },
+			pretenders: [
+				{ selector: 'Para', as: 'p' },
+				{ selector: 'MyLink', as: 'a' },
+			],
+			rule: [{ tag: 'Para', contents: [{ oneOrMore: 'MyLink' }] }],
+		});
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('[permitted-contents-issue-3739-006] origin-mode evaluates choice patterns under pretender', async () => {
+		// The user rule on `<Switcher>` uses a `choice` pattern so mode
+		// propagation through `choice.ts` is exercised. Branch A requires a
+		// `<CaseA>`; Branch B requires a `<CaseB>`. Supplying `<CaseB>` must
+		// satisfy the second branch. This guarantees the mode argument flows
+		// through choice → order → recursiveBranch correctly.
+		const source = '<Switcher><CaseB/></Switcher>';
+		const { violations } = await mlRuleTest(rule, source, {
+			parser: { '.*': '@markuplint/jsx-parser' },
+			pretenders: [
+				{ selector: 'Switcher', as: 'div' },
+				{ selector: 'CaseA', as: 'span' },
+				{ selector: 'CaseB', as: 'em' },
+			],
+			rule: [
+				{
+					tag: 'Switcher',
+					contents: [{ choice: [[{ require: 'CaseA' }], [{ require: 'CaseB' }]] }],
+				},
+			],
+		});
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('[permitted-contents-issue-3739-007] origin-mode does not fire when the user has no rule for rawName', async () => {
+		// Pretender is active but the user defined no tag rule keyed on the
+		// component name. The walkOn guard in index.ts should therefore NOT
+		// enqueue origin mode, so the only pass that runs is pretended mode
+		// and there should be no spurious origin-mode noise. Functions as a
+		// regression test for the mode enablement guard.
+		const source = '<Widget><div>ok</div></Widget>';
+		const { violations } = await mlRuleTest(rule, source, {
+			parser: { '.*': '@markuplint/jsx-parser' },
+			pretenders: [{ selector: 'Widget', as: 'section' }],
+			// No `rule:` entry for Widget — origin mode must stay dormant.
+		});
+		expect(violations).toStrictEqual([]);
 	});
 });

--- a/packages/@markuplint/rules/src/permitted-contents/index.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/index.ts
@@ -1,4 +1,4 @@
-import type { ChildNode, Options, TagRule } from './types.js';
+import type { ChildNode, Mode, Options, TagRule } from './types.js';
 import type { Translator } from '@markuplint/i18n';
 
 import { createRule } from '@markuplint/ml-core';
@@ -109,106 +109,133 @@ export default createRule<TagRule[], Options>({
 				}
 			}
 
-			const results = contentModel(el, el.rule.value, el.rule.options);
-			for (const { type, scope, query, hint } of results) {
-				let message = '';
-
-				if (hint.max != null) {
-					message =
-						t('there is more content than it needs') +
-						t('. ') +
-						t('the max number of elements required is {0}', `${hint.max}`);
-				}
-
-				switch (type) {
-					case 'MATCHED':
-					case 'MATCHED_ZERO': {
-						break;
-					}
-					case 'MISSING_NODE_ONE_OR_MORE': {
-						if (
-							scope.rule.options.ignoreHasMutableChildren &&
-							(!scope.is(scope.ELEMENT_NODE) || scope.hasMutableChildren())
-						) {
-							break;
-						}
-
-						message =
-							message ||
-							t('Require {0}', t('one or more elements')) + t('. ') + '(' + t('Need "{0*}"', query) + ')';
-
-						report({
-							scope,
-							message,
-						});
-						break;
-					}
-					case 'MISSING_NODE_REQUIRED': {
-						if (
-							scope.rule.options.ignoreHasMutableChildren &&
-							(!scope.is(scope.ELEMENT_NODE) || scope.hasMutableChildren())
-						) {
-							break;
-						}
-
-						message =
-							message ||
-							t('Require {0}', t('an {0}', 'element')) + t('. ') + '(' + t('Need "{0*}"', query) + ')';
-
-						report({
-							scope,
-							message,
-						});
-						break;
-					}
-					case 'UNEXPECTED_EXTRA_NODE': {
-						const not = hint.not ?? scope;
-
-						message =
-							message ||
-							(transparentMode.has(scope)
-								? t(
-										'{0} is not allowed in {1} through the transparent model in this context',
-										name(not, t),
-										name(el, t),
-									)
-								: t('{0} is not allowed in {1} in this context', name(not, t), name(el, t)));
-
-						report({
-							scope: not,
-							message,
-						});
-						break;
-					}
-					case 'TRANSPARENT_MODEL_DISALLOWS': {
-						const not = hint.not ?? scope;
-						const tp = hint.transparent ?? el;
-
-						report({
-							scope: not,
-							message: t(
-								'{0} is {1} but {2}',
-								name(tp, t),
-								t('a {0}', 'transparent model'),
-								t('also disallows {0} in this context', name(not, t)),
-							),
-						});
-						break;
-					}
-					case 'NOTHING': {
-						report({
-							scope: el,
-							message: t('{0} disallows {1}', t('the {0}', 'element'), 'contents'),
-						});
-						break;
-					}
-					default: {
-						throw new Error('Unreachable code');
-					}
-				}
+			// Build the mode list. `'pretended'` always runs and preserves the historical
+			// behaviour. `'origin'` additionally fires when the element is pretending and
+			// the user has declared a content model keyed on its original AST name, so
+			// that user-defined custom-tag rules are not silently bypassed by pretending
+			// (see issue #3739).
+			const modes: Mode[] = ['pretended'];
+			if (el.pretenderContext?.type === 'pretender' && el.rule.value.some(r => r.tag === el.rawName)) {
+				modes.push('origin');
 			}
 
-			transparentMode.clear();
+			for (const mode of modes) {
+				const results = contentModel(el, el.rule.value, el.rule.options, mode);
+				for (const { type, scope, query, hint } of results) {
+					let message = '';
+
+					if (hint.max != null) {
+						message =
+							t('there is more content than it needs') +
+							t('. ') +
+							t('the max number of elements required is {0}', `${hint.max}`);
+					}
+
+					switch (type) {
+						case 'MATCHED':
+						case 'MATCHED_ZERO': {
+							break;
+						}
+						case 'MISSING_NODE_ONE_OR_MORE': {
+							if (
+								scope.rule.options.ignoreHasMutableChildren &&
+								(!scope.is(scope.ELEMENT_NODE) || scope.hasMutableChildren())
+							) {
+								break;
+							}
+
+							message =
+								message ||
+								t('Require {0}', t('one or more elements')) +
+									t('. ') +
+									'(' +
+									t('Need "{0*}"', query) +
+									')';
+
+							report({
+								scope,
+								message,
+							});
+							break;
+						}
+						case 'MISSING_NODE_REQUIRED': {
+							if (
+								scope.rule.options.ignoreHasMutableChildren &&
+								(!scope.is(scope.ELEMENT_NODE) || scope.hasMutableChildren())
+							) {
+								break;
+							}
+
+							message =
+								message ||
+								t('Require {0}', t('an {0}', 'element')) +
+									t('. ') +
+									'(' +
+									t('Need "{0*}"', query) +
+									')';
+
+							report({
+								scope,
+								message,
+							});
+							break;
+						}
+						case 'UNEXPECTED_EXTRA_NODE': {
+							const not = hint.not ?? scope;
+
+							message =
+								message ||
+								(transparentMode.has(scope)
+									? t(
+											'{0} is not allowed in {1} through the transparent model in this context',
+											name(not, t, mode),
+											name(el, t, mode),
+										)
+									: t(
+											'{0} is not allowed in {1} in this context',
+											name(not, t, mode),
+											name(el, t, mode),
+										));
+
+							report({
+								scope: not,
+								message,
+							});
+							break;
+						}
+						case 'TRANSPARENT_MODEL_DISALLOWS': {
+							const not = hint.not ?? scope;
+							const tp = hint.transparent ?? el;
+
+							report({
+								scope: not,
+								message: t(
+									'{0} is {1} but {2}',
+									name(tp, t, mode),
+									t('a {0}', 'transparent model'),
+									t('also disallows {0} in this context', name(not, t, mode)),
+								),
+							});
+							break;
+						}
+						case 'NOTHING': {
+							report({
+								scope: el,
+								message: t('{0} disallows {1}', t('the {0}', 'element'), 'contents'),
+							});
+							break;
+						}
+						default: {
+							throw new Error('Unreachable code');
+						}
+					}
+				}
+
+				// Clear the per-element transparent-model tracker between passes so that
+				// errors reported in one mode do not carry the "through the transparent
+				// model" phrasing into the other mode's diagnostics.
+				transparentMode.clear();
+			}
 		});
 	},
 });
@@ -218,17 +245,25 @@ export default createRule<TagRule[], Options>({
  * Used in error messages to describe the offending node (e.g., 'the "div" element',
  * 'the text node', 'the comment', 'the doctype', 'the code block').
  *
+ * In `'origin'` mode, uses {@link MLElement.rawName} so that the diagnostic refers
+ * to the original AST identity (e.g. the component name `"Breadcrumbs"`) rather
+ * than the pretender target (`"nav"`). `'pretended'` mode preserves the historical
+ * behaviour and prints the visible `localName`.
+ *
  * @param scope - The child node to generate a name for.
  * @param t - The translator function for localized message formatting.
+ * @param mode - Which identity to surface in the message.
  * @returns A localized string describing the node.
  */
 function name(
 	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
 	scope: ChildNode,
 	t: Translator,
+	mode: Mode,
 ) {
 	if (scope.is(scope.ELEMENT_NODE)) {
-		return t('the "{0}" {1}', scope.localName, 'element');
+		const displayName = mode === 'origin' ? scope.rawName : scope.localName;
+		return t('the "{0}" {1}', displayName, 'element');
 	}
 	if (scope.is(scope.TEXT_NODE)) {
 		return t('the {0}', 'text node');

--- a/packages/@markuplint/rules/src/permitted-contents/matches-selector.spec.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/matches-selector.spec.ts
@@ -7,7 +7,7 @@ import { matchesSelector } from './matches-selector.js';
 function c(model: any, innerHtml: string) {
 	const el = createTestElement(`<div>${innerHtml}</div>`, { specs });
 	const child = [...el.childNodes][0];
-	return matchesSelector(model, child, specs, 0);
+	return matchesSelector(model, child, specs, 0, 'pretended');
 }
 
 test('[permitted-contents-invalid-001] a', () => {

--- a/packages/@markuplint/rules/src/permitted-contents/matches-selector.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/matches-selector.ts
@@ -1,4 +1,4 @@
-import type { ChildNode, Result, Specs } from './types.js';
+import type { ChildNode, Mode, Result, Specs } from './types.js';
 import type { Category } from '@markuplint/ml-spec';
 
 import { contentModelCategoryToTagNames } from '@markuplint/ml-spec';
@@ -52,6 +52,7 @@ export function matchesSelector(
 	childNode: ChildNode | undefined,
 	specs: Specs,
 	depth: number,
+	mode: Mode,
 ): SelectorResult {
 	const nodeLog = cmLog.extend(`node#${depth}`);
 
@@ -164,7 +165,7 @@ export function matchesSelector(
 			};
 		}
 
-		const result = matches(selector, childNode, specs);
+		const result = matches(selector, childNode, specs, mode);
 		nodeLog('%s.matches(%s) => %s', childNode.raw, query, result.matched);
 
 		if (result.matched) {

--- a/packages/@markuplint/rules/src/permitted-contents/order.spec.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/order.spec.ts
@@ -6,7 +6,7 @@ import { order } from './order.js';
 
 function c(models: any, innerHtml: string) {
 	const el = createTestElement(`<div>${innerHtml}</div>`);
-	return order(models, [...el.childNodes], specs, { ignoreHasMutableChildren: true }, 0);
+	return order(models, [...el.childNodes], [], specs, { ignoreHasMutableChildren: true }, 0, 'pretended');
 }
 
 test('[permitted-contents-invalid-001] ordered requires', () => {

--- a/packages/@markuplint/rules/src/permitted-contents/order.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/order.ts
@@ -20,9 +20,16 @@ import { Collection, mergeHints, modelLog } from './utils.js';
  *
  * @param contents - An ordered array of content model patterns to match sequentially.
  * @param childNodes - The child nodes to validate against the patterns.
+ * @param rules - User-defined tag rules. `order` does not consult them directly; they are
+ *                threaded through so nested helpers (especially `representTransparentNodes`)
+ *                can resolve content models via `resolveContentModel`. Do not remove even if
+ *                it looks unused here.
  * @param specs - The resolved spec data for content model lookups.
  * @param options - Validation behavior options.
  * @param depth - The current recursion depth, used for debug logging and nested pattern matching.
+ * @param mode - Whether we are evaluating the element's `'origin'` or `'pretended'` identity.
+ *               Propagated unchanged into `complexBranch` so downstream selector matching
+ *               honors the same view.
  * @returns A result indicating overall match status and the matched/unmatched node partitioning.
  */
 export function order(

--- a/packages/@markuplint/rules/src/permitted-contents/order.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/order.ts
@@ -1,4 +1,4 @@
-import type { ChildNode, Options, Result, Specs } from './types.js';
+import type { ChildNode, Mode, Options, Result, Specs, TagRule } from './types.js';
 import type { PermittedContentPattern } from '@markuplint/ml-spec';
 import type { ReadonlyDeep } from 'type-fest';
 
@@ -29,9 +29,11 @@ export function order(
 	contents: ReadonlyDeep<PermittedContentPattern[]>,
 	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
 	childNodes: readonly ChildNode[],
+	rules: readonly TagRule[],
 	specs: Specs,
 	options: Options,
 	depth: number,
+	mode: Mode,
 ): Result {
 	const orderLog = cmLog.extend(`order#${depth}`);
 	const btLog = cmLog.extend(`backtrack#${depth}`);
@@ -49,7 +51,7 @@ export function order(
 	const unmatchedResults: Result[] = [];
 
 	while (patterns.length > 0 && patterns[0]) {
-		result = complexBranch(patterns[0], collection.unmatched, specs, options, depth);
+		result = complexBranch(patterns[0], collection.unmatched, rules, specs, options, depth, mode);
 		collection.addMatched(result.matched);
 
 		if (result.type !== 'UNEXPECTED_EXTRA_NODE' && result.type !== 'MATCHED' && result.type !== 'MATCHED_ZERO') {

--- a/packages/@markuplint/rules/src/permitted-contents/recursive-branch.spec.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/recursive-branch.spec.ts
@@ -6,7 +6,7 @@ import { recursiveBranch } from './recursive-branch.js';
 
 function c(models: any, innerHtml: string) {
 	const el = createTestElement(`<div>${innerHtml}</div>`);
-	return recursiveBranch(models, [...el.childNodes], specs, { ignoreHasMutableChildren: true }, 0);
+	return recursiveBranch(models, [...el.childNodes], [], specs, { ignoreHasMutableChildren: true }, 0, 'pretended');
 }
 
 test('[permitted-contents-invalid-001] a', () => {

--- a/packages/@markuplint/rules/src/permitted-contents/recursive-branch.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/recursive-branch.ts
@@ -1,5 +1,5 @@
 import type { SelectorResult } from './matches-selector.js';
-import type { ChildNode, Options, Specs } from './types.js';
+import type { ChildNode, Mode, Options, Specs, TagRule } from './types.js';
 import type { PermittedContentPattern, Model } from '@markuplint/ml-spec';
 import type { ReadonlyDeep } from 'type-fest';
 
@@ -28,23 +28,25 @@ export function recursiveBranch(
 	model: ReadonlyDeep<Model | PermittedContentPattern[]>,
 	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
 	childNodes: readonly ChildNode[],
+	rules: readonly TagRule[],
 	specs: Specs,
 	options: Options,
 	depth: number,
+	mode: Mode,
 ): SelectorResult {
 	if (!isModel(model)) {
-		return order(model, childNodes, specs, options, depth + 1);
+		return order(model, childNodes, rules, specs, options, depth + 1, mode);
 	}
 
 	if (typeof model === 'string') {
-		return matchesSelector(model, childNodes[0], specs, depth);
+		return matchesSelector(model, childNodes[0], specs, depth, mode);
 	}
 
 	const collection = new Collection(childNodes);
 
 	let lastUnmatched: SelectorResult | null = null;
 	for (const query of model) {
-		const result = matchesSelector(query, collection.unmatched[0], specs, depth);
+		const result = matchesSelector(query, collection.unmatched[0], specs, depth, mode);
 		collection.addMatched(result.matched);
 
 		if (result.type === 'MATCHED' || result.type === 'MATCHED_ZERO') {

--- a/packages/@markuplint/rules/src/permitted-contents/recursive-branch.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/recursive-branch.ts
@@ -19,9 +19,12 @@ import { Collection, isModel } from './utils.js';
  *
  * @param model - Either a terminal model (selector string or array of selector strings) or a nested pattern array.
  * @param childNodes - The child nodes to validate against the model.
+ * @param rules - User-defined tag rules. Threaded through for transparent-model recursion;
+ *                not consulted here directly. See `order` for the rationale.
  * @param specs - The resolved spec data for content model lookups.
  * @param options - Validation behavior options.
  * @param depth - The current recursion depth, used for debug logging and nested evaluation.
+ * @param mode - Whether we are evaluating the element's `'origin'` or `'pretended'` identity.
  * @returns A selector result indicating whether the first unmatched child node matches the model.
  */
 export function recursiveBranch(

--- a/packages/@markuplint/rules/src/permitted-contents/represent-transparent-nodes.spec.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/represent-transparent-nodes.spec.ts
@@ -6,10 +6,16 @@ import { representTransparentNodes, transparentMode } from './represent-transpar
 
 function c(html: string, evaluateConditionalChildNodes = true) {
 	const el = createTestElement(`<div>${html}</div>`);
-	const patterns = representTransparentNodes([...el.children], specs, {
-		ignoreHasMutableChildren: true,
-		evaluateConditionalChildNodes,
-	});
+	const patterns = representTransparentNodes(
+		[...el.children],
+		[],
+		specs,
+		{
+			ignoreHasMutableChildren: true,
+			evaluateConditionalChildNodes,
+		},
+		'pretended',
+	);
 	return patterns.map(({ nodes }) => nodes.map(n => n.nodeName.toLowerCase() + (transparentMode.has(n) ? '*' : '')));
 }
 

--- a/packages/@markuplint/rules/src/permitted-contents/represent-transparent-nodes.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/represent-transparent-nodes.ts
@@ -1,7 +1,6 @@
-import type { ChildNode, Options, Result, Specs } from './types.js';
+import type { ChildNode, Mode, Options, Result, Specs, TagRule } from './types.js';
 
-import { getContentModel } from '@markuplint/ml-spec';
-
+import { resolveContentModel } from './content-model.js';
 import { order } from './order.js';
 import { Collection, isTransparent, matches } from './utils.js';
 
@@ -99,12 +98,14 @@ const MAX_PATTERNS = 1024;
 export function representTransparentNodes(
 	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
 	childNodes: readonly ChildNode[],
+	rules: readonly TagRule[],
 	specs: Specs,
 	options: Options,
+	mode: Mode,
 ): TransparentNode[] {
 	const parentElement = childNodes[0]?.parentElement;
 	const parentResults = parentElement
-		? representTransparentNodes([parentElement], specs, options)
+		? representTransparentNodes([parentElement], rules, specs, options, mode)
 		: [{ nodes: [], errors: [] }];
 
 	let patterns: (ChildNode | Result)[][] = [[]];
@@ -117,7 +118,7 @@ export function representTransparentNodes(
 			continue;
 		}
 
-		const models = getContentModel(childNode, specs.specs);
+		const models = resolveContentModel(childNode, rules, specs, mode);
 
 		if (models == null || typeof models === 'boolean') {
 			for (const p of patterns) {
@@ -150,9 +151,11 @@ export function representTransparentNodes(
 				const result = order(
 					noTransparentModels,
 					collection.unmatched,
+					rules,
 					specs,
 					options,
 					Number.POSITIVE_INFINITY,
+					mode,
 				);
 				unmatched = result.unmatched;
 			} else {
@@ -177,7 +180,7 @@ export function representTransparentNodes(
 				transparentMode.set(child, true);
 
 				if (child.is(child.ELEMENT_NODE)) {
-					const transparentCondMatched = matches(transparent.transparent, child, specs);
+					const transparentCondMatched = matches(transparent.transparent, child, specs, mode);
 
 					if (!transparentCondMatched.matched) {
 						branchChildren.push({

--- a/packages/@markuplint/rules/src/permitted-contents/start.spec.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/start.spec.ts
@@ -9,10 +9,17 @@ function c(html: string, selector = '') {
 	const root = createTestElement(html, { specs: htmlSpecs });
 	const el = selector ? root.querySelector(selector) : root;
 	if (!el) throw new Error('Not found target element');
-	return start(getContentModel(el, specs)!, el, htmlSpecs, {
-		ignoreHasMutableChildren: true,
-		evaluateConditionalChildNodes: true,
-	});
+	return start(
+		getContentModel(el, specs)!,
+		el,
+		[],
+		htmlSpecs,
+		{
+			ignoreHasMutableChildren: true,
+			evaluateConditionalChildNodes: true,
+		},
+		'pretended',
+	);
 }
 
 test('[permitted-contents-invalid-001] transparent: <a>', () => {

--- a/packages/@markuplint/rules/src/permitted-contents/start.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/start.ts
@@ -1,4 +1,4 @@
-import type { ContentModelResult, Element, Options, Specs } from './types.js';
+import type { ContentModelResult, Element, Mode, Options, Specs, TagRule } from './types.js';
 import type { ContentModel } from '@markuplint/ml-spec';
 import type { ReadonlyDeep } from 'type-fest';
 
@@ -24,8 +24,10 @@ export function start(
 	contents: ReadonlyDeep<ContentModel['contents']>,
 	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
 	el: Element,
+	rules: readonly TagRule[],
 	specs: Specs,
 	options: Options,
+	mode: Mode,
 ): ContentModelResult[] {
 	const childNodesPatterns = options.evaluateConditionalChildNodes
 		? el.conditionalChildNodes().map(childNodes => [...childNodes])
@@ -64,10 +66,10 @@ export function start(
 			];
 		}
 
-		const patterns = representTransparentNodes(childNodes, specs, options);
+		const patterns = representTransparentNodes(childNodes, rules, specs, options, mode);
 
 		return patterns.flatMap(({ nodes, errors }) => {
-			const result = order(contents, nodes, specs, options, 0);
+			const result = order(contents, nodes, rules, specs, options, 0, mode);
 
 			return [
 				{

--- a/packages/@markuplint/rules/src/permitted-contents/types.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/types.ts
@@ -117,6 +117,21 @@ export type TagRule = {
 } & ReadonlyDeep<ContentModel>;
 
 /**
+ * Which identity of a pretendered element is being evaluated during a
+ * content-model check. `'pretended'` is the default view: the element is
+ * validated against the HTML spec for the pretender target name (e.g. a
+ * `<Breadcrumbs>` pretending to `<nav>` is validated as `<nav>`).
+ * `'origin'` re-runs the validation with the pretender context suppressed,
+ * so the element is validated against any user-defined tag rule keyed on
+ * the original AST name (e.g. `Breadcrumbs`).
+ *
+ * The mode is threaded through every helper so that selector matching,
+ * transparent-model resolution, and content-model lookups all agree on the
+ * same view of the element identity.
+ */
+export type Mode = 'origin' | 'pretended';
+
+/**
  * Options for the permitted-contents rule that control validation behavior.
  */
 export type Options = {

--- a/packages/@markuplint/rules/src/permitted-contents/utils.spec.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/utils.spec.ts
@@ -1,0 +1,53 @@
+import specs from '@markuplint/html-spec';
+import { createTestDocument } from '@markuplint/ml-core';
+import { test, expect } from 'vitest';
+
+import { matches } from './utils.js';
+
+/**
+ * Builds a document whose `<x-comp>` element pretends to be `<div>`, and
+ * returns the `<x-comp>` element for direct inspection.
+ */
+function getPretendedElement() {
+	const doc = createTestDocument<any, any>('<x-comp>x</x-comp>', {
+		specs,
+		pretenders: [{ selector: 'x-comp', as: 'div' }],
+	});
+	const el = doc.nodeList.find(node => node.is(node.ELEMENT_NODE) && node.rawName === 'x-comp');
+	if (!el?.is(el.ELEMENT_NODE)) {
+		throw new Error('Test fixture is broken: expected an x-comp element.');
+	}
+	return el;
+}
+
+test('[permitted-contents-issue-3739-008] matches() restores pretenderContext after the selector engine throws', () => {
+	// An invalid combinator-leading selector (`> span`) forces
+	// `createSelector(...).search(node)` to throw `InvalidSelectorError`.
+	// The `matches()` helper temporarily nulls `pretenderContext` in `'origin'`
+	// mode; if the `finally` branch failed to restore it, subsequent lookups
+	// would see the element in its origin identity forever. This test pins the
+	// restoration path so regressions in the try/finally are caught.
+	const el = getPretendedElement();
+	const savedCtx = el.pretenderContext;
+	expect(savedCtx?.type).toBe('pretender');
+
+	expect(() => matches('> span', el, specs, 'origin')).toThrow();
+
+	// Critical assertion: pretenderContext must be the exact same reference
+	// as before the throw, not null, not a rebuilt copy.
+	expect(el.pretenderContext).toBe(savedCtx);
+});
+
+test('[permitted-contents-issue-3739-009] matches() leaves pretenderContext untouched in pretended mode', () => {
+	// Pretended mode does not touch `pretenderContext` at all; guards against
+	// an accidental future refactor that starts mutating the context for both
+	// modes.
+	const el = getPretendedElement();
+	const savedCtx = el.pretenderContext;
+	expect(savedCtx?.type).toBe('pretender');
+
+	// A valid selector that matches the pretender target.
+	const result = matches('div', el, specs, 'pretended');
+	expect(result.matched).toBe(true);
+	expect(el.pretenderContext).toBe(savedCtx);
+});

--- a/packages/@markuplint/rules/src/permitted-contents/utils.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/utils.ts
@@ -1,4 +1,4 @@
-import type { ChildNode, Hints, MissingNodeReason, RepeatSign, Specs } from './types.js';
+import type { ChildNode, Hints, MissingNodeReason, Mode, RepeatSign, Specs } from './types.js';
 import type {
 	PermittedContentPattern,
 	PermittedContentChoice,
@@ -49,9 +49,18 @@ export function isModel(model: ReadonlyDeep<Model | PermittedContentPattern[]>):
  * selector engine. Returns whether the node matched and, if not, the deepest
  * unmatched descendant node for diagnostic purposes.
  *
+ * When `mode === 'origin'` and the node has an active pretender context, the
+ * context is temporarily suppressed so that the selector engine reads the
+ * element's original AST identity (`rawName` / original attrs) instead of the
+ * pretender target. The mutation mirrors the pattern already used by
+ * `MLElement.matchMLSelector` and is safe because the selector engine runs
+ * synchronously — the original context is restored in `finally` before the
+ * call returns.
+ *
  * @param selector - The CSS selector string to test against.
  * @param node - The child node to test.
  * @param specs - The spec data passed to the selector engine for attribute resolution.
+ * @param mode - Which identity to match against (`'pretended'` is the default view).
  * @returns An object with `matched: true` if the node matches, or `matched: false` with an optional `not` node.
  */
 export function matches(
@@ -59,26 +68,71 @@ export function matches(
 	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
 	node: ChildNode,
 	specs: Specs,
+	mode: Mode,
 ) {
-	const selectorResult = createSelector(selector, specs as MLMLSpec).search(node);
-
-	const matched = selectorResult.filter((r): r is SelectorMatchedResult => r.matched);
-
-	if (matched.length > 0) {
-		return {
-			matched: true,
-		};
+	let savedPretenderContext: ReturnType<typeof suppressPretender> = null;
+	if (mode === 'origin') {
+		savedPretenderContext = suppressPretender(node);
 	}
+	try {
+		const selectorResult = createSelector(selector, specs as MLMLSpec).search(node);
 
-	const not = selectorResult
-		.flatMap(r => (r.matched ? [] : (r.not ?? [])))
-		.flatMap(descendants)
-		.shift();
+		const matched = selectorResult.filter((r): r is SelectorMatchedResult => r.matched);
 
-	return {
-		matched: false,
-		not,
-	};
+		if (matched.length > 0) {
+			return {
+				matched: true,
+			};
+		}
+
+		const not = selectorResult
+			.flatMap(r => (r.matched ? [] : (r.not ?? [])))
+			.flatMap(descendants)
+			.shift();
+
+		return {
+			matched: false,
+			not,
+		};
+	} finally {
+		if (savedPretenderContext) {
+			restorePretender(node, savedPretenderContext);
+		}
+	}
+}
+
+/**
+ * Temporarily hides the pretender context on an element so that selector
+ * matching sees its original AST identity. Returns the saved context for
+ * later restoration, or `null` if the node is not an element with an active
+ * pretender.
+ */
+function suppressPretender(
+	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+	node: ChildNode,
+) {
+	if (!node.is(node.ELEMENT_NODE)) {
+		return null;
+	}
+	const pretenderContext = node.pretenderContext;
+	if (pretenderContext?.type !== 'pretender') {
+		return null;
+	}
+	node.pretenderContext = null;
+	return pretenderContext;
+}
+
+/**
+ * Restores a pretender context previously saved by {@link suppressPretender}.
+ */
+function restorePretender(
+	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+	node: ChildNode,
+	saved: NonNullable<ReturnType<typeof suppressPretender>>,
+) {
+	if (node.is(node.ELEMENT_NODE)) {
+		node.pretenderContext = saved;
+	}
 }
 
 /**

--- a/website/docs/guides/beyond-html.md
+++ b/website/docs/guides/beyond-html.md
@@ -226,6 +226,8 @@ This works well for small projects, but manually maintaining the list becomes te
 
 See the details of [`pretenders`](/docs/configuration/properties#pretenders) property on the configuration if you want.
 
+To enforce structural relationships between components (e.g., a `<Breadcrumbs>` must contain a `<BreadcrumbList>`), combine pretenders with the [`permitted-contents`](/docs/rules/permitted-contents) rule. Its tag-rule entries are evaluated against the component's source-level name in addition to the pretended HTML content model, so component-level structure can be validated alongside the underlying HTML.
+
 ### Dynamic scanning {#pretenders-scan}
 
 :::caution[Experimental]

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/beyond-html.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/beyond-html.md
@@ -227,6 +227,8 @@ const Component = ({ list }) => {
 
 必要であれば、設定の[`pretenders`](/docs/configuration/properties#pretenders)プロパティの詳細を参照してください。
 
+コンポーネント間の構造上の関係（たとえば`<Breadcrumbs>`の中に必ず`<BreadcrumbList>`を置くなど）を検証したい場合は、`pretenders`を[`permitted-contents`](/docs/rules/permitted-contents)ルールと組み合わせてください。タグルールのエントリーはコンポーネントのソースレベル名に対して、pretend後のHTMLコンテンツモデルとは別に評価されるため、元のHTMLと併せてコンポーネントレベルの構造を検証できます。
+
 ### 動的スキャン {#pretenders-scan}
 
 :::caution[実験的機能]


### PR DESCRIPTION
## Summary

- Fix `permitted-contents` silently ignoring user-defined tag rules on pretendered elements (closes #3739). The rule now evaluates each pretendered element in two independent passes (`pretended` + `origin`), so component-level structure declared via `{ tag: "ComponentName" }` is no longer bypassed by the `pretenders` option.
- Thread a `mode: 'origin' | 'pretended'` argument through all internal helpers (`contentModel`, `start`, `order`, `complexBranch`, `choice`, `countPattern`, `recursiveBranch`, `matchesSelector`, `representTransparentNodes`, `matches`). The new `resolveContentModel` helper centralises pretender-aware lookup; `matches()` temporarily suppresses `pretenderContext` in origin mode (try/finally), mirroring the pattern in `MLElement.matchMLSelector`.
- Document the new behaviour in `permitted-contents` README (English + Japanese) and cross-link from the beyond-html guide in both locales.

## Compatibility

Not a breaking change. The `pretended` pass is bit-for-bit identical to the previous behaviour, and the `origin` pass only fires when the user has declared a tag rule keyed on the component's source-level name. Configurations without such rules are unaffected; all 3357 pre-existing tests remain green.

Users who already combined `pretenders` with a `{ tag: "ComponentName" }` entry may start seeing new violations that were previously suppressed — this is the intended bug fix.

## Test plan

- [x] `yarn build` — all 39 projects
- [x] `yarn test` — 3364 passed (1 skipped); adds 9 new tests (`permitted-contents-issue-3739-001`…`009`) covering origin-only violations, pretended-only violations, mixed-pass scenarios, transparent-model pretender children, choice-pattern mode propagation, the origin-mode non-firing guard, and `matches()` `pretenderContext` restore-on-throw unit tests
- [x] `yarn lint-check` — 0 format / lint issues
- [x] Manual CLI repro against `scan`-based pretenders + custom tag rule now reports the expected violation (previously silent)

## Follow-up

- #3740 tracks the same `getSpec(el, specs)` pretender gap in other rules (`wai-aria-*`, `invalid-attr`, `deprecated-element`, `no-unsupported-features`). Scoped out of this PR.