### PR TITLE
docs: branch doc URLs by markuplint version in configure skill

### DIFF
--- a/skills/markuplint-configure/SKILL.md
+++ b/skills/markuplint-configure/SKILL.md
@@ -22,6 +22,17 @@ Add, remove, or adjust Markuplint rules.
 
 ### 1. Understand the Context
 
+**Determine the documentation site based on the installed markuplint version:**
+
+```shell
+npx markuplint --version
+```
+
+- If the version contains `alpha`, `beta`, or `rc` (e.g., `5.0.0-alpha.1`) → use `https://next.markuplint.dev` as the doc base
+- Otherwise (stable release) → use `https://markuplint.dev` as the doc base
+
+Use the determined doc base for all documentation URLs in subsequent steps.
+
 If `$ARGUMENTS` contains a file path or line reference, read that file first.
 
 Run Markuplint on the target to see current violations:
@@ -68,7 +79,7 @@ If the scope is element-level, choose between:
 The AI agent should propose a CSS selector based on the code context. Use the element's class, ID, tag name, or attributes to build the selector.
 
 For rule details, fetch the rule's documentation:
-`https://markuplint.dev/docs/rules/{rule-id}`
+`{doc-base}/docs/rules/{rule-id}` (where `{doc-base}` is determined in Step 1)
 
 ### 5. Propose the Change
 
@@ -195,5 +206,5 @@ These are frequently requested. Propose them directly when relevant:
 ### Selector tips
 
 - Ancestor matching: use `:is(nav *)` (NOT `:closest()` — it is deprecated)
-- For selector syntax details: https://markuplint.dev/docs/guides/selectors
-- For all config properties: https://markuplint.dev/docs/configuration/properties
+- For selector syntax details: `{doc-base}/docs/guides/selectors`
+- For all config properties: `{doc-base}/docs/configuration/properties`


### PR DESCRIPTION
## Summary

- Add version detection step to `markuplint-configure` SKILL.md so the AI agent determines the correct documentation site based on the installed markuplint version
- v5-alpha/beta/rc → `https://next.markuplint.dev`
- Stable releases → `https://markuplint.dev`

Closes #3744

## Test plan

- [x] `yarn lint-check` passed (oxlint 0 errors/0 warnings, oxfmt OK)
- [x] `yarn build` passed (39 projects)
- [x] `yarn test` passed (226 files, 3394 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)