### PR TITLE
fix(github): derive sandbox Yarn version from root packageManager

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -435,6 +435,14 @@ jobs:
                   cp -r ${{ github.workspace }}/test ${{ github.workspace }}/../sandbox
                   find ${{ github.workspace }}/../sandbox/test -maxdepth 1 2>/dev/null || true
 
+            # Capture the root packageManager BEFORE the deletion step below,
+            # so the sandbox Setup step can reuse the same Yarn version
+            # without drifting from the repository's pin.
+            - name: Capture root packageManager
+              if: matrix.pm == 'yarn'
+              id: capture-package-manager
+              run: echo "value=$(jq -er '.packageManager' package.json)" >> "$GITHUB_OUTPUT"
+
             - name: Delete package manager settings
               run: jq 'del(.packageManager)' package.json > tmp.json && mv tmp.json package.json
 
@@ -448,12 +456,18 @@ jobs:
             - name: Setup Yarn v4 for sandbox
               if: matrix.pm == 'yarn'
               working-directory: ../sandbox/test/isolated-env/${{ matrix.env }}
+              env:
+                  PACKAGE_MANAGER: ${{ steps.capture-package-manager.outputs.value }}
               run: |
                   cp ${{ github.workspace }}/.yarnrc.yml .yarnrc.yml
                   echo 'enableHardenedMode: false' >> .yarnrc.yml
                   # Build resolutions from dependencies to force yarn to use file: versions
-                  # for transitive dependencies (prevents npm registry fallback)
-                  jq '. + {"packageManager": "yarn@4.12.0"} + {"resolutions": .dependencies}' package.json > tmp.json && mv tmp.json package.json
+                  # for transitive dependencies (prevents npm registry fallback).
+                  # PACKAGE_MANAGER is captured from the root package.json before the
+                  # "Delete package manager settings" step, so the sandbox stays in sync
+                  # with the repository's Yarn version on every bump.
+                  echo "Using packageManager from root: $PACKAGE_MANAGER"
+                  jq --arg pm "$PACKAGE_MANAGER" '. + {"packageManager": $pm} + {"resolutions": .dependencies}' package.json > tmp.json && mv tmp.json package.json
 
             - name: Install dependencies
               working-directory: ../sandbox/test/isolated-env/${{ matrix.env }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Its purpose is all developers are able to better markup and fit each of diverse 
 You need:
 
 - Node.js v24 or later (the exact version is pinned in `.mise.toml`; install [mise](https://mise.jdx.dev/) and run `mise install` to match it)
-- Yarn
+- Yarn 4.x (pinned in both `.mise.toml` and `package.json#packageManager` — bump them together; CI derives the sandbox Yarn version from the latter)
 
 After cloning this repository, you can also install them through [Docker](https://github.com/markuplint/markuplint/blob/main/Dockerfile).
 


### PR DESCRIPTION
## Summary

- The `isolated-env` job in `.github/workflows/test.yml` hardcoded `packageManager: "yarn@4.12.0"` for the sandbox `package.json`. After the repo was bumped to Yarn 4.14.1 (commit `0aac205a1`), `.yarnrc.yml` gained `approvedGitRepositories` (Yarn 4.13+), which 4.12.0 rejects with `Usage Error: Unrecognized or legacy configuration settings found: approvedGitRepositories`, breaking `isolated-env (yarn, esm/ts/ts-config-ts)` on every PR.
- This change derives `packageManager` from the root `package.json` so the sandbox always tracks the repository's Yarn version and we never drift again.
- `jq -er` is used so that a missing/`null` `packageManager` field fails the step loudly instead of silently writing the literal string `"null"`. The resolved value is also echoed for easier debugging on future bumps.
- `CONTRIBUTING.md` is updated to document that `.mise.toml` and `package.json#packageManager` are the two pinning points and CI derives the sandbox Yarn version from the latter.

Closes #3758

## Test plan

- [ ] CI: `isolated-env (ubuntu-latest, yarn, esm)` passes
- [ ] CI: `isolated-env (ubuntu-latest, yarn, ts)` passes
- [ ] CI: `isolated-env (ubuntu-latest, yarn, ts-config-ts)` passes
- [ ] CI: other `isolated-env` matrix jobs (npm/pnpm) remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)