### PR TITLE
chore(github): track v4 in renovate and add 7-day release cooldown

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,6 +13,12 @@
 		"enabled": true,
 		"automerge": true
 	},
+	"minimumReleaseAge": "7 days",
+	"internalChecksFilter": "strict",
+	"osvVulnerabilityAlerts": true,
+	"vulnerabilityAlerts": {
+		"minimumReleaseAge": null
+	},
 	"autoApprove": true,
 	"labels": ["Dependencies", "Renovate"],
 	"packageRules": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,6 +8,7 @@
 		":pinDevDependencies",
 		":semanticCommitTypeAll(chore)"
 	],
+	"baseBranches": ["dev", "v4"],
 	"lockFileMaintenance": {
 		"enabled": true,
 		"automerge": true

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -8,3 +8,4 @@ enableScripts: true
 nodeLinker: node-modules
 
 npmRegistryServer: "https://registry.npmjs.org"
+npmMinimalAgeGate: 7d

--- a/website/.yarnrc.yml
+++ b/website/.yarnrc.yml
@@ -1,1 +1,2 @@
 nodeLinker: node-modules
+npmMinimalAgeGate: 7d


### PR DESCRIPTION
## Summary

- Renovate: add \`v4\` to \`baseBranches\` so the release-maintenance branch gets the same update policy (minor/patch automerge) as \`dev\`
- Supply-chain hardening: block packages newer than 7 days
  - \`.yarnrc.yml\` / \`website/.yarnrc.yml\`: \`npmMinimalAgeGate: 7d\` (Yarn 4.10+; we're on 4.14)
  - \`.github/renovate.json\`: \`minimumReleaseAge: 7 days\`, \`internalChecksFilter: strict\`, \`osvVulnerabilityAlerts\` on, with \`vulnerabilityAlerts.minimumReleaseAge: null\` so CVE patches bypass the gate

Inspired by d-zero-dev/frontend-env#886. Rationale for 7 days: most malicious packages are taken down within hours/days, 3 days is too short, 14+ days slows us down too much.

## Test plan

- [ ] \`yarn install\` works (yarn recognizes \`npmMinimalAgeGate\`)
- [ ] Next Renovate run opens PRs against both \`dev\` and \`v4\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)