### PR TITLE
ci(github): apply version labels by base branch

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,7 +1,12 @@
-# Current Version
-v4.x:
-    - changed-files:
-          - any-glob-to-any-file: '*'
+# Version labels (applied by base branch)
+v4:
+    - base-branch: ['v4']
+
+v5:
+    - base-branch: ['dev']
+
+v6:
+    - base-branch: ['v6']
 
 Command Line Interface:
     - changed-files:


### PR DESCRIPTION
## Summary

- Replace the `v4.x: '*'` wildcard rule in `.github/labeler.yml` that was auto-tagging every PR (causing ~1,000 PRs to be incorrectly tagged)
- Apply version labels based on PR base branch: `v4` → v4, `dev` → v5, `v6` → v6
- Companion to label taxonomy cleanup (done via gh API on existing issues/PRs):
  - Consolidated `v2.x` / `v3.x` / `v4.0` / `v4.x` / `v5.0` / `v5.x` / `v6.0` into `v2` / `v3` / `v4` / `v5` / `v6`
  - Re-sorted 205 PRs previously mis-tagged `v4.x` into `v5` (196) and `v6` (9) based on base branch and merge date (cutoff: 2026-02-20, first v5 tag)

## Test plan

- [ ] After merge, open a test PR against `dev` and confirm only `v5` is applied (not `v4.x`)
- [ ] Verify existing labels render correctly on the repo labels page

🤖 Generated with [Claude Code](https://claude.com/claude-code)