### PR TITLE
fix(ml-config): restore `oneOf` structure in `rules` definition of `config.schema.json`

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -2,30 +2,40 @@
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"definitions": {
 		"rules": {
-			"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/schema.json#/definitions/rules",
-			"additionalProperties": false,
-			"patternProperties": {
-				"^[^/]+/[^/]+$": {
-					"oneOf": [
-						{
-							"$ref": "#/definitions/custom-rule-value"
-						},
-						{
-							"type": "object",
-							"additionalProperties": false,
-							"properties": {
-								"value": { "$ref": "#/definitions/custom-rule-value" },
-								"severity": {
-									"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/ml-config/schema.json#/definitions/severity"
+			"oneOf": [
+				{
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/schema.json#/definitions/rules"
+				},
+				{
+					"title": "Custom rule",
+					"description": "@see https://markuplint.dev/docs/guides/applying-rules#applying-custom-rules",
+					"examples": ["[plugin-name]/[rule-name]"],
+					"type": "object",
+					"additionalProperties": false,
+					"patternProperties": {
+						"^[^/]+/[^/]+$": {
+							"oneOf": [
+								{
+									"$ref": "#/definitions/custom-rule-value"
 								},
-								"reason": {
-									"type": "string"
+								{
+									"type": "object",
+									"additionalProperties": false,
+									"properties": {
+										"value": { "$ref": "#/definitions/custom-rule-value" },
+										"severity": {
+											"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/ml-config/schema.json#/definitions/severity"
+										},
+										"reason": {
+											"type": "string"
+										}
+									}
 								}
-							}
+							]
 						}
-					]
+					}
 				}
-			}
+			]
 		},
 		"custom-rule-value": {
 			"type": ["string", "boolean", "number", "array", "object"]


### PR DESCRIPTION
## Summary

- Fixes a bug where standard rule names (e.g. `required-attr` — any name without a slash) were flagged as `Property X is not allowed` in `.markuplintrc.json` inside VSCode.
- Restores the `rules` definition of `config.schema.json` from `$ref` with sibling keywords to a proper `oneOf` structure.

## Root cause

The current `rules` definition:

```json
"rules": {
  "$ref": "https://.../rules/schema.json#/definitions/rules",
  "additionalProperties": false,
  "patternProperties": { "^[^/]+/[^/]+$": { ... } }
}
```

- Per JSON Schema draft-07, keywords sibling to `$ref` **MUST be ignored**.
- However, VSCode's `vscode-json-languageservice` applies sibling keywords alongside `$ref` (aligning with newer-draft behavior).
- As a result, `additionalProperties: false` + `patternProperties: "^[^/]+/[^/]+$"` take effect and reject every standard rule name that does not contain a slash — all 37 rules — as `Property X is not allowed`.
- Ajv strictly follows draft-07 and ignores the siblings, so the CLI validates fine → **this is why CLI and editor disagreed**.

This PR reverts to the correct `oneOf` structure used before commit `2b1225116` (2024-01-22):

```json
"rules": {
  "oneOf": [
    { "$ref": "https://.../rules/schema.json#/definitions/rules" },
    { "type": "object", "additionalProperties": false, "patternProperties": { "^[^/]+/[^/]+$": { ... } } }
  ]
}
```

## Test plan

- [x] Manually validated with Ajv (all pass):
  - `rules: { 'required-attr': false }` — valid
  - `rules: { 'my-plugin/my-rule': true }` — valid
  - `nodeRules[].rules: { 'required-attr': false }` — valid (the reported bug scenario)
  - `nodeRules[].rules: { 'my-plugin/my-rule': true }` — valid
  - `rules: { 'no-such-rule': false }` — correctly rejected
- [ ] After merge, confirm in VSCode with the markuplint extension that opening a `.markuplintrc.json` with `nodeRules[].rules` entries does not produce false `not allowed` warnings (the extension fetches from the `main` branch, so v4 → main merge is required to reach users).

## Notes

- This branch is based on `v4`. The VSCode extension references `raw.githubusercontent.com/.../main/config.schema.json`, so **a v4 → main merge is required** for the fix to reach users.
- Before this patch, `config.schema.json` on `main` and `v4` was byte-identical, so both branches carried the same bug. Merging this into `main` will resolve it everywhere the extension points.
- The `dev` branch carries the same structural bug and needs a separate follow-up fix (preserving `dev`'s own `^[^/]+/\*$` namespace-wildcard addition).

Fixes #3743

🤖 Generated with [Claude Code](https://claude.com/claude-code)