### PR TITLE
fix(ml-config): restore `oneOf` in `rules`/`baseRules` of `config.schema.json`

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -11,40 +11,50 @@
 			}
 		},
 		"rules": {
-			"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/schema.json#/definitions/rules",
-			"additionalProperties": false,
-			"patternProperties": {
-				"^[^/]+/.+$": {
-					"oneOf": [
-						{
-							"$ref": "#/definitions/custom-rule-value"
-						},
-						{
-							"type": "object",
-							"additionalProperties": false,
-							"properties": {
-								"value": {
+			"oneOf": [
+				{
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/schema.json#/definitions/rules"
+				},
+				{
+					"title": "Custom rule",
+					"description": "@see https://markuplint.dev/docs/guides/applying-rules#applying-custom-rules",
+					"examples": ["[plugin-name]/[rule-name]"],
+					"type": "object",
+					"additionalProperties": false,
+					"patternProperties": {
+						"^[^/]+/.+$": {
+							"oneOf": [
+								{
 									"$ref": "#/definitions/custom-rule-value"
 								},
-								"severity": {
-									"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/ml-config/schema.json#/definitions/severity"
+								{
+									"type": "object",
+									"additionalProperties": false,
+									"properties": {
+										"value": {
+											"$ref": "#/definitions/custom-rule-value"
+										},
+										"severity": {
+											"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/ml-config/schema.json#/definitions/severity"
+										},
+										"reason": {
+											"type": "string"
+										}
+									}
 								},
-								"reason": {
-									"type": "string"
+								{
+									"$ref": "#/definitions/namedRuleGroup"
 								}
-							}
+							]
 						},
-						{
-							"$ref": "#/definitions/namedRuleGroup"
+						"^[^/]+/\\*$": {
+							"type": "boolean",
+							"const": false,
+							"description": "Namespace wildcard disable. Disables all virtual rules with this namespace prefix (e.g., 'a11y/*': false)."
 						}
-					]
-				},
-				"^[^/]+/\\*$": {
-					"type": "boolean",
-					"const": false,
-					"description": "Namespace wildcard disable. Disables all virtual rules with this namespace prefix (e.g., 'a11y/*': false)."
+					}
 				}
-			}
+			]
 		},
 		"namedRuleGroup": {
 			"type": "object",
@@ -66,7 +76,6 @@
 		},
 		"baseRules": {
 			"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/schema.json#/definitions/rules",
-			"additionalProperties": false,
 			"description": "Rules without named rule group support. Used inside nodeRules, childNodeRules, and namedRuleGroup."
 		},
 		"custom-rule-value": {


### PR DESCRIPTION
## Summary

- Applies the same `$ref`-with-siblings fix as v4 PR #3786 to `dev`.
- Preserves `dev`-specific extensions: `^[^/]+/\*$` namespace wildcard (`'a11y/*': false`) and `namedRuleGroup` variants.
- Additionally fixes `baseRules`, which had the same anti-pattern — affecting `nodeRules[].rules`, `childNodeRules[].rules`, and `namedRuleGroup.rules` too.

## Root cause

Both `rules` and `baseRules` in `config.schema.json` were structured as `$ref` with sibling `additionalProperties: false` (and in `rules`'s case, also `patternProperties`). Per JSON Schema draft-07, siblings of `$ref` are ignored, so Ajv (CLI) was fine. VSCode's `vscode-json-languageservice` applies siblings, so every standard rule name (no slash) was flagged as `Property X is not allowed` in `.markuplintrc.json`.

This PR:

- `rules`: wraps in `oneOf` so the standard rule set (via `$ref`) and the custom rule map (with `patternProperties` for plugin rules and namespace wildcard) are alternatives rather than conflicting sibling constraints.
- `baseRules`: drops the redundant sibling `additionalProperties: false` — the `$ref` target already has `additionalProperties: false` listing the standard rules.

## Test plan

- [x] Manually validated with Ajv (all pass):
  - `rules: { 'required-attr': false }` — valid
  - `rules: { 'required-attr': { severity: 'error' } }` — valid
  - `rules: { 'my-plugin/my-rule': true }` — valid
  - `rules: { 'a11y/*': false }` — valid (namespace wildcard disable)
  - `nodeRules[].rules: { 'required-attr': false }` — valid (the reported bug scenario)
  - `childNodeRules[].rules: { 'required-attr': false }` — valid
  - `nodeRules[].rules: { 'required-attr': { severity: 'warning' } }` — valid
  - `rules: { 'no-such-rule': false }` — correctly rejected
  - `rules: { 'a11y/*': true }` — correctly rejected (wildcard only accepts `false`)
  - `nodeRules[].rules: { 'my-plugin/my-rule': true }` — correctly rejected (plugin rules not allowed in baseRules)

## Notes

- The VSCode extension fetches from the `main` branch, so merging this into `dev` does not reach end users on its own. Once `dev` becomes the release line (v5/v6), this will take effect.
- v4 already received the equivalent fix via #3786 and has been merged into `main`, so existing 4.x users are unblocked.

Refs #3743

🤖 Generated with [Claude Code](https://claude.com/claude-code)