### PR TITLE
fix(types): extend URL forbidden code point detection and fix vtab trim bug

### DIFF
--- a/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
@@ -2382,3 +2382,48 @@ describe('#3189 link[as] conditional enum', () => {
 		expect(violations.some(v => v.raw === 'script')).toBe(false);
 	});
 });
+
+describe('#3629 URL forbidden code points', () => {
+	test('[invalid-attr-issue-3629-001] C1 control U+0080 in href', async () => {
+		const { violations } = await mlRuleTest(rule, '<a href="http://example.com/\u0080">x</a>');
+		expect(violations.some(v => v.message.includes('unexpected characters'))).toBe(true);
+	});
+
+	test('[invalid-attr-issue-3629-002] C1 control U+009F in href', async () => {
+		const { violations } = await mlRuleTest(rule, '<a href="http://example.com/\u009F">x</a>');
+		expect(violations.some(v => v.message.includes('unexpected characters'))).toBe(true);
+	});
+
+	test('[invalid-attr-issue-3629-003] BMP noncharacter U+FDD0 in href', async () => {
+		const { violations } = await mlRuleTest(rule, '<a href="http://example.com/\uFDD0">x</a>');
+		expect(violations.some(v => v.message.includes('unexpected characters'))).toBe(true);
+	});
+
+	test('[invalid-attr-issue-3629-004] BMP noncharacter U+FFFE in href', async () => {
+		const { violations } = await mlRuleTest(rule, '<a href="http://example.com/\uFFFE">x</a>');
+		expect(violations.some(v => v.message.includes('unexpected characters'))).toBe(true);
+	});
+
+	test('[invalid-attr-issue-3629-005] supplementary plane noncharacter U+1FFFE in href', async () => {
+		const { violations } = await mlRuleTest(rule, '<a href="http://example.com/\u{1FFFE}">x</a>');
+		expect(violations.some(v => v.message.includes('unexpected characters'))).toBe(true);
+	});
+
+	test('[invalid-attr-issue-3629-006] trailing vertical tab U+000B in href is not silently stripped', async () => {
+		// Regression for JavaScript String.prototype.trim() stripping U+000B
+		// before the forbidden-code-point check.
+		const { violations } = await mlRuleTest(rule, '<a href="http://example.com/\u000B">x</a>');
+		expect(violations.some(v => v.message.includes('unexpected characters'))).toBe(true);
+	});
+
+	test('[invalid-attr-issue-3629-007] PUA code point in href is accepted', async () => {
+		// Guard against over-broad regex: U+E000 (BMP PUA) is not forbidden.
+		const { violations } = await mlRuleTest(rule, '<a href="http://example.com/\uE000">x</a>');
+		expect(violations.some(v => v.message.includes('unexpected characters'))).toBe(false);
+	});
+
+	test('[invalid-attr-issue-3629-008] emoji (U+1F4A9) in href is accepted', async () => {
+		const { violations } = await mlRuleTest(rule, '<a href="http://example.com/\u{1F4A9}">x</a>');
+		expect(violations.some(v => v.message.includes('unexpected characters'))).toBe(false);
+	});
+});

--- a/packages/@markuplint/types/src/whatwg/check-url.spec.ts
+++ b/packages/@markuplint/types/src/whatwg/check-url.spec.ts
@@ -56,6 +56,42 @@ test('C0 control characters', () => {
 	expect(check('http://example.com/\u007F').matched).toBe(false);
 });
 
+test('C1 control characters (U+0080–U+009F)', () => {
+	expect(check('http://example.com/\u0080').matched).toBe(false);
+	expect(check('http://example.com/\u009F').matched).toBe(false);
+});
+
+test('BMP Unicode noncharacters', () => {
+	expect(check('http://example.com/\uFDD0').matched).toBe(false);
+	expect(check('http://example.com/\uFDEF').matched).toBe(false);
+	expect(check('http://example.com/\uFFFE').matched).toBe(false);
+	expect(check('http://example.com/\uFFFF').matched).toBe(false);
+});
+
+test('supplementary plane noncharacters (U+XFFFE / U+XFFFF)', () => {
+	expect(check('http://example.com/\u{1FFFE}').matched).toBe(false);
+	expect(check('http://example.com/\u{1FFFF}').matched).toBe(false);
+	expect(check('http://example.com/\u{10FFFE}').matched).toBe(false);
+	expect(check('http://example.com/\u{10FFFF}').matched).toBe(false);
+});
+
+test('trailing vertical tab is not silently stripped', () => {
+	// JavaScript's String.prototype.trim() treats U+000B as whitespace and
+	// would silently remove it before the forbidden-code-point check runs.
+	// HTML "strip leading and trailing ASCII whitespace" only strips
+	// U+0009 / U+000A / U+000C / U+000D / U+0020 — so U+000B must still
+	// trigger a forbidden code point error at the boundary.
+	expect(check('http://example.com/path\u000B').matched).toBe(false);
+	expect(check('http://example.com/\u000B').matched).toBe(false);
+});
+
+test('NBSP (U+00A0) is not a forbidden code point', () => {
+	// NBSP is not in the HTML forbidden code point set.
+	// (new URL() may still reject the overall URL; this test focuses on
+	// NBSP not being classified as a forbidden code point itself.)
+	expect(check('\u00A0').matched).toBe(true);
+});
+
 test('space in URL (unencoded)', () => {
 	// Spaces in path cause new URL() to fail for absolute URLs
 	// For relative URLs with dummy base, space is allowed by new URL()

--- a/packages/@markuplint/types/src/whatwg/check-url.spec.ts
+++ b/packages/@markuplint/types/src/whatwg/check-url.spec.ts
@@ -2,6 +2,8 @@ import { test, expect } from 'vitest';
 
 import { checkURL } from './check-url.js';
 
+// cspell:ignore FDEF FFFE XFFFE XFFFF AFFFE AFFFF BFFFE BFFFF CFFFE CFFFF DFFFE DFFFF EFFFE EFFFF FFFFE FFFFF
+
 const check = checkURL();
 
 test('valid absolute URLs', () => {

--- a/packages/@markuplint/types/src/whatwg/check-url.spec.ts
+++ b/packages/@markuplint/types/src/whatwg/check-url.spec.ts
@@ -75,21 +75,68 @@ test('supplementary plane noncharacters (U+XFFFE / U+XFFFF)', () => {
 	expect(check('http://example.com/\u{10FFFF}').matched).toBe(false);
 });
 
-test('trailing vertical tab is not silently stripped', () => {
+test('vertical tab at any boundary is not silently stripped', () => {
 	// JavaScript's String.prototype.trim() treats U+000B as whitespace and
 	// would silently remove it before the forbidden-code-point check runs.
 	// HTML "strip leading and trailing ASCII whitespace" only strips
 	// U+0009 / U+000A / U+000C / U+000D / U+0020 — so U+000B must still
-	// trigger a forbidden code point error at the boundary.
-	expect(check('http://example.com/path\u000B').matched).toBe(false);
+	// trigger a forbidden code point error at any position.
+	expect(check('\u000Bhttp://example.com/').matched).toBe(false);
 	expect(check('http://example.com/\u000B').matched).toBe(false);
+	expect(check('\u000Bhttp://example.com/\u000B').matched).toBe(false);
+	expect(check('http://example.com/path\u000B').matched).toBe(false);
 });
 
-test('NBSP (U+00A0) is not a forbidden code point', () => {
-	// NBSP is not in the HTML forbidden code point set.
-	// (new URL() may still reject the overall URL; this test focuses on
-	// NBSP not being classified as a forbidden code point itself.)
-	expect(check('\u00A0').matched).toBe(true);
+test('HTML ASCII whitespace at URL boundaries is stripped', () => {
+	// Per HTML "strip leading and trailing ASCII whitespace":
+	// TAB (U+0009), LF (U+000A), FF (U+000C), CR (U+000D), SPACE (U+0020).
+	// Mid-URL TAB / LF / CR are caught by ILLEGAL_WHITESPACE; these cases
+	// only exercise the boundary-strip behaviour of stripAsciiWhitespace.
+	expect(check('\thttps://example.com').matched).toBe(true);
+	expect(check('\nhttps://example.com').matched).toBe(true);
+	expect(check('\fhttps://example.com').matched).toBe(true);
+	expect(check('\rhttps://example.com').matched).toBe(true);
+	expect(check('https://example.com\t\n\f\r ').matched).toBe(true);
+	expect(check('\t\n\f\r https://example.com\t\n\f\r ').matched).toBe(true);
+});
+
+test('NBSP embedded in URL is not classified as a forbidden code point', () => {
+	// NBSP (U+00A0) is not in HTML LS "forbidden code points" and must pass
+	// the FORBIDDEN_CODE_POINT check. new URL() percent-encodes it in the
+	// path, so the full validation accepts it.
+	expect(check('http://example.com/\u00A0').matched).toBe(true);
+});
+
+test('non-ASCII code points outside the forbidden set are valid', () => {
+	// Guard against accidental regex range expansion: PUA and emoji must
+	// not be misclassified as forbidden.
+	expect(check('http://example.com/\u{E000}').matched).toBe(true); // BMP PUA start
+	expect(check('http://example.com/\u{F8FF}').matched).toBe(true); // BMP PUA end
+	expect(check('http://example.com/\u{F0000}').matched).toBe(true); // Supp-A PUA
+	expect(check('http://example.com/\u{100000}').matched).toBe(true); // Supp-B PUA
+	expect(check('http://example.com/\u{1F4A9}').matched).toBe(true); // emoji
+});
+
+test('code points adjacent to forbidden ranges are valid', () => {
+	// Boundary guards for the FORBIDDEN_CODE_POINT regex.
+	expect(check('http://example.com/\u007E').matched).toBe(true); // just before DEL
+	expect(check('http://example.com/\u00A0').matched).toBe(true); // just after C1
+	expect(check('http://example.com/\uFDCF').matched).toBe(true); // just before FDD0
+	expect(check('http://example.com/\uFDF0').matched).toBe(true); // just after FDEF
+	expect(check('http://example.com/\uFFFD').matched).toBe(true); // just before FFFE
+	expect(check('http://example.com/\u{1FFFD}').matched).toBe(true); // before 1FFFE
+	expect(check('http://example.com/\u{10FFFD}').matched).toBe(true); // before 10FFFE
+});
+
+test('multiple consecutive forbidden code points are detected', () => {
+	// `test()` short-circuits at the first match, but the regex has to be
+	// general enough that the first match can be ANY of the forbidden code
+	// points. A regression that accidentally anchors the regex would fail
+	// one of these cases.
+	expect(check('http://example.com/\u0080\u0081').matched).toBe(false);
+	expect(check('http://example.com/\uFDD0\uFFFE').matched).toBe(false);
+	expect(check('http://example.com/\u{1FFFE}\u{2FFFE}').matched).toBe(false);
+	expect(check('http://example.com/ab\u{10FFFF}c').matched).toBe(false);
 });
 
 test('space in URL (unencoded)', () => {

--- a/packages/@markuplint/types/src/whatwg/check-url.ts
+++ b/packages/@markuplint/types/src/whatwg/check-url.ts
@@ -25,11 +25,37 @@ const ILLEGAL_WHITESPACE = /[\t\n\r]/;
 const MALFORMED_PERCENT = /%(?![0-9A-F]{2})/i;
 
 /**
- * C0 control characters (U+0000–U+001F) and DEL (U+007F) are forbidden
- * in URLs. Excludes TAB/LF/CR which are caught by ILLEGAL_WHITESPACE.
+ * Forbidden code points per HTML Living Standard and URL spec.
+ *
+ * Covers:
+ * - C0 controls (U+0000–U+001F) except TAB/LF/CR which are caught by
+ *   ILLEGAL_WHITESPACE
+ * - DEL (U+007F) and C1 controls (U+0080–U+009F)
+ * - Unicode noncharacters:
+ *   - BMP: U+FDD0–U+FDEF, U+FFFE, U+FFFF
+ *   - Supplementary planes: U+XFFFE / U+XFFFF for X = 1..10 (hex)
+ *
+ * Requires the `u` flag for code points above U+FFFF.
+ *
+ * @see https://infra.spec.whatwg.org/#noncharacter
+ * @see https://html.spec.whatwg.org/multipage/parsing.html#preprocessing-the-input-stream
  */
-// eslint-disable-next-line no-control-regex
-const C0_CONTROL = /[\u0000-\u0008\v\u000E-\u001F\u007F]/;
+const FORBIDDEN_CODE_POINT =
+	// eslint-disable-next-line no-control-regex
+	/[\u0000-\u0008\v\u000E-\u001F\u007F-\u009F\uFDD0-\uFDEF\uFFFE\uFFFF\u{1FFFE}\u{1FFFF}\u{2FFFE}\u{2FFFF}\u{3FFFE}\u{3FFFF}\u{4FFFE}\u{4FFFF}\u{5FFFE}\u{5FFFF}\u{6FFFE}\u{6FFFF}\u{7FFFE}\u{7FFFF}\u{8FFFE}\u{8FFFF}\u{9FFFE}\u{9FFFF}\u{AFFFE}\u{AFFFF}\u{BFFFE}\u{BFFFF}\u{CFFFE}\u{CFFFF}\u{DFFFE}\u{DFFFF}\u{EFFFE}\u{EFFFF}\u{FFFFE}\u{FFFFF}\u{10FFFE}\u{10FFFF}]/u;
+
+/**
+ * Strips only HTML ASCII whitespace (TAB/LF/FF/CR/SPACE) from both ends.
+ *
+ * Unlike `String.prototype.trim()`, this does not strip U+000B (vertical tab)
+ * or any other Unicode whitespace, so forbidden code points at URL
+ * boundaries are preserved for the forbidden-code-point check below.
+ *
+ * @see https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace
+ */
+function stripAsciiWhitespace(value: string): string {
+	return value.replaceAll(/^[\t\n\f\r ]+|[\t\n\f\r ]+$/g, '');
+}
 
 /**
  * Unencoded space in URL body (after trimming leading/trailing spaces).
@@ -46,7 +72,7 @@ const UNENCODED_SPACE = / /;
  * the nu-html-checker's galimatias StrictErrorHandler behavior:
  * - Illegal whitespace (tabs, newlines) in URL
  * - Malformed percent-encoding
- * - C0 control characters
+ * - Forbidden code points (C0/C1 controls, Unicode noncharacters)
  * - URLs that fail `new URL()` parsing (even with a dummy base)
  *
  * @see https://html.spec.whatwg.org/multipage/urls-and-fetching.html#valid-url-potentially-surrounded-by-spaces
@@ -56,7 +82,7 @@ export const checkURL: CustomSyntaxChecker = () =>
 	function checkURL(value) {
 		log('CHECK: url');
 
-		const trimmed = value.trim();
+		const trimmed = stripAsciiWhitespace(value);
 
 		// Empty URL is valid for some attributes (e.g., <a href="">)
 		// The spec says "valid URL potentially surrounded by spaces"
@@ -70,8 +96,8 @@ export const checkURL: CustomSyntaxChecker = () =>
 			return unmatched(trimmed, 'unexpected-token');
 		}
 
-		// Check for C0 control characters
-		if (C0_CONTROL.test(trimmed)) {
+		// Check for forbidden code points (C0/C1 controls, noncharacters)
+		if (FORBIDDEN_CODE_POINT.test(trimmed)) {
 			return unmatched(trimmed, 'unexpected-token');
 		}
 

--- a/packages/@markuplint/types/src/whatwg/check-url.ts
+++ b/packages/@markuplint/types/src/whatwg/check-url.ts
@@ -3,6 +3,8 @@ import type { CustomSyntaxChecker } from '../types.js';
 import { log } from '../debug.js';
 import { matched, unmatched } from '../match-result.js';
 
+// cspell:ignore FDEF FFFE XFFFE XFFFF AFFFE AFFFF BFFFE BFFFF CFFFE CFFFF DFFFE DFFFF EFFFE EFFFF FFFFE FFFFF
+
 /**
  * Dummy base URL for resolving relative URLs.
  * Used only for syntax validation — the actual base URL is irrelevant.


### PR DESCRIPTION
## Summary

Closes #3629.

- Extend `@markuplint/types` `checkURL` to reject **C1 controls** (U+0080–U+009F) and **Unicode noncharacters** (U+FDD0–U+FDEF, U+FFFE/U+FFFF, and plane-end U+XFFFE/U+XFFFF for planes 1 through 16).
- Replace `String.prototype.trim()` with an HTML-spec ASCII whitespace strip (`\t\n\f\r ` only) so trailing / leading **U+000B (vertical tab)** is no longer silently removed before the forbidden-code-point check.
- Add unit-level boundary tests (leading/trailing/both/mid vtab, HTML ASCII whitespace surround, adjacent-valid code points, non-ASCII valid code points, consecutive forbidden code points) and `[invalid-attr-issue-3629-001..008]` integration tests exercising the full `invalid-attr` pipeline.

### nu-html-checker benchmark (before → after)

- Pass: 2436 / 3852 (63.2%) → 2459 / 3852 (63.8%) — **+23**
- Newly detected on `*-novalid.html` fixtures: C1 controls, BMP / supplementary-plane noncharacters, trailing U+000B in URL boundaries.

### Spec references

- [HTML LS — preprocessing the input stream](https://html.spec.whatwg.org/multipage/parsing.html#preprocessing-the-input-stream)
- [Infra — noncharacter](https://infra.spec.whatwg.org/#noncharacter)
- [Infra — strip leading and trailing ASCII whitespace](https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace)

### Compatibility

This is detection-scope tightening, equivalent in character to #3598 / #3189 (also v5-rc fixes for previously-missed errors). Consistent with those precedents, no v4 → v5 migration-doc entry is added.

## Test plan

- [x] \`npx vitest run packages/@markuplint/types/src/whatwg/check-url.spec.ts\` — 23/23 pass
- [x] \`npx vitest run packages/@markuplint/rules/src/invalid-attr\` — 161/161 pass
- [x] \`yarn lint-check\` (oxlint + oxfmt) — 0 errors / 0 warnings
- [x] \`yarn build\` — 39 projects success
- [x] \`yarn test\` — 3453 pass / 1 skipped / 0 typecheck errors
- [x] \`node --experimental-strip-types tests/external/nu-validator-report.ts\` — pass rate 63.2% → 63.8%

🤖 Generated with [Claude Code](https://claude.com/claude-code)