### PR TITLE
chore: drop #3734 from bench xref config

### DIFF
--- a/tests/external/bench/issue-xref.config.ts
+++ b/tests/external/bench/issue-xref.config.ts
@@ -91,13 +91,6 @@ export const xrefMappings: readonly XrefMapping[] = [
 	},
 	{
 		kind: 'primary',
-		issue: 3734,
-		filter: /meta\/refresh-.*novalid/,
-		note:
-			'Five refresh-syntax fixtures are `nu-only`. `http-equiv="content-type"` syntax has no dedicated fixture in the current nu-validator suite — that half of the issue needs either a manual test or a new upstream fixture.',
-	},
-	{
-		kind: 'primary',
 		issue: 3735,
 		filter: /aria-hidden-on-input-hidden|popovertarget-with-aria-expanded|aria-expanded-with-popovertarget/,
 		note:


### PR DESCRIPTION
Follow-up to #3804 (merged).

## Summary

- Removes the primary mapping for #3734 from `tests/external/bench/issue-xref.config.ts`. The issue closed when #3804 merged; per `tests/external/CLAUDE.md` → "Updating issue-xref.config.ts" the mapping should be dropped at that point.
- The umbrella block (#3684) auto-derives from remaining primary mappings, so no separate edit is needed on the config side. The live #3684 body was also updated directly to check off #3734 and to stop listing it under "残りの v5.x Open Issues（真のギャップ）".

## Verification

- `yarn bench:xref --audit` → `[xref] audit: all 14 mapped issues are still OPEN` (was 1 CLOSED)
- `npx vitest run tests/external/bench/xref-issue.spec.ts` → 42 passed (invariant tests including "every primary filter matches ≥1 fixture" and "no duplicate primary issue numbers")
- `yarn lint-check` → 0 warnings / 0 errors

## Test plan

- [x] Local audit green
- [x] Xref invariant spec green
- [ ] CI `Bench xref audit` workflow picks up the config change and confirms no CLOSED references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)