### PR TITLE
fix(vscode): convert absolute paths to file:// URLs before import (#3795)

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
-		include: ['./packages/**/*.spec.{js,mjs,ts}'],
+		include: ['./packages/**/*.spec.{js,mjs,ts}', './vscode/src/**/*.spec.{js,mjs,ts}'],
 		testTimeout: 10000,
 	},
 });

--- a/vscode/src/server/get-module.spec.ts
+++ b/vscode/src/server/get-module.spec.ts
@@ -1,0 +1,71 @@
+import { describe, test, expect } from 'vitest';
+
+import { toImportSpecifier } from './get-module.js';
+
+describe('toImportSpecifier', () => {
+	test('converts a Windows drive-letter absolute path to a file:// URL', () => {
+		expect(toImportSpecifier('C:\\Users\\a\\markuplint\\lib\\index.mjs')).toBe(
+			'file:///C:/Users/a/markuplint/lib/index.mjs',
+		);
+	});
+
+	test('converts a lowercase-drive Windows path to a file:// URL', () => {
+		expect(toImportSpecifier('c:\\Users\\name\\node_modules\\markuplint\\lib\\index.mjs')).toBe(
+			'file:///c:/Users/name/node_modules/markuplint/lib/index.mjs',
+		);
+	});
+
+	test('never leaves a bare drive-letter prefix as the import specifier', () => {
+		const result = toImportSpecifier('c:\\foo\\bar.mjs');
+		expect(result.startsWith('file://')).toBe(true);
+		expect(result).not.toMatch(/^c:/);
+	});
+
+	test('URL-encodes spaces in Windows paths (Program Files)', () => {
+		expect(toImportSpecifier('c:\\Program Files\\node_modules\\markuplint\\lib\\index.mjs')).toBe(
+			'file:///c:/Program%20Files/node_modules/markuplint/lib/index.mjs',
+		);
+	});
+
+	test('URL-encodes non-ASCII characters in Windows paths', () => {
+		expect(toImportSpecifier('c:\\Users\\太郎\\lib.mjs')).toBe('file:///c:/Users/%E5%A4%AA%E9%83%8E/lib.mjs');
+	});
+
+	test('URL-encodes reserved characters like # in Windows paths', () => {
+		expect(toImportSpecifier('c:\\Users\\foo#bar\\lib.mjs')).toBe('file:///c:/Users/foo%23bar/lib.mjs');
+	});
+
+	test('converts a POSIX absolute path to a file:// URL', () => {
+		expect(toImportSpecifier('/tmp/markuplint/lib/index.mjs')).toBe('file:///tmp/markuplint/lib/index.mjs');
+	});
+
+	test('URL-encodes spaces in POSIX paths', () => {
+		expect(toImportSpecifier('/tmp/my project/lib.mjs')).toBe('file:///tmp/my%20project/lib.mjs');
+	});
+
+	test('does not convert bare module specifiers like "markuplint"', () => {
+		expect(toImportSpecifier('markuplint')).toBe('markuplint');
+	});
+
+	test('does not convert scoped bare specifiers like "@markuplint/pug-parser"', () => {
+		expect(toImportSpecifier('@markuplint/pug-parser')).toBe('@markuplint/pug-parser');
+	});
+
+	test('does not accidentally prefix ./ specifiers with file:///', () => {
+		expect(toImportSpecifier('./local.js')).toBe('./local.js');
+	});
+
+	test('does not convert ../ relative specifiers', () => {
+		expect(toImportSpecifier('../lib/index.js')).toBe('../lib/index.js');
+	});
+
+	test('does not convert empty strings', () => {
+		expect(toImportSpecifier('')).toBe('');
+	});
+
+	test('leaves UNC paths as-is for the caller to handle (known limitation)', () => {
+		// UNC path handling is tracked as a follow-up (see PR description for #3795).
+		// Assert the current behavior so any future change is explicit.
+		expect(toImportSpecifier('\\\\server\\share\\foo.mjs')).toBe('\\\\server\\share\\foo.mjs');
+	});
+});

--- a/vscode/src/server/get-module.ts
+++ b/vscode/src/server/get-module.ts
@@ -2,8 +2,54 @@ import type { Log } from '../types.js';
 import type { ARIAVersion } from '@markuplint/ml-spec';
 
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 import { Files } from 'vscode-languageserver/node.js';
+
+/**
+ * Convert a module path into a specifier that Node's ESM `import()` accepts.
+ *
+ * On Windows, raw drive-letter paths like `c:\foo` are rejected by the ESM
+ * loader (`ERR_UNSUPPORTED_ESM_URL_SCHEME: Received protocol 'c:'`) because
+ * the drive letter is parsed as a URL scheme. They must be converted to
+ * `file://` URLs first.
+ *
+ * Detection is OS-independent so that POSIX CI can exercise the Windows
+ * code path.
+ *
+ * Mirrors `packages/@markuplint/file-resolver/src/general-import.ts` —
+ * keep the two in sync when adjusting Windows-path handling.
+ *
+ * @param modPath - A module specifier — typically the result of `Files.resolve`
+ *   or `require.resolve`, which may be a bare module name (`markuplint`), a
+ *   relative path (`./foo`), or an absolute path (Windows or POSIX).
+ * @returns A specifier safe to pass to `import()`. Absolute paths are converted
+ *   to `file://` URLs with each segment percent-encoded; bare and relative
+ *   specifiers are returned unchanged. UNC paths (`\\server\share\...`) are
+ *   passed through unchanged as a known limitation.
+ * @see https://github.com/markuplint/markuplint/issues/3795
+ * @see https://nodejs.org/api/esm.html#urls
+ */
+export function toImportSpecifier(modPath: string): string {
+	const isWindowsAbsolute = /^[a-z]:[/\\]/i.test(modPath);
+	const isPosixAbsolute = modPath.startsWith('/');
+	if (!isWindowsAbsolute && !isPosixAbsolute) {
+		return modPath;
+	}
+	if (isWindowsAbsolute) {
+		// pathToFileURL on a POSIX runtime misinterprets Windows-style paths,
+		// so build the URL explicitly. Percent-encode each path segment so that
+		// spaces (`Program Files`), non-ASCII characters (e.g. Japanese
+		// usernames), and URL-reserved characters like `#` / `?` do not get
+		// reinterpreted as fragment/query delimiters by Node's URL parser.
+		// The drive-letter segment (`c:`) is kept as-is to match the
+		// `pathToFileURL` output shape on Windows (`file:///c:/...`).
+		const [drive, ...rest] = modPath.replaceAll('\\', '/').split('/');
+		const encoded = [drive, ...rest.map(segment => encodeURIComponent(segment))].join('/');
+		return `file:///${encoded}`;
+	}
+	return pathToFileURL(modPath).href;
+}
 
 export async function getModule(log: Log): Promise<Module> {
 	let markuplint: any;
@@ -13,7 +59,10 @@ export async function getModule(log: Log): Promise<Module> {
 		log('Getting module', 'debug');
 		const modPath = await fileResolve(message => log(message));
 		log(`import("${modPath}")`, 'debug');
-		markuplint = await import(modPath);
+		// IMPORTANT: modPath may be a Windows absolute path (c:\...).
+		// Always convert via toImportSpecifier() before passing to import() —
+		// raw drive-letter paths trigger ERR_UNSUPPORTED_ESM_URL_SCHEME.
+		markuplint = await import(toImportSpecifier(modPath));
 		log(`Found package: ${modPath}`, 'debug');
 		const packageJsonPath = path.resolve(path.dirname(modPath), '..', 'package.json');
 		// eslint-disable-next-line @typescript-eslint/no-require-imports


### PR DESCRIPTION
## Summary

- Fixes #3795: the VS Code extension crashed on Windows with `ERR_UNSUPPORTED_ESM_URL_SCHEME: Received protocol 'c:'` whenever it tried to load the workspace-local `markuplint` via dynamic `import()`. Node's ESM loader parses `c:` as a URL scheme and rejects raw Windows absolute paths.
- Introduces a pure helper `toImportSpecifier()` that detects Windows **and** POSIX absolute paths (regex-based, OS-independent) and converts them to `file://` URLs with each path segment percent-encoded — so spaces (`Program Files`), non-ASCII characters (e.g. Japanese user names), and URL-reserved characters (`#`, `?`) round-trip correctly.
- Adds `vscode/src/server/get-module.spec.ts` with 14 tests covering Windows drive-letter paths, POSIX paths, spaces, Unicode, reserved characters, bare specifiers, relative specifiers, empty strings, and the known UNC-path limitation.
- Adds `./vscode/src/**/*.spec.{js,mjs,ts}` to the root `vitest.config.ts` so the new test runs under `yarn test` on v4 (dev already had this).

## Reproduction (before the fix)

On Windows, with a workspace that has `markuplint` installed locally:

```
Failed to resolve local package: Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]:
Only URLs with a scheme in: file, data, node, and electron are supported
by the default ESM loader. On Windows, absolute paths must be valid
file:// URLs. Received protocol 'c:'
```

Minimal standalone repro:

```js
// Node.js on Windows — fails before this fix, succeeds after
await import('c:\\any\\absolute\\path\\to\\some.mjs');
```

After the fix, `getModule()` wraps the resolved path with `toImportSpecifier()`, turning `c:\Users\...` into `file:///c:/Users/...` before passing to `import()`.

## Test plan

- [x] `yarn lint-check` — 0 errors / 0 warnings (CSpell skipped due to a known worktree limitation; cspell verified out-of-band)
- [x] `yarn build` — 37 projects built successfully
- [x] `yarn test` — 142 files / 1434 tests passing, including the new 14 unit tests
- [ ] **Windows verification needed** — if anyone on Windows can check out this branch, `yarn install && yarn build && npm run vscode:build` inside `vscode/`, then reload the extension and open a workspace with locally-installed markuplint, please confirm the error no longer appears. (I do not have a Windows environment; #3795 reporter @aloayzab88 was asked upstream.)

## Follow-ups

- #3806: Add a Windows runner to `test-vscode.yml` so Windows-only extension bugs don't keep slipping past CI.

## Notes

- **Not a breaking change.** Pure bug fix; `toImportSpecifier` is a new named export but `vscode/package.json` is private, so there's no external API surface.
- UNC paths (`\\server\share\...`) are intentionally passed through unchanged (asserted by a regression test). Full UNC support is left as a follow-up.
- Mirrors the same `pathToFileURL` pattern already used in `packages/@markuplint/file-resolver/src/general-import.ts:38-44`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)