### PR TITLE
ci(vscode): add Windows runner to test-vscode workflow (#3806)

### DIFF
--- a/.github/workflows/test-vscode.yml
+++ b/.github/workflows/test-vscode.yml
@@ -10,17 +10,29 @@ on:
 
 jobs:
     test:
-        runs-on: ubuntu-latest
+        # Run the VS Code extension integration tests on both Linux and Windows.
+        # Windows coverage exists specifically because of bugs like #3795 — the
+        # `ERR_UNSUPPORTED_ESM_URL_SCHEME` crash that only manifested on Windows
+        # drive-letter paths and went undetected under ubuntu-only CI.
+        strategy:
+            fail-fast: false
+            matrix:
+                os:
+                    - ubuntu-latest
+                    - windows-latest
+        runs-on: ${{ matrix.os }}
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
               with:
                   # SEE: https://github.com/lerna/lerna/issues/2542
                   fetch-depth: '0'
 
-            - name: Install Xvfb
+            - name: Install Xvfb (Linux only)
+              if: runner.os == 'Linux'
               run: sudo apt-get update && sudo apt-get install -y xvfb
 
-            - name: Start Xvfb
+            - name: Start Xvfb (Linux only)
+              if: runner.os == 'Linux'
               run: |
                   Xvfb :99 &
                   echo "DISPLAY=:99.0" >> "$GITHUB_ENV"
@@ -31,12 +43,15 @@ jobs:
                   node-version: 22
 
             - name: Enable Corepack and setup Yarn v4
+              shell: bash
               run: |
                   corepack enable
                   yarn --version
 
             - name: Install dependencies
+              shell: bash
               run: yarn install --immutable && yarn run build
 
             - name: Run tests
+              shell: bash
               run: cd vscode && yarn install && npm run vscode:build && npm run vscode:test


### PR DESCRIPTION
## Summary

Closes #3806.

Extends `.github/workflows/test-vscode.yml` so the VS Code extension integration test job runs on both `ubuntu-latest` and `windows-latest`.

### Why

The Windows-only crash in #3795 (`ERR_UNSUPPORTED_ESM_URL_SCHEME` on drive-letter paths) shipped undetected because the extension was only ever tested on Linux CI. Adding a Windows runner closes that structural coverage gap so the next Windows-only bug in this extension fails fast on PR rather than in a user's bug report.

### What changed

- Introduced a matrix over `os` with `fail-fast: false` so a failure on one platform doesn't hide the other.
- Guarded the Xvfb install/start steps with `if: runner.os == 'Linux'` — Windows runners already have a display and `@vscode/test-electron` handles the rest.
- Pinned `shell: bash` for install/test steps to keep `&&` chaining behaving the same on Windows (git-bash) as on Linux.

### Follow-ups (out of scope)

- If Windows CI turns out to be flaky, consider caching `node_modules` / the downloaded VS Code binary to cut the Windows job time.
- If we adopt Windows caching, also evaluate concurrent shard testing or matrix over Node versions.

## Test plan

- [x] `actionlint` passes on the new workflow.
- [ ] **CI itself is the test.** On this PR, confirm the new `test (windows-latest)` check runs the full `vscode:test` suite and turns green. If it fails, the workflow needs more Windows-specific adjustments before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)