### PR TITLE
fix(vscode): widen engines.vscode range to allow VS Code 1.117+ (#3795)

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -13,7 +13,7 @@
 		"theme": "dark"
 	},
 	"engines": {
-		"vscode": "1.116.0"
+		"vscode": ">=1.116.0"
 	},
 	"categories": [
 		"Programming Languages",


### PR DESCRIPTION
## Summary

- The fixed value `"1.116.0"` set in [b2a9239d](https://github.com/markuplint/markuplint/commit/b2a9239dd66cb6141965632ae0f8fd0189c533a9) was treated by the VS Code Marketplace as **exactly 1.116.0**, so users on VS Code 1.117+ were marked incompatible and never received the v4.18.1 update that fixes the Windows ESM URL crash (#3795).
- Widen the constraint to `>=1.116.0` so any version at or above the minimum is accepted.
- v5 (`dev`) already uses `^1.99.1`; only v4 was affected.

## Test plan

- [x] `yarn lint-check` (cspell exits 1 due to known worktree glob issue; ESLint / Prettier pass)
- [x] `yarn build`
- [x] `yarn test` (142 files / 1434 passed)
- [ ] After release as v4.18.2, confirm the reporter on VS Code 1.117 receives the update from the Marketplace