### PR TITLE
fix(selector): match HTML attribute names ASCII case-insensitively

### DIFF
--- a/packages/@markuplint/selector/ARCHITECTURE.ja.md
+++ b/packages/@markuplint/selector/ARCHITECTURE.ja.md
@@ -148,6 +148,20 @@ Selector
 - **StructuredSelector** -- 単一のセレクタ（カンマなし）を表現します。コンビネータで連結された `SelectorTarget` ノードのチェーンを構築します。マッチング時は右から左へチェーンをたどります。
 - **SelectorTarget** -- 単一の複合セレクタを要素に対してマッチングします。ID、タグ、クラス、属性、ユニバーサルセレクタ、擬似クラス（拡張擬似クラスを含む）を処理します。
 
+## HTML 名前空間の扱い
+
+HTML LS / Selectors L4 の規定により、要素が HTML 名前空間にある場合は名前比較を ASCII case-insensitive で行い、それ以外では case-sensitive のままとします。タグ名・属性名のいずれの比較も `isPureHTMLElement(el)` でガードしてから case-folding を適用するか判定します。
+
+| 比較対象 | HTML 要素                                                              | SVG / MathML / カスタム要素 |
+| -------- | ---------------------------------------------------------------------- | --------------------------- |
+| タグ名   | `SelectorTarget#matchWithoutCombineChecking` で case-fold              | そのまま比較                |
+| 属性名   | `attrMatch` で case-fold                                               | そのまま比較                |
+| 属性値   | `i` フラグ指定時のみ case-fold（仕様により値の casing は著者の制御下） | 同左                        |
+
+`isPureHTMLElement(el)`（`is.ts`）は `el.localName !== el.nodeName` のときに `true` を返します。HTML パーサーの慣例として localName は小文字形（例: `meta`）、nodeName は大文字形（例: `META`）になり、両者が異なるため成立します。SVG / MathML / カスタム要素では `localName === nodeName` となるため、ガードは自然に case-sensitive 比較側へ流れます。
+
+新しい比較ロジックを追加する際は、必ず同じガードを通してください。さもないと SVG の `viewBox` と HTML の `CHARSET` が逆方向にドリフトしていきます。
+
 ## 2 つのマッチングシステム
 
 ### CSS セレクタマッチング

--- a/packages/@markuplint/selector/ARCHITECTURE.md
+++ b/packages/@markuplint/selector/ARCHITECTURE.md
@@ -148,6 +148,26 @@ Selector
 - **StructuredSelector** -- Represents a single selector (without commas). Builds a chain of `SelectorTarget` nodes linked by combinators. Traverses the chain from right to left during matching.
 - **SelectorTarget** -- Matches a single compound selector against an element. Handles ID, tag, class, attribute, universal selectors, and pseudo-classes (including extended pseudo-classes).
 
+## HTML Namespace Handling
+
+Per HTML LS / Selectors L4, name comparisons use ASCII case-insensitive
+matching when the element is in the HTML namespace, and case-sensitive
+matching otherwise. The selector engine routes both tag and attribute
+name comparisons through `isPureHTMLElement(el)` before deciding whether
+to fold case.
+
+| Comparison      | HTML element                                                                           | SVG / MathML / custom element |
+| --------------- | -------------------------------------------------------------------------------------- | ----------------------------- |
+| Tag name        | Folded in `SelectorTarget#matchWithoutCombineChecking`                                 | Compared as-is                |
+| Attribute name  | Folded in `attrMatch`                                                                  | Compared as-is                |
+| Attribute value | Folded only when the `i` flag is set (the spec puts value casing under author control) | Same                          |
+
+`isPureHTMLElement(el)` (`is.ts`) returns `true` when `el.localName !== el.nodeName`. That is the convention HTML parsers use: localName is the lowercased form, nodeName is uppercased (for example, `localName === 'meta'` while `nodeName === 'META'`). SVG / MathML / custom elements keep `localName === nodeName`, so the guard naturally falls through to case-sensitive comparison there.
+
+Adding new selector logic that compares names against an element should
+go through the same guard. Otherwise SVG content like `viewBox` and
+HTML content like `CHARSET` will start drifting in opposite directions.
+
 ## Two Matching Systems
 
 ### CSS Selector Matching

--- a/packages/@markuplint/selector/README.md
+++ b/packages/@markuplint/selector/README.md
@@ -60,6 +60,20 @@ Supported selectors and operators:
 | Column combinator                                | <code>div \|\| span</code>                                                                | ❌      |
 | Multiple selectors                               | `div, span`                                                                               | ✅      |
 
+## Case sensitivity
+
+Per HTML LS / Selectors Level 4 — Case sensitivity, names are matched
+according to the element's namespace:
+
+| Match target    | HTML namespace                                                                                            | SVG / MathML / custom elements                  |
+| --------------- | --------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| Tag name        | ASCII case-insensitive (`DIV` matches `div`)                                                              | Case-sensitive                                  |
+| Attribute name  | ASCII case-insensitive (`[CHARSET]` matches `<meta CHARSET>` and `<meta charset>`)                        | Case-sensitive (e.g. SVG `viewBox` ≠ `viewbox`) |
+| Attribute value | Case-sensitive by default; use the `i` flag (e.g. `[lang="en" i]`) for case-insensitive value comparisons | Same                                            |
+
+The `i` flag scopes to attribute **values** only — it does not affect
+attribute name matching, which is governed by the namespace rules above.
+
 ## Extended Selector
 
 The below is selectors that are extended by markuplint:

--- a/packages/@markuplint/selector/src/selector.spec.ts
+++ b/packages/@markuplint/selector/src/selector.spec.ts
@@ -93,6 +93,78 @@ describe('selector matching', () => {
 		expect(createSelector('[f="f"]').match(el)).toBe(false);
 	});
 
+	test('attribute names are matched ASCII case-insensitively on HTML elements', () => {
+		// HTML LS / Selectors L4: attribute names are ASCII case-insensitive
+		// when the element is in the HTML namespace. The parser preserves the
+		// original raw casing on the AST, so the selector engine must fold case.
+		const el = createTestElement('<meta CHARSET="utf-8">');
+		expect(createSelector('[charset]').match(el)).toBeTruthy();
+		expect(createSelector('[CHARSET]').match(el)).toBeTruthy();
+		expect(createSelector('[Charset]').match(el)).toBeTruthy();
+		expect(createSelector('meta[charset="utf-8" i]').match(el)).toBeTruthy();
+	});
+
+	test('attribute names with uppercase preserved on element match against lowercase selectors', () => {
+		// JSDOM normalises HTML attribute names to lowercase, but markuplint's
+		// own parser preserves the raw source casing. Build a plain SelectorElement
+		// (the structural type used internally) to reproduce that scenario.
+		const mockHtmlElement = {
+			nodeType: 1,
+			nodeName: 'META',
+			localName: 'meta',
+			id: '',
+			namespaceURI: 'http://www.w3.org/1999/xhtml',
+			classList: { contains: () => false },
+			attributes: [
+				{
+					name: 'CHARSET',
+					localName: 'CHARSET',
+					value: 'utf-8',
+					namespaceURI: null,
+				},
+			],
+			parentNode: null,
+			parentElement: null,
+			previousElementSibling: null,
+			nextElementSibling: null,
+			children: [],
+		};
+		expect(createSelector('[charset]').match(mockHtmlElement)).toBeTruthy();
+		expect(createSelector('[Charset]').match(mockHtmlElement)).toBeTruthy();
+		expect(createSelector('meta[charset]').match(mockHtmlElement)).toBeTruthy();
+	});
+
+	test('attribute names are matched case-sensitively on non-HTML elements', () => {
+		// Per SVG spec, attribute names like `viewBox` are case-sensitive.
+		// `isPureHTMLElement(el)` returns false when localName === nodeName
+		// (the SVG / MathML / custom element convention), so case-folding
+		// must not apply.
+		const mockSvgElement = {
+			nodeType: 1,
+			nodeName: 'svg',
+			localName: 'svg',
+			id: '',
+			namespaceURI: 'http://www.w3.org/2000/svg',
+			classList: { contains: () => false },
+			attributes: [
+				{
+					name: 'viewBox',
+					localName: 'viewBox',
+					value: '0 0 10 10',
+					namespaceURI: null,
+				},
+			],
+			parentNode: null,
+			parentElement: null,
+			previousElementSibling: null,
+			nextElementSibling: null,
+			children: [],
+		};
+		expect(createSelector('[viewBox]').match(mockSvgElement)).toBeTruthy();
+		expect(createSelector('[viewbox]').match(mockSvgElement)).toBe(false);
+		expect(createSelector('[VIEWBOX]').match(mockSvgElement)).toBe(false);
+	});
+
 	test(':not', () => {
 		const el = createTestElement('<div id="hoge" class="foo bar"></div>');
 		expect(createSelector('*:not(a)').match(el)).toBeTruthy();

--- a/packages/@markuplint/selector/src/selector.ts
+++ b/packages/@markuplint/selector/src/selector.ts
@@ -599,8 +599,16 @@ function attrMatch(
 	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
 	el: SelectorElement,
 ) {
+	// HTML LS / Selectors L4: attribute names are ASCII case-insensitive when
+	// the element is in the HTML namespace. SVG, MathML, and custom elements
+	// keep case-sensitive matching (e.g. SVG `viewBox`). The `isPureHTMLElement`
+	// guard mirrors the same convention used for tag-name matching in
+	// SelectorTarget#matchWithoutCombineChecking.
+	const isHTML = isPureHTMLElement(el);
+	const selectorAttrName = isHTML ? attr.attribute.toLowerCase() : attr.attribute;
 	return [...el.attributes].some(attrOfEl => {
-		if (attr.attribute !== attrOfEl.localName) {
+		const elAttrName = isHTML ? attrOfEl.localName.toLowerCase() : attrOfEl.localName;
+		if (selectorAttrName !== elAttrName) {
 			return false;
 		}
 		if (attr.namespace != null && attr.namespace !== true && attr.namespace !== '*') {

--- a/tests/external/CLAUDE.md
+++ b/tests/external/CLAUDE.md
@@ -165,6 +165,50 @@ Still regenerates the diff, spec, and report. Raw markuplint
 snapshots live only on your disk; commit the `diff/*.json` / spec
 changes that fall out of the rerun.
 
+### Adding a preset virtual rule (gotcha)
+
+`bench/config.ts` curates rules explicitly; it does **not**
+`extends: ['markuplint:html-standard']`. The intent is to keep the
+benchmark surface aligned with nu-validator capabilities rather than
+the full preset.
+
+The trade-off: any new entry in a preset's `nodeRules[]` (virtual
+rule) is invisible to the benchmark until it is also mirrored in
+`bench/config.ts`'s `nodeRules[]` with the same selectors. Without
+this, fixtures the new virtual rule should detect remain stuck at
+`nu-only` and look like a missing markuplint feature when the rule
+already exists.
+
+This bit Issue #3634: the three meta-uniqueness virtual rules added
+to `preset.html-standard.jsonc` in PR #3677 never fired during bench
+runs until the same `disallowed-element` selectors were mirrored into
+`bench/config.ts`.
+
+When adding or modifying a preset virtual rule:
+
+1. Add the selector(s) to the relevant preset (`preset.html-standard.jsonc`).
+2. Mirror the same selectors in `bench/config.ts` `nodeRules[]` with a
+   comment naming the source preset rule.
+3. Run `yarn bench:update:ml` and verify the target fixtures flip
+   from `nu-only` → `match-error`.
+4. If the rule does not map onto any nu-validator capability, skip
+   step 2 and add a `// not mirrored: <reason>` comment to the
+   preset rule's JSDoc so the next maintainer knows it was a
+   conscious decision.
+
+Selector caveats worth knowing while writing nodeRules:
+
+- For HTML elements the selector engine matches attribute names ASCII
+  case-insensitively (per HTML LS / Selectors L4), so lowercase selectors
+  like `[charset]` match `<meta CHARSET>` as expected. Use lowercase to
+  match HTML's normative form.
+- The `i` flag (e.g. `[name="description" i]`) only applies to attribute
+  *values* — it is unnecessary for the attribute *name*, which is already
+  case-folded for HTML.
+- Sibling selectors (`~`) only match elements that follow the anchor.
+  Coexistence-style constraints typically need both directions
+  (`a ~ b` *and* `b ~ a`) so the rule fires regardless of source order.
+
 ### Reproducing a specific nu-only / nu-over entry
 
 Because parallel nu-validator runs flicker on some aria-owns fixtures

--- a/tests/external/bench/config.ts
+++ b/tests/external/bench/config.ts
@@ -12,6 +12,12 @@ export const BENCHMARK_CONFIG_ID = 'all-rules';
  * maps onto a nu-validator capability so the coverage comparison is
  * apples-to-apples. Not exported to end users — this is purely the config
  * the benchmark feeds into `mlTest()`.
+ *
+ * `nodeRules` mirrors the document-uniqueness virtual rules defined in
+ * `markuplint:html-standard` (preset.html-standard.jsonc). The preset is
+ * intentionally not extended wholesale to keep the rule surface curated
+ * for nu-validator parity; only the entries that map onto a nu capability
+ * are mirrored here.
  */
 export const benchmarkConfig: Config = {
 	rules: {
@@ -37,4 +43,25 @@ export const benchmarkConfig: Config = {
 		'wai-aria-required-parent-role': true,
 		'wai-aria-no-global-prop': true,
 	},
+	nodeRules: [
+		{
+			selector: ':where(head)',
+			rules: {
+				// Selectors mirror the document-uniqueness virtual rules in
+				// `markuplint:html-standard`. Attribute names follow HTML's
+				// ASCII case-insensitive matching (handled by the selector
+				// engine), and the `i` flag is applied to value comparisons
+				// where the spec calls for it.
+				'disallowed-element': [
+					// Mirrors html-standard/no-duplicate-charset
+					'meta[charset] ~ meta[charset]',
+					// Mirrors html-standard/no-duplicate-description
+					'meta[name="description" i] ~ meta[name="description" i]',
+					// Mirrors html-standard/no-charset-http-equiv-coexist
+					'meta[charset] ~ meta[http-equiv="content-type" i]',
+					'meta[http-equiv="content-type" i] ~ meta[charset]',
+				],
+			},
+		},
+	],
 };

--- a/tests/external/bench/issue-xref.config.ts
+++ b/tests/external/bench/issue-xref.config.ts
@@ -57,11 +57,12 @@ export type UmbrellaMapping = {
 
 export type XrefMapping = PrimaryMapping | SecondaryMapping | UmbrellaMapping;
 
-// Body override for #3634: the original text listed 4 bullets including a
-// `<main>` uniqueness claim already covered by `no-duplicate-visible-main`,
-// and hard-coded a "~9 missed errors" count. The rewrite drops the `<main>`
-// bullet and defers the count to the xref block below it (single source of
-// truth). Text lives in `issue-xref/3634-body.md` so it can be proof-read
+// Body override for #3634: the original issue text framed the remaining
+// `nu-only` fixtures as a missing markuplint feature, but the three
+// constraints were already implemented in PR #3677 as preset virtual
+// rules. The fixtures stayed `nu-only` until those rules were mirrored
+// into `bench/config.ts`. The replacement body records that resolution
+// path; lives in `issue-xref/3634-body.md` so it can be proof-read
 // without escaping.
 
 export const xrefMappings: readonly XrefMapping[] = [
@@ -72,7 +73,7 @@ export const xrefMappings: readonly XrefMapping[] = [
 		filter:
 			/meta.*multiple-charset|meta.*duplicate-charset|meta.*multiple-description|charset-and-(content-type|http-equiv)|multiple-visible-main|multiple-main-visible/,
 		note:
-			'Visible `<main>` uniqueness is already covered by `no-duplicate-visible-main` (both fixtures are `match-error`). The remaining gap is meta uniqueness + charset/http-equiv coexistence.',
+			'All meta-uniqueness fixtures are `match-error` after PR #3677 introduced the preset virtual rules and the bench config mirrored their selectors. `<main>` uniqueness is covered separately by `no-duplicate-visible-main`.',
 		bodyOverride: () => loadBodyOverride('3634-body.md'),
 	},
 	{

--- a/tests/external/bench/issue-xref/3634-body.md
+++ b/tests/external/bench/issue-xref/3634-body.md
@@ -1,16 +1,30 @@
 ## Summary
 
-Add validation for meta elements that must appear at most once per document or that must not coexist with conflicting siblings.
-
-## What to enforce
+Document-level uniqueness for `<meta>` elements:
 
 - `<meta charset>` must not appear more than once
 - `<meta name="description">` must not appear more than once
 - `<meta charset>` and `<meta http-equiv="content-type">` must not coexist
 
-## Background
+## Resolution
 
-Visible `<main>` uniqueness was originally listed here, but the nu-validator compatibility benchmark confirms markuplint's `no-duplicate-visible-main` rule already detects it (both relevant fixtures are `match-error`). Dropped from scope.
+The three constraints were implemented in PR #3677 as virtual rules in
+`markuplint:html-standard` (`no-duplicate-charset`,
+`no-duplicate-description`, `no-charset-http-equiv-coexist`), each
+backed by `disallowed-element` with sibling-selector patterns.
+
+The benchmark continued to report the affected fixtures as `nu-only`
+because `tests/external/bench/config.ts` enables a curated rule list
+and does not `extends` the preset, so virtual rules added under
+`nodeRules[]` were invisible to the bench. Mirroring the same
+`disallowed-element` selectors into `bench/config.ts` flips the
+fixtures to `match-error`. See the gotcha note in
+[`tests/external/CLAUDE.md`](https://github.com/markuplint/markuplint/blob/dev/tests/external/CLAUDE.md#adding-a-preset-virtual-rule-gotcha)
+for the workflow.
+
+Visible `<main>` uniqueness was originally listed here too, but
+`no-duplicate-visible-main` already covered it (both fixtures
+`match-error`); it was dropped from scope before this fix.
 
 ## Spec reference
 
@@ -18,4 +32,5 @@ Visible `<main>` uniqueness was originally listed here, but the nu-validator com
 
 ## Impact
 
-See the cross-reference block below for the exact fixture list and current count.
+See the cross-reference block below for the fixture list and the
+post-fix verdict tally.

--- a/tests/external/snapshots/diff/coverage.json
+++ b/tests/external/snapshots/diff/coverage.json
@@ -13948,8 +13948,8 @@
 			"path": "html/assertions/multiple-meta-charset-novalid.html",
 			"category": "assertions",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -31278,16 +31278,16 @@
 			"path": "html/elements/meta/charset-and-content-type-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
 			"path": "html/elements/meta/charset-and-http-equiv-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -31390,8 +31390,8 @@
 			"path": "html/elements/meta/duplicate-charset-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -31422,16 +31422,16 @@
 			"path": "html/elements/meta/multiple-charset-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
 			"path": "html/elements/meta/multiple-description-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -31446,8 +31446,8 @@
 			"path": "html/elements/meta/names-standard-isvalid.html",
 			"category": "invalid-attr",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{

--- a/tests/external/snapshots/diff/markuplint-only.json
+++ b/tests/external/snapshots/diff/markuplint-only.json
@@ -7317,6 +7317,13 @@
 			]
 		},
 		{
+			"path": "html/elements/meta/names-standard-isvalid.html",
+			"category": "invalid-attr",
+			"ruleIds": [
+				"disallowed-element"
+			]
+		},
+		{
 			"path": "html/elements/meta/refresh-isvalid.html",
 			"category": "invalid-attr",
 			"ruleIds": [

--- a/tests/external/snapshots/diff/nu-only.json
+++ b/tests/external/snapshots/diff/nu-only.json
@@ -348,13 +348,6 @@
 			]
 		},
 		{
-			"path": "html/assertions/multiple-meta-charset-novalid.html",
-			"category": "assertions",
-			"nuMessageIds": [
-				"nv-6d7f2118591b"
-			]
-		},
-		{
 			"path": "html/assertions/select-multiple-selected-novalid.html",
 			"category": "assertions",
 			"nuMessageIds": [
@@ -6084,20 +6077,6 @@
 			]
 		},
 		{
-			"path": "html/elements/meta/charset-and-content-type-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-c391183c18e8"
-			]
-		},
-		{
-			"path": "html/elements/meta/charset-and-http-equiv-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-3b48808fc6d6"
-			]
-		},
-		{
 			"path": "html/elements/meta/content-security-policy/csp-invalid-directive-haswarn.html",
 			"category": "invalid-attr",
 			"nuMessageIds": [
@@ -6119,32 +6098,11 @@
 			]
 		},
 		{
-			"path": "html/elements/meta/duplicate-charset-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-a92b1a905045"
-			]
-		},
-		{
 			"path": "html/elements/meta/itemprop-with-name-novalid.html",
 			"category": "invalid-attr",
 			"nuMessageIds": [
 				"nv-e421b32ec6be",
 				"nv-4fc0d9c94280"
-			]
-		},
-		{
-			"path": "html/elements/meta/multiple-charset-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-f1d2eea343f1"
-			]
-		},
-		{
-			"path": "html/elements/meta/multiple-description-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-7e55d06632de"
 			]
 		},
 		{

--- a/tests/external/snapshots/diff/summary.md
+++ b/tests/external/snapshots/diff/summary.md
@@ -1,6 +1,6 @@
 # nu-validator Benchmark Summary
 
-- generated: 2026-04-23T13:31:47.088Z
+- generated: 2026-04-27T06:10:57.755Z
 - submodule: `142931395412c00434ffb40a14d65992efd17aa8`
 - nu-validator: `ghcr.io/validator/validator@sha256:59b0e97e2664755f1597ba9b6a0ecbdc4c67bd1518d1318acd29d9a08900389b`
 - markuplint: `5.0.0-rc.4`
@@ -9,11 +9,11 @@
 ## Totals
 
 - files: **5442**
-- match-error: **2063** (both tools flagged)
-- match-clean: **925** (neither flagged)
-- nu-only: **1447** (only nu-validator flagged; markuplint coverage candidates — open a markuplint issue after a spec read)
+- match-error: **2069** (both tools flagged)
+- match-clean: **924** (neither flagged)
+- nu-only: **1441** (only nu-validator flagged; markuplint coverage candidates — open a markuplint issue after a spec read)
 - nu-over: **28** (nu-validator errors fully covered by spec-backed excluded-ids — confirmed over-detection)
-- overall match rate: **54.9%**
+- overall match rate: **55.0%**
 - excluded-ids: 3 entries, 1 pattern(s)
 
 ## Per-Category
@@ -21,19 +21,19 @@
 | Category | Files | Match rate | match-error | match-clean | ml-only | nu-only | nu-over |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
 | aria | 780 | 79.1% | 159 | 458 | 144 | 19 | 0 |
-| assertions | 40 | 57.5% | 22 | 1 | 0 | 17 | 0 |
+| assertions | 40 | 60.0% | 23 | 1 | 0 | 16 | 0 |
 | content-model | 98 | 98.0% | 48 | 48 | 0 | 2 | 0 |
 | data-types | 56 | 71.4% | 35 | 5 | 1 | 15 | 0 |
 | deprecated | 12 | 91.7% | 11 | 0 | 1 | 0 | 0 |
 | global-attr | 57 | 73.7% | 23 | 19 | 8 | 7 | 0 |
 | id-duplication | 1 | 100.0% | 1 | 0 | 0 | 0 | 0 |
-| invalid-attr | 3086 | 57.7% | 1549 | 232 | 59 | 1220 | 26 |
+| invalid-attr | 3086 | 57.8% | 1554 | 231 | 60 | 1215 | 26 |
 | required-attr | 5 | 80.0% | 4 | 0 | 0 | 1 | 0 |
 | uncategorized | 1307 | 28.5% | 211 | 162 | 766 | 166 | 2 |
 
 ## Informational: ml-only
 
-**979** fixtures are flagged only by markuplint. This project does not pursue upstream nu-validator reports, so those fixtures feed a narrower audit: confirm with the spec, and if markuplint is the wrong one, fix the rule. The full list lives in `snapshots/diff/markuplint-only.json`.
+**980** fixtures are flagged only by markuplint. This project does not pursue upstream nu-validator reports, so those fixtures feed a narrower audit: confirm with the spec, and if markuplint is the wrong one, fix the rule. The full list lives in `snapshots/diff/markuplint-only.json`.
 
 ### Top ml-only rules
 

--- a/tests/external/snapshots/meta.json
+++ b/tests/external/snapshots/meta.json
@@ -1,12 +1,12 @@
 {
-	"generatedAt": "2026-04-23T13:31:47.088Z",
+	"generatedAt": "2026-04-27T06:10:57.755Z",
 	"submoduleSha": "142931395412c00434ffb40a14d65992efd17aa8",
 	"nuValidatorImage": "ghcr.io/validator/validator@sha256:59b0e97e2664755f1597ba9b6a0ecbdc4c67bd1518d1318acd29d9a08900389b",
 	"markuplintVersion": "5.0.0-rc.4",
 	"nodeVersion": "24.14.1",
 	"totalFilesNu": 5442,
 	"totalFilesMl": 5442,
-	"totalNuMessages": 9734,
-	"totalMlViolations": 9781,
+	"totalNuMessages": 9735,
+	"totalMlViolations": 9789,
 	"totalNuFailures": 0
 }


### PR DESCRIPTION
## Summary

Closes #3634.

Two-part fix uncovered while auditing the bench-xref entry for #3634:

1. **`@markuplint/selector` — attribute name case-folding for HTML elements.** The engine was comparing attribute names case-sensitively, so `[charset]` did not match `<meta CHARSET>` even though HTML LS / Selectors L4 require ASCII case-insensitive matching for HTML-namespace elements. Apply the same `isPureHTMLElement(el)` guard already used for tag-name matching. SVG / MathML / custom elements keep case-sensitive matching (e.g. SVG `viewBox` ≠ `viewbox`).
2. **`tests/external/bench/config.ts` — mirror html-standard's meta-uniqueness virtual rules.** PR #3677 added three `nodeRules` to `markuplint:html-standard` (`no-duplicate-charset`, `no-duplicate-description`, `no-charset-http-equiv-coexist`), but the bench config does not extend the preset, so those rules never fired. Mirror the same `disallowed-element` selectors so the bench reflects the preset experience.

## Resulting verdict change

After regenerating snapshots:

| fixture | before | after |
| --- | --- | --- |
| `meta/charset-and-content-type-novalid.html` | nu-only | match-error |
| `meta/charset-and-http-equiv-novalid.html` | nu-only | match-error |
| `meta/duplicate-charset-novalid.html` | nu-only | match-error |
| `meta/multiple-charset-novalid.html` | nu-only | match-error |
| `meta/multiple-description-novalid.html` | nu-only | match-error |
| `assertions/multiple-meta-charset-novalid.html` (bonus) | nu-only | match-error |
| `meta/names-standard-isvalid.html` | match-clean | ml-only |

The last entry is informational: the fixture has multiple `<meta name="…description…">` with different ASCII case. The HTML spec requires ASCII case-insensitive matching for `name` values, so markuplint correctly flags duplicates while nu-validator misses it.

Aggregate match rate: 54.9% → 55.0%.

## Documentation

- `@markuplint/selector` README: add a "Case sensitivity" matrix that covers tag / attribute name / attribute value rules per namespace.
- `@markuplint/selector` ARCHITECTURE.md (en/ja): add an "HTML Namespace Handling" section pointing at `isPureHTMLElement(el)` as the central guard.
- `tests/external/CLAUDE.md`: document the preset → bench mirror discipline (the gotcha that left #3634 dormant), plus selector caveats for nodeRules authoring.
- `tests/external/bench/issue-xref/3634-body.md` + `issue-xref.config.ts`: rewrite the cross-reference body to record the actual resolution path through PR #3677.

## Test plan

- [x] `yarn lint-check` (oxlint / oxfmt) — 0 errors / 0 warnings
- [x] `yarn build` — 39 projects
- [x] `yarn test` — 3636 passed (+3 new selector tests for HTML case-fold, mock real-world parser scenario, SVG case preservation)
- [x] `yarn bench:verify` — 5442/5442
- [x] Verified the selector fix with the test temporarily disabled (the two HTML-case tests fail; the SVG test stays green)
- [x] Manual `mlTest` runs covering `<meta CHARSET>` / `<meta HTTP-EQUIV>` / `<meta NAME>` patterns