### PR TITLE
fix(rules): only require aria-valuenow on focusable separators (#3682)

### DIFF
--- a/packages/@markuplint/html-spec/docs/maintenance.ja.md
+++ b/packages/@markuplint/html-spec/docs/maintenance.ja.md
@@ -276,6 +276,21 @@ description の表現変更などの表面的な変更は、更新された `ind
 - `contents: true`（任意のコンテンツ許可）
 - `permittedRoles: true`, `implicitRole: false`
 
+### 10. スクレイプ済みARIAロールデータのオーバーライド
+
+ARIAロール定義はW3C仕様からスクレイプされ、`src/spec.*.jsonc` には由来しない。仕様の本文がW3Cのソースマークアップに表現されない実行時条件を述べている場合（例: WAI-ARIAでは `separator` の `aria-valuenow` は要素がフォーカス可能なときのみ必須）、`generator/aria.ts` のロール処理ループ末尾で手動オーバーライドを適用する。
+
+**手順**:
+
+1. `packages/@markuplint/html-spec/generator/aria.ts` を開く
+2. ロールpushループの後（`return roles.toSorted(...)` の直前）にある既存の手動オーバーライドブロックを探す。ロール名でマッチさせ、対象の `ownedProperties` エントリのみを書き換える形で新しいオーバーライドを追加
+3. オーバーライドが新しいフィールド（例: `requiredCondition`）を導入する場合、`packages/@markuplint/ml-spec/src/types/index.ts` の対応するunion型（`ARIARoleOwnedProperties` / `ARIAProperty`）も拡張する
+4. 該当ルールが新フィールドを参照するよう、`packages/@markuplint/rules/` 側を更新する
+5. `yarn up:gen` で `index.json` を再生成。差分が対象のロール／プロパティエントリのみに収まっていること（surgicalであること）を確認
+6. 参照: WAI-ARIA https://www.w3.org/TR/wai-aria/、ARIA in HTML https://w3c.github.io/html-aria/
+
+**generatorオーバーライドを使わない判断**: オーバーライドが「要素ごと」に適用されるべき場合（ロール単位ではなく）、`src/spec.<element>.jsonc` を編集する。要素レベルのデータ（`implicitRole`、`permittedRoles` など）はそちらが本来の置き場所。
+
 ## ファイル分類
 
 ### 編集可能なファイル（これらを変更）

--- a/packages/@markuplint/html-spec/docs/maintenance.md
+++ b/packages/@markuplint/html-spec/docs/maintenance.md
@@ -335,6 +335,21 @@ Obsolete elements automatically get:
 - `contents: true` (any content allowed)
 - `permittedRoles: true`, `implicitRole: false`
 
+### 10. Overriding Scraped ARIA Role Data
+
+ARIA role definitions are scraped from W3C specifications and are NOT driven by `src/spec.*.jsonc`. When the spec text describes a runtime condition that the W3C source markup does not encode (e.g. WAI-ARIA: `separator`'s `aria-valuenow` is required only when the element is focusable), apply a manual override at the end of the role-processing loop in `generator/aria.ts`.
+
+**Procedure**:
+
+1. Open `packages/@markuplint/html-spec/generator/aria.ts`
+2. After the role-push loop (just before `return roles.toSorted(...)`), look for the existing manual-override block. Add a new override there, locating the role by name and rewriting only the affected `ownedProperties` entry.
+3. If the override introduces a new field (e.g. `requiredCondition`), extend the corresponding union type in `packages/@markuplint/ml-spec/src/types/index.ts` (`ARIARoleOwnedProperties` / `ARIAProperty`).
+4. Update the consuming rule(s) in `packages/@markuplint/rules/` to honor the new field.
+5. Run `yarn up:gen` to regenerate `index.json`. Confirm the diff is surgical -- it should touch only the targeted role/property entries.
+6. Reference: WAI-ARIA https://www.w3.org/TR/wai-aria/, ARIA in HTML https://w3c.github.io/html-aria/.
+
+**When NOT to use a generator override**: If the override would apply per-element rather than per-role, edit `src/spec.<element>.jsonc` instead -- element-level data is the right home for ARIA-in-HTML mappings (`implicitRole`, `permittedRoles`, etc.).
+
 ## File Classification
 
 ### Editable Files (modify these)

--- a/packages/@markuplint/html-spec/generator/aria.ts
+++ b/packages/@markuplint/html-spec/generator/aria.ts
@@ -311,6 +311,26 @@ async function getRoles(version: ARIAVersion, graphicsAria = false) {
 		}
 	}
 
+	// Manual overrides for properties whose required state is conditional on a runtime
+	// quality the W3C source markup does not encode. ARIA only requires `aria-valuenow`
+	// on a `separator` when it is focusable; the spec text says so but the
+	// `.role-required-properties` table marks it unconditionally. The literal values
+	// allowed in `requiredCondition` are defined on `ARIARoleOwnedProperties` in
+	// `@markuplint/ml-spec/src/types/index.ts` — extend that union before adding new
+	// conditions here.
+	const separatorRoleIndex = roles.findIndex(role => role.name === 'separator');
+	if (separatorRoleIndex !== -1) {
+		const separatorRole = roles[separatorRoleIndex]!;
+		roles[separatorRoleIndex] = {
+			...separatorRole,
+			ownedProperties: separatorRole.ownedProperties?.map(prop =>
+				prop.name === 'aria-valuenow' && prop.required
+					? { ...prop, requiredCondition: 'focusable' as const }
+					: prop,
+			),
+		};
+	}
+
 	return roles.toSorted(nameCompare);
 }
 

--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -10685,7 +10685,8 @@
 							},
 							{
 								"name": "aria-valuenow",
-								"required": true
+								"required": true,
+								"requiredCondition": "focusable"
 							},
 							{
 								"name": "aria-valuetext"
@@ -26422,7 +26423,8 @@
 							},
 							{
 								"name": "aria-valuenow",
-								"required": true
+								"required": true,
+								"requiredCondition": "focusable"
 							},
 							{
 								"name": "aria-valuetext"
@@ -40909,7 +40911,8 @@
 							},
 							{
 								"name": "aria-valuenow",
-								"required": true
+								"required": true,
+								"requiredCondition": "focusable"
 							},
 							{
 								"name": "aria-valuetext"

--- a/packages/@markuplint/ml-spec/src/types/index.ts
+++ b/packages/@markuplint/ml-spec/src/types/index.ts
@@ -289,11 +289,19 @@ export type ARIARoleInSchema = Partial<
 /**
  * Describes a property owned by an ARIA role, including whether it is inherited,
  * required, or deprecated.
+ *
+ * `requiredCondition` qualifies `required: true` so that the property is only
+ * required when the condition holds. The W3C ARIA source markup does not encode
+ * such conditions; values are populated by manual overrides in
+ * `@markuplint/html-spec/generator/aria.ts`. Currently the only value is
+ * `'focusable'` (applied to `separator`'s `aria-valuenow`); the `wai-aria`
+ * checker resolves this through `mayBeFocusable` from `@markuplint/ml-spec`.
  */
 export type ARIARoleOwnedProperties = {
 	readonly name: string;
 	readonly inherited?: true;
 	readonly required?: true;
+	readonly requiredCondition?: 'focusable';
 	readonly deprecated?: true;
 };
 

--- a/packages/@markuplint/rules/src/wai-aria-required-props/README.ja.md
+++ b/packages/@markuplint/rules/src/wai-aria-required-props/README.ja.md
@@ -23,3 +23,24 @@ description: ロールに必須のARIAプロパティが指定されていない
 ```
 
 <!-- textlint-enable ja-technical-writing/ja-no-mixed-period -->
+
+:::note 条件付き必須: `separator`
+
+`separator`ロールにおいて、`aria-valuenow`は要素がフォーカス可能な場合（`tabindex`を持つ、`<button>`や`<a href>`などのインタラクティブコンテンツである等）にのみ必須となります。フォーカス不能な`<div role="separator">`は[WAI-ARIA](https://www.w3.org/TR/wai-aria/#separator)に従い静的な構造的セパレーターとして扱われ、`aria-valuenow`は不要です。
+
+<!-- textlint-disable ja-technical-writing/ja-no-mixed-period -->
+
+```html
+<!-- ✅ 静的な構造的セパレーター -->
+<div role="separator"></div>
+
+<!-- ❌ フォーカス可能だが aria-valuenow が欠落 -->
+<div role="separator" tabindex="0"></div>
+
+<!-- ✅ フォーカス可能で aria-valuenow あり -->
+<div role="separator" tabindex="0" aria-valuenow="50"></div>
+```
+
+<!-- textlint-enable ja-technical-writing/ja-no-mixed-period -->
+
+:::

--- a/packages/@markuplint/rules/src/wai-aria-required-props/README.md
+++ b/packages/@markuplint/rules/src/wai-aria-required-props/README.md
@@ -20,3 +20,20 @@ This rule is part of the [`wai-aria`](../wai-aria/) rule family, split for granu
 ```html
 <div role="slider" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100"></div>
 ```
+
+:::note Conditional required: `separator`
+
+For the `separator` role, `aria-valuenow` is required only when the element is focusable (e.g. has `tabindex`, or is interactive content like `<button>` / `<a href>`). A non-focusable `<div role="separator">` is treated as a static structural separator per [WAI-ARIA](https://www.w3.org/TR/wai-aria/#separator) and does not require `aria-valuenow`.
+
+```html
+<!-- ✅ Static structural separator -->
+<div role="separator"></div>
+
+<!-- ❌ Focusable separator missing aria-valuenow -->
+<div role="separator" tabindex="0"></div>
+
+<!-- ✅ Focusable separator with aria-valuenow -->
+<div role="separator" tabindex="0" aria-valuenow="50"></div>
+```
+
+:::

--- a/packages/@markuplint/rules/src/wai-aria-required-props/index.spec.ts
+++ b/packages/@markuplint/rules/src/wai-aria-required-props/index.spec.ts
@@ -19,3 +19,63 @@ test('[wai-aria-required-props-invalid-001] role missing required prop', async (
 	expect(violations.length).toBeGreaterThanOrEqual(1);
 	expect(violations[0]!.severity).toBe('error');
 });
+
+test('[wai-aria-required-props-issue-3682-001] non-focusable separator does not require aria-valuenow', async () => {
+	expect((await mlRuleTest(rule, '<div role="separator"></div>')).violations).toStrictEqual([]);
+});
+
+test('[wai-aria-required-props-issue-3682-002] separator with tabindex="0" requires aria-valuenow', async () => {
+	const { violations } = await mlRuleTest(rule, '<div role="separator" tabindex="0"></div>');
+	expect(violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 1,
+			message: 'Require the "aria-valuenow" ARIA property on the "separator" role',
+			raw: '<div role="separator" tabindex="0">',
+		},
+	]);
+});
+
+test('[wai-aria-required-props-issue-3682-003] focusable separator with aria-valuenow is valid', async () => {
+	expect(
+		(await mlRuleTest(rule, '<div role="separator" tabindex="0" aria-valuenow="50"></div>')).violations,
+	).toStrictEqual([]);
+});
+
+test('[wai-aria-required-props-issue-3682-004] button with role="separator" requires aria-valuenow (button is interactive)', async () => {
+	const { violations } = await mlRuleTest(rule, '<button role="separator">Drag</button>');
+	expect(violations.length).toBeGreaterThanOrEqual(1);
+	expect(violations[0]!.message).toContain('aria-valuenow');
+});
+
+test('[wai-aria-required-props-issue-3682-005] separator with tabindex="-1" still requires aria-valuenow', async () => {
+	const { violations } = await mlRuleTest(rule, '<div role="separator" tabindex="-1"></div>');
+	expect(violations.length).toBeGreaterThanOrEqual(1);
+	expect(violations[0]!.message).toContain('aria-valuenow');
+});
+
+test('[wai-aria-required-props-issue-3682-006] hr with explicit role="separator" is valid (not focusable)', async () => {
+	expect((await mlRuleTest(rule, '<hr role="separator">')).violations).toStrictEqual([]);
+});
+
+test('[wai-aria-required-props-issue-3682-007] non-focusable separator is valid pinned to ARIA 1.2', async () => {
+	const { violations } = await mlRuleTest(rule, '<div role="separator"></div>', {
+		rule: { options: { version: '1.2' } },
+	});
+	expect(violations).toStrictEqual([]);
+});
+
+test('[wai-aria-required-props-issue-3682-008] focusable separator pinned to ARIA 1.2 reports missing aria-valuenow', async () => {
+	const { violations } = await mlRuleTest(rule, '<div role="separator" tabindex="0"></div>', {
+		rule: { options: { version: '1.2' } },
+	});
+	expect(violations.length).toBeGreaterThanOrEqual(1);
+	expect(violations.some(v => v.message.includes('aria-valuenow'))).toBe(true);
+});
+
+test('[wai-aria-required-props-issue-3682-009] separator with contenteditable requires aria-valuenow', async () => {
+	const { violations } = await mlRuleTest(rule, '<div role="separator" contenteditable>x</div>');
+	expect(violations.length).toBeGreaterThanOrEqual(1);
+	expect(violations[0]!.message).toContain('aria-valuenow');
+});

--- a/packages/@markuplint/rules/src/wai-aria/checkings/required-prop.ts
+++ b/packages/@markuplint/rules/src/wai-aria/checkings/required-prop.ts
@@ -1,7 +1,13 @@
 import type { Options } from '../types.js';
 import type { ElementChecker } from '@markuplint/ml-core';
 
-import { ARIA_RECOMMENDED_VERSION, getARIA, type ARIAProperty, type ARIARole } from '@markuplint/ml-spec';
+import {
+	ARIA_RECOMMENDED_VERSION,
+	getARIA,
+	mayBeFocusable,
+	type ARIAProperty,
+	type ARIARole,
+} from '@markuplint/ml-spec';
 
 /**
  * Checks whether all required ARIA properties for the element's computed role are present.
@@ -10,6 +16,10 @@ import { ARIA_RECOMMENDED_VERSION, getARIA, type ARIAProperty, type ARIARole } f
  * `aria-valuenow`). This checker verifies that explicitly-set roles have their required
  * properties. Implicit roles are skipped since the browser provides default semantics.
  * Alternative native HTML attributes that satisfy the requirement are also considered.
+ *
+ * If a property declares `requiredCondition: 'focusable'` (currently only `separator`'s
+ * `aria-valuenow`), the requirement is gated by `mayBeFocusable`: a non-focusable
+ * separator no longer reports a missing `aria-valuenow`.
  *
  * @param el - The element node to inspect for required properties.
  * @param role - The computed ARIA role (with an optional `isImplicit` flag).
@@ -29,8 +39,16 @@ export const checkingRequiredProp: ElementChecker<
 		if (role.isImplicit) {
 			return;
 		}
-		const requiredProps = role.ownedProperties.filter(s => s.required).map(s => s.name);
-		for (const requiredProp of requiredProps) {
+		const requiredProps = role.ownedProperties.filter(s => {
+			if (!s.required) return false;
+			// `requiredCondition: 'focusable'` makes the property required only when the
+			// element may be focusable (e.g. `separator`'s `aria-valuenow`).
+			if (s.requiredCondition === 'focusable' && !mayBeFocusable(el, el.ownerMLDocument.specs)) {
+				return false;
+			}
+			return true;
+		});
+		for (const { name: requiredProp } of requiredProps) {
 			const has = el.attributes.some(attr => {
 				const attrName = attr.name.toLowerCase();
 				return attrName === requiredProp;

--- a/packages/@markuplint/rules/src/wai-aria/index.spec.ts
+++ b/packages/@markuplint/rules/src/wai-aria/index.spec.ts
@@ -2664,3 +2664,29 @@ describe('Issue #3588 — input element permitted roles', () => {
 		expect(violations).toStrictEqual([]);
 	});
 });
+
+// #3682: separator should only require aria-valuenow when focusable
+describe('Issue #3682 — separator focusable conditional aria-valuenow', () => {
+	test('[wai-aria-issue-3682-001] non-focusable separator without aria-valuenow is valid', async () => {
+		const { violations } = await mlRuleTest(rule, '<div role="separator"></div>');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('[wai-aria-issue-3682-002] focusable separator (tabindex="0") without aria-valuenow reports a missing required prop', async () => {
+		const { violations } = await mlRuleTest(rule, '<div role="separator" tabindex="0"></div>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 1,
+				message: 'Require the "aria-valuenow" ARIA property on the "separator" role',
+				raw: '<div role="separator" tabindex="0">',
+			},
+		]);
+	});
+
+	test('[wai-aria-issue-3682-003] focusable separator with aria-valuenow is valid', async () => {
+		const { violations } = await mlRuleTest(rule, '<div role="separator" tabindex="0" aria-valuenow="50"></div>');
+		expect(violations).toStrictEqual([]);
+	});
+});


### PR DESCRIPTION
Fixes #3682

## What is the purpose of this PR?

- [x] Fix bug
- [x] Update specs
- [x] Improve or refactor rules
- [x] Update documents

### Description

`wai-aria-required-props` and the `wai-aria` umbrella rule used to flag every `<div role=\"separator\">` for missing `aria-valuenow`. The WAI-ARIA spec text only requires the property when the separator is focusable — a static structural separator MUST NOT trigger the violation.

#### Changes

1. **`@markuplint/ml-spec`** — Add optional `requiredCondition?: 'focusable'` to `ARIARoleOwnedProperties`. The W3C source markup does not encode runtime conditions; this field exists for manual overrides applied in `@markuplint/html-spec`'s generator.
2. **`@markuplint/html-spec`** — In `generator/aria.ts`, after the role scrape, override `separator`'s `aria-valuenow` to `requiredCondition: 'focusable'`. Re-run \`yarn up:gen\` produces a surgical 3-line diff in \`index.json\` (one entry per ARIA 1.1 / 1.2 / 1.3). Documented the new override procedure in \`docs/maintenance.md\` (en + ja).
3. **`@markuplint/rules`** — `checkingRequiredProp` now consults \`mayBeFocusable(el, specs)\` when a property declares \`requiredCondition: 'focusable'\`, skipping the requirement for non-focusable separators. Added 11 regression tests covering non-focusable, \`tabindex=\"0\"\`/\`-1\`, \`<button role=separator>\`, \`<hr role=separator>\`, ARIA 1.2 pin, and \`contenteditable\`. Updated \`wai-aria-required-props\` README (en + ja) with the conditional behavior.

## Checklist

- [x] Fix bug
  - [x] Add the test that can check whether resolved the issue.
- [x] Update specs
  - [x] Element / Attribute (none — change is at the ARIA role layer)
- [x] Improve or refactor rules
- [x] Update documents — \`wai-aria-required-props\` README (en/ja), \`html-spec/docs/maintenance.md\` (en/ja), JSDoc

## Verification

- \`yarn build\` — 39 projects success
- \`yarn test\` — 3648 passed | 1 skipped
- \`yarn lint-check\` — 0 errors / 0 warnings (oxlint + oxfmt clean)
- \`tests/external/snapshots\` will refresh on the next \`auto/update-html-spec\` cron — the 7 ml-only fixtures listed in #3682's bench-xref should resolve to match-clean.