### PR TITLE
feat(html-spec): require itemscope/itemtype for itemid and itemtype

### DIFF
--- a/packages/@markuplint/html-spec/docs/element-spec-format.ja.md
+++ b/packages/@markuplint/html-spec/docs/element-spec-format.ja.md
@@ -456,6 +456,18 @@ SVG 属性で使用される CSS やSVG 固有の型を山括弧記法で指定�
 }
 ```
 
+**他属性の存在 (cross-attribute presence)** `condition` のセレクタは、同じ要素上に**他の属性が存在する**ことを要求するためにも使用できます。Microdata の `itemref` / `itemid` / `itemtype` がこのパターンです。HTML Living Standard では、`itemid` は `itemscope` と `itemtype` の両方が指定された要素上でしか有効になりません:
+
+```jsonc
+// HTML LS §5.7.4: https://html.spec.whatwg.org/multipage/microdata.html#attr-itemid
+"itemid": {
+    "type": "URL",
+    "condition": "[itemscope][itemtype]"
+}
+```
+
+condition が満たされない場合、`@markuplint/rules` の `invalid-attr` が `The "<attr>" attribute is disallowed` を報告します。仕様文に「X must not be specified on elements that do not have Y (and Z)」と書かれている制約を表現する場合に使用します。
+
 ---
 
 ## `aria`

--- a/packages/@markuplint/html-spec/docs/element-spec-format.md
+++ b/packages/@markuplint/html-spec/docs/element-spec-format.md
@@ -307,6 +307,23 @@ single CSS selector string or an array. The `i` flag enables case-insensitive ma
 "checked": { "type": "Boolean", "condition": ["[type='checkbox' i]", "[type='radio' i]"] }
 ```
 
+**Cross-attribute presence.** `condition` selectors can also require that _other
+attributes_ exist on the same element. Microdata's `itemref`, `itemid`, and `itemtype`
+use this — for example, the HTML Living Standard says `itemid` is only valid on an
+element that already has both `itemscope` and `itemtype`:
+
+```jsonc
+// HTML LS §5.7.4: https://html.spec.whatwg.org/multipage/microdata.html#attr-itemid
+"itemid": {
+    "type": "URL",
+    "condition": "[itemscope][itemtype]"
+}
+```
+
+When the condition fails, `@markuplint/rules`' `invalid-attr` reports
+`The "<attr>" attribute is disallowed`. Use this whenever the spec wording is
+"X must not be specified on elements that do not have Y (and Z)".
+
 ## ARIA Integration
 
 The `aria` object defines ARIA role and property integration.

--- a/packages/@markuplint/html-spec/docs/maintenance.ja.md
+++ b/packages/@markuplint/html-spec/docs/maintenance.ja.md
@@ -55,9 +55,24 @@
 
 1. 該当する `src/spec.<element>.jsonc` を開く
 2. `attributes` オブジェクトにエントリを追加・変更
-3. 条件付き属性の場合、CSSセレクタで `condition` フィールドを追加
-4. `yarn workspace @markuplint/html-spec run gen` を実行
-5. `index.json` で属性が正しいメタデータとともに表示されることを確認
+3. 条件付き属性の場合、CSSセレクタで `condition` フィールドを追加:
+   ```jsonc
+   "accept": {
+     "type": { "token": "Accept", "separator": "comma" },
+     "condition": "[type='file' i]"
+   }
+   ```
+4. **他属性の存在を要求する制約**（「X は Y がないと指定できない」）を表現する場合は、必須となる他属性をセレクタに並べる。Microdata の `itemid` / `itemtype` / `itemref` は `src/spec-common.attributes.jsonc` でこのパターンを使用:
+   ```jsonc
+   // HTML LS §5.7.4: itemid は itemscope と itemtype の両方を持つ要素にしか指定できない
+   "itemid": {
+     "type": "URL",
+     "condition": "[itemscope][itemtype]"
+   }
+   ```
+   condition が失敗すると `invalid-attr` が `The "<attr>" attribute is disallowed` を報告する。新しいルールコードは不要 — `helpers.ts#isValidAttr` が condition を消費する。
+5. `yarn workspace @markuplint/html-spec run gen` を実行
+6. `index.json` で属性が正しいメタデータとともに表示されることを確認
 
 ### 2b. 条件付き値型（`ConditionalAttributeType[]`）の使用
 

--- a/packages/@markuplint/html-spec/docs/maintenance.md
+++ b/packages/@markuplint/html-spec/docs/maintenance.md
@@ -74,8 +74,23 @@ will cause the element to be silently excluded from the build output.
      "condition": "[type='file' i]"
    }
    ```
-4. Run `yarn workspace @markuplint/html-spec run gen`
-5. Check `index.json` to confirm the attribute appears with correct metadata
+4. To express **cross-attribute presence constraints** ("X must not be specified
+   without Y"), use a selector that matches the required other attributes. This
+   is how Microdata's `itemid` / `itemtype` / `itemref` are encoded in
+   `src/spec-common.attributes.jsonc`:
+   ```jsonc
+   // HTML LS §5.7.4: itemid must not be specified on elements that do not have
+   // both an itemscope and itemtype attribute.
+   "itemid": {
+     "type": "URL",
+     "condition": "[itemscope][itemtype]"
+   }
+   ```
+   When the condition fails, `invalid-attr` reports
+   `The "<attr>" attribute is disallowed`. No new rule code is required — the
+   condition is consumed by `helpers.ts#isValidAttr`.
+5. Run `yarn workspace @markuplint/html-spec run gen`
+6. Check `index.json` to confirm the attribute appears with correct metadata
 
 ### 2b. Using Conditional Value Types (`ConditionalAttributeType[]`)
 

--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -363,7 +363,8 @@
 					"type": "CustomElementName"
 				},
 				"itemid": {
-					"type": "URL"
+					"type": "URL",
+					"condition": "[itemscope][itemtype]"
 				},
 				"itemprop": {
 					"type": {
@@ -389,7 +390,8 @@
 						"ordered": false,
 						"unique": true,
 						"separator": "space"
-					}
+					},
+					"condition": "[itemscope]"
 				},
 				"lang": {
 					"type": "BCP47"

--- a/packages/@markuplint/html-spec/src/spec-common.attributes.jsonc
+++ b/packages/@markuplint/html-spec/src/spec-common.attributes.jsonc
@@ -135,7 +135,10 @@
 		},
 		// https://html.spec.whatwg.org/multipage/microdata.html#attr-itemid
 		"itemid": {
-			"type": "URL"
+			"type": "URL",
+			// HTML LS §5.7.4: itemid must not be specified on elements that do
+			// not have both an itemscope attribute and an itemtype attribute.
+			"condition": "[itemscope][itemtype]"
 		},
 		// https://html.spec.whatwg.org/multipage/microdata.html#names:-the-itemprop-attribute
 		"itemprop": {
@@ -165,7 +168,10 @@
 				"ordered": false,
 				"unique": true,
 				"separator": "space"
-			}
+			},
+			// HTML LS §5.7.4: itemtype must not be specified on elements that
+			// do not have an itemscope attribute specified.
+			"condition": "[itemscope]"
 		},
 		// https://html.spec.whatwg.org/multipage/dom.html#attr-lang
 		"lang": {

--- a/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
@@ -2623,3 +2623,99 @@ describe('#3803 meta[property] with rdfa-style allowAttrs', () => {
 		expect(violations.some(v => v.raw === 'bogus')).toBe(true);
 	});
 });
+
+describe('#3733 Microdata cross-attribute constraints', () => {
+	test('[invalid-attr-issue-3733-001] itemscope alone is valid', async () => {
+		const { violations } = await mlRuleTest(rule, '<div itemscope></div>');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('[invalid-attr-issue-3733-002] itemscope + itemtype is valid', async () => {
+		const { violations } = await mlRuleTest(rule, '<div itemscope itemtype="https://schema.org/Thing"></div>');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('[invalid-attr-issue-3733-003] itemscope + itemtype + itemid is valid', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<div itemscope itemtype="https://schema.org/Thing" itemid="https://example.com/r"></div>',
+		);
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('[invalid-attr-issue-3733-004] itemid without itemscope/itemtype is disallowed', async () => {
+		const { violations } = await mlRuleTest(rule, '<div itemid="https://example.com/r"></div>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 6,
+				message: 'The "itemid" attribute is disallowed',
+				raw: 'itemid',
+			},
+		]);
+	});
+
+	test('[invalid-attr-issue-3733-005] itemid with itemscope but without itemtype is disallowed', async () => {
+		const { violations } = await mlRuleTest(rule, '<div itemscope itemid="https://example.com/r"></div>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 16,
+				message: 'The "itemid" attribute is disallowed',
+				raw: 'itemid',
+			},
+		]);
+	});
+
+	test('[invalid-attr-issue-3733-006] itemid with itemtype but without itemscope is disallowed (both itemid and itemtype reported)', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<div itemtype="https://schema.org/Thing" itemid="https://example.com/r"></div>',
+		);
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 6,
+				message: 'The "itemtype" attribute is disallowed',
+				raw: 'itemtype',
+			},
+			{
+				severity: 'error',
+				line: 1,
+				col: 42,
+				message: 'The "itemid" attribute is disallowed',
+				raw: 'itemid',
+			},
+		]);
+	});
+
+	test('[invalid-attr-issue-3733-007] itemtype without itemscope is disallowed', async () => {
+		const { violations } = await mlRuleTest(rule, '<div itemtype="https://schema.org/Thing"></div>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 6,
+				message: 'The "itemtype" attribute is disallowed',
+				raw: 'itemtype',
+			},
+		]);
+	});
+
+	test('[invalid-attr-issue-3733-008] invalid-value precedes condition: non-AbsoluteURL itemtype reports value error, not disallowed', async () => {
+		// helpers.ts isValidAttr: when attrCheck reports invalid-value, the
+		// condition-based 'disallowed' branch is skipped (the `if` requires
+		// `invalid === false`). Pin this order so future helpers refactors
+		// surface as a test failure here.
+		// Note: empty `itemtype=""` does NOT exercise this — empty token lists
+		// pass attrCheck and fall through to condition. A non-AbsoluteURL value
+		// is what triggers the value error first.
+		const { violations } = await mlRuleTest(rule, '<div itemtype="not-absolute"></div>');
+		expect(violations.some(v => v.message.includes('disallowed'))).toBe(false);
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.raw).toBe('not-absolute');
+	});
+});


### PR DESCRIPTION
## Summary
- Encode the HTML LS §5.7.4 Microdata cross-attribute presence constraints in `spec-common.attributes.jsonc`: `itemid` requires `[itemscope][itemtype]`, `itemtype` requires `[itemscope]`. `invalid-attr` reports violations via the existing `condition`-disallowed branch — same mechanism `itemref` already uses, no rule code changes needed.
- Document the cross-attribute presence pattern in `element-spec-format.md` and `maintenance.md` (EN + JA), using `itemid` / `itemtype` / `itemref` as the canonical example so future maintainers can discover the pattern.
- Add 8 regression tests under `invalid-attr` (3 valid, 4 invalid, 1 boundary that pins `invalid-value` precedence over the condition-disallow branch in `helpers.ts isValidAttr`).

Closes #3733

## Test plan
- [x] `yarn test` — 241 files, 3656 passed / 1 skipped
- [x] `yarn lint-check` — 0 oxlint/oxfmt errors (CSpell exit 1 is the worktree known issue, 0 files checked)
- [x] `yarn build`
- [x] New `[invalid-attr-issue-3733-001]`–`-008` all pass
- [ ] Post-merge: regenerate `tests/external/snapshots/` to verify the 6 `nu-only` fixtures for `itemid-without-*` / `itemtype-without-itemscope` flip to `match-error`