### PR TITLE
feat(rules,html-spec): enforce three contextual ARIA constraints (#3735)

### DIFF
--- a/packages/@markuplint/html-spec/docs/element-spec-format.ja.md
+++ b/packages/@markuplint/html-spec/docs/element-spec-format.ja.md
@@ -531,6 +531,32 @@ CSS セレクタをキーとし、そのセレクタに合致する場合の ARI
 }
 ```
 
+**他属性の存在で `properties.without` を切り替える** `conditions` のセレクタは、同じ要素上の **他属性の存在条件**で `properties` を切り替える用途にも使えます。`<button popovertarget>` は popover API が expanded 状態を自動管理するため、手動の `aria-expanded` を仕様で禁じています:
+
+```jsonc
+"button": {
+  "aria": {
+    "conditions": {
+      "[popovertarget]": {
+        "properties": {
+          "global": true,
+          "role": true,
+          "without": [
+            {
+              "type": "must-not",
+              "name": "aria-expanded",
+              "alt": { "method": "set-attr", "target": "popovertarget" }
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+condition がマッチしたとき `wai-aria-disallowed-props` が `without` エントリを報告します。「属性 X は属性 Y があるとき指定してはならない」を表現する典型パターンです。
+
 ### `properties`
 
 ARIA プロパティの使用制約を定義します。

--- a/packages/@markuplint/html-spec/docs/element-spec-format.md
+++ b/packages/@markuplint/html-spec/docs/element-spec-format.md
@@ -375,6 +375,37 @@ Maps CSS selectors to ARIA overrides. Condition keys use the same CSS selector s
 - `"dl > div"` -- div as direct child of dl
 - `"[type='checkbox' i][aria-pressed]"` -- compound selectors
 
+**Cross-attribute presence with `properties.without`.** A `conditions` selector
+can also gate `properties` on the presence of another attribute on the same
+element. `<button popovertarget>` triggers the popover API which manages the
+expanded state automatically, so the spec data forbids a manual `aria-expanded`:
+
+```jsonc
+"button": {
+  "aria": {
+    "conditions": {
+      "[popovertarget]": {
+        "properties": {
+          "global": true,
+          "role": true,
+          "without": [
+            {
+              "type": "must-not",
+              "name": "aria-expanded",
+              "alt": { "method": "set-attr", "target": "popovertarget" }
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+When the condition matches, `wai-aria-disallowed-props` reports the `without`
+entry. This is the canonical pattern for "attribute X must not appear when
+attribute Y is present".
+
 ### Version-Specific ARIA Overrides
 
 Use version keys (`"1.1"`, `"1.2"`) as sibling properties to override ARIA for specific

--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -49656,6 +49656,24 @@
 					"tab",
 					"treeitem"
 				],
+				"conditions": {
+					"[popovertarget]": {
+						"properties": {
+							"global": true,
+							"role": true,
+							"without": [
+								{
+									"type": "must-not",
+									"name": "aria-expanded",
+									"alt": {
+										"method": "set-attr",
+										"target": "popovertarget"
+									}
+								}
+							]
+						}
+					}
+				},
 				"1.1": {
 					"permittedRoles": [
 						"checkbox",

--- a/packages/@markuplint/html-spec/src/spec.button.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.button.jsonc
@@ -89,6 +89,28 @@
 			"tab",
 			"treeitem"
 		],
+		"conditions": {
+			// HTML LS Popover API: a button that triggers a popover via the
+			// popovertarget attribute manages the expanded/collapsed state
+			// automatically, so authors must not also set aria-expanded.
+			// @see https://html.spec.whatwg.org/multipage/popover.html#attr-popovertarget
+			"[popovertarget]": {
+				"properties": {
+					"global": true,
+					"role": true,
+					"without": [
+						{
+							"type": "must-not",
+							"name": "aria-expanded",
+							"alt": {
+								"method": "set-attr",
+								"target": "popovertarget"
+							}
+						}
+					]
+				}
+			}
+		},
 		"1.1": {
 			"permittedRoles": [
 				"checkbox",

--- a/packages/@markuplint/rules/src/wai-aria-disallowed-props/README.ja.md
+++ b/packages/@markuplint/rules/src/wai-aria-disallowed-props/README.ja.md
@@ -1,11 +1,14 @@
 ---
-description: 要素のロールで許可されていないARIAプロパティ/ステート、または命名禁止（naming prohibition）の対象となるARIAプロパティが指定された場合に警告します。
+description: 要素のロールで許可されていないARIAプロパティ/ステート、特定の要素状態で禁止されたARIA属性、または命名禁止（naming prohibition）の対象となるARIA属性が指定された場合に警告します。
 ---
 
 # `wai-aria-disallowed-props`
 
-要素のロールで許可されていないARIAプロパティ/ステートが指定された場合に警告します。
-また、[ARIA in HTML](https://w3c.github.io/html-aria/#dfn-naming-prohibited)で定義される「命名禁止（naming prohibition）」制約も強制します。`<cite>`、`<abbr>`、`<figcaption>` のような暗黙ロールを持たない要素では、命名をサポートするロールを明示的に設定しない限り、`aria-label`、`aria-labelledby`、`aria-braillelabel` を使用できません。
+[ARIA in HTML](https://w3c.github.io/html-aria/) が定める以下の方法で禁止されているARIAプロパティ/ステートを検出します。
+
+1. **計算されたロールで許可されていない** — 例: `role="heading"` 上の `aria-pressed`
+2. **命名禁止（naming prohibition）** — `<cite>`、`<abbr>`、`<figcaption>` のような暗黙ロールを持たない要素では、命名をサポートするロールを明示的に設定しない限り、`aria-label`、`aria-labelledby`、`aria-braillelabel` を使用できません。
+3. **要素固有の禁止** — 特定の要素状態ではすべての `aria-*` 属性が禁止されます（例: `<input type="hidden">`）。また、ある属性が指定されているときに別の `aria-*` が禁止される場合もあります（例: `<button popovertarget>` では popover API が状態を自動管理するため `aria-expanded` 禁止）。
 
 このルールは[`wai-aria`](../wai-aria/)ルールファミリーの一部で、きめ細かなseverity制御のために分割されたものです。
 
@@ -16,6 +19,8 @@ description: 要素のロールで許可されていないARIAプロパティ/�
 ```html
 <div role="heading" aria-pressed="true"></div>
 <cite aria-label="x">y</cite>
+<input type="hidden" aria-hidden="true" />
+<button popovertarget="p" aria-expanded="false">Toggle</button>
 ```
 
 ✅ 正しいコード例
@@ -23,6 +28,8 @@ description: 要素のロールで許可されていないARIAプロパティ/�
 ```html
 <div role="button" aria-pressed="true"></div>
 <cite role="button" aria-label="x">y</cite>
+<input type="hidden" />
+<button popovertarget="p">Toggle</button>
 ```
 
 <!-- textlint-enable ja-technical-writing/ja-no-mixed-period -->

--- a/packages/@markuplint/rules/src/wai-aria-disallowed-props/README.md
+++ b/packages/@markuplint/rules/src/wai-aria-disallowed-props/README.md
@@ -1,12 +1,15 @@
 ---
 id: wai-aria-disallowed-props
-description: Warns when an ARIA property or state is not allowed on the element's computed role or is subject to naming prohibition.
+description: Warns when an ARIA property or state is disallowed on the element's computed role, on a specific element type, or by the naming-prohibition rule.
 ---
 
 # `wai-aria-disallowed-props`
 
-Warns when an ARIA property or state is not allowed on the element's computed role.
-Also enforces the "naming prohibition" constraint defined by [ARIA in HTML](https://w3c.github.io/html-aria/#dfn-naming-prohibited): elements without an implicit role (such as `<cite>`, `<abbr>`, `<figcaption>`) must not use `aria-label`, `aria-labelledby`, or `aria-braillelabel` unless an explicit role that supports naming is set.
+Warns when an ARIA property or state is disallowed in any of the following ways defined by [ARIA in HTML](https://w3c.github.io/html-aria/):
+
+1. **Not allowed on the computed role** — e.g. `aria-pressed` on `role="heading"`.
+2. **Naming prohibition** — elements without an implicit role (`<cite>`, `<abbr>`, `<figcaption>`, etc.) must not use `aria-label`, `aria-labelledby`, or `aria-braillelabel` unless an explicit naming-supported role is set.
+3. **Element-specific prohibitions** — every `aria-*` attribute is forbidden on certain element states (e.g. `<input type="hidden">`), and individual attributes may be forbidden when another attribute is present (e.g. `aria-expanded` on `<button popovertarget>` because the popover API manages the state automatically).
 
 This rule is part of the [`wai-aria`](../wai-aria/) rule family, split for granular severity control.
 
@@ -15,6 +18,8 @@ This rule is part of the [`wai-aria`](../wai-aria/) rule family, split for granu
 ```html
 <div role="heading" aria-pressed="true"></div>
 <cite aria-label="x">y</cite>
+<input type="hidden" aria-hidden="true" />
+<button popovertarget="p" aria-expanded="false">Toggle</button>
 ```
 
 ✅ Examples of **correct** code for this rule
@@ -22,4 +27,6 @@ This rule is part of the [`wai-aria`](../wai-aria/) rule family, split for granu
 ```html
 <div role="button" aria-pressed="true"></div>
 <cite role="button" aria-label="x">y</cite>
+<input type="hidden" />
+<button popovertarget="p">Toggle</button>
 ```

--- a/packages/@markuplint/rules/src/wai-aria-disallowed-props/index.spec.ts
+++ b/packages/@markuplint/rules/src/wai-aria-disallowed-props/index.spec.ts
@@ -128,3 +128,62 @@ test('[wai-aria-disallowed-props-issue-3630-010] custom element with aria-label 
 	// Custom elements are not in the namingProhibited list; no violation.
 	expect((await mlRuleTest(rule, '<my-widget aria-label="x">y</my-widget>')).violations).toStrictEqual([]);
 });
+
+// #3735 P1: button[popovertarget] must not have aria-expanded. The popover API
+// manages the expanded/collapsed state automatically, so a manual aria-expanded
+// is redundant and may drift from the actual state.
+test('[wai-aria-disallowed-props-issue-3735-001] button[popovertarget] aria-expanded is must-not', async () => {
+	const { violations } = await mlRuleTest(rule, '<button popovertarget="p" aria-expanded="false">x</button>');
+	expect(violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 27,
+			message:
+				'The "aria-expanded" ARIA state must not use on the "button" element. As its state is already provided by the "popovertarget" attribute',
+			raw: 'aria-expanded="false"',
+		},
+	]);
+});
+
+test('[wai-aria-disallowed-props-issue-3735-002] button without popovertarget allows aria-expanded', async () => {
+	// Sanity check: without popovertarget the conditional must not fire.
+	expect((await mlRuleTest(rule, '<button aria-expanded="false">x</button>')).violations).toStrictEqual([]);
+});
+
+// #3735 P2: input[type=hidden] sets `properties: false` in spec data, meaning
+// any aria-* attribute is disallowed. The check must fire even though the
+// element has no implicit role and no explicit role (same root cause as #3630
+// naming prohibition).
+test('[wai-aria-disallowed-props-issue-3735-003] aria-hidden on input[type=hidden] is disallowed', async () => {
+	const { violations } = await mlRuleTest(rule, '<input type="hidden" aria-hidden="true">');
+	expect(violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 22,
+			message: 'The "aria-hidden" ARIA state is disallowed on the "input" element',
+			raw: 'aria-hidden="true"',
+		},
+	]);
+});
+
+test('[wai-aria-disallowed-props-issue-3735-004] any aria-* on input[type=hidden] is disallowed', async () => {
+	// Confirms the rule fires for arbitrary aria-* attrs, not only aria-hidden.
+	const { violations } = await mlRuleTest(rule, '<input type="hidden" aria-label="x">');
+	expect(violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 22,
+			message: 'The "aria-label" ARIA property is disallowed on the "input" element',
+			raw: 'aria-label="x"',
+		},
+	]);
+});
+
+test('[wai-aria-disallowed-props-issue-3735-005] input[type=text] aria-hidden is allowed (properties not false)', async () => {
+	// Sanity check: properties=false is specific to type=hidden. type=text has
+	// implicitRole=textbox and supports global aria-* attrs including aria-hidden.
+	expect((await mlRuleTest(rule, '<input type="text" aria-hidden="true">')).violations).toStrictEqual([]);
+});

--- a/packages/@markuplint/rules/src/wai-aria-permitted-roles/index.spec.ts
+++ b/packages/@markuplint/rules/src/wai-aria-permitted-roles/index.spec.ts
@@ -112,3 +112,34 @@ test('[wai-aria-permitted-roles-valid-003] img with alt text and permitted role 
 test('[wai-aria-permitted-roles-valid-004] img with aria-label and role=img is valid', async () => {
 	expect((await mlRuleTest(rule, '<img src="x.png" aria-label="foo" role="img">')).violations).toStrictEqual([]);
 });
+
+// #3735 P3 regression: <summary> sets permittedRoles=false in html-spec, so
+// any explicit role is rejected — including the implicit "button" role. Pin
+// this so future spec updates do not silently start permitting role on summary.
+test('[wai-aria-permitted-roles-issue-3735-001] role=button on summary inside details is rejected', async () => {
+	const { violations } = await mlRuleTest(rule, '<details><summary role="button">x</summary><p>y</p></details>');
+	expect(violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 25,
+			message:
+				'Cannot overwrite the "button" role to the "summary" element according to ARIA in HTML specification',
+			raw: 'button',
+		},
+	]);
+});
+
+test('[wai-aria-permitted-roles-issue-3735-002] non-implicit role on summary is also rejected', async () => {
+	const { violations } = await mlRuleTest(rule, '<details><summary role="generic">x</summary><p>y</p></details>');
+	expect(violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 25,
+			message:
+				'Cannot overwrite the "generic" role to the "summary" element according to ARIA in HTML specification',
+			raw: 'generic',
+		},
+	]);
+});

--- a/packages/@markuplint/rules/src/wai-aria/checkings/disallowed-prop.ts
+++ b/packages/@markuplint/rules/src/wai-aria/checkings/disallowed-prop.ts
@@ -78,6 +78,35 @@ export const checkingDisallowedProp: AttrChecker<
 			};
 		}
 
+		// Spec data may set `properties: false` to forbid every aria-* attribute on
+		// elements that have no implicit role and accept no explicit role
+		// (e.g. `input[type=hidden]`). The role-based check below would skip such
+		// elements because `role` is null, so handle that case here.
+		// Note: when an explicit `role=` is present, `role` is non-null and this
+		// branch is skipped — but `wai-aria-permitted-roles` already rejects the
+		// explicit role for elements whose spec says `permittedRoles: false`,
+		// so the user sees a violation either way.
+		//
+		// Design note on the gating asymmetry: naming prohibition (above) fires
+		// unconditionally because it is a hard ARIA-in-HTML rule, whereas this
+		// `properties: false` branch is gated on `disallowSetImplicitProps` to
+		// match the `properties.without` check below — both encode element-
+		// specific aria-* prohibitions that users may want to opt out of.
+		if (!role && disallowSetImplicitProps && elAriaSpec?.properties === false) {
+			return {
+				scope: attr,
+				message: t(
+					'{0:c} on {1}',
+					t(
+						'{0} is {1:c}',
+						t('the "{0*}" {1}', attr.name, `ARIA ${propSpec?.type ?? 'property'}`),
+						'disallowed',
+					),
+					t('the "{0*}" {1}', attr.ownerElement.localName, 'element'),
+				),
+			};
+		}
+
 		if (!role) {
 			return;
 		}

--- a/packages/@markuplint/rules/src/wai-aria/index.spec.ts
+++ b/packages/@markuplint/rules/src/wai-aria/index.spec.ts
@@ -517,9 +517,9 @@ describe('Set the property/state explicitly when its element has semantic HTML a
 
 	// #3735 P1/P2 opt-out boundary: both `properties.without` (P1) and
 	// `properties === false` (P2) are gated on `disallowSetImplicitProps`. Pin
-	// this so a future refactor that ungates one without the other surfaces
-	// here. (#3630 naming prohibition is intentionally NOT gated; that asymmetry
-	// is by design — see comments in `disallowed-prop.ts`.)
+	// this so a future refactor that drops the gate from one without the other
+	// surfaces here. (#3630 naming prohibition is intentionally NOT gated; that
+	// asymmetry is by design — see comments in `disallowed-prop.ts`.)
 	test('[wai-aria-issue-3735-001] disallowSetImplicitProps:false opts out of button[popovertarget] aria-expanded check', async () => {
 		const { violations } = await mlRuleTest(rule, '<button popovertarget="p" aria-expanded="false">x</button>', {
 			rule: { options: { disallowSetImplicitProps: false } },

--- a/packages/@markuplint/rules/src/wai-aria/index.spec.ts
+++ b/packages/@markuplint/rules/src/wai-aria/index.spec.ts
@@ -514,6 +514,25 @@ describe('Set the property/state explicitly when its element has semantic HTML a
 
 		expect(violations).toStrictEqual([]);
 	});
+
+	// #3735 P1/P2 opt-out boundary: both `properties.without` (P1) and
+	// `properties === false` (P2) are gated on `disallowSetImplicitProps`. Pin
+	// this so a future refactor that ungates one without the other surfaces
+	// here. (#3630 naming prohibition is intentionally NOT gated; that asymmetry
+	// is by design — see comments in `disallowed-prop.ts`.)
+	test('[wai-aria-issue-3735-001] disallowSetImplicitProps:false opts out of button[popovertarget] aria-expanded check', async () => {
+		const { violations } = await mlRuleTest(rule, '<button popovertarget="p" aria-expanded="false">x</button>', {
+			rule: { options: { disallowSetImplicitProps: false } },
+		});
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('[wai-aria-issue-3735-002] disallowSetImplicitProps:false opts out of input[type=hidden] aria-* check', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="hidden" aria-hidden="true">', {
+			rule: { options: { disallowSetImplicitProps: false } },
+		});
+		expect(violations).toStrictEqual([]);
+	});
 });
 
 describe('Allowed Accessibility Child Roles', () => {


### PR DESCRIPTION
## Summary
Closes #3735. Three patterns — two new detections and one regression pin.

- **P1 (`button[popovertarget]` + `aria-expanded`)**: HTML LS popover API manages the expanded state automatically, so a manual `aria-expanded` is forbidden. Encoded as a new `aria.conditions["[popovertarget]"]` block in `spec.button.jsonc` with `properties.without` `must-not`. No new rule code — reported via the existing `properties.without` branch in `disallowed-prop.ts`.
- **P2 (`input[type="hidden"]` + any `aria-*`)**: html-spec already says `properties: false` for `input[type=hidden]`, but `disallowed-prop.ts` early-returned when the computed role was null and missed it. Add a new branch before the `!role` early return that fires when `elAriaSpec.properties === false`, gated on `disallowSetImplicitProps` (matching the existing `properties.without` opt-out, not the always-on naming-prohibition rule).
- **P3 (`<details><summary role>`)**: already detected by `wai-aria-permitted-roles` via `permittedRoles: false`. Pin with regression tests so future spec edits don't silently start permitting role on `<summary>`.

Docs: `element-spec-format.md` + `wai-aria-disallowed-props/README.md` (EN+JA) updated to document the cross-attribute presence pattern and the three categories of disallowed-props checks. Inline comment in `disallowed-prop.ts` explains the gating asymmetry between naming-prohibition (unconditional) and `properties: false` (gated).

## Test plan
- [x] `yarn test` — 241 files, 3665 passed / 1 skipped
- [x] `yarn lint-check` — 0 oxlint/oxfmt errors (CSpell exit 1 is the worktree known issue, 0 files checked)
- [x] `yarn build`
- [x] 9 new regression tests across 3 spec files (P1×2, P2×3, P3×2, opt-out×2)
- [ ] Post-merge: regenerate `tests/external/snapshots/` to verify the 3 `nu-only` fixtures (`aria-expanded-with-popovertarget`, `aria-hidden-on-input-hidden`, `popovertarget-with-aria-expanded`) flip to `match-error`