### PR TITLE
fix!: reject pretender on standard HTML elements (#3740)

### DIFF
--- a/packages/@markuplint/ml-core/docs/ml-dom/pretender.ja.md
+++ b/packages/@markuplint/ml-core/docs/ml-dom/pretender.ja.md
@@ -32,15 +32,20 @@ MLDocument コンストラクタ
 
 `MLElement` の `pretending()` メソッドがコアの初期化ロジックです。ドキュメントのコンストラクション中に、要素ごとに1回呼び出されます。
 
-**ステップ 0: HTML 要素の拒否**
+**ステップ 0: 標準 HTML 要素の拒否**
 
 ```typescript
-if (this.elementType === 'html') {
+if (
+  this.elementType === 'html' &&
+  getSpecByTagName(this.ownerMLDocument.specs.specs, this.localName, this.namespaceURI) != null
+) {
   return;
 }
 ```
 
-Pretender は非 HTML 要素（Web Component および JSX/Vue/Svelte 等の authored 要素）にのみ適用されます。明示的な `pretenders` 設定もインライン `as` 属性も、標準 HTML 要素に対しては無視されます。HTML 要素を別の要素に偽装させると、その元タグに対する仕様駆動のルール（deprecation 警告、ARIA role 制約、ブラウザサポートチェックなど）が暗黙に隠されてしまうためです（issue #3740 参照）。
+Pretender は仕様データに該当エントリを持つ標準 HTML 要素（例: `<button>`、`<marquee>`、`<input>`）には決して適用されません。これらを別の要素に偽装させると、元タグに対する仕様駆動のルール（deprecation 警告、ARIA role 制約、ブラウザサポートチェックなど）が暗黙に隠されてしまうためです（issue #3740 参照）。
+
+HTML パーサーが小文字化した非標準的な名前（例: `<SimpleButton>` が `simplebutton` になる）は `elementType === 'html'` を持ちますが、spec エントリがないため、以下のステップに進み pretender 対象として残ります。これは `pretenders.scan` のワークフローがコンポーネント名をルート HTML 要素にマッピングするために必要な動作です。
 
 **ステップ 1: マッチする設定を検索**
 
@@ -54,10 +59,12 @@ Pretender 設定を反復し、CSS セレクタがこの要素にマッチする
 
 ```typescript
 const asAttrValue = this.getAttribute('as');
-const pretenderElement = pretenderConfig?.as ?? (asAttrValue ? { element: asAttrValue, inheritAttrs: true } : null);
+const pretenderElement =
+  pretenderConfig?.as ??
+  (this.elementType === 'html' || !asAttrValue ? null : { element: asAttrValue, inheritAttrs: true });
 ```
 
-明示的な設定がマッチせず、要素が `as` 属性を持つ場合、その属性値をフォールバックとして使用します。これにより、明示的な設定なしで `<MyButton as="button">` が動作します。（HTML 要素はステップ 0 で早期 return するため、ここには到達しません）
+明示的な設定がマッチせず、要素が非 HTML 要素（`elementType !== 'html'`）で `as` 属性を持つ場合、その属性値をフォールバックとして使用します。これにより、明示的な設定なしで `<MyButton as="button">` が動作します。インライン `as` に対する `elementType === 'html'` ガードは #3740 以前から保持されています — `<SimpleButton>` のような非標準 HTML パース名は `pretenders` config 経由なら動作しますが、インライン `as` は引き続き無視されます。
 
 **ステップ 3: Pretender 定義の解決**
 

--- a/packages/@markuplint/ml-core/docs/ml-dom/pretender.ja.md
+++ b/packages/@markuplint/ml-core/docs/ml-dom/pretender.ja.md
@@ -32,6 +32,16 @@ MLDocument コンストラクタ
 
 `MLElement` の `pretending()` メソッドがコアの初期化ロジックです。ドキュメントのコンストラクション中に、要素ごとに1回呼び出されます。
 
+**ステップ 0: HTML 要素の拒否**
+
+```typescript
+if (this.elementType === 'html') {
+  return;
+}
+```
+
+Pretender は非 HTML 要素（Web Component および JSX/Vue/Svelte 等の authored 要素）にのみ適用されます。明示的な `pretenders` 設定もインライン `as` 属性も、標準 HTML 要素に対しては無視されます。HTML 要素を別の要素に偽装させると、その元タグに対する仕様駆動のルール（deprecation 警告、ARIA role 制約、ブラウザサポートチェックなど）が暗黙に隠されてしまうためです（issue #3740 参照）。
+
 **ステップ 1: マッチする設定を検索**
 
 ```typescript
@@ -44,12 +54,10 @@ Pretender 設定を反復し、CSS セレクタがこの要素にマッチする
 
 ```typescript
 const asAttrValue = this.getAttribute('as');
-const pretenderElement =
-  pretenderConfig?.as ??
-  (this.elementType === 'html' || !asAttrValue ? null : { element: asAttrValue, inheritAttrs: true });
+const pretenderElement = pretenderConfig?.as ?? (asAttrValue ? { element: asAttrValue, inheritAttrs: true } : null);
 ```
 
-明示的な設定がマッチしないが、要素が非 HTML 要素（つまり `elementType !== 'html'`）で `as` 属性を持つ場合、その属性値をフォールバックとして使用します。これにより、明示的な設定なしで `<MyButton as="button">` が動作します。
+明示的な設定がマッチせず、要素が `as` 属性を持つ場合、その属性値をフォールバックとして使用します。これにより、明示的な設定なしで `<MyButton as="button">` が動作します。（HTML 要素はステップ 0 で早期 return するため、ここには到達しません）
 
 **ステップ 3: Pretender 定義の解決**
 

--- a/packages/@markuplint/ml-core/docs/ml-dom/pretender.md
+++ b/packages/@markuplint/ml-core/docs/ml-dom/pretender.md
@@ -32,15 +32,20 @@ This ordering is intentional: pretenders must be established **before** rule map
 
 The `pretending()` method on `MLElement` is the core initialization logic. It is called once per element during document construction.
 
-**Step 0: Reject HTML elements**
+**Step 0: Reject standard HTML elements**
 
 ```typescript
-if (this.elementType === 'html') {
+if (
+  this.elementType === 'html' &&
+  getSpecByTagName(this.ownerMLDocument.specs.specs, this.localName, this.namespaceURI) != null
+) {
   return;
 }
 ```
 
-Pretenders apply only to non-HTML elements (web components and authored elements such as JSX, Vue, and Svelte components). Both the explicit `pretenders` config **and** the inline `as` attribute are no-ops on standard HTML elements. Allowing an HTML element to masquerade as another would silently mask spec-driven rules — deprecation warnings, ARIA role restrictions, browser-support checks — keyed on the original tag (see issue #3740).
+Pretenders never apply to a recognised standard HTML element (one with an entry in the active spec set, e.g. `<button>`, `<marquee>`, `<input>`). Allowing such elements to masquerade as another would silently mask spec-driven rules — deprecation warnings, ARIA role restrictions, browser-support checks — keyed on the original tag (see issue #3740).
+
+PascalCase or otherwise unconventional names parsed as plain HTML (such as `<SimpleButton>` lowered by the HTML parser to `simplebutton`) carry `elementType === 'html'` from the parser but have no spec entry. Those still reach the steps below and remain pretender-eligible — this is what the `pretenders.scan` workflow relies on to map component names to their root HTML element.
 
 **Step 1: Find matching config**
 
@@ -54,10 +59,12 @@ Iterate through the pretender configurations and find the first one whose CSS se
 
 ```typescript
 const asAttrValue = this.getAttribute('as');
-const pretenderElement = pretenderConfig?.as ?? (asAttrValue ? { element: asAttrValue, inheritAttrs: true } : null);
+const pretenderElement =
+  pretenderConfig?.as ??
+  (this.elementType === 'html' || !asAttrValue ? null : { element: asAttrValue, inheritAttrs: true });
 ```
 
-If no explicit config matches and the element has an `as` attribute, use that attribute value as a fallback. This allows `<MyButton as="button">` to work without explicit config. (HTML elements never reach this step, since Step 0 returns early.)
+If no explicit config matches but the element is a non-HTML element (`elementType !== 'html'`) and has an `as` attribute, use that attribute value as a fallback. This allows `<MyButton as="button">` to work without explicit config. The `elementType === 'html'` guard on the inline `as` attribute is preserved from before #3740 — non-spec HTML-parsed names like `<SimpleButton>` keep working through `pretenders` config but their inline `as` is still ignored.
 
 **Step 3: Resolve the pretender definition**
 

--- a/packages/@markuplint/ml-core/docs/ml-dom/pretender.md
+++ b/packages/@markuplint/ml-core/docs/ml-dom/pretender.md
@@ -32,6 +32,16 @@ This ordering is intentional: pretenders must be established **before** rule map
 
 The `pretending()` method on `MLElement` is the core initialization logic. It is called once per element during document construction.
 
+**Step 0: Reject HTML elements**
+
+```typescript
+if (this.elementType === 'html') {
+  return;
+}
+```
+
+Pretenders apply only to non-HTML elements (web components and authored elements such as JSX, Vue, and Svelte components). Both the explicit `pretenders` config **and** the inline `as` attribute are no-ops on standard HTML elements. Allowing an HTML element to masquerade as another would silently mask spec-driven rules — deprecation warnings, ARIA role restrictions, browser-support checks — keyed on the original tag (see issue #3740).
+
 **Step 1: Find matching config**
 
 ```typescript
@@ -44,12 +54,10 @@ Iterate through the pretender configurations and find the first one whose CSS se
 
 ```typescript
 const asAttrValue = this.getAttribute('as');
-const pretenderElement =
-  pretenderConfig?.as ??
-  (this.elementType === 'html' || !asAttrValue ? null : { element: asAttrValue, inheritAttrs: true });
+const pretenderElement = pretenderConfig?.as ?? (asAttrValue ? { element: asAttrValue, inheritAttrs: true } : null);
 ```
 
-If no explicit config matches but the element is a non-HTML element (i.e., `elementType !== 'html'`) and has an `as` attribute, use that attribute value as a fallback. This allows `<MyButton as="button">` to work without explicit config.
+If no explicit config matches and the element has an `as` attribute, use that attribute value as a fallback. This allows `<MyButton as="button">` to work without explicit config. (HTML elements never reach this step, since Step 0 returns early.)
 
 **Step 3: Resolve the pretender definition**
 

--- a/packages/@markuplint/ml-core/src/index.spec.ts
+++ b/packages/@markuplint/ml-core/src/index.spec.ts
@@ -335,6 +335,55 @@ div#hoge.foo.bar
 		expect(el.pretenderContext?.type).toBe('pretender');
 		expect([...(el.pretenderContext as any).as.childNodes].length).toBeGreaterThan(0);
 	});
+
+	// Issue #3740: HTML elements must never be pretendered. Allowing `<marquee as="div">`
+	// or a config-driven HTML→HTML pretender would silently mask standards-conformance
+	// violations (deprecation, ARIA role restrictions) on the original tag.
+	test('pretenders: ignored when selector matches an HTML element (issue-3740)', () => {
+		const el = createTestElement('<marquee>x</marquee>', {
+			specs,
+			pretenders: [
+				{
+					selector: 'marquee',
+					as: 'div',
+				},
+			],
+		});
+		expect(el.pretenderContext).toBeNull();
+		expect(el.localName).toBe('marquee');
+	});
+
+	test('pretenders: still applies to web-component selectors (issue-3740)', () => {
+		const el = createTestElement('<x-marquee>x</x-marquee>', {
+			specs,
+			pretenders: [
+				{
+					selector: 'x-marquee',
+					as: 'marquee',
+				},
+			],
+		});
+		expect(el.pretenderContext?.type).toBe('pretender');
+		expect(el.localName).toBe('marquee');
+	});
+
+	test('pretenders: applies to non-spec custom names parsed as HTML (issue-3740)', () => {
+		// `<SimpleButton>` lowercased by the HTML parser becomes `simplebutton`. It is
+		// not a hyphenated custom element, so the parser tags it `elementType='html'`,
+		// but the spec has no entry — pretender should still apply (covers the
+		// pretenders.scan workflow).
+		const el = createTestElement('<SimpleButton>x</SimpleButton>', {
+			specs,
+			pretenders: [
+				{
+					selector: 'SimpleButton',
+					as: 'button',
+				},
+			],
+		});
+		expect(el.pretenderContext?.type).toBe('pretender');
+		expect(el.localName).toBe('button');
+	});
 });
 
 describe('Rule', () => {

--- a/packages/@markuplint/ml-core/src/index.spec.ts
+++ b/packages/@markuplint/ml-core/src/index.spec.ts
@@ -384,6 +384,24 @@ div#hoge.foo.bar
 		expect(el.pretenderContext?.type).toBe('pretender');
 		expect(el.localName).toBe('button');
 	});
+
+	test('pretenders: aria field on HTML selector is ignored (issue-3740)', () => {
+		// Even an `aria` payload cannot opt an HTML element back into pretender mode —
+		// the entire config entry is a no-op when the selector resolves to a standard
+		// HTML element. This guards against accidentally bypassing the standard-HTML
+		// reject by adding `aria.name`.
+		const el = createTestElement('<button>x</button>', {
+			specs,
+			pretenders: [
+				{
+					selector: 'button',
+					as: { element: 'a', aria: { name: 'overridden' } },
+				},
+			],
+		});
+		expect(el.pretenderContext).toBeNull();
+		expect(el.localName).toBe('button');
+	});
 });
 
 describe('Rule', () => {

--- a/packages/@markuplint/ml-core/src/ml-dom/node/element.ts
+++ b/packages/@markuplint/ml-core/src/ml-dom/node/element.ts
@@ -3936,13 +3936,11 @@ export class MLElement<T extends RuleConfigValue, O extends PlainData = undefine
 		// from the parser but have no spec entry; those remain pretender-eligible
 		// (this is what `pretenders.scan` relies on). The legacy "no inline `as=` on
 		// HTML elements" guard is preserved further down for that case.
-		if (this.elementType === 'html') {
-			const specs = this.ownerMLDocument.specs.specs;
-			// In tests, the spec collection can be omitted entirely. Be defensive and
-			// fall through to the legacy logic (production callers always supply specs).
-			if (specs && getSpecByTagName(specs, this.localName, this.namespaceURI) != null) {
-				return;
-			}
+		if (
+			this.elementType === 'html' &&
+			getSpecByTagName(this.ownerMLDocument.specs.specs, this.localName, this.namespaceURI) != null
+		) {
+			return;
 		}
 		const pretenderConfig = pretenders?.find(option => this.matches(option.selector));
 		const asAttrValue = this.getAttribute('as');

--- a/packages/@markuplint/ml-core/src/ml-dom/node/element.ts
+++ b/packages/@markuplint/ml-core/src/ml-dom/node/element.ts
@@ -23,7 +23,7 @@ import type {
 } from '@markuplint/ml-config';
 import type { ARIAVersion } from '@markuplint/ml-spec';
 
-import { resolveNamespace } from '@markuplint/ml-spec';
+import { getSpecByTagName, resolveNamespace } from '@markuplint/ml-spec';
 import type { SelectorMatches } from '@markuplint/selector';
 import { matchSelector } from '@markuplint/selector';
 
@@ -3926,6 +3926,24 @@ export class MLElement<T extends RuleConfigValue, O extends PlainData = undefine
 	 * @param pretenders - Optional array of pretender configurations to match against
 	 */
 	pretending(pretenders?: readonly Pretender[]) {
+		// Pretender must not apply to a recognised standard HTML element (e.g. <marquee>,
+		// <h1>, <button>). Allowing such elements to masquerade as another would silently
+		// mask spec-driven rules — deprecation, ARIA role restrictions, browser support —
+		// keyed on the original tag. See issue #3740.
+		//
+		// Names that the HTML parser cannot distinguish from typos (PascalCase JSX-like
+		// usage in plain HTML such as `<SimpleButton>`) get `elementType === 'html'`
+		// from the parser but have no spec entry; those remain pretender-eligible
+		// (this is what `pretenders.scan` relies on). The legacy "no inline `as=` on
+		// HTML elements" guard is preserved further down for that case.
+		if (this.elementType === 'html') {
+			const specs = this.ownerMLDocument.specs.specs;
+			// In tests, the spec collection can be omitted entirely. Be defensive and
+			// fall through to the legacy logic (production callers always supply specs).
+			if (specs && getSpecByTagName(specs, this.localName, this.namespaceURI) != null) {
+				return;
+			}
+		}
 		const pretenderConfig = pretenders?.find(option => this.matches(option.selector));
 		const asAttrValue = this.getAttribute('as');
 		const pretenderElement: Pretender['as'] | null =

--- a/packages/@markuplint/ml-core/src/test/index.ts
+++ b/packages/@markuplint/ml-core/src/test/index.ts
@@ -47,7 +47,7 @@ export function createTestDocument<T extends RuleConfigValue = any, O extends Pl
 	const document = new MLDocument<T, O>(
 		ast,
 		ruleset,
-		[options?.specs ?? ({} as any), {}],
+		[options?.specs ?? (spec as unknown as MLMLSpec), {}],
 		{ ariaVersion: ARIA_RECOMMENDED_VERSION },
 		options?.pretenders ? { pretenders: options.pretenders } : undefined,
 	);

--- a/packages/@markuplint/rules/src/deprecated-element/index.spec.ts
+++ b/packages/@markuplint/rules/src/deprecated-element/index.spec.ts
@@ -103,3 +103,21 @@ test('[deprecated-element-issue-3740-004] web-component pretendered to obsolete 
 		},
 	]);
 });
+
+test('[deprecated-element-issue-3740-005] Vue web-component pretendered to obsolete HTML reports', async () => {
+	// Cross-parser regression: confirm the pretender filter relaxation works when
+	// the AST originates from `@markuplint/vue-parser`, not just JSX.
+	const { violations } = await mlRuleTest(rule, '<template><x-marquee>x</x-marquee></template>', {
+		parser: { '.*': '@markuplint/vue-parser' },
+		pretenders: [{ selector: 'x-marquee', as: 'marquee' }],
+	});
+	expect(violations).toStrictEqual([
+		{
+			severity: 'error',
+			message: 'The "marquee" element is obsolete',
+			line: 1,
+			col: 11,
+			raw: '<x-marquee>',
+		},
+	]);
+});

--- a/packages/@markuplint/rules/src/deprecated-element/index.spec.ts
+++ b/packages/@markuplint/rules/src/deprecated-element/index.spec.ts
@@ -39,3 +39,67 @@ test('[deprecated-element-invalid-001] deprecated', async () => {
 		},
 	]);
 });
+
+test('[deprecated-element-issue-3740-001] JSX component pretendered to obsolete HTML still reports', async () => {
+	const { violations } = await mlRuleTest(rule, '<Marquee>x</Marquee>', {
+		parser: { '.*': '@markuplint/jsx-parser' },
+		pretenders: [{ selector: 'Marquee', as: 'marquee' }],
+	});
+	expect(violations).toStrictEqual([
+		{
+			severity: 'error',
+			message: 'The "marquee" element is obsolete',
+			line: 1,
+			col: 1,
+			raw: '<Marquee>',
+		},
+	]);
+});
+
+test('[deprecated-element-issue-3740-002] JSX component pretendered with inheritAttrs object form', async () => {
+	const { violations } = await mlRuleTest(rule, '<Marquee>x</Marquee>', {
+		parser: { '.*': '@markuplint/jsx-parser' },
+		pretenders: [{ selector: 'Marquee', as: { element: 'marquee', inheritAttrs: true } }],
+	});
+	expect(violations).toStrictEqual([
+		{
+			severity: 'error',
+			message: 'The "marquee" element is obsolete',
+			line: 1,
+			col: 1,
+			raw: '<Marquee>',
+		},
+	]);
+});
+
+test('[deprecated-element-issue-3740-003] HTML→HTML pretender ignored: original deprecation surfaces', async () => {
+	// `pretenders` config now no-ops when the selector matches an HTML element,
+	// so `<marquee as="div">` keeps marquee identity and the obsolete check fires.
+	const { violations } = await mlRuleTest(rule, '<marquee>x</marquee>', {
+		pretenders: [{ selector: 'marquee', as: 'div' }],
+	});
+	expect(violations).toStrictEqual([
+		{
+			severity: 'error',
+			message: 'The "marquee" element is obsolete',
+			line: 1,
+			col: 1,
+			raw: '<marquee>',
+		},
+	]);
+});
+
+test('[deprecated-element-issue-3740-004] web-component pretendered to obsolete HTML reports', async () => {
+	const { violations } = await mlRuleTest(rule, '<x-marquee>x</x-marquee>', {
+		pretenders: [{ selector: 'x-marquee', as: 'marquee' }],
+	});
+	expect(violations).toStrictEqual([
+		{
+			severity: 'error',
+			message: 'The "marquee" element is obsolete',
+			line: 1,
+			col: 1,
+			raw: '<x-marquee>',
+		},
+	]);
+});

--- a/packages/@markuplint/rules/src/deprecated-element/index.ts
+++ b/packages/@markuplint/rules/src/deprecated-element/index.ts
@@ -17,7 +17,10 @@ export default createRule({
 					el.namespaceURI === 'http://www.w3.org/1999/xhtml' ||
 					el.namespaceURI === 'http://www.w3.org/2000/svg'
 				) ||
-				el.elementType !== 'html'
+				// Web components and authored elements (JSX/Vue/Svelte) reach this rule
+				// through `pretenders`: they masquerade as a known HTML element via
+				// `el.localName`, so the spec lookup below resolves correctly. See #3740.
+				(el.elementType !== 'html' && el.pretenderContext?.type !== 'pretender')
 			) {
 				return;
 			}

--- a/packages/@markuplint/rules/src/no-unsupported-features/index.spec.ts
+++ b/packages/@markuplint/rules/src/no-unsupported-features/index.spec.ts
@@ -244,3 +244,47 @@ describe('SVG elements are skipped', () => {
 		expect(circleViolation).toBeUndefined();
 	});
 });
+
+describe('pretender gap (issue #3740)', () => {
+	test('[no-unsupported-features-issue-3740-001] JSX component pretendered to old HTML reports against browserslist', async () => {
+		const { violations } = await mlRuleTest(rule, '<Dialog>x</Dialog>', {
+			parser: { '.*': '@markuplint/jsx-parser' },
+			pretenders: [{ selector: 'Dialog', as: 'dialog' }],
+			rule: { options: { browserslist: 'ie 11' } },
+		});
+		const dialogViolation = violations.find(v => v.message.includes('"dialog"'));
+		expect(dialogViolation).toBeDefined();
+	});
+
+	test('[no-unsupported-features-issue-3740-002] JSX with object inheritAttrs pretender reports', async () => {
+		const { violations } = await mlRuleTest(rule, '<Dialog>x</Dialog>', {
+			parser: { '.*': '@markuplint/jsx-parser' },
+			pretenders: [{ selector: 'Dialog', as: { element: 'dialog', inheritAttrs: true } }],
+			rule: { options: { browserslist: 'ie 11' } },
+		});
+		const dialogViolation = violations.find(v => v.message.includes('"dialog"'));
+		expect(dialogViolation).toBeDefined();
+	});
+
+	test('[no-unsupported-features-issue-3740-003] HTML→HTML pretender ignored: original element checked', async () => {
+		// `pretenders` config is now no-op for HTML element selectors, so the
+		// original `<dialog>` is still evaluated against the browserslist target.
+		const { violations } = await mlRuleTest(rule, '<dialog>x</dialog>', {
+			pretenders: [{ selector: 'dialog', as: 'div' }],
+			rule: { options: { browserslist: 'ie 11' } },
+		});
+		const dialogViolation = violations.find(v => v.message.includes('"dialog"'));
+		expect(dialogViolation).toBeDefined();
+	});
+
+	test('[no-unsupported-features-issue-3740-004] web-component pretendered to experimental HTML reports', async () => {
+		const { violations } = await mlRuleTest(rule, '<x-iframe credentialless></x-iframe>', {
+			pretenders: [{ selector: 'x-iframe', as: { element: 'iframe', inheritAttrs: true } }],
+			rule: { options: { checkExperimental: true } },
+		});
+		const experimentalViolation = violations.find(
+			v => v.message.includes('experimental') && v.message.includes('"credentialless"'),
+		);
+		expect(experimentalViolation).toBeDefined();
+	});
+});

--- a/packages/@markuplint/rules/src/no-unsupported-features/index.spec.ts
+++ b/packages/@markuplint/rules/src/no-unsupported-features/index.spec.ts
@@ -252,8 +252,14 @@ describe('pretender gap (issue #3740)', () => {
 			pretenders: [{ selector: 'Dialog', as: 'dialog' }],
 			rule: { options: { browserslist: 'ie 11' } },
 		});
-		const dialogViolation = violations.find(v => v.message.includes('"dialog"'));
-		expect(dialogViolation).toBeDefined();
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.severity).toBe('warning');
+		expect(violations[0]?.message).toContain('"dialog"');
+		expect(violations[0]?.message).toContain('element');
+		expect(violations[0]?.message).toContain('Internet Explorer');
+		expect(violations[0]?.line).toBe(1);
+		expect(violations[0]?.col).toBe(1);
+		expect(violations[0]?.raw).toBe('<Dialog>');
 	});
 
 	test('[no-unsupported-features-issue-3740-002] JSX with object inheritAttrs pretender reports', async () => {
@@ -262,8 +268,11 @@ describe('pretender gap (issue #3740)', () => {
 			pretenders: [{ selector: 'Dialog', as: { element: 'dialog', inheritAttrs: true } }],
 			rule: { options: { browserslist: 'ie 11' } },
 		});
-		const dialogViolation = violations.find(v => v.message.includes('"dialog"'));
-		expect(dialogViolation).toBeDefined();
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.severity).toBe('warning');
+		expect(violations[0]?.message).toContain('"dialog"');
+		expect(violations[0]?.message).toContain('Internet Explorer');
+		expect(violations[0]?.raw).toBe('<Dialog>');
 	});
 
 	test('[no-unsupported-features-issue-3740-003] HTML→HTML pretender ignored: original element checked', async () => {
@@ -273,8 +282,11 @@ describe('pretender gap (issue #3740)', () => {
 			pretenders: [{ selector: 'dialog', as: 'div' }],
 			rule: { options: { browserslist: 'ie 11' } },
 		});
-		const dialogViolation = violations.find(v => v.message.includes('"dialog"'));
-		expect(dialogViolation).toBeDefined();
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.severity).toBe('warning');
+		expect(violations[0]?.message).toContain('"dialog"');
+		expect(violations[0]?.message).toContain('Internet Explorer');
+		expect(violations[0]?.raw).toBe('<dialog>');
 	});
 
 	test('[no-unsupported-features-issue-3740-004] web-component pretendered to experimental HTML reports', async () => {
@@ -282,9 +294,10 @@ describe('pretender gap (issue #3740)', () => {
 			pretenders: [{ selector: 'x-iframe', as: { element: 'iframe', inheritAttrs: true } }],
 			rule: { options: { checkExperimental: true } },
 		});
-		const experimentalViolation = violations.find(
-			v => v.message.includes('experimental') && v.message.includes('"credentialless"'),
-		);
-		expect(experimentalViolation).toBeDefined();
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.severity).toBe('warning');
+		expect(violations[0]?.message).toContain('"credentialless"');
+		expect(violations[0]?.message).toContain('experimental');
+		expect(violations[0]?.raw).toBe('credentialless');
 	});
 });

--- a/packages/@markuplint/rules/src/no-unsupported-features/index.ts
+++ b/packages/@markuplint/rules/src/no-unsupported-features/index.ts
@@ -56,8 +56,13 @@ export default createRule<boolean, Options>({
 		const ignoreFeatures = new Set(options.ignoreFeatures);
 
 		await document.walkOn('Element', async el => {
-			// Only check HTML elements
-			if (el.namespaceURI !== 'http://www.w3.org/1999/xhtml' || el.elementType !== 'html') {
+			// Web components and authored elements (JSX/Vue/Svelte) reach this rule
+			// via `pretenders`: they masquerade as a known HTML element on `el.localName`,
+			// so spec / BCD lookups below resolve correctly. See #3740.
+			if (
+				el.namespaceURI !== 'http://www.w3.org/1999/xhtml' ||
+				(el.elementType !== 'html' && el.pretenderContext?.type !== 'pretender')
+			) {
 				return;
 			}
 

--- a/packages/@markuplint/rules/src/wai-aria-permitted-roles/index.spec.ts
+++ b/packages/@markuplint/rules/src/wai-aria-permitted-roles/index.spec.ts
@@ -143,3 +143,21 @@ test('[wai-aria-permitted-roles-issue-3735-002] non-implicit role on summary is 
 		},
 	]);
 });
+
+test('[wai-aria-permitted-roles-issue-3740-001] HTML→HTML pretender no-ops: original h1 role restriction still fires', async () => {
+	// Issue #3740: `pretenders` config with an HTML element selector is now ignored,
+	// so `<h1 role="button">` is checked against h1's permitted roles even when the
+	// user attempted to mask it with `as: 'div'`.
+	const { violations } = await mlRuleTest(rule, '<h1 role="button">x</h1>', {
+		pretenders: [{ selector: 'h1', as: 'div' }],
+	});
+	expect(violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 11,
+			message: 'Cannot overwrite the "button" role to the "h1" element according to ARIA in HTML specification',
+			raw: 'button',
+		},
+	]);
+});

--- a/website/docs/configuration/properties.md
+++ b/website/docs/configuration/properties.md
@@ -881,6 +881,10 @@ The value can be either an **array** of pretender definitions or an **object** w
 
 It accepts [**Selector**](/docs/guides/selectors) to matche the target component. It's required.
 
+:::caution Standard HTML elements are excluded
+A pretender entry whose selector resolves to a standard HTML or SVG element is silently ignored. Pretenders apply only to custom components — web components, JSX/Vue/Svelte authored components, or unknown HTML-parsed names with no spec entry. Targeting `<button>`, `<marquee>`, etc. is a no-op (see [migration notes](/docs/migration/v4-to-v5/config#pretenders-no-longer-apply-to-standard-html-tags)).
+:::
+
 #### `as`
 
 It accepts an **element name** or an **element with properties**. It's required.

--- a/website/docs/guides/beyond-html.md
+++ b/website/docs/guides/beyond-html.md
@@ -181,6 +181,10 @@ In addition, **spec plugins** include definitions for framework-specific attribu
 
 In **React**, **Vue**, and more, custom components cannot be evaluated as HTML elements. This means Markuplint's content model rules — such as [`permitted-contents`](/docs/rules/permitted-contents) — have no way of knowing what a component actually renders. Without this information, a `<Button>` component that renders a `<button>` element is treated as an unknown element, and invalid nesting like `<a><Button /></a>` (interactive content inside interactive content) goes undetected.
 
+:::note Scope
+Pretenders apply to **custom components only** — web components, JSX/Vue/Svelte authored components, and HTML-parsed names that have no spec entry. Targeting a standard HTML element (`<marquee>`, `<button>`, etc.) is a no-op so that deprecation, ARIA, and browser-support rules keyed on the original tag are not silently masked.
+:::
+
 <!-- prettier-ignore-start -->
 ```jsx
 <List>{/* No evaluate as native HTML Element */}

--- a/website/docs/migration/v4-to-v5/config.md
+++ b/website/docs/migration/v4-to-v5/config.md
@@ -9,16 +9,17 @@ v5 improves configuration with global settings, named rules, and cleaner merge b
 
 ## What changed
 
-| Change                                            | Who is affected                              |
-| ------------------------------------------------- | -------------------------------------------- |
-| New `ruleCommonSettings` property                 | All config authors                           |
-| Named nodeRules                                   | Preset users and authors                     |
-| `specConformance` metadata                        | Preset authors                               |
-| nodeRules/childNodeRules deduplicate by name      | Configs using `extends` with named nodeRules |
-| Rule array values override instead of concatenate | Configs using `extends` with array values    |
-| Rule options shallow merge instead of deep merge  | Configs using `extends` with nested options  |
-| Pretender `data` appends instead of overrides     | Configs using `extends` with pretenders      |
-| `--config` flag loads only the specified file     | CLI users with `--config`                    |
+| Change                                            | Who is affected                                  |
+| ------------------------------------------------- | ------------------------------------------------ |
+| New `ruleCommonSettings` property                 | All config authors                               |
+| Named nodeRules                                   | Preset users and authors                         |
+| `specConformance` metadata                        | Preset authors                                   |
+| nodeRules/childNodeRules deduplicate by name      | Configs using `extends` with named nodeRules     |
+| Rule array values override instead of concatenate | Configs using `extends` with array values        |
+| Rule options shallow merge instead of deep merge  | Configs using `extends` with nested options      |
+| Pretender `data` appends instead of overrides     | Configs using `extends` with pretenders          |
+| Pretenders no longer apply to standard HTML tags  | Configs targeting HTML elements via `pretenders` |
+| `--config` flag loads only the specified file     | CLI users with `--config`                        |
 
 ## `ruleCommonSettings`
 
@@ -311,6 +312,37 @@ This change makes pretender configs more composable.
 | `data`    | Override    | **Append**  |
 
 **How to migrate:** This is generally non-breaking. If you need to replace pretender data entirely, define all pretenders in a single config instead of using `extends`.
+
+## Pretenders no longer apply to standard HTML tags
+
+:::caution Breaking Change
+If you used `pretenders` (or the inline `as=` attribute) to make a standard HTML element behave like another, those entries are now ignored.
+:::
+
+**Why:** A pretender entry whose selector resolves to a recognised HTML / SVG element silently masked spec-driven rules — deprecation warnings, ARIA role restrictions, and browser-support checks — keyed on the original tag. The pretender system was always intended for custom components only; v5 enforces that. See [issue #3740](https://github.com/markuplint/markuplint/issues/3740).
+
+**Before (v4):** `<marquee as="div">` or a config-driven `pretenders: [{ selector: 'marquee', as: 'div' }]` masqueraded the original tag, suppressing the marquee deprecation warning.
+
+```json
+{
+  "pretenders": [{ "selector": "marquee", "as": "div" }]
+}
+```
+
+**After (v5):** Pretenders apply only when the source element is a custom component — that is, anything **except** an element listed in `@markuplint/html-spec` (or any user-supplied spec). Practically, that means:
+
+| Source element                                                                     | Pretender applies?                                         |
+| ---------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| Standard HTML / SVG tag (`<button>`, `<marquee>`, …)                               | No                                                         |
+| Web component / autonomous custom element (`<x-foo>`)                              | Yes                                                        |
+| Authored component (JSX/Vue/Svelte `<MyButton>`)                                   | Yes                                                        |
+| Unknown HTML-parsed name without a hyphen (`<simplebutton>` from `<SimpleButton>`) | Yes — kept eligible so `pretenders.scan` continues to work |
+
+**How to migrate:**
+
+1. Search your config(s) for `pretenders` entries whose `selector` matches an HTML or SVG element name. Drop them — the original element is now linted on its own merits.
+2. Inline `<HTMLElement as="…">` in templates was already a no-op in v4; that behaviour is preserved.
+3. If you intentionally wanted to silence violations on the standard tag (for example, to keep using `<marquee>` without warnings), use the per-rule `disabled` setting or an `ignore`/`severity` override instead. Pretenders are not the right tool for that.
 
 ## `--config` flag behavior
 

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/configuration/properties.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/configuration/properties.md
@@ -845,6 +845,10 @@ interface Config {
 
 対象コンポーネントにマッチさせるための[**セレクタ**](/docs/guides/selectors)を受け取ります。必須です。
 
+:::caution 標準 HTML 要素は対象外
+セレクタが標準 HTML / SVG 要素にマッチする pretender エントリは暗黙的に無視されます。pretender は custom component（Web Components、JSX/Vue/Svelte 等の authored component、または HTML パースで spec エントリがない不明な名前）のみが対象です。`<button>` や `<marquee>` を指定しても何も起きません（[移行ガイド](/docs/migration/v4-to-v5/config#pretender-が標準-html-要素には適用されなくなった)を参照）。
+:::
+
 #### `as`
 
 **要素名**もしくは**要素のプロパティ**を受け取ります。必須です。

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/beyond-html.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/beyond-html.md
@@ -182,6 +182,10 @@ const Component = ({ list }) => {
 
 **React**や**Vue**などでは、カスタムコンポーネントをHTML要素として評価ができません。つまり、markuplintのコンテンツモデルルール — [`permitted-contents`](/docs/rules/permitted-contents)など — は、コンポーネントが実際に何をレンダリングするか知る手段がありません。この情報がないと、`<button>`要素をレンダリングする`<Button>`コンポーネントは未知の要素として扱われ、`<a><Button /></a>`（インタラクティブコンテンツの中にインタラクティブコンテンツ）のような不正なネストが検出されません。
 
+:::note 適用範囲
+プリテンダーは**カスタムコンポーネントのみ**を対象とします — Web Components、JSX/Vue/Svelte 等の authored component、および HTML パースで spec エントリが存在しない名前です。標準 HTML 要素（`<marquee>`、`<button>` など）を指定しても何も起きません。これにより、元タグに紐づく deprecation・ARIA・ブラウザサポートルールが暗黙に隠されることを防いでいます。
+:::
+
 <!-- prettier-ignore-start -->
 ```jsx
 <List>{/* ネイティブのHTML要素として評価できない */}

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/migration/v4-to-v5/config.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/migration/v4-to-v5/config.md
@@ -9,16 +9,17 @@ v5 ではグローバル設定、名前付きルール、よりシンプルな�
 
 ## 変更一覧
 
-| 変更内容                                    | 影響を受ける人                              |
-| ------------------------------------------- | ------------------------------------------- |
-| 新しい `ruleCommonSettings` プロパティ      | すべての設定ファイル作成者                  |
-| Named nodeRules                             | プリセットのユーザーと作成者                |
-| `specConformance` メタデータ                | プリセット作成者                            |
-| nodeRules/childNodeRules が名前で重複排除   | `extends` で named nodeRules を使う設定     |
-| ルールの配列値が連結から上書きに変更        | `extends` で配列値を使う設定                |
-| ルール options が shallow merge に変更      | `extends` でネストされた options を使う設定 |
-| Pretender の `data` が上書きから追加に変更  | `extends` で pretenders を使う設定          |
-| `--config` フラグが指定ファイルのみ読み込み | `--config` を使う CLI ユーザー              |
+| 変更内容                                         | 影響を受ける人                              |
+| ------------------------------------------------ | ------------------------------------------- |
+| 新しい `ruleCommonSettings` プロパティ           | すべての設定ファイル作成者                  |
+| Named nodeRules                                  | プリセットのユーザーと作成者                |
+| `specConformance` メタデータ                     | プリセット作成者                            |
+| nodeRules/childNodeRules が名前で重複排除        | `extends` で named nodeRules を使う設定     |
+| ルールの配列値が連結から上書きに変更             | `extends` で配列値を使う設定                |
+| ルール options が shallow merge に変更           | `extends` でネストされた options を使う設定 |
+| Pretender の `data` が上書きから追加に変更       | `extends` で pretenders を使う設定          |
+| Pretender が標準 HTML 要素には適用されなくなった | `pretenders` で HTML 要素を指定している設定 |
+| `--config` フラグが指定ファイルのみ読み込み      | `--config` を使う CLI ユーザー              |
 
 ## `ruleCommonSettings`
 
@@ -311,6 +312,37 @@ v5 では `extends` 使用時の `nodeRules` と `childNodeRules` のマージ�
 | `data`     | 上書き    | **追加**  |
 
 **移行方法:** これは一般的に非破壊的な改善です。pretender データを完全に置き換える必要がある場合は、`extends` を使わず単一の設定ですべての pretenders を定義してください。
+
+## Pretender が標準 HTML 要素には適用されなくなった
+
+:::caution 破壊的変更
+`pretenders`（またはインライン `as=` 属性）で標準 HTML 要素を別の要素として振る舞わせていた場合、それらのエントリは無視されるようになりました。
+:::
+
+**理由:** セレクタが認識可能な HTML / SVG 要素にマッチする pretender エントリは、deprecation 警告・ARIA role 制約・ブラウザサポートチェックといった元タグに紐づく仕様ベースのルールを暗黙に隠してしまっていました。pretender はもともと custom component 専用の仕組みとして設計されており、v5 でその制約を実装に反映しました。詳細は [issue #3740](https://github.com/markuplint/markuplint/issues/3740) を参照してください。
+
+**変更前 (v4):** `<marquee as="div">` や `pretenders: [{ selector: 'marquee', as: 'div' }]` で marquee 要素を div として振る舞わせ、deprecation 警告を抑制できていました。
+
+```json
+{
+  "pretenders": [{ "selector": "marquee", "as": "div" }]
+}
+```
+
+**変更後 (v5):** pretender は元の要素が custom component の場合のみ適用されます。具体的には、`@markuplint/html-spec`（またはユーザー指定の spec）に登録された要素**以外**が対象です。
+
+| 元の要素                                                                               | pretender が適用される?               |
+| -------------------------------------------------------------------------------------- | ------------------------------------- |
+| 標準 HTML / SVG タグ（`<button>`, `<marquee>` など）                                   | いいえ                                |
+| Web component / autonomous custom element（`<x-foo>`）                                 | はい                                  |
+| Authored component（JSX/Vue/Svelte の `<MyButton>` など）                              | はい                                  |
+| HTML パーサーがハイフンなしで読み取った未登録名（`<SimpleButton>` → `<simplebutton>`） | はい — `pretenders.scan` のために維持 |
+
+**移行方法:**
+
+1. 設定ファイルを検索し、`pretenders` の `selector` が HTML / SVG 要素名にマッチしているエントリを削除してください。元要素はそのまま検査されます。
+2. テンプレート上のインライン `<HTMLElement as="…">` は v4 でも no-op だったため、挙動は変わりません。
+3. 標準タグの違反を意図的に黙らせていた場合（例: `<marquee>` を警告なしで使い続けたい）、pretender ではなく該当ルールの `disabled` 設定や `severity` / `ignore` で対応してください。
 
 ## `--config` フラグの動作
 


### PR DESCRIPTION
## Summary

- **B**: ml-core's `pretending()` now rejects pretender for standard HTML elements (selector matched in the active spec set). The legacy `elementType === 'html'` guard for inline `as=` is preserved so non-spec HTML-parsed names like `<SimpleButton>` still flow through `pretenders.scan` as before.
- **A**: `deprecated-element` and `no-unsupported-features` no longer early-return on pretendered JSX/Vue/Svelte components, so `<Marquee as="marquee">` and `<Dialog as="dialog">` reach the spec lookup and report the original tag's deprecation / browser-support violation.
- Pretender architecture docs (en/ja) updated to reflect the new step-0 reject and the preserved legacy guard.

## Why this scope (vs. issue body's 21 files)

Investigation against 4 of the rules listed in #3740 — `invalid-attr`, `wai-aria` family (master + 16 sub-rules), `no-use-event-handler-attr`, and `case-sensitive-*` — showed they already work correctly: `invalid-attr` and `wai-aria` rules either route attrs through the pretender's synthetic `as` element or have no `elementType` filter at all; `no-use-event-handler-attr` walks `Attr`, so `attr.ownerElement` resolves to the pretender helper; `case-sensitive-*` are HTML-specific by design. The only real silent bypasses were the two rules with an early-return `el.elementType !== 'html'` filter on `walkOn('Element')`.

The HTML→HTML masking case (`<marquee as="div">`, `<h1 role="button" as="div">`) is fixed by the ml-core change rather than per-rule, since `pretenders` config already documented (`ml-core/docs/ml-dom/pretender.md` line 49) that pretenders target non-HTML elements only.

## Compatibility

**BREAKING CHANGE**: `pretenders` config entries whose selector matches a standard HTML element (one with a spec entry) are now ignored. Existing `<marquee as="div">`-style configurations that suppressed markuplint violations need to remove the entry — the original element will now be linted on its own merits. Public-facing docs already showed only custom-component examples; production tests in this repo did not use HTML→HTML pretenders.

## Test plan

- [x] `yarn build` — all 39 projects pass
- [x] `yarn test` — 3677 passed, 1 skipped, 0 failed
- [x] `yarn lint-check` — oxfmt + oxlint clean (CSpell skipped: known worktree limitation; CI will re-run)
- [x] New regression coverage: `[pretenders ignored when selector matches an HTML element]` and `[pretenders applies to non-spec custom names parsed as HTML]` in ml-core; `[deprecated-element-issue-3740-001…004]`, `[no-unsupported-features-issue-3740-001…004]`, `[wai-aria-permitted-roles-issue-3740-001]` in rules.

Closes #3740.

🤖 Generated with [Claude Code](https://claude.com/claude-code)