### PR TITLE
feat: cover assertions slice in nu-validator bench coverage

### DIFF
--- a/.claude/skills/bench-rule-enable/SKILL.md
+++ b/.claude/skills/bench-rule-enable/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: bench-rule-enable
+metadata:
+  internal: true
+description: >
+  Enable an existing or newly-added markuplint rule on the
+  nu-validator bench by editing tests/external/bench/config.ts. Covers
+  the flat-rule case (rules: { '<name>': true }) and the severity
+  override case (rules: { '<name>': { severity: 'error' } }) that
+  bench-virtual-rule does not. Use when a rule exists in the registry
+  but the relevant nu fixtures stay nu-only because the rule is not
+  enabled in the bench config, or when a rule's default severity is
+  warning but the spec text it mirrors is a MUST / MUST NOT.
+  Trigger keywords: enable bench rule, bench config flat rule,
+  severity override bench, rule not flagging on bench, warning vs
+  error in bench, escalate severity bench, wai-aria-implicit-props
+  bench, bench coverage missing rule.
+---
+
+# Bench Rule Enable Skill
+
+`tests/external/bench/config.ts` curates rules explicitly (no
+`extends: ['markuplint:html-standard']`). A rule that exists in the
+markuplint registry will not affect bench verdicts until it is added
+to that file. This skill covers the two non-virtual-rule patterns:
+
+- **Flat enable**: adding `'<rule-name>': true` for a rule whose
+  default behaviour matches the bench's spec-conformance lens.
+- **Severity override**: adding `'<rule-name>': { severity: 'error' }`
+  for a rule whose default severity is `'warning'` but whose
+  underlying assertion is a MUST / MUST NOT in the spec text.
+
+For preset-defined virtual rules (`nodeRules[]` selectors), use
+`bench-virtual-rule` instead.
+
+## When to add a rule to the bench
+
+The bench is the spec-conformance comparison surface. A rule belongs
+in `bench/config.ts` only when its assertions map onto a
+nu-validator capability. Use this checklist:
+
+1. The rule is registered in `packages/@markuplint/rules/src/index.ts`.
+2. The rule reports diagnostics with severity `'error'` (or you
+   intend to override severity — see the next section).
+3. Either:
+   - nu-validator currently fires on the same markup pattern, OR
+   - the spec the rule cites contains MUST / MUST NOT language and
+     the discrepancy in nu's coverage is documented in
+     `bench-triage`'s audit log.
+
+If both nu and the spec are silent, do **not** enable the rule in
+the bench — it would inflate `ml-only` without producing a
+spec-aligned signal.
+
+## Pattern 1: flat enable
+
+Most new conformance rules ship as flat enable.
+
+```ts
+// tests/external/bench/config.ts
+export const benchmarkConfig: Config = {
+  rules: {
+    // ...existing entries kept alphabetical...
+    'meter-value-bounds': true,
+    // ...
+  },
+  // ...
+};
+```
+
+After editing:
+
+```sh
+yarn build --scope @markuplint/rules
+yarn bench:update --target markuplint --filter '<bench fixture path>'
+```
+
+Expect the targeted fixtures to flip from `nu-only` to
+`match-error`. If a fixture stays `nu-only`, the rule is not
+matching that specific HTML (re-read the rule and the fixture).
+
+## Pattern 2: severity override
+
+A rule whose default `meta.defaultSeverity` is `'warning'` does not
+contribute to bench verdicts (see `compare.ts#judgeMlState` — only
+errors flip ml state). Override for the bench-only run:
+
+```ts
+// tests/external/bench/config.ts
+export const benchmarkConfig: Config = {
+  rules: {
+    // The user-facing default is 'warning' for ergonomic reasons; the
+    // bench treats it as a hard error to align with the spec text the
+    // rule mirrors. Document the spec citation inline so the
+    // override survives audit.
+    'wai-aria-implicit-props': { severity: 'error' },
+  },
+};
+```
+
+Inline comment must include:
+
+- The spec citation that justifies treating the rule as error
+- A reason why the user-facing default stays at `'warning'` (so the
+  next maintainer does not "harmonise" by raising the user-facing
+  default unconditionally)
+
+## Side-effect check
+
+Severity overrides have ripple effects: fixtures that previously
+were `match-clean` (both clean) may flip to `ml-only` (ml strict, nu
+lax). This is **not a regression** when:
+
+- The spec the rule cites is a MUST / MUST NOT, and
+- The fixture's filename includes `-haswarn` (nu fires only a
+  warning, not an error)
+
+Confirm by inspecting `markuplint-only.json` after the bench run:
+```sh
+node -e '
+const j = require("./tests/external/snapshots/diff/markuplint-only.json");
+const newish = j.entries.filter(e => e.ruleIds?.includes("<rule-name>"));
+for (const e of newish) console.log(e.path);
+'
+```
+
+Each affected fixture should be a legitimate "ml strict, nu lax"
+case per the bench-triage SKILL ml-only readings. Anything else is a
+real over-detection — back out the severity override.
+
+## Verification
+
+```sh
+yarn bench:update --target markuplint
+yarn bench:compare
+```
+
+Compare `tests/external/snapshots/diff/summary.md`:
+
+- Per-category match-error count for the rule's domain should rise
+- nu-only count should fall by the same amount (within nu-validator
+  parallel-load flicker)
+- ml-only delta should match the side-effect analysis above
+
+Pin against `--concurrency 1` before filing for a stable verdict.

--- a/packages/@markuplint/config-presets/README.md
+++ b/packages/@markuplint/config-presets/README.md
@@ -65,6 +65,12 @@ Require the `datetime` attribute if the content of the `time` element is invalid
 Specify required attr| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
 [Enforce WHATWG constraints between `srcset`, `sizes`, and `loading` attributes](https://html.spec.whatwg.org/multipage/images.html#srcset-attributes)| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
 [Validate link type keywords](https://html.spec.whatwg.org/multipage/links.html#linkTypes)|Validates that `rel` attribute keywords are allowed on the given element and context (e.g., body-ok for `<link>` inside `<body>`).|✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
+[`<input type="button">` with empty `value`](https://html.spec.whatwg.org/multipage/input.html#button-state-(type=button))|Mirrors nu-validator's hardcoded assertion. HTML LS itself does not state this verbatim; see the rule's README for the precise sourcing.|✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
+[`<input type="file">` value must be empty when specified](https://html.spec.whatwg.org/multipage/input.html#file-upload-state-(type=file))| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
+[`<label>` may contain at most one form-control descendant](https://html.spec.whatwg.org/multipage/forms.html#the-label-element)| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
+[`<map>` `id` must equal `name` when both are specified](https://html.spec.whatwg.org/multipage/image-maps.html#the-map-element)| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
+[`<meter>` attribute inequalities (min ≤ value ≤ max etc.)](https://html.spec.whatwg.org/multipage/form-elements.html#the-meter-element)| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
+[Single `<select>` allows at most one selected `<option>`](https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element)| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
 [Specify `charset=UTF-8`](https://html.spec.whatwg.org/multipage/semantics.html#charset)| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
 [No duplicate meta charset](https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-charset)|There must not be more than one meta element with a charset attribute per document.|✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
 [No duplicate meta description](https://html.spec.whatwg.org/multipage/semantics.html#standard-metadata-names)|There must not be more than one meta element where the name attribute value is an ASCII case-insensitive match for "description" per document.|✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|

--- a/packages/@markuplint/config-presets/src/preset.html-standard.jsonc
+++ b/packages/@markuplint/config-presets/src/preset.html-standard.jsonc
@@ -231,6 +231,81 @@
 					"options": { "allowMicroformats": true }
 				}
 			}
+		},
+
+		/**
+		 * `<input type="button">` with empty `value`
+		 *
+		 * Mirrors nu-validator's hardcoded assertion. HTML LS itself does not
+		 * state this verbatim; see the rule's README for the precise sourcing.
+		 *
+		 * @see https://html.spec.whatwg.org/multipage/input.html#button-state-(type=button)
+		 */
+		"html-standard/input-button-non-empty-value": {
+			"specConformance": "non-normative",
+			"rules": {
+				"input-button-non-empty-value": true
+			}
+		},
+
+		/**
+		 * `<input type="file">` value must be empty when specified
+		 *
+		 * @see https://html.spec.whatwg.org/multipage/input.html#file-upload-state-(type=file)
+		 */
+		"html-standard/input-file-empty-value": {
+			"specConformance": "normative",
+			"rules": {
+				"input-file-empty-value": true
+			}
+		},
+
+		/**
+		 * `<label>` may contain at most one form-control descendant
+		 *
+		 * @see https://html.spec.whatwg.org/multipage/forms.html#the-label-element
+		 */
+		"html-standard/label-no-multiple-controls": {
+			"specConformance": "normative",
+			"rules": {
+				"label-no-multiple-controls": true
+			}
+		},
+
+		/**
+		 * `<map>` `id` must equal `name` when both are specified
+		 *
+		 * @see https://html.spec.whatwg.org/multipage/image-maps.html#the-map-element
+		 */
+		"html-standard/map-id-name-match": {
+			"specConformance": "normative",
+			"rules": {
+				"map-id-name-match": true
+			}
+		},
+
+		/**
+		 * `<meter>` attribute inequalities (min ≤ value ≤ max etc.)
+		 *
+		 * @see https://html.spec.whatwg.org/multipage/form-elements.html#the-meter-element
+		 */
+		"html-standard/meter-value-bounds": {
+			"specConformance": "normative",
+			"rules": {
+				"meter-value-bounds": true
+			}
+		},
+
+		/**
+		 * Single `<select>` allows at most one selected `<option>`
+		 *
+		 * @see https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element
+		 */
+		"html-standard/no-extra-selected-options": {
+			"specConformance": "normative",
+			"rules": {
+				"no-extra-selected-options": true
+			}
 		}
 	},
 	"nodeRules": [

--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -49368,7 +49368,10 @@
 			"attributes": {
 				"dir": {
 					"description": "The direction in which text should be rendered in this element's contents. Possible values are: ltr: Indicates that the text should go in a left-to-right direction. rtl: Indicates that the text should go in a right-to-left direction.",
-					"required": true
+					"required": true,
+					"type": {
+						"enum": ["ltr", "rtl"]
+					}
 				}
 			}
 		},

--- a/packages/@markuplint/html-spec/src/spec.bdo.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.bdo.jsonc
@@ -16,9 +16,12 @@
 	},
 	"attributes": {
 		// https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-bdo-element
-		// "The dir global content attribute is required on this element."
+		// "The dir global content attribute is required on this element. The attribute's value must not be the keyword auto."
 		"dir": {
-			"required": true
+			"required": true,
+			"type": {
+				"enum": ["ltr", "rtl"]
+			}
 		}
 	},
 	"aria": {

--- a/packages/@markuplint/rules/schema.json
+++ b/packages/@markuplint/rules/schema.json
@@ -69,6 +69,9 @@
 				"link-types": {
 					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/link-types/schema.json"
 				},
+				"map-id-name-match": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/map-id-name-match/schema.json"
+				},
 				"meter-value-bounds": {
 					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/meter-value-bounds/schema.json"
 				},

--- a/packages/@markuplint/rules/schema.json
+++ b/packages/@markuplint/rules/schema.json
@@ -69,6 +69,9 @@
 				"link-types": {
 					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/link-types/schema.json"
 				},
+				"meter-value-bounds": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/meter-value-bounds/schema.json"
+				},
 				"neighbor-popovers": {
 					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/neighbor-popovers/schema.json"
 				},

--- a/packages/@markuplint/rules/schema.json
+++ b/packages/@markuplint/rules/schema.json
@@ -99,6 +99,9 @@
 				"no-empty-palpable-content": {
 					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/no-empty-palpable-content/schema.json"
 				},
+				"no-extra-selected-options": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/no-extra-selected-options/schema.json"
+				},
 				"no-hard-code-id": {
 					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/no-hard-code-id/schema.json"
 				},

--- a/packages/@markuplint/rules/schema.json
+++ b/packages/@markuplint/rules/schema.json
@@ -63,6 +63,9 @@
 				"label-has-control": {
 					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/label-has-control/schema.json"
 				},
+				"label-no-multiple-controls": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/label-no-multiple-controls/schema.json"
+				},
 				"landmark-roles": {
 					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/landmark-roles/schema.json"
 				},

--- a/packages/@markuplint/rules/schema.json
+++ b/packages/@markuplint/rules/schema.json
@@ -57,6 +57,9 @@
 				"ineffective-attr": {
 					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/ineffective-attr/schema.json"
 				},
+				"input-button-non-empty-value": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/input-button-non-empty-value/schema.json"
+				},
 				"input-file-empty-value": {
 					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/input-file-empty-value/schema.json"
 				},

--- a/packages/@markuplint/rules/schema.json
+++ b/packages/@markuplint/rules/schema.json
@@ -57,6 +57,9 @@
 				"ineffective-attr": {
 					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/ineffective-attr/schema.json"
 				},
+				"input-file-empty-value": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/input-file-empty-value/schema.json"
+				},
 				"invalid-attr": {
 					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/invalid-attr/schema.json"
 				},

--- a/packages/@markuplint/rules/src/index.ts
+++ b/packages/@markuplint/rules/src/index.ts
@@ -28,6 +28,7 @@ import IdDuplication from './id-duplication/index.js';
 import IneffectiveAttr from './ineffective-attr/index.js';
 import InvalidAttr from './invalid-attr/index.js';
 import LabelHasControl from './label-has-control/index.js';
+import LabelNoMultipleControls from './label-no-multiple-controls/index.js';
 import LandmarkRoles from './landmark-roles/index.js';
 import LinkTypes from './link-types/index.js';
 import MapIdNameMatch from './map-id-name-match/index.js';
@@ -101,6 +102,7 @@ const rules = {
 	'ineffective-attr': IneffectiveAttr,
 	'invalid-attr': InvalidAttr,
 	'label-has-control': LabelHasControl,
+	'label-no-multiple-controls': LabelNoMultipleControls,
 	'landmark-roles': LandmarkRoles,
 	'link-types': LinkTypes,
 	'map-id-name-match': MapIdNameMatch,

--- a/packages/@markuplint/rules/src/index.ts
+++ b/packages/@markuplint/rules/src/index.ts
@@ -26,6 +26,7 @@ import HeadElementOrder from './head-element-order/index.js';
 import HeadingLevels from './heading-levels/index.js';
 import IdDuplication from './id-duplication/index.js';
 import IneffectiveAttr from './ineffective-attr/index.js';
+import InputButtonNonEmptyValue from './input-button-non-empty-value/index.js';
 import InputFileEmptyValue from './input-file-empty-value/index.js';
 import InvalidAttr from './invalid-attr/index.js';
 import LabelHasControl from './label-has-control/index.js';
@@ -101,6 +102,7 @@ const rules = {
 	'heading-levels': HeadingLevels,
 	'id-duplication': IdDuplication,
 	'ineffective-attr': IneffectiveAttr,
+	'input-button-non-empty-value': InputButtonNonEmptyValue,
 	'input-file-empty-value': InputFileEmptyValue,
 	'invalid-attr': InvalidAttr,
 	'label-has-control': LabelHasControl,

--- a/packages/@markuplint/rules/src/index.ts
+++ b/packages/@markuplint/rules/src/index.ts
@@ -30,6 +30,7 @@ import InvalidAttr from './invalid-attr/index.js';
 import LabelHasControl from './label-has-control/index.js';
 import LandmarkRoles from './landmark-roles/index.js';
 import LinkTypes from './link-types/index.js';
+import MeterValueBounds from './meter-value-bounds/index.js';
 import NeighborPopovers from './neighbor-popovers/index.js';
 import NoAmbiguousNavigableTargetNames from './no-ambiguous-navigable-target-names/index.js';
 import NoBooleanAttrValue from './no-boolean-attr-value/index.js';
@@ -100,6 +101,7 @@ const rules = {
 	'label-has-control': LabelHasControl,
 	'landmark-roles': LandmarkRoles,
 	'link-types': LinkTypes,
+	'meter-value-bounds': MeterValueBounds,
 	'neighbor-popovers': NeighborPopovers,
 	'no-ambiguous-navigable-target-names': NoAmbiguousNavigableTargetNames,
 	'no-boolean-attr-value': NoBooleanAttrValue,

--- a/packages/@markuplint/rules/src/index.ts
+++ b/packages/@markuplint/rules/src/index.ts
@@ -30,6 +30,7 @@ import InvalidAttr from './invalid-attr/index.js';
 import LabelHasControl from './label-has-control/index.js';
 import LandmarkRoles from './landmark-roles/index.js';
 import LinkTypes from './link-types/index.js';
+import MapIdNameMatch from './map-id-name-match/index.js';
 import MeterValueBounds from './meter-value-bounds/index.js';
 import NeighborPopovers from './neighbor-popovers/index.js';
 import NoAmbiguousNavigableTargetNames from './no-ambiguous-navigable-target-names/index.js';
@@ -102,6 +103,7 @@ const rules = {
 	'label-has-control': LabelHasControl,
 	'landmark-roles': LandmarkRoles,
 	'link-types': LinkTypes,
+	'map-id-name-match': MapIdNameMatch,
 	'meter-value-bounds': MeterValueBounds,
 	'neighbor-popovers': NeighborPopovers,
 	'no-ambiguous-navigable-target-names': NoAmbiguousNavigableTargetNames,

--- a/packages/@markuplint/rules/src/index.ts
+++ b/packages/@markuplint/rules/src/index.ts
@@ -40,6 +40,7 @@ import NoDuplicateAutofocus from './no-duplicate-autofocus/index.js';
 import NoDuplicateDt from './no-duplicate-dt/index.js';
 import NoDuplicateVisibleMain from './no-duplicate-visible-main/index.js';
 import NoEmptyPalpableContent from './no-empty-palpable-content/index.js';
+import NoExtraSelectedOptions from './no-extra-selected-options/index.js';
 import NoHardCodeId from './no-hard-code-id/index.js';
 import NoOrphanedEndTag from './no-orphaned-end-tag/index.js';
 import NoReferToNonExistentId from './no-refer-to-non-existent-id/index.js';
@@ -111,6 +112,7 @@ const rules = {
 	'no-duplicate-dt': NoDuplicateDt,
 	'no-duplicate-visible-main': NoDuplicateVisibleMain,
 	'no-empty-palpable-content': NoEmptyPalpableContent,
+	'no-extra-selected-options': NoExtraSelectedOptions,
 	'no-hard-code-id': NoHardCodeId,
 	'no-orphaned-end-tag': NoOrphanedEndTag,
 	'no-refer-to-non-existent-id': NoReferToNonExistentId,

--- a/packages/@markuplint/rules/src/index.ts
+++ b/packages/@markuplint/rules/src/index.ts
@@ -26,6 +26,7 @@ import HeadElementOrder from './head-element-order/index.js';
 import HeadingLevels from './heading-levels/index.js';
 import IdDuplication from './id-duplication/index.js';
 import IneffectiveAttr from './ineffective-attr/index.js';
+import InputFileEmptyValue from './input-file-empty-value/index.js';
 import InvalidAttr from './invalid-attr/index.js';
 import LabelHasControl from './label-has-control/index.js';
 import LabelNoMultipleControls from './label-no-multiple-controls/index.js';
@@ -100,6 +101,7 @@ const rules = {
 	'heading-levels': HeadingLevels,
 	'id-duplication': IdDuplication,
 	'ineffective-attr': IneffectiveAttr,
+	'input-file-empty-value': InputFileEmptyValue,
 	'invalid-attr': InvalidAttr,
 	'label-has-control': LabelHasControl,
 	'label-no-multiple-controls': LabelNoMultipleControls,

--- a/packages/@markuplint/rules/src/input-button-non-empty-value/README.ja.md
+++ b/packages/@markuplint/rules/src/input-button-non-empty-value/README.ja.md
@@ -1,0 +1,20 @@
+---
+id: input-button-non-empty-value
+description: `<input type="button">` に value 属性を指定する場合、空文字列にしてはならないことを強制します。
+---
+
+# `input-button-non-empty-value`
+
+[HTML Living Standard §4.10.5.1.21 (Button state)](<https://html.spec.whatwg.org/multipage/input.html#button-state-(type=button)>) では、`value` 属性をボタンのラベルとして利用すると規定されています。属性自体は省略可能（UA が既定ラベルを提供）ですが、明示的に `value=""` と空文字列を指定するのは避けるべきです。本ルールはこの「指定はされたが空文字列」のケースのみをエラーとし、属性が無いケースは対象外とします。
+
+❌ このルールに適合しない**誤った**コードの例
+
+```html
+<input type="button" value="" />
+```
+
+✅ このルールに適合する**正しい**コードの例
+
+```html
+<input type="button" value="OK" /> <input type="button" />
+```

--- a/packages/@markuplint/rules/src/input-button-non-empty-value/README.ja.md
+++ b/packages/@markuplint/rules/src/input-button-non-empty-value/README.ja.md
@@ -5,7 +5,7 @@ description: `<input type="button">` に value 属性を指定する場合、空
 
 # `input-button-non-empty-value`
 
-[HTML Living Standard §4.10.5.1.21 (Button state)](<https://html.spec.whatwg.org/multipage/input.html#button-state-(type=button)>) では、`value` 属性をボタンのラベルとして利用すると規定されています。属性自体は省略可能（UA が既定ラベルを提供）ですが、明示的に `value=""` と空文字列を指定するのは避けるべきです。本ルールはこの「指定はされたが空文字列」のケースのみをエラーとし、属性が無いケースは対象外とします。
+`<input type="button">` に `value=""` を書くことを禁じます。HTML Living Standard の [Button state §4.10.5.1.21](<https://html.spec.whatwg.org/multipage/input.html#button-state-(type=button)>) は「UA が value 属性をボタンのラベルとして表示する／省略時は UA 既定ラベルを使う」とだけ規定しており、明示的な「空文字列にしてはならない」という文言は仕様書には存在しません。「空文字列を許容しない」というアサートは [nu-validator の schematron-equiv assertions](https://github.com/validator/validator/blob/main/src/nu/validator/checker/schematronequiv/Assertions.java) にハードコードされたもので（`must have non-empty attribute "value"` を検索）、nu はこれをエラーとして報告します。本ルールはこの conformance シグナルを踏襲しつつ保守的に振る舞います — `value=""` のように明示的に空文字列が指定されたケースのみ検査し、value 自体を省略したケースは仕様通り問題なしとして扱います。
 
 ❌ このルールに適合しない**誤った**コードの例
 

--- a/packages/@markuplint/rules/src/input-button-non-empty-value/README.md
+++ b/packages/@markuplint/rules/src/input-button-non-empty-value/README.md
@@ -1,0 +1,20 @@
+---
+id: input-button-non-empty-value
+description: Forbid an empty value attribute on <input type="button"> elements; if specified the value must be non-empty.
+---
+
+# `input-button-non-empty-value`
+
+Per [HTML Living Standard §4.10.5.1.21 (Button state)](<https://html.spec.whatwg.org/multipage/input.html#button-state-(type=button)>) the user agent uses the `value` attribute as the button label. The attribute may be omitted (the UA provides a default label), but a _specified_ `value` must not be the empty string. This rule reports the explicit empty-string case and leaves missing-value handling alone.
+
+❌ Examples of **incorrect** code for this rule
+
+```html
+<input type="button" value="" />
+```
+
+✅ Examples of **correct** code for this rule
+
+```html
+<input type="button" value="OK" /> <input type="button" />
+```

--- a/packages/@markuplint/rules/src/input-button-non-empty-value/README.md
+++ b/packages/@markuplint/rules/src/input-button-non-empty-value/README.md
@@ -5,7 +5,7 @@ description: Forbid an empty value attribute on <input type="button"> elements; 
 
 # `input-button-non-empty-value`
 
-Per [HTML Living Standard §4.10.5.1.21 (Button state)](<https://html.spec.whatwg.org/multipage/input.html#button-state-(type=button)>) the user agent uses the `value` attribute as the button label. The attribute may be omitted (the UA provides a default label), but a _specified_ `value` must not be the empty string. This rule reports the explicit empty-string case and leaves missing-value handling alone.
+Forbid `<input type="button">` from carrying `value=""`. The HTML Living Standard does not state this constraint verbatim — the [Button state section §4.10.5.1.21](<https://html.spec.whatwg.org/multipage/input.html#button-state-(type=button)>) only describes that the UA renders the `value` attribute as the button label and supplies a default when the attribute is missing. The "must not be the empty string" assertion is hard-coded by [nu-validator's schematron-equiv assertions](https://github.com/validator/validator/blob/main/src/nu/validator/checker/schematronequiv/Assertions.java) (search for `must have non-empty attribute "value"`). nu reports this as an error; this rule mirrors that conformance signal but takes the conservative stance — it fires only on the explicit `value=""` case and leaves missing-value handling alone (the spec text permits omission).
 
 ❌ Examples of **incorrect** code for this rule
 

--- a/packages/@markuplint/rules/src/input-button-non-empty-value/index.spec.ts
+++ b/packages/@markuplint/rules/src/input-button-non-empty-value/index.spec.ts
@@ -20,13 +20,19 @@ test('[input-button-non-empty-value-valid-003] non-button type with empty value'
 
 test('[input-button-non-empty-value-invalid-001] empty value on type=button', async () => {
 	const { violations } = await mlRuleTest(rule, '<input type="button" value="">');
-	expect(violations.length).toBe(1);
-	expect(violations[0]?.message).toBe(
-		'The "value" attribute on a "input" element with "type=button" must not be the empty string',
-	);
+	expect(violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 29,
+			message: 'The "value" attribute on a "input" element with "type=button" must not be the empty string',
+			raw: '',
+		},
+	]);
 });
 
 test('[input-button-non-empty-value-invalid-002] case-insensitive type matching', async () => {
 	const { violations } = await mlRuleTest(rule, '<input type="BUTTON" value="">');
 	expect(violations.length).toBe(1);
+	expect(violations[0]?.raw).toBe('');
 });

--- a/packages/@markuplint/rules/src/input-button-non-empty-value/index.spec.ts
+++ b/packages/@markuplint/rules/src/input-button-non-empty-value/index.spec.ts
@@ -1,0 +1,32 @@
+import { mlRuleTest } from 'markuplint';
+import { test, expect } from 'vitest';
+
+import rule from './index.js';
+
+test('[input-button-non-empty-value-valid-001] non-empty value', async () => {
+	const { violations } = await mlRuleTest(rule, '<input type="button" value="OK">');
+	expect(violations.length).toBe(0);
+});
+
+test('[input-button-non-empty-value-valid-002] missing value attribute is acceptable', async () => {
+	const { violations } = await mlRuleTest(rule, '<input type="button">');
+	expect(violations.length).toBe(0);
+});
+
+test('[input-button-non-empty-value-valid-003] non-button type with empty value', async () => {
+	const { violations } = await mlRuleTest(rule, '<input type="text" value="">');
+	expect(violations.length).toBe(0);
+});
+
+test('[input-button-non-empty-value-invalid-001] empty value on type=button', async () => {
+	const { violations } = await mlRuleTest(rule, '<input type="button" value="">');
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe(
+		'The "value" attribute on a "input" element with "type=button" must not be the empty string',
+	);
+});
+
+test('[input-button-non-empty-value-invalid-002] case-insensitive type matching', async () => {
+	const { violations } = await mlRuleTest(rule, '<input type="BUTTON" value="">');
+	expect(violations.length).toBe(1);
+});

--- a/packages/@markuplint/rules/src/input-button-non-empty-value/index.ts
+++ b/packages/@markuplint/rules/src/input-button-non-empty-value/index.ts
@@ -3,13 +3,17 @@ import { createRule } from '@markuplint/ml-core';
 import meta from './meta.js';
 
 /**
- * `<input type="button">` may omit the `value` attribute (the user
- * agent supplies a default label) but, when specified, the attribute
- * must not be the empty string. This mirrors nu-validator's assertion
- * for the Button state and is the conservative reading of HTML LS
- * (omission allowed; empty-string-when-specified flagged).
+ * Mirror nu-validator's hardcoded assertion that `<input type="button">`
+ * must not carry `value=""`. HTML LS itself describes only that the user
+ * agent renders the value as the button label (and supplies a default
+ * when the attribute is missing); the explicit "non-empty" requirement
+ * is from nu-validator's `Assertions.java` (the same schematron-equiv
+ * file that drives the Button-state diagnostic). This rule fires only
+ * on the explicit empty-string case so spec-permitted omission is
+ * preserved.
  *
  * @see https://html.spec.whatwg.org/multipage/input.html#button-state-(type=button)
+ * @see https://github.com/validator/validator/blob/main/src/nu/validator/checker/schematronequiv/Assertions.java (search "must have non-empty attribute")
  */
 export default createRule<boolean, null>({
 	meta: meta,
@@ -18,6 +22,8 @@ export default createRule<boolean, null>({
 	async verify({ document, report, t }) {
 		await document.walkOn('Element', el => {
 			if (el.localName !== 'input') return;
+			// Pretender inputs with no `as` pin: attributes are unknown until typed.
+			if (el.pretenderContext?.type === 'pretender' && !el.hasAttribute('as')) return;
 
 			const typeAttr = el.getAttributeNode('type');
 			const valueAttr = el.getAttributeNode('value');

--- a/packages/@markuplint/rules/src/input-button-non-empty-value/index.ts
+++ b/packages/@markuplint/rules/src/input-button-non-empty-value/index.ts
@@ -1,0 +1,45 @@
+import { createRule } from '@markuplint/ml-core';
+
+import meta from './meta.js';
+
+/**
+ * `<input type="button">` may omit the `value` attribute (the user
+ * agent supplies a default label) but, when specified, the attribute
+ * must not be the empty string. This mirrors nu-validator's assertion
+ * for the Button state and is the conservative reading of HTML LS
+ * (omission allowed; empty-string-when-specified flagged).
+ *
+ * @see https://html.spec.whatwg.org/multipage/input.html#button-state-(type=button)
+ */
+export default createRule<boolean, null>({
+	meta: meta,
+	defaultValue: true,
+	defaultOptions: null,
+	async verify({ document, report, t }) {
+		await document.walkOn('Element', el => {
+			if (el.localName !== 'input') return;
+
+			const typeAttr = el.getAttributeNode('type');
+			const valueAttr = el.getAttributeNode('value');
+
+			if (!typeAttr || !valueAttr) return;
+			if (typeAttr.isDynamicValue || valueAttr.isDynamicValue) return;
+			if (typeAttr.value.toLowerCase() !== 'button') return;
+			if (valueAttr.value !== '') return;
+
+			report({
+				scope: valueAttr,
+				line: valueAttr.valueNode?.startLine,
+				col: valueAttr.valueNode?.startCol,
+				raw: valueAttr.valueNode?.raw,
+				message: t(
+					'The "{0}" attribute on a "{1}" element with "{2}={3}" must not be the empty string',
+					'value',
+					'input',
+					'type',
+					'button',
+				),
+			});
+		});
+	},
+});

--- a/packages/@markuplint/rules/src/input-button-non-empty-value/meta.ts
+++ b/packages/@markuplint/rules/src/input-button-non-empty-value/meta.ts
@@ -1,0 +1,3 @@
+export default {
+	category: 'validation',
+} as const;

--- a/packages/@markuplint/rules/src/input-button-non-empty-value/schema.json
+++ b/packages/@markuplint/rules/src/input-button-non-empty-value/schema.json
@@ -1,0 +1,29 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"value": {
+			"type": "boolean",
+			"description": "Forbid an empty value attribute on <input type=\"button\"> elements; if specified the value must be non-empty.",
+			"description:ja": "`<input type=\"button\">` に value 属性を指定する場合、空文字列にしてはならないことを強制します。"
+		}
+	},
+	"oneOf": [
+		{
+			"$ref": "#/definitions/value"
+		},
+		{
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"value": { "$ref": "#/definitions/value" },
+				"severity": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/ml-config/schema.json#/definitions/severity",
+					"default": "error"
+				},
+				"reason": {
+					"type": "string"
+				}
+			}
+		}
+	]
+}

--- a/packages/@markuplint/rules/src/input-file-empty-value/README.ja.md
+++ b/packages/@markuplint/rules/src/input-file-empty-value/README.ja.md
@@ -1,0 +1,22 @@
+---
+id: input-file-empty-value
+description: HTML LS §4.10.5.1.18 に従い、`<input type="file">` の value 属性は省略または空文字列のみ許容します。
+---
+
+# `input-file-empty-value`
+
+[HTML Living Standard §4.10.5.1.18 (File Upload state)](<https://html.spec.whatwg.org/multipage/input.html#file-upload-state-(type=file)>) によれば、`<input type="file">` には空文字列以外の `value` 属性を指定できません。
+
+> The `value` attribute, if specified, must have a value that is the empty string.
+
+❌ このルールに適合しない**誤った**コードの例
+
+```html
+<input type="file" value="document.pdf" />
+```
+
+✅ このルールに適合する**正しい**コードの例
+
+```html
+<input type="file" /> <input type="file" value="" />
+```

--- a/packages/@markuplint/rules/src/input-file-empty-value/README.md
+++ b/packages/@markuplint/rules/src/input-file-empty-value/README.md
@@ -1,0 +1,22 @@
+---
+id: input-file-empty-value
+description: Require <input type="file"> elements to omit the value attribute or set it to the empty string, per HTML LS §4.10.5.1.18.
+---
+
+# `input-file-empty-value`
+
+Per [HTML Living Standard §4.10.5.1.18 (File Upload state)](<https://html.spec.whatwg.org/multipage/input.html#file-upload-state-(type=file)>), `<input type="file">` may not carry a non-empty `value` attribute. The spec text reads:
+
+> The `value` attribute, if specified, must have a value that is the empty string.
+
+❌ Examples of **incorrect** code for this rule
+
+```html
+<input type="file" value="document.pdf" />
+```
+
+✅ Examples of **correct** code for this rule
+
+```html
+<input type="file" /> <input type="file" value="" />
+```

--- a/packages/@markuplint/rules/src/input-file-empty-value/index.spec.ts
+++ b/packages/@markuplint/rules/src/input-file-empty-value/index.spec.ts
@@ -20,14 +20,19 @@ test('[input-file-empty-value-valid-003] non-file type with value', async () => 
 
 test('[input-file-empty-value-invalid-001] non-empty value on type=file', async () => {
 	const { violations } = await mlRuleTest(rule, '<input type="file" value="document.pdf">');
-	expect(violations.length).toBe(1);
-	expect(violations[0]?.message).toBe(
-		'The "value" attribute on a "input" element with "type=file" must be the empty string',
-	);
-	expect(violations[0]?.raw).toBe('document.pdf');
+	expect(violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 27,
+			message: 'The "value" attribute on a "input" element with "type=file" must be the empty string',
+			raw: 'document.pdf',
+		},
+	]);
 });
 
 test('[input-file-empty-value-invalid-002] case-insensitive type matching', async () => {
 	const { violations } = await mlRuleTest(rule, '<input type="FILE" value="x">');
 	expect(violations.length).toBe(1);
+	expect(violations[0]?.raw).toBe('x');
 });

--- a/packages/@markuplint/rules/src/input-file-empty-value/index.spec.ts
+++ b/packages/@markuplint/rules/src/input-file-empty-value/index.spec.ts
@@ -1,0 +1,33 @@
+import { mlRuleTest } from 'markuplint';
+import { test, expect } from 'vitest';
+
+import rule from './index.js';
+
+test('[input-file-empty-value-valid-001] no value attribute', async () => {
+	const { violations } = await mlRuleTest(rule, '<input type="file">');
+	expect(violations.length).toBe(0);
+});
+
+test('[input-file-empty-value-valid-002] empty value attribute', async () => {
+	const { violations } = await mlRuleTest(rule, '<input type="file" value="">');
+	expect(violations.length).toBe(0);
+});
+
+test('[input-file-empty-value-valid-003] non-file type with value', async () => {
+	const { violations } = await mlRuleTest(rule, '<input type="text" value="anything">');
+	expect(violations.length).toBe(0);
+});
+
+test('[input-file-empty-value-invalid-001] non-empty value on type=file', async () => {
+	const { violations } = await mlRuleTest(rule, '<input type="file" value="document.pdf">');
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe(
+		'The "value" attribute on a "input" element with "type=file" must be the empty string',
+	);
+	expect(violations[0]?.raw).toBe('document.pdf');
+});
+
+test('[input-file-empty-value-invalid-002] case-insensitive type matching', async () => {
+	const { violations } = await mlRuleTest(rule, '<input type="FILE" value="x">');
+	expect(violations.length).toBe(1);
+});

--- a/packages/@markuplint/rules/src/input-file-empty-value/index.ts
+++ b/packages/@markuplint/rules/src/input-file-empty-value/index.ts
@@ -1,0 +1,44 @@
+import { createRule } from '@markuplint/ml-core';
+
+import meta from './meta.js';
+
+/**
+ * `<input type="file">` may carry the `value` attribute only when its
+ * value is the empty string. Per HTML LS §4.10.5.1.18 (File Upload
+ * state): "The value attribute, if specified, must have a value that
+ * is the empty string."
+ *
+ * @see https://html.spec.whatwg.org/multipage/input.html#file-upload-state-(type=file)
+ */
+export default createRule<boolean, null>({
+	meta: meta,
+	defaultValue: true,
+	defaultOptions: null,
+	async verify({ document, report, t }) {
+		await document.walkOn('Element', el => {
+			if (el.localName !== 'input') return;
+
+			const typeAttr = el.getAttributeNode('type');
+			const valueAttr = el.getAttributeNode('value');
+
+			if (!typeAttr || !valueAttr) return;
+			if (typeAttr.isDynamicValue || valueAttr.isDynamicValue) return;
+			if (typeAttr.value.toLowerCase() !== 'file') return;
+			if (valueAttr.value === '') return;
+
+			report({
+				scope: valueAttr,
+				line: valueAttr.valueNode?.startLine,
+				col: valueAttr.valueNode?.startCol,
+				raw: valueAttr.valueNode?.raw,
+				message: t(
+					'The "{0}" attribute on a "{1}" element with "{2}={3}" must be the empty string',
+					'value',
+					'input',
+					'type',
+					'file',
+				),
+			});
+		});
+	},
+});

--- a/packages/@markuplint/rules/src/input-file-empty-value/index.ts
+++ b/packages/@markuplint/rules/src/input-file-empty-value/index.ts
@@ -17,6 +17,8 @@ export default createRule<boolean, null>({
 	async verify({ document, report, t }) {
 		await document.walkOn('Element', el => {
 			if (el.localName !== 'input') return;
+			// Pretender inputs with no `as` pin: attributes are unknown until typed.
+			if (el.pretenderContext?.type === 'pretender' && !el.hasAttribute('as')) return;
 
 			const typeAttr = el.getAttributeNode('type');
 			const valueAttr = el.getAttributeNode('value');

--- a/packages/@markuplint/rules/src/input-file-empty-value/meta.ts
+++ b/packages/@markuplint/rules/src/input-file-empty-value/meta.ts
@@ -1,0 +1,3 @@
+export default {
+	category: 'validation',
+} as const;

--- a/packages/@markuplint/rules/src/input-file-empty-value/schema.json
+++ b/packages/@markuplint/rules/src/input-file-empty-value/schema.json
@@ -1,0 +1,29 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"value": {
+			"type": "boolean",
+			"description": "Require <input type=\"file\"> elements to omit the value attribute or set it to the empty string, per HTML LS §4.10.5.1.18.",
+			"description:ja": "HTML LS §4.10.5.1.18 に従い、`<input type=\"file\">` の value 属性は省略または空文字列のみ許容します。"
+		}
+	},
+	"oneOf": [
+		{
+			"$ref": "#/definitions/value"
+		},
+		{
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"value": { "$ref": "#/definitions/value" },
+				"severity": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/ml-config/schema.json#/definitions/severity",
+					"default": "error"
+				},
+				"reason": {
+					"type": "string"
+				}
+			}
+		}
+	]
+}

--- a/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
@@ -2719,3 +2719,27 @@ describe('#3733 Microdata cross-attribute constraints', () => {
 		expect(violations[0]?.raw).toBe('not-absolute');
 	});
 });
+
+describe('bdo[dir] enum override (HTML LS §4.5.5)', () => {
+	// HTML LS forbids `dir="auto"` on `<bdo>`:
+	// "The dir global content attribute is required on this element. The attribute's value must not be the keyword auto."
+	// https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-bdo-element
+
+	test('[invalid-attr-invalid-030] bdo dir="auto" is forbidden', async () => {
+		const { violations } = await mlRuleTest(rule, '<bdo dir="auto">x</bdo>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 11,
+				message: 'The "dir" attribute expects either "ltr", "rtl"',
+				raw: 'auto',
+			},
+		]);
+	});
+
+	test('[invalid-attr-valid-022] bdo dir="ltr" and dir="rtl" are accepted', async () => {
+		expect((await mlRuleTest(rule, '<bdo dir="ltr">x</bdo>')).violations.length).toBe(0);
+		expect((await mlRuleTest(rule, '<bdo dir="rtl">x</bdo>')).violations.length).toBe(0);
+	});
+});

--- a/packages/@markuplint/rules/src/label-no-multiple-controls/README.ja.md
+++ b/packages/@markuplint/rules/src/label-no-multiple-controls/README.ja.md
@@ -1,0 +1,23 @@
+---
+id: label-no-multiple-controls
+description: HTML LS §4.10.4 が定める「label要素の配下にフォームコントロール子孫は最大1個」というルールを強制します。
+---
+
+# `label-no-multiple-controls`
+
+[HTML Living Standard §4.10.4 (the label element)](https://html.spec.whatwg.org/multipage/forms.html#the-label-element) によれば、`<label>` 要素はそのリスト（`button`, `input`, `meter`, `output`, `progress`, `select`, `textarea`）のうち最大1個までしか子孫として持てません。
+
+本ルールはこの conformance を error として強制します。a11y 寄りのソフトな相棒ルール [`label-has-control`](../label-has-control/) と組み合わせて運用してください。
+
+❌ このルールに適合しない**誤った**コードの例
+
+```html
+<label>Name: <input type="text" name="first" /> <input type="text" name="last" /></label>
+```
+
+✅ このルールに適合する**正しい**コードの例
+
+```html
+<label>Name: <input type="text" name="full" /></label> <label for="meter1">Score:</label>
+<meter id="meter1" value="3" max="10">3</meter>
+```

--- a/packages/@markuplint/rules/src/label-no-multiple-controls/README.md
+++ b/packages/@markuplint/rules/src/label-no-multiple-controls/README.md
@@ -1,0 +1,23 @@
+---
+id: label-no-multiple-controls
+description: Disallow more than one form-control descendant of a label element per HTML LS §4.10.4.
+---
+
+# `label-no-multiple-controls`
+
+Per [HTML Living Standard §4.10.4 (the label element)](https://html.spec.whatwg.org/multipage/forms.html#the-label-element), a `<label>` element may contain at most one descendant form control from this list: `button`, `input`, `meter`, `output`, `progress`, `select`, `textarea`.
+
+This rule enforces the conformance assertion. The complementary [`label-has-control`](../label-has-control/) rule covers the broader a11y heuristic (every label associates with its first control).
+
+❌ Examples of **incorrect** code for this rule
+
+```html
+<label>Name: <input type="text" name="first" /> <input type="text" name="last" /></label>
+```
+
+✅ Examples of **correct** code for this rule
+
+```html
+<label>Name: <input type="text" name="full" /></label> <label for="meter1">Score:</label>
+<meter id="meter1" value="3" max="10">3</meter>
+```

--- a/packages/@markuplint/rules/src/label-no-multiple-controls/index.spec.ts
+++ b/packages/@markuplint/rules/src/label-no-multiple-controls/index.spec.ts
@@ -1,0 +1,46 @@
+import { mlRuleTest } from 'markuplint';
+import { test, expect } from 'vitest';
+
+import rule from './index.js';
+
+test('[label-no-multiple-controls-valid-001] empty label', async () => {
+	const { violations } = await mlRuleTest(rule, '<label>Name</label>');
+	expect(violations.length).toBe(0);
+});
+
+test('[label-no-multiple-controls-valid-002] one input', async () => {
+	const { violations } = await mlRuleTest(rule, '<label>Name <input type="text"></label>');
+	expect(violations.length).toBe(0);
+});
+
+test('[label-no-multiple-controls-valid-003] meter alone', async () => {
+	const { violations } = await mlRuleTest(rule, '<label>Score <meter value="3" max="10">3</meter></label>');
+	expect(violations.length).toBe(0);
+});
+
+test('[label-no-multiple-controls-invalid-001] two inputs', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		'<label>Name: <input type="text" name="first"> <input type="text" name="last"></label>',
+	);
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe(
+		'The "label" element may contain at most one form-control descendant (button, input, meter, output, progress, select, or textarea)',
+	);
+});
+
+test('[label-no-multiple-controls-invalid-002] mixed control types', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		'<label>Score <progress value="50" max="100">50</progress> <input type="number"></label>',
+	);
+	expect(violations.length).toBe(1);
+});
+
+test('[label-no-multiple-controls-invalid-003] three controls reports two excess', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		'<label><input> <select><option>x</option></select> <textarea></textarea></label>',
+	);
+	expect(violations.length).toBe(2);
+});

--- a/packages/@markuplint/rules/src/label-no-multiple-controls/index.spec.ts
+++ b/packages/@markuplint/rules/src/label-no-multiple-controls/index.spec.ts
@@ -23,10 +23,16 @@ test('[label-no-multiple-controls-invalid-001] two inputs', async () => {
 		rule,
 		'<label>Name: <input type="text" name="first"> <input type="text" name="last"></label>',
 	);
-	expect(violations.length).toBe(1);
-	expect(violations[0]?.message).toBe(
-		'The "label" element may contain at most one form-control descendant (button, input, meter, output, progress, select, or textarea)',
-	);
+	expect(violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 47,
+			message:
+				'The "label" element may contain at most one form-control descendant (button, input, meter, output, progress, select, or textarea)',
+			raw: '<input type="text" name="last">',
+		},
+	]);
 });
 
 test('[label-no-multiple-controls-invalid-002] mixed control types', async () => {
@@ -35,6 +41,10 @@ test('[label-no-multiple-controls-invalid-002] mixed control types', async () =>
 		'<label>Score <progress value="50" max="100">50</progress> <input type="number"></label>',
 	);
 	expect(violations.length).toBe(1);
+	expect(violations[0]?.line).toBe(1);
+	// `<input type="number">` follows the closing </progress>; pin position so a future
+	// scope/serialisation change is caught here rather than only on the bench.
+	expect(violations[0]?.col).toBe(59);
 });
 
 test('[label-no-multiple-controls-invalid-003] three controls reports two excess', async () => {
@@ -43,4 +53,5 @@ test('[label-no-multiple-controls-invalid-003] three controls reports two excess
 		'<label><input> <select><option>x</option></select> <textarea></textarea></label>',
 	);
 	expect(violations.length).toBe(2);
+	expect(violations.map(v => v.col)).toStrictEqual([16, 52]);
 });

--- a/packages/@markuplint/rules/src/label-no-multiple-controls/index.ts
+++ b/packages/@markuplint/rules/src/label-no-multiple-controls/index.ts
@@ -1,0 +1,45 @@
+import { createRule } from '@markuplint/ml-core';
+
+import meta from './meta.js';
+
+/**
+ * The HTML LS list of form-control descendants that may appear under a
+ * `<label>` element. Per the spec only one of these may exist per label.
+ *
+ * @see https://html.spec.whatwg.org/multipage/forms.html#the-label-element
+ */
+const FORM_CONTROL_SELECTOR = ['button', 'input', 'meter', 'output', 'progress', 'select', 'textarea'].join(',');
+
+/**
+ * Disallow more than one form-control descendant under a `<label>`.
+ * Per HTML LS §4.10.4: "The label element may contain at most one
+ * descendant button element, input element, meter element, output
+ * element, progress element, select element, or textarea element."
+ */
+export default createRule<boolean, null>({
+	meta: meta,
+	defaultValue: true,
+	defaultOptions: null,
+	async verify({ document, report, t }) {
+		await document.walkOn('Element', el => {
+			if (el.localName !== 'label') return;
+
+			// Pretender labels have unknown descendants until the `as` attribute pins the type.
+			if (el.pretenderContext?.type === 'pretender' && !el.hasAttribute('as')) return;
+
+			const controls = [...el.querySelectorAll(FORM_CONTROL_SELECTOR)];
+			if (controls.length <= 1) return;
+
+			for (const control of controls.slice(1)) {
+				report({
+					scope: control,
+					message: t(
+						'The "{0}" element may contain at most one form-control descendant ({1})',
+						'label',
+						'button, input, meter, output, progress, select, or textarea',
+					),
+				});
+			}
+		});
+	},
+});

--- a/packages/@markuplint/rules/src/label-no-multiple-controls/meta.ts
+++ b/packages/@markuplint/rules/src/label-no-multiple-controls/meta.ts
@@ -1,0 +1,3 @@
+export default {
+	category: 'validation',
+} as const;

--- a/packages/@markuplint/rules/src/label-no-multiple-controls/schema.json
+++ b/packages/@markuplint/rules/src/label-no-multiple-controls/schema.json
@@ -1,0 +1,29 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"value": {
+			"type": "boolean",
+			"description": "Disallow more than one form-control descendant of a label element per HTML LS §4.10.4.",
+			"description:ja": "HTML LS §4.10.4 が定める「label要素の配下にフォームコントロール子孫は最大1個」というルールを強制します。"
+		}
+	},
+	"oneOf": [
+		{
+			"$ref": "#/definitions/value"
+		},
+		{
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"value": { "$ref": "#/definitions/value" },
+				"severity": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/ml-config/schema.json#/definitions/severity",
+					"default": "error"
+				},
+				"reason": {
+					"type": "string"
+				}
+			}
+		}
+	]
+}

--- a/packages/@markuplint/rules/src/map-id-name-match/README.ja.md
+++ b/packages/@markuplint/rules/src/map-id-name-match/README.ja.md
@@ -7,6 +7,8 @@ description: map要素にidとnameの両方が指定されているとき、両�
 
 [HTML Living Standard §4.8.13 (the map element)](https://html.spec.whatwg.org/multipage/image-maps.html#the-map-element) によれば、`<map>` 要素に `id` 属性と `name` 属性の両方が指定されている場合、それらの値は同じでなければなりません。
 
+比較は **大文字小文字を区別** します。仕様の "same value" を strict string equality として解釈するため、`<map id="Foo" name="foo">` も検知されます。なお `<map>` の `name` 属性自体は `<img usemap>` とのマッチングでは case-insensitive ですが、これは本ルールとは別の仕様です。
+
 ❌ このルールに適合しない**誤った**コードの例
 
 ```html

--- a/packages/@markuplint/rules/src/map-id-name-match/README.ja.md
+++ b/packages/@markuplint/rules/src/map-id-name-match/README.ja.md
@@ -1,0 +1,20 @@
+---
+id: map-id-name-match
+description: map要素にidとnameの両方が指定されているとき、両者の値が一致することを要求します。
+---
+
+# `map-id-name-match`
+
+[HTML Living Standard §4.8.13 (the map element)](https://html.spec.whatwg.org/multipage/image-maps.html#the-map-element) によれば、`<map>` 要素に `id` 属性と `name` 属性の両方が指定されている場合、それらの値は同じでなければなりません。
+
+❌ このルールに適合しない**誤った**コードの例
+
+```html
+<map id="foo" name="bar"><area href="a.html" alt="A" /></map>
+```
+
+✅ このルールに適合する**正しい**コードの例
+
+```html
+<map id="foo" name="foo"><area href="a.html" alt="A" /></map> <map name="foo"><area href="a.html" alt="A" /></map>
+```

--- a/packages/@markuplint/rules/src/map-id-name-match/README.md
+++ b/packages/@markuplint/rules/src/map-id-name-match/README.md
@@ -1,0 +1,20 @@
+---
+id: map-id-name-match
+description: Require that, when both attributes are present on a map element, the id attribute has the same value as the name attribute.
+---
+
+# `map-id-name-match`
+
+Per [HTML Living Standard §4.8.13 (the map element)](https://html.spec.whatwg.org/multipage/image-maps.html#the-map-element), when a `<map>` element has both an `id` and a `name` attribute, the two attributes must have the same value.
+
+❌ Examples of **incorrect** code for this rule
+
+```html
+<map id="foo" name="bar"><area href="a.html" alt="A" /></map>
+```
+
+✅ Examples of **correct** code for this rule
+
+```html
+<map id="foo" name="foo"><area href="a.html" alt="A" /></map> <map name="foo"><area href="a.html" alt="A" /></map>
+```

--- a/packages/@markuplint/rules/src/map-id-name-match/README.md
+++ b/packages/@markuplint/rules/src/map-id-name-match/README.md
@@ -7,6 +7,8 @@ description: Require that, when both attributes are present on a map element, th
 
 Per [HTML Living Standard §4.8.13 (the map element)](https://html.spec.whatwg.org/multipage/image-maps.html#the-map-element), when a `<map>` element has both an `id` and a `name` attribute, the two attributes must have the same value.
 
+The comparison is **case-sensitive**. The spec text "same value" is taken as strict string equality; `<map id="Foo" name="foo">` is therefore reported. Note that the map's `name` attribute itself is matched case-insensitively against `<img usemap>` per the parsing rules, but that is a separate concern from this conformance assertion.
+
 ❌ Examples of **incorrect** code for this rule
 
 ```html

--- a/packages/@markuplint/rules/src/map-id-name-match/index.spec.ts
+++ b/packages/@markuplint/rules/src/map-id-name-match/index.spec.ts
@@ -20,9 +20,22 @@ test('[map-id-name-match-valid-003] id and name match', async () => {
 
 test('[map-id-name-match-invalid-001] id and name mismatch', async () => {
 	const { violations } = await mlRuleTest(rule, '<map id="foo" name="bar"><area href="a.html" alt="A"></map>');
+	expect(violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 10,
+			message: 'The "id" attribute on a "map" element must have the same value as the "name" attribute',
+			raw: 'foo',
+		},
+	]);
+});
+
+test('[map-id-name-match-invalid-002] case-sensitive comparison', async () => {
+	// HTML LS `<map>` requires the id and name attributes to be string-equal; the comparison
+	// is case-sensitive even though the name attribute itself is matched case-insensitively
+	// against `<img usemap>`. Pinning here so a future relaxation surfaces explicitly.
+	const { violations } = await mlRuleTest(rule, '<map id="Foo" name="foo"><area href="a.html" alt="A"></map>');
 	expect(violations.length).toBe(1);
-	expect(violations[0]?.message).toBe(
-		'The "id" attribute on a "map" element must have the same value as the "name" attribute',
-	);
-	expect(violations[0]?.raw).toBe('foo');
+	expect(violations[0]?.raw).toBe('Foo');
 });

--- a/packages/@markuplint/rules/src/map-id-name-match/index.spec.ts
+++ b/packages/@markuplint/rules/src/map-id-name-match/index.spec.ts
@@ -1,0 +1,28 @@
+import { mlRuleTest } from 'markuplint';
+import { test, expect } from 'vitest';
+
+import rule from './index.js';
+
+test('[map-id-name-match-valid-001] map without id', async () => {
+	const { violations } = await mlRuleTest(rule, '<map name="foo"><area href="a.html" alt="A"></map>');
+	expect(violations.length).toBe(0);
+});
+
+test('[map-id-name-match-valid-002] map without name', async () => {
+	const { violations } = await mlRuleTest(rule, '<map id="foo"><area href="a.html" alt="A"></map>');
+	expect(violations.length).toBe(0);
+});
+
+test('[map-id-name-match-valid-003] id and name match', async () => {
+	const { violations } = await mlRuleTest(rule, '<map id="foo" name="foo"><area href="a.html" alt="A"></map>');
+	expect(violations.length).toBe(0);
+});
+
+test('[map-id-name-match-invalid-001] id and name mismatch', async () => {
+	const { violations } = await mlRuleTest(rule, '<map id="foo" name="bar"><area href="a.html" alt="A"></map>');
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe(
+		'The "id" attribute on a "map" element must have the same value as the "name" attribute',
+	);
+	expect(violations[0]?.raw).toBe('foo');
+});

--- a/packages/@markuplint/rules/src/map-id-name-match/index.ts
+++ b/packages/@markuplint/rules/src/map-id-name-match/index.ts
@@ -17,6 +17,8 @@ export default createRule<boolean, null>({
 	async verify({ document, report, t }) {
 		await document.walkOn('Element', el => {
 			if (el.localName !== 'map') return;
+			// Pretender maps with no `as` pin: attributes are unknown until typed.
+			if (el.pretenderContext?.type === 'pretender' && !el.hasAttribute('as')) return;
 
 			const idAttr = el.getAttributeNode('id');
 			const nameAttr = el.getAttributeNode('name');

--- a/packages/@markuplint/rules/src/map-id-name-match/index.ts
+++ b/packages/@markuplint/rules/src/map-id-name-match/index.ts
@@ -1,0 +1,43 @@
+import { createRule } from '@markuplint/ml-core';
+
+import meta from './meta.js';
+
+/**
+ * Require that a `<map>` element's `id` attribute, when present, has
+ * the same value as its `name` attribute. Per HTML LS §4.8.13:
+ * "If the id attribute is also specified, both attributes must have
+ * the same value."
+ *
+ * @see https://html.spec.whatwg.org/multipage/image-maps.html#the-map-element
+ */
+export default createRule<boolean, null>({
+	meta: meta,
+	defaultValue: true,
+	defaultOptions: null,
+	async verify({ document, report, t }) {
+		await document.walkOn('Element', el => {
+			if (el.localName !== 'map') return;
+
+			const idAttr = el.getAttributeNode('id');
+			const nameAttr = el.getAttributeNode('name');
+
+			if (!idAttr || !nameAttr) return;
+			if (idAttr.isDynamicValue || nameAttr.isDynamicValue) return;
+
+			if (idAttr.value === nameAttr.value) return;
+
+			report({
+				scope: idAttr,
+				line: idAttr.valueNode?.startLine,
+				col: idAttr.valueNode?.startCol,
+				raw: idAttr.valueNode?.raw,
+				message: t(
+					'The "{0}" attribute on a "{1}" element must have the same value as the "{2}" attribute',
+					'id',
+					'map',
+					'name',
+				),
+			});
+		});
+	},
+});

--- a/packages/@markuplint/rules/src/map-id-name-match/meta.ts
+++ b/packages/@markuplint/rules/src/map-id-name-match/meta.ts
@@ -1,0 +1,3 @@
+export default {
+	category: 'validation',
+} as const;

--- a/packages/@markuplint/rules/src/map-id-name-match/schema.json
+++ b/packages/@markuplint/rules/src/map-id-name-match/schema.json
@@ -1,0 +1,29 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"value": {
+			"type": "boolean",
+			"description": "Require that, when both attributes are present on a map element, the id attribute has the same value as the name attribute.",
+			"description:ja": "map要素にidとnameの両方が指定されているとき、両者の値が一致することを要求します。"
+		}
+	},
+	"oneOf": [
+		{
+			"$ref": "#/definitions/value"
+		},
+		{
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"value": { "$ref": "#/definitions/value" },
+				"severity": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/ml-config/schema.json#/definitions/severity",
+					"default": "error"
+				},
+				"reason": {
+					"type": "string"
+				}
+			}
+		}
+	]
+}

--- a/packages/@markuplint/rules/src/meter-value-bounds/README.ja.md
+++ b/packages/@markuplint/rules/src/meter-value-bounds/README.ja.md
@@ -1,0 +1,30 @@
+---
+id: meter-value-bounds
+description: meter要素の属性 (min, max, value, low, high, optimum) 間の HTML LS 仕様で定められた不等式関係を検証します。
+---
+
+# `meter-value-bounds`
+
+[HTML Living Standard §4.10.14 (the meter element)](https://html.spec.whatwg.org/multipage/form-elements.html#the-meter-element) が定める不等式を検証します。
+
+- `min ≤ value ≤ max`
+- `min ≤ low ≤ max`（`low` 指定時）
+- `min ≤ high ≤ max`（`high` 指定時）
+- `min ≤ optimum ≤ max`（`optimum` 指定時）
+- `low ≤ high`（両方が指定されたとき）
+
+`min` 省略時は `0`、`max` 省略時は `1`、`value` 省略時は `min` を既定値として用います。属性値そのものがパースできない場合は [`invalid-attr`](../invalid-attr/) ルールが扱うため、本ルールは検査をスキップします。
+
+❌ このルールに適合しない**誤った**コードの例
+
+```html
+<meter value="10" max="5">10 out of 5</meter>
+<meter value="5" min="3" optimum="1">5</meter>
+<meter value="5" low="8" high="3">5</meter>
+```
+
+✅ このルールに適合する**正しい**コードの例
+
+```html
+<meter value="0.5">half</meter> <meter value="5" min="0" max="10" low="3" high="7" optimum="6">5</meter>
+```

--- a/packages/@markuplint/rules/src/meter-value-bounds/README.md
+++ b/packages/@markuplint/rules/src/meter-value-bounds/README.md
@@ -13,7 +13,7 @@ Enforce the inequalities required by [HTML Living Standard §4.10.14 (the meter 
 - `min ≤ optimum ≤ max` (when `optimum` is specified)
 - `low ≤ high` (when both are specified)
 
-When `min` is omitted it defaults to `0`; when `max` is omitted it defaults to `1`; when `value` is omitted it defaults to `min`. Authored-but-unparseable attribute values are deferred to [`invalid-attr`](../invalid-attr/) and skipped here to avoid compounding diagnostics.
+When `min` is omitted it defaults to `0`; when `max` is omitted it defaults to `1`; when `value` is omitted it defaults to `min`. Authored-but-unparsable attribute values are deferred to [`invalid-attr`](../invalid-attr/) and skipped here to avoid compounding diagnostics.
 
 ❌ Examples of **incorrect** code for this rule
 

--- a/packages/@markuplint/rules/src/meter-value-bounds/README.md
+++ b/packages/@markuplint/rules/src/meter-value-bounds/README.md
@@ -1,0 +1,30 @@
+---
+id: meter-value-bounds
+description: Enforce HTML LS inequalities between meter element attributes (min, max, value, low, high, optimum).
+---
+
+# `meter-value-bounds`
+
+Enforce the inequalities required by [HTML Living Standard §4.10.14 (the meter element)](https://html.spec.whatwg.org/multipage/form-elements.html#the-meter-element):
+
+- `min ≤ value ≤ max`
+- `min ≤ low ≤ max` (when `low` is specified)
+- `min ≤ high ≤ max` (when `high` is specified)
+- `min ≤ optimum ≤ max` (when `optimum` is specified)
+- `low ≤ high` (when both are specified)
+
+When `min` is omitted it defaults to `0`; when `max` is omitted it defaults to `1`; when `value` is omitted it defaults to `min`. Authored-but-unparseable attribute values are deferred to [`invalid-attr`](../invalid-attr/) and skipped here to avoid compounding diagnostics.
+
+❌ Examples of **incorrect** code for this rule
+
+```html
+<meter value="10" max="5">10 out of 5</meter>
+<meter value="5" min="3" optimum="1">5</meter>
+<meter value="5" low="8" high="3">5</meter>
+```
+
+✅ Examples of **correct** code for this rule
+
+```html
+<meter value="0.5">half</meter> <meter value="5" min="0" max="10" low="3" high="7" optimum="6">5</meter>
+```

--- a/packages/@markuplint/rules/src/meter-value-bounds/index.spec.ts
+++ b/packages/@markuplint/rules/src/meter-value-bounds/index.spec.ts
@@ -128,7 +128,7 @@ test('[meter-value-bounds-valid-005] dynamic value attributes are skipped', asyn
 	expect(violations.length).toBe(0);
 });
 
-test('[meter-value-bounds-valid-006] unparseable specified value is left to invalid-attr', async () => {
+test('[meter-value-bounds-valid-006] unparsable specified value is left to invalid-attr', async () => {
 	const { violations } = await mlRuleTest(rule, '<meter value="abc" max="10">abc</meter>');
 	expect(violations.length).toBe(0);
 });

--- a/packages/@markuplint/rules/src/meter-value-bounds/index.spec.ts
+++ b/packages/@markuplint/rules/src/meter-value-bounds/index.spec.ts
@@ -1,0 +1,134 @@
+import { mlRuleTest } from 'markuplint';
+import { test, expect } from 'vitest';
+
+import rule from './index.js';
+
+test('[meter-value-bounds-valid-001] meter without any attributes', async () => {
+	const { violations } = await mlRuleTest(rule, '<meter>5</meter>');
+	expect(violations.length).toBe(0);
+});
+
+test('[meter-value-bounds-valid-002] meter with value within default bounds', async () => {
+	const { violations } = await mlRuleTest(rule, '<meter value="0.5">half</meter>');
+	expect(violations.length).toBe(0);
+});
+
+test('[meter-value-bounds-valid-003] meter with all attributes consistent', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		'<meter value="5" min="0" max="10" low="3" high="7" optimum="6">5</meter>',
+	);
+	expect(violations.length).toBe(0);
+});
+
+test('[meter-value-bounds-valid-004] meter with negative range', async () => {
+	const { violations } = await mlRuleTest(rule, '<meter value="-5" min="-10" max="0">-5</meter>');
+	expect(violations.length).toBe(0);
+});
+
+test('[meter-value-bounds-invalid-001] value exceeds max', async () => {
+	const { violations } = await mlRuleTest(rule, '<meter value="10" max="5">10 out of 5</meter>');
+	expect(violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 15,
+			message:
+				'The value of the "value" attribute must be less than or equal to the value of the "max" attribute',
+			raw: '10',
+		},
+	]);
+});
+
+test('[meter-value-bounds-invalid-002] value exceeds default max (1)', async () => {
+	const { violations } = await mlRuleTest(rule, '<meter value="2">2</meter>');
+	expect(violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 15,
+			message:
+				'The value of the "value" attribute must be less than or equal to one when the "max" attribute is absent',
+			raw: '2',
+		},
+	]);
+});
+
+test('[meter-value-bounds-invalid-003] value below min', async () => {
+	const { violations } = await mlRuleTest(rule, '<meter value="0" min="5">0 out of 10</meter>');
+	expect(violations.some(v => /min.+less than or equal to one when the "max"/.test(v.message))).toBe(true);
+	expect(violations.some(v => /min.+less than or equal to the value of the "value"/.test(v.message))).toBe(true);
+});
+
+test('[meter-value-bounds-invalid-004] min exceeds max', async () => {
+	const { violations } = await mlRuleTest(rule, '<meter value="5" min="10" max="5">5</meter>');
+	expect(violations.some(v => /min.+less than or equal to the value of the "max"/.test(v.message))).toBe(true);
+	expect(violations.some(v => /min.+less than or equal to the value of the "value"/.test(v.message))).toBe(true);
+});
+
+test('[meter-value-bounds-invalid-005] high exceeds max', async () => {
+	const { violations } = await mlRuleTest(rule, '<meter value="5" max="10" high="15">5</meter>');
+	expect(violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 33,
+			message: 'The value of the "high" attribute must be less than or equal to the value of the "max" attribute',
+			raw: '15',
+		},
+	]);
+});
+
+test('[meter-value-bounds-invalid-006] low exceeds high (both specified, max default)', async () => {
+	const { violations } = await mlRuleTest(rule, '<meter value="5" low="8" high="3">5</meter>');
+	const messages = violations.map(v => v.message);
+	expect(messages).toContain(
+		'The value of the "value" attribute must be less than or equal to one when the "max" attribute is absent',
+	);
+	expect(messages).toContain(
+		'The value of the "low" attribute must be less than or equal to one when the "max" attribute is absent',
+	);
+	expect(messages).toContain(
+		'The value of the "high" attribute must be less than or equal to one when the "max" attribute is absent',
+	);
+	expect(messages).toContain(
+		'The value of the "low" attribute must be less than or equal to the value of the "high" attribute',
+	);
+});
+
+test('[meter-value-bounds-invalid-007] optimum exceeds max', async () => {
+	const { violations } = await mlRuleTest(rule, '<meter value="5" max="10" optimum="15">5</meter>');
+	expect(violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 36,
+			message:
+				'The value of the "optimum" attribute must be less than or equal to the value of the "max" attribute',
+			raw: '15',
+		},
+	]);
+});
+
+test('[meter-value-bounds-invalid-008] optimum below min', async () => {
+	const { violations } = await mlRuleTest(rule, '<meter value="5" min="3" optimum="1">5</meter>');
+	const messages = violations.map(v => v.message);
+	expect(messages).toContain(
+		'The value of the "min" attribute must be less than or equal to one when the "max" attribute is absent',
+	);
+	expect(messages).toContain(
+		'The value of the "value" attribute must be less than or equal to one when the "max" attribute is absent',
+	);
+});
+
+test('[meter-value-bounds-valid-005] dynamic value attributes are skipped', async () => {
+	// Templating frameworks pass through to invalid-attr / parser layers; the bounds rule
+	// has nothing to assert without a concrete numeric value.
+	const { violations } = await mlRuleTest(rule, '<meter value="{{ score }}" max="10">{{ score }}</meter>');
+	expect(violations.length).toBe(0);
+});
+
+test('[meter-value-bounds-valid-006] unparseable specified value is left to invalid-attr', async () => {
+	const { violations } = await mlRuleTest(rule, '<meter value="abc" max="10">abc</meter>');
+	expect(violations.length).toBe(0);
+});

--- a/packages/@markuplint/rules/src/meter-value-bounds/index.ts
+++ b/packages/@markuplint/rules/src/meter-value-bounds/index.ts
@@ -28,6 +28,8 @@ export default createRule<boolean, null>({
 	async verify({ document, report, t }) {
 		await document.walkOn('Element', el => {
 			if (el.localName !== 'meter') return;
+			// Pretender meters with no `as` pin: descendants/attributes are unknown until typed.
+			if (el.pretenderContext?.type === 'pretender' && !el.hasAttribute('as')) return;
 
 			const valueAttr = el.getAttributeNode('value');
 			const minAttr = el.getAttributeNode('min');

--- a/packages/@markuplint/rules/src/meter-value-bounds/index.ts
+++ b/packages/@markuplint/rules/src/meter-value-bounds/index.ts
@@ -56,7 +56,7 @@ export default createRule<boolean, null>({
 			const highNum = parseFloatAttr(highAttr?.value);
 			const optimumNum = parseFloatAttr(optimumAttr?.value);
 
-			// Authored-but-unparseable values are reported by `invalid-attr`; skip the bounds
+			// Authored-but-unparsable values are reported by `invalid-attr`; skip the bounds
 			// check entirely so we don't compound the diagnostic noise.
 			if (
 				(valueAttr && valueNum === null) ||

--- a/packages/@markuplint/rules/src/meter-value-bounds/index.ts
+++ b/packages/@markuplint/rules/src/meter-value-bounds/index.ts
@@ -1,0 +1,150 @@
+import { createRule } from '@markuplint/ml-core';
+
+import meta from './meta.js';
+
+const DEFAULT_MIN = 0;
+const DEFAULT_MAX = 1;
+
+function parseFloatAttr(raw: string | undefined): number | null {
+	if (raw === undefined) return null;
+	const trimmed = raw.trim();
+	if (trimmed === '') return null;
+	const n = Number(trimmed);
+	return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Enforce HTML LS §4.10.14 inequalities for `<meter>`:
+ * minimum ≤ value ≤ maximum, plus minimum ≤ low/high/optimum ≤ maximum
+ * and low ≤ high when both are specified. Defaults: min=0, max=1,
+ * value=min.
+ *
+ * @see https://html.spec.whatwg.org/multipage/form-elements.html#the-meter-element
+ */
+export default createRule<boolean, null>({
+	meta: meta,
+	defaultValue: true,
+	defaultOptions: null,
+	async verify({ document, report, t }) {
+		await document.walkOn('Element', el => {
+			if (el.localName !== 'meter') return;
+
+			const valueAttr = el.getAttributeNode('value');
+			const minAttr = el.getAttributeNode('min');
+			const maxAttr = el.getAttributeNode('max');
+			const lowAttr = el.getAttributeNode('low');
+			const highAttr = el.getAttributeNode('high');
+			const optimumAttr = el.getAttributeNode('optimum');
+
+			if (
+				valueAttr?.isDynamicValue ||
+				minAttr?.isDynamicValue ||
+				maxAttr?.isDynamicValue ||
+				lowAttr?.isDynamicValue ||
+				highAttr?.isDynamicValue ||
+				optimumAttr?.isDynamicValue
+			) {
+				return;
+			}
+
+			const valueNum = parseFloatAttr(valueAttr?.value);
+			const minNum = parseFloatAttr(minAttr?.value);
+			const maxNum = parseFloatAttr(maxAttr?.value);
+			const lowNum = parseFloatAttr(lowAttr?.value);
+			const highNum = parseFloatAttr(highAttr?.value);
+			const optimumNum = parseFloatAttr(optimumAttr?.value);
+
+			// Authored-but-unparseable values are reported by `invalid-attr`; skip the bounds
+			// check entirely so we don't compound the diagnostic noise.
+			if (
+				(valueAttr && valueNum === null) ||
+				(minAttr && minNum === null) ||
+				(maxAttr && maxNum === null) ||
+				(lowAttr && lowNum === null) ||
+				(highAttr && highNum === null) ||
+				(optimumAttr && optimumNum === null)
+			) {
+				return;
+			}
+
+			const minValue = minNum ?? DEFAULT_MIN;
+			const maxValue = maxNum ?? DEFAULT_MAX;
+			const valueValue = valueNum ?? minValue;
+
+			type ReportableAttr = ReturnType<typeof el.getAttributeNode>;
+			const reportLE = (
+				lowerName: string,
+				lowerAttr: ReportableAttr,
+				upperName: string,
+				upperAttr: ReportableAttr,
+				upperDefault: number,
+			) => {
+				const upperDesc = upperAttr
+					? t('the value of the "{0}" attribute', upperName)
+					: t(
+							'{0} when the "{1}" attribute is absent',
+							upperDefault === 1 ? 'one' : String(upperDefault),
+							upperName,
+						);
+				const message = t(
+					'The value of the "{0}" attribute must be less than or equal to {1}',
+					lowerName,
+					upperDesc,
+				);
+				const scope = lowerAttr ?? upperAttr;
+				if (scope) {
+					report({
+						scope: scope,
+						line: scope.valueNode?.startLine,
+						col: scope.valueNode?.startCol,
+						raw: scope.valueNode?.raw,
+						message: message,
+					});
+				} else {
+					report({ scope: el, message: message });
+				}
+			};
+
+			if (minValue > maxValue) {
+				reportLE('min', minAttr, 'max', maxAttr, DEFAULT_MAX);
+			}
+			if (minValue > valueValue) {
+				reportLE('min', minAttr, 'value', valueAttr, DEFAULT_MIN);
+			}
+			if (valueValue > maxValue) {
+				reportLE('value', valueAttr, 'max', maxAttr, DEFAULT_MAX);
+			}
+
+			if (lowAttr && lowNum !== null) {
+				if (minValue > lowNum) {
+					reportLE('min', minAttr, 'low', lowAttr, DEFAULT_MIN);
+				}
+				if (lowNum > maxValue) {
+					reportLE('low', lowAttr, 'max', maxAttr, DEFAULT_MAX);
+				}
+			}
+
+			if (highAttr && highNum !== null) {
+				if (minValue > highNum) {
+					reportLE('min', minAttr, 'high', highAttr, DEFAULT_MIN);
+				}
+				if (highNum > maxValue) {
+					reportLE('high', highAttr, 'max', maxAttr, DEFAULT_MAX);
+				}
+			}
+
+			if (optimumAttr && optimumNum !== null) {
+				if (minValue > optimumNum) {
+					reportLE('min', minAttr, 'optimum', optimumAttr, DEFAULT_MIN);
+				}
+				if (optimumNum > maxValue) {
+					reportLE('optimum', optimumAttr, 'max', maxAttr, DEFAULT_MAX);
+				}
+			}
+
+			if (lowAttr && highAttr && lowNum !== null && highNum !== null && lowNum > highNum) {
+				reportLE('low', lowAttr, 'high', highAttr, 0);
+			}
+		});
+	},
+});

--- a/packages/@markuplint/rules/src/meter-value-bounds/meta.ts
+++ b/packages/@markuplint/rules/src/meter-value-bounds/meta.ts
@@ -1,0 +1,3 @@
+export default {
+	category: 'validation',
+} as const;

--- a/packages/@markuplint/rules/src/meter-value-bounds/schema.json
+++ b/packages/@markuplint/rules/src/meter-value-bounds/schema.json
@@ -1,0 +1,29 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"value": {
+			"type": "boolean",
+			"description": "Enforce HTML LS inequalities between meter element attributes (min, max, value, low, high, optimum).",
+			"description:ja": "meter要素の属性 (min, max, value, low, high, optimum) 間の HTML LS 仕様で定められた不等式関係を検証します。"
+		}
+	},
+	"oneOf": [
+		{
+			"$ref": "#/definitions/value"
+		},
+		{
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"value": { "$ref": "#/definitions/value" },
+				"severity": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/ml-config/schema.json#/definitions/severity",
+					"default": "error"
+				},
+				"reason": {
+					"type": "string"
+				}
+			}
+		}
+	]
+}

--- a/packages/@markuplint/rules/src/no-extra-selected-options/README.ja.md
+++ b/packages/@markuplint/rules/src/no-extra-selected-options/README.ja.md
@@ -1,0 +1,32 @@
+---
+id: no-extra-selected-options
+description: multiple属性を持たないselect要素の配下に、selected属性付きoption要素が複数ある状態を禁じます。
+---
+
+# `no-extra-selected-options`
+
+[HTML Living Standard §4.10.7 (the select element)](https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element) では、`multiple` 属性を持たない `<select>` の "list of options" のうち `selected` 属性が付いている `<option>` は最大1個までと定められています。
+
+ここでの "list of options" は、`<select>` の直接の `<option>` 子要素と、`<optgroup>` 子要素配下の `<option>` 要素のことです。
+
+❌ このルールに適合しない**誤った**コードの例
+
+```html
+<select>
+  <option selected>One</option>
+  <option selected>Two</option>
+</select>
+```
+
+✅ このルールに適合する**正しい**コードの例
+
+```html
+<select>
+  <option selected>One</option>
+  <option>Two</option>
+</select>
+<select multiple>
+  <option selected>One</option>
+  <option selected>Two</option>
+</select>
+```

--- a/packages/@markuplint/rules/src/no-extra-selected-options/README.md
+++ b/packages/@markuplint/rules/src/no-extra-selected-options/README.md
@@ -1,0 +1,32 @@
+---
+id: no-extra-selected-options
+description: Disallow multiple selected option elements in a select that lacks the multiple attribute.
+---
+
+# `no-extra-selected-options`
+
+Per [HTML Living Standard §4.10.7 (the select element)](https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element), a `<select>` element without the `multiple` attribute may have at most one option in its list of options whose `selected` attribute is set.
+
+The "list of options" covers direct `<option>` children of `<select>` and `<option>` children of any `<optgroup>` children.
+
+❌ Examples of **incorrect** code for this rule
+
+```html
+<select>
+  <option selected>One</option>
+  <option selected>Two</option>
+</select>
+```
+
+✅ Examples of **correct** code for this rule
+
+```html
+<select>
+  <option selected>One</option>
+  <option>Two</option>
+</select>
+<select multiple>
+  <option selected>One</option>
+  <option selected>Two</option>
+</select>
+```

--- a/packages/@markuplint/rules/src/no-extra-selected-options/index.spec.ts
+++ b/packages/@markuplint/rules/src/no-extra-selected-options/index.spec.ts
@@ -34,10 +34,16 @@ test('[no-extra-selected-options-invalid-001] two selected options without multi
 		rule,
 		'<select><option selected>a</option><option selected>b</option></select>',
 	);
-	expect(violations.length).toBe(1);
-	expect(violations[0]?.message).toBe(
-		'The "select" element cannot have more than one selected "option" descendant unless the "multiple" attribute is specified',
-	);
+	expect(violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 36,
+			message:
+				'The "select" element cannot have more than one selected "option" descendant unless the "multiple" attribute is specified',
+			raw: '<option selected>',
+		},
+	]);
 });
 
 test('[no-extra-selected-options-invalid-002] selected spans select and optgroup descendants', async () => {
@@ -46,6 +52,8 @@ test('[no-extra-selected-options-invalid-002] selected spans select and optgroup
 		'<select><option selected>a</option><optgroup label="g"><option selected>b</option></optgroup></select>',
 	);
 	expect(violations.length).toBe(1);
+	expect(violations[0]?.line).toBe(1);
+	expect(violations[0]?.col).toBe(56);
 });
 
 test('[no-extra-selected-options-invalid-003] three selected reports two excess', async () => {
@@ -54,4 +62,5 @@ test('[no-extra-selected-options-invalid-003] three selected reports two excess'
 		'<select><option selected>a</option><option selected>b</option><option selected>c</option></select>',
 	);
 	expect(violations.length).toBe(2);
+	expect(violations.map(v => v.col)).toStrictEqual([36, 63]);
 });

--- a/packages/@markuplint/rules/src/no-extra-selected-options/index.spec.ts
+++ b/packages/@markuplint/rules/src/no-extra-selected-options/index.spec.ts
@@ -1,0 +1,57 @@
+import { mlRuleTest } from 'markuplint';
+import { test, expect } from 'vitest';
+
+import rule from './index.js';
+
+test('[no-extra-selected-options-valid-001] zero selected options', async () => {
+	const { violations } = await mlRuleTest(rule, '<select><option>a</option><option>b</option></select>');
+	expect(violations.length).toBe(0);
+});
+
+test('[no-extra-selected-options-valid-002] exactly one selected option', async () => {
+	const { violations } = await mlRuleTest(rule, '<select><option selected>a</option><option>b</option></select>');
+	expect(violations.length).toBe(0);
+});
+
+test('[no-extra-selected-options-valid-003] multiple selected with multiple attribute', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		'<select multiple><option selected>a</option><option selected>b</option></select>',
+	);
+	expect(violations.length).toBe(0);
+});
+
+test('[no-extra-selected-options-valid-004] selected options inside optgroup respected', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		'<select><optgroup label="g"><option selected>a</option><option>b</option></optgroup></select>',
+	);
+	expect(violations.length).toBe(0);
+});
+
+test('[no-extra-selected-options-invalid-001] two selected options without multiple', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		'<select><option selected>a</option><option selected>b</option></select>',
+	);
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe(
+		'The "select" element cannot have more than one selected "option" descendant unless the "multiple" attribute is specified',
+	);
+});
+
+test('[no-extra-selected-options-invalid-002] selected spans select and optgroup descendants', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		'<select><option selected>a</option><optgroup label="g"><option selected>b</option></optgroup></select>',
+	);
+	expect(violations.length).toBe(1);
+});
+
+test('[no-extra-selected-options-invalid-003] three selected reports two excess', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		'<select><option selected>a</option><option selected>b</option><option selected>c</option></select>',
+	);
+	expect(violations.length).toBe(2);
+});

--- a/packages/@markuplint/rules/src/no-extra-selected-options/index.ts
+++ b/packages/@markuplint/rules/src/no-extra-selected-options/index.ts
@@ -17,6 +17,8 @@ export default createRule<boolean, null>({
 	async verify({ document, report, t }) {
 		await document.walkOn('Element', el => {
 			if (el.localName !== 'select') return;
+			// Pretender selects with no `as` pin: descendants are unknown until typed.
+			if (el.pretenderContext?.type === 'pretender' && !el.hasAttribute('as')) return;
 			if (el.hasAttribute('multiple')) return;
 
 			const selected = [

--- a/packages/@markuplint/rules/src/no-extra-selected-options/index.ts
+++ b/packages/@markuplint/rules/src/no-extra-selected-options/index.ts
@@ -1,0 +1,40 @@
+import { createRule } from '@markuplint/ml-core';
+
+import meta from './meta.js';
+
+/**
+ * Forbid more than one `selected` option in a `<select>` that does not
+ * carry the `multiple` attribute. Mirrors HTML LS §4.10.7's "list of
+ * options" rule (direct `<option>` children, plus `<option>` children
+ * of `<optgroup>` children).
+ *
+ * @see https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element
+ */
+export default createRule<boolean, null>({
+	meta: meta,
+	defaultValue: true,
+	defaultOptions: null,
+	async verify({ document, report, t }) {
+		await document.walkOn('Element', el => {
+			if (el.localName !== 'select') return;
+			if (el.hasAttribute('multiple')) return;
+
+			const selected = [
+				...el.querySelectorAll(':scope > option[selected], :scope > optgroup > option[selected]'),
+			];
+			if (selected.length <= 1) return;
+
+			for (const opt of selected.slice(1)) {
+				report({
+					scope: opt,
+					message: t(
+						'The "{0}" element cannot have more than one selected "{1}" descendant unless the "{2}" attribute is specified',
+						'select',
+						'option',
+						'multiple',
+					),
+				});
+			}
+		});
+	},
+});

--- a/packages/@markuplint/rules/src/no-extra-selected-options/meta.ts
+++ b/packages/@markuplint/rules/src/no-extra-selected-options/meta.ts
@@ -1,0 +1,3 @@
+export default {
+	category: 'validation',
+} as const;

--- a/packages/@markuplint/rules/src/no-extra-selected-options/schema.json
+++ b/packages/@markuplint/rules/src/no-extra-selected-options/schema.json
@@ -1,0 +1,29 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"value": {
+			"type": "boolean",
+			"description": "Disallow multiple selected option elements in a select that lacks the multiple attribute.",
+			"description:ja": "multiple属性を持たないselect要素の配下に、selected属性付きoption要素が複数ある状態を禁じます。"
+		}
+	},
+	"oneOf": [
+		{
+			"$ref": "#/definitions/value"
+		},
+		{
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"value": { "$ref": "#/definitions/value" },
+				"severity": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/ml-config/schema.json#/definitions/severity",
+					"default": "error"
+				},
+				"reason": {
+					"type": "string"
+				}
+			}
+		}
+	]
+}

--- a/packages/markuplint/src/cli/init/get-default-rules.spec.ts
+++ b/packages/markuplint/src/cli/init/get-default-rules.spec.ts
@@ -73,6 +73,10 @@ test('default-rules', () => {
 			category: 'style',
 			defaultValue: false,
 		},
+		'input-file-empty-value': {
+			category: 'validation',
+			defaultValue: true,
+		},
 		'invalid-attr': {
 			category: 'validation',
 			defaultValue: true,

--- a/packages/markuplint/src/cli/init/get-default-rules.spec.ts
+++ b/packages/markuplint/src/cli/init/get-default-rules.spec.ts
@@ -89,6 +89,10 @@ test('default-rules', () => {
 			category: 'validation',
 			defaultValue: true,
 		},
+		'meter-value-bounds': {
+			category: 'validation',
+			defaultValue: true,
+		},
 		'neighbor-popovers': {
 			category: 'a11y',
 			defaultValue: true,

--- a/packages/markuplint/src/cli/init/get-default-rules.spec.ts
+++ b/packages/markuplint/src/cli/init/get-default-rules.spec.ts
@@ -89,6 +89,10 @@ test('default-rules', () => {
 			category: 'validation',
 			defaultValue: true,
 		},
+		'map-id-name-match': {
+			category: 'validation',
+			defaultValue: true,
+		},
 		'meter-value-bounds': {
 			category: 'validation',
 			defaultValue: true,

--- a/packages/markuplint/src/cli/init/get-default-rules.spec.ts
+++ b/packages/markuplint/src/cli/init/get-default-rules.spec.ts
@@ -129,6 +129,10 @@ test('default-rules', () => {
 			category: 'validation',
 			defaultValue: false,
 		},
+		'no-extra-selected-options': {
+			category: 'validation',
+			defaultValue: true,
+		},
 		'no-hard-code-id': {
 			category: 'maintainability',
 			defaultValue: false,

--- a/packages/markuplint/src/cli/init/get-default-rules.spec.ts
+++ b/packages/markuplint/src/cli/init/get-default-rules.spec.ts
@@ -73,6 +73,10 @@ test('default-rules', () => {
 			category: 'style',
 			defaultValue: false,
 		},
+		'input-button-non-empty-value': {
+			category: 'validation',
+			defaultValue: true,
+		},
 		'input-file-empty-value': {
 			category: 'validation',
 			defaultValue: true,

--- a/packages/markuplint/src/cli/init/get-default-rules.spec.ts
+++ b/packages/markuplint/src/cli/init/get-default-rules.spec.ts
@@ -81,6 +81,10 @@ test('default-rules', () => {
 			category: 'a11y',
 			defaultValue: false,
 		},
+		'label-no-multiple-controls': {
+			category: 'validation',
+			defaultValue: true,
+		},
 		'landmark-roles': {
 			category: 'a11y',
 			defaultValue: false,

--- a/tests/external/CLAUDE.md
+++ b/tests/external/CLAUDE.md
@@ -33,6 +33,7 @@ you). Raw `snapshots/{nu-validator,markuplint}/**` are gitignored.
 | Triage a `nu-only` fixture; audit a coverage claim | `bench-triage` |
 | First-time setup, Docker / submodule trouble, repopulating raw snapshots | `bench-setup` |
 | New preset virtual rule (`nodeRules`) not firing on the bench | `bench-virtual-rule` |
+| Enable a flat rule on the bench, or override its severity | `bench-rule-enable` |
 | Sync `<!-- bench-xref -->` blocks onto GitHub Issue bodies; pre-release checklist | `bench-xref` |
 
 ## Architecture

--- a/tests/external/bench/config.ts
+++ b/tests/external/bench/config.ts
@@ -24,6 +24,7 @@ export const benchmarkConfig: Config = {
 		'permitted-contents': true,
 		'required-attr': true,
 		'invalid-attr': true,
+		'label-no-multiple-controls': true,
 		'deprecated-element': true,
 		'deprecated-attr': true,
 		'id-duplication': true,

--- a/tests/external/bench/config.ts
+++ b/tests/external/bench/config.ts
@@ -31,6 +31,7 @@ export const benchmarkConfig: Config = {
 		'no-duplicate-visible-main': true,
 		'placeholder-label-option': true,
 		'link-types': { options: { allowMicroformats: true } },
+		'meter-value-bounds': true,
 		'no-orphaned-end-tag': true,
 		'srcset-sizes-constraint': true,
 		'wai-aria-non-existent-role': true,

--- a/tests/external/bench/config.ts
+++ b/tests/external/bench/config.ts
@@ -23,6 +23,7 @@ export const benchmarkConfig: Config = {
 	rules: {
 		'permitted-contents': true,
 		'required-attr': true,
+		'input-button-non-empty-value': true,
 		'input-file-empty-value': true,
 		'invalid-attr': true,
 		'label-no-multiple-controls': true,

--- a/tests/external/bench/config.ts
+++ b/tests/external/bench/config.ts
@@ -32,6 +32,7 @@ export const benchmarkConfig: Config = {
 		'placeholder-label-option': true,
 		'link-types': { options: { allowMicroformats: true } },
 		'meter-value-bounds': true,
+		'no-extra-selected-options': true,
 		'no-orphaned-end-tag': true,
 		'srcset-sizes-constraint': true,
 		'wai-aria-non-existent-role': true,

--- a/tests/external/bench/config.ts
+++ b/tests/external/bench/config.ts
@@ -23,6 +23,7 @@ export const benchmarkConfig: Config = {
 	rules: {
 		'permitted-contents': true,
 		'required-attr': true,
+		'input-file-empty-value': true,
 		'invalid-attr': true,
 		'label-no-multiple-controls': true,
 		'deprecated-element': true,

--- a/tests/external/bench/config.ts
+++ b/tests/external/bench/config.ts
@@ -42,6 +42,10 @@ export const benchmarkConfig: Config = {
 		'wai-aria-permitted-roles': true,
 		'wai-aria-required-props': true,
 		'wai-aria-disallowed-props': true,
+		// HTML LS / ARIA in HTML conformance: native HTML attributes MUST be used in preference
+		// to their ARIA equivalents. The rule defaults to severity 'warning' for ergonomic reasons;
+		// the bench treats it as a hard error to align with ARIA-in-HTML §6.
+		'wai-aria-implicit-props': { severity: 'error' },
 		'wai-aria-value': true,
 		'wai-aria-required-owned-elements': true,
 		'wai-aria-required-parent-role': true,

--- a/tests/external/bench/config.ts
+++ b/tests/external/bench/config.ts
@@ -31,6 +31,7 @@ export const benchmarkConfig: Config = {
 		'no-duplicate-visible-main': true,
 		'placeholder-label-option': true,
 		'link-types': { options: { allowMicroformats: true } },
+		'map-id-name-match': true,
 		'meter-value-bounds': true,
 		'no-extra-selected-options': true,
 		'no-orphaned-end-tag': true,

--- a/tests/external/snapshots/diff/coverage.json
+++ b/tests/external/snapshots/diff/coverage.json
@@ -523,33 +523,33 @@
 		{
 			"path": "html-aria/author-requirements/574.html",
 			"category": "aria",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "clean",
-			"verdict": "match-clean",
+			"verdict": "nu-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/author-requirements/575.html",
 			"category": "aria",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "clean",
-			"verdict": "match-clean",
+			"verdict": "nu-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/author-requirements/576.html",
 			"category": "aria",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "clean",
-			"verdict": "match-clean",
+			"verdict": "nu-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/author-requirements/577.html",
 			"category": "aria",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "clean",
-			"verdict": "match-clean",
+			"verdict": "nu-only",
 			"excludedIds": []
 		},
 		{
@@ -707,9 +707,9 @@
 		{
 			"path": "html-aria/misc/aria-activedescendant-bad-value-haswarn.html",
 			"category": "aria",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "clean",
-			"verdict": "match-clean",
+			"verdict": "nu-only",
 			"excludedIds": []
 		},
 		{
@@ -1019,25 +1019,25 @@
 		{
 			"path": "html-aria/misc/aria-controls-broken-idref-novalid.html",
 			"category": "aria",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
+			"verdict": "match-clean",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/misc/aria-describedby-broken-idref-novalid.html",
 			"category": "aria",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
+			"verdict": "match-clean",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/misc/aria-disabled-true-on-disabled-haswarn.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -1067,9 +1067,9 @@
 		{
 			"path": "html-aria/misc/aria-flowto-broken-idref-novalid.html",
 			"category": "aria",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
+			"verdict": "match-clean",
 			"excludedIds": []
 		},
 		{
@@ -1108,8 +1108,8 @@
 			"path": "html-aria/misc/aria-hidden-true-with-hidden-until-found-novalid.html",
 			"category": "aria",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -1459,9 +1459,9 @@
 		{
 			"path": "html-aria/misc/aria-labelledby-broken-idref-novalid.html",
 			"category": "aria",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "error",
-			"verdict": "match-error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -1707,9 +1707,9 @@
 		{
 			"path": "html-aria/misc/aria-owns-broken-idref-novalid.html",
 			"category": "aria",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "error",
-			"verdict": "match-error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -2060,8 +2060,8 @@
 			"path": "html-aria/misc/placeholder-and-aria-placeholder-novalid.html",
 			"category": "aria",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -2283,9 +2283,9 @@
 		{
 			"path": "html-aria/misc/unnecessary-role-listitem-novalid.html",
 			"category": "aria",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
+			"verdict": "match-clean",
 			"excludedIds": []
 		},
 		{
@@ -3035,41 +3035,41 @@
 		{
 			"path": "html-aria/presentational-children/testcase-839.html",
 			"category": "aria",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "clean",
-			"verdict": "match-clean",
+			"verdict": "nu-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/presentational-children/testcase-840.html",
 			"category": "aria",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "clean",
-			"verdict": "match-clean",
+			"verdict": "nu-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/presentational-children/testcase-842.html",
 			"category": "aria",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "clean",
-			"verdict": "match-clean",
+			"verdict": "nu-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/presentational-children/testcase-843.html",
 			"category": "aria",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "clean",
-			"verdict": "match-clean",
+			"verdict": "nu-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/presentational-children/testcase-844.html",
 			"category": "aria",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "clean",
-			"verdict": "match-clean",
+			"verdict": "nu-only",
 			"excludedIds": []
 		},
 		{
@@ -6187,9 +6187,9 @@
 		{
 			"path": "html-aria/setsize-posinset-level/testcase-769.html",
 			"category": "aria",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "error",
-			"verdict": "ml-only",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -13668,8 +13668,8 @@
 			"path": "html/assertions/aria-placeholder-invalid-novalid.html",
 			"category": "assertions",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -13692,8 +13692,8 @@
 			"path": "html/assertions/bdo-dir-auto-novalid.html",
 			"category": "assertions",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -13732,16 +13732,16 @@
 			"path": "html/assertions/input-button-empty-value-novalid.html",
 			"category": "assertions",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
 			"path": "html/assertions/input-file-value-novalid.html",
 			"category": "assertions",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -13772,8 +13772,8 @@
 			"path": "html/assertions/label-one-control-novalid.html",
 			"category": "assertions",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -13860,8 +13860,8 @@
 			"path": "html/assertions/map-id-name-mismatch-novalid.html",
 			"category": "assertions",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -13876,40 +13876,40 @@
 			"path": "html/assertions/meter-high-exceeds-max-novalid.html",
 			"category": "assertions",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
 			"path": "html/assertions/meter-low-exceeds-high-novalid.html",
 			"category": "assertions",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
 			"path": "html/assertions/meter-min-exceeds-max-novalid.html",
 			"category": "assertions",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
 			"path": "html/assertions/meter-optimum-below-min-novalid.html",
 			"category": "assertions",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
 			"path": "html/assertions/meter-optimum-exceeds-max-novalid.html",
 			"category": "assertions",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -13924,16 +13924,16 @@
 			"path": "html/assertions/meter-value-below-min-novalid.html",
 			"category": "assertions",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
 			"path": "html/assertions/meter-value-exceeds-max-novalid.html",
 			"category": "assertions",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -14004,8 +14004,8 @@
 			"path": "html/assertions/select-multiple-selected-novalid.html",
 			"category": "assertions",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -14115,9 +14115,9 @@
 		{
 			"path": "html/attributes/data/not-xml-serializable-novalid.html",
 			"category": "global-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
+			"verdict": "match-clean",
 			"excludedIds": []
 		},
 		{
@@ -18492,16 +18492,16 @@
 			"path": "html/elements/bdo/dir-auto-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
 			"path": "html/elements/bdo/invalid-dir-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -21530,8 +21530,8 @@
 			"path": "html/elements/dir/bdo-auto-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -25338,8 +25338,8 @@
 			"path": "html/elements/input/button-empty-value-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -30076,16 +30076,16 @@
 			"path": "html/elements/label/multiple-descendants-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
 			"path": "html/elements/label/multiple-labelable-descendants-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -31214,8 +31214,8 @@
 			"path": "html/elements/map/id-name-mismatch-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -31532,112 +31532,112 @@
 			"path": "html/elements/meter/high-below-min-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
 			"path": "html/elements/meter/high-exceeds-max-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
 			"path": "html/elements/meter/low-below-min-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
 			"path": "html/elements/meter/low-exceeds-high-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
 			"path": "html/elements/meter/low-exceeds-max-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
 			"path": "html/elements/meter/max-below-zero-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
 			"path": "html/elements/meter/min-exceeds-max-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
 			"path": "html/elements/meter/min-exceeds-one-no-max-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
 			"path": "html/elements/meter/min-exceeds-value-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
 			"path": "html/elements/meter/optimum-below-min-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
 			"path": "html/elements/meter/optimum-exceeds-max-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
 			"path": "html/elements/meter/value-below-min-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
 			"path": "html/elements/meter/value-below-zero-no-min-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
 			"path": "html/elements/meter/value-exceeds-max-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -36978,16 +36978,16 @@
 			"path": "html/elements/select/multiple-selected-without-multiple-attr-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
 			"path": "html/elements/select/multiple-selected-without-multiple-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{

--- a/tests/external/snapshots/diff/markuplint-only.json
+++ b/tests/external/snapshots/diff/markuplint-only.json
@@ -8,10 +8,31 @@
 			]
 		},
 		{
+			"path": "html-aria/misc/aria-disabled-true-on-disabled-haswarn.html",
+			"category": "aria",
+			"ruleIds": [
+				"wai-aria-implicit-props"
+			]
+		},
+		{
 			"path": "html-aria/misc/aria-haspopup-on-datalist-input-haswarn.html",
 			"category": "aria",
 			"ruleIds": [
 				"wai-aria-disallowed-props"
+			]
+		},
+		{
+			"path": "html-aria/misc/aria-labelledby-broken-idref-novalid.html",
+			"category": "aria",
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
+		},
+		{
+			"path": "html-aria/misc/aria-owns-broken-idref-novalid.html",
+			"category": "aria",
+			"ruleIds": [
+				"wai-aria-required-parent-role"
 			]
 		},
 		{
@@ -972,13 +993,6 @@
 			"category": "aria",
 			"ruleIds": [
 				"wai-aria-disallowed-props"
-			]
-		},
-		{
-			"path": "html-aria/setsize-posinset-level/testcase-769.html",
-			"category": "aria",
-			"ruleIds": [
-				"wai-aria-required-parent-role"
 			]
 		},
 		{

--- a/tests/external/snapshots/diff/nu-only.json
+++ b/tests/external/snapshots/diff/nu-only.json
@@ -1,6 +1,41 @@
 {
 	"entries": [
 		{
+			"path": "html-aria/author-requirements/574.html",
+			"category": "aria",
+			"nuMessageIds": [
+				"nv-374285ecf319"
+			]
+		},
+		{
+			"path": "html-aria/author-requirements/575.html",
+			"category": "aria",
+			"nuMessageIds": [
+				"nv-00a3cfaf103b"
+			]
+		},
+		{
+			"path": "html-aria/author-requirements/576.html",
+			"category": "aria",
+			"nuMessageIds": [
+				"nv-b1c9dc6d3f45"
+			]
+		},
+		{
+			"path": "html-aria/author-requirements/577.html",
+			"category": "aria",
+			"nuMessageIds": [
+				"nv-b0be41d0320e"
+			]
+		},
+		{
+			"path": "html-aria/misc/aria-activedescendant-bad-value-haswarn.html",
+			"category": "aria",
+			"nuMessageIds": [
+				"nv-a3764348e85c"
+			]
+		},
+		{
 			"path": "html-aria/misc/aria-braillelabel-autonomous-custom-element-novalid.html",
 			"category": "aria",
 			"nuMessageIds": [
@@ -8,38 +43,10 @@
 			]
 		},
 		{
-			"path": "html-aria/misc/aria-controls-broken-idref-novalid.html",
-			"category": "aria",
-			"nuMessageIds": [
-				"nv-4bc475a786da"
-			]
-		},
-		{
-			"path": "html-aria/misc/aria-describedby-broken-idref-novalid.html",
-			"category": "aria",
-			"nuMessageIds": [
-				"nv-535915c8681f"
-			]
-		},
-		{
 			"path": "html-aria/misc/aria-expanded-with-command-novalid.html",
 			"category": "aria",
 			"nuMessageIds": [
 				"nv-5c22b7821665"
-			]
-		},
-		{
-			"path": "html-aria/misc/aria-flowto-broken-idref-novalid.html",
-			"category": "aria",
-			"nuMessageIds": [
-				"nv-ecd1cfd3e4e3"
-			]
-		},
-		{
-			"path": "html-aria/misc/aria-hidden-true-with-hidden-until-found-novalid.html",
-			"category": "aria",
-			"nuMessageIds": [
-				"nv-3356debcf7dc"
 			]
 		},
 		{
@@ -71,13 +78,6 @@
 			]
 		},
 		{
-			"path": "html-aria/misc/placeholder-and-aria-placeholder-novalid.html",
-			"category": "aria",
-			"nuMessageIds": [
-				"nv-19bdf3602b5c"
-			]
-		},
-		{
 			"path": "html-aria/misc/role-tab-with-no-role-tabpanel-novalid.html",
 			"category": "aria",
 			"nuMessageIds": [
@@ -101,17 +101,65 @@
 			]
 		},
 		{
-			"path": "html-aria/misc/unnecessary-role-listitem-novalid.html",
-			"category": "aria",
-			"nuMessageIds": [
-				"nv-2cb286280aff"
-			]
-		},
-		{
 			"path": "html-aria/misc/wbr-aria-atomic-novalid.html",
 			"category": "aria",
 			"nuMessageIds": [
 				"nv-d37ed4902519"
+			]
+		},
+		{
+			"path": "html-aria/presentational-children/testcase-839.html",
+			"category": "aria",
+			"nuMessageIds": [
+				"nv-8305ac8bd5a3",
+				"nv-bf7292cf8fa4",
+				"nv-25cfe8e63733",
+				"nv-8a6e3c27869e",
+				"nv-3289d779f642"
+			]
+		},
+		{
+			"path": "html-aria/presentational-children/testcase-840.html",
+			"category": "aria",
+			"nuMessageIds": [
+				"nv-49f0cdb7fcd8",
+				"nv-95d811d6ee5b",
+				"nv-e632316505a3",
+				"nv-ef08cddabb45",
+				"nv-fd7e8ba2e301"
+			]
+		},
+		{
+			"path": "html-aria/presentational-children/testcase-842.html",
+			"category": "aria",
+			"nuMessageIds": [
+				"nv-5b27d5e6eb26",
+				"nv-491a1baf670b",
+				"nv-09d98b44c8d4",
+				"nv-d0da1f3ae445",
+				"nv-5cc5acad4f63"
+			]
+		},
+		{
+			"path": "html-aria/presentational-children/testcase-843.html",
+			"category": "aria",
+			"nuMessageIds": [
+				"nv-ef7cd33b4f69",
+				"nv-c1dbccf437f6",
+				"nv-f850781a73d6",
+				"nv-147b44d11a09",
+				"nv-3c38e66bfd39"
+			]
+		},
+		{
+			"path": "html-aria/presentational-children/testcase-844.html",
+			"category": "aria",
+			"nuMessageIds": [
+				"nv-69d60981968f",
+				"nv-b67f48607a78",
+				"nv-e94e07105cb4",
+				"nv-9364f4d2a3d9",
+				"nv-72f27ad4c9e6"
 			]
 		},
 		{
@@ -207,115 +255,10 @@
 			]
 		},
 		{
-			"path": "html/assertions/aria-placeholder-invalid-novalid.html",
-			"category": "assertions",
-			"nuMessageIds": [
-				"nv-66e46bd99411"
-			]
-		},
-		{
-			"path": "html/assertions/bdo-dir-auto-novalid.html",
-			"category": "assertions",
-			"nuMessageIds": [
-				"nv-a87566e2a111"
-			]
-		},
-		{
-			"path": "html/assertions/input-button-empty-value-novalid.html",
-			"category": "assertions",
-			"nuMessageIds": [
-				"nv-b48d819ec363"
-			]
-		},
-		{
-			"path": "html/assertions/input-file-value-novalid.html",
-			"category": "assertions",
-			"nuMessageIds": [
-				"nv-54d1dac14d54"
-			]
-		},
-		{
-			"path": "html/assertions/label-one-control-novalid.html",
-			"category": "assertions",
-			"nuMessageIds": [
-				"nv-3284e8e57db0"
-			]
-		},
-		{
 			"path": "html/assertions/link-preload-missing-as-novalid.html",
 			"category": "required-attr",
 			"nuMessageIds": [
 				"nv-193d8b9558bf"
-			]
-		},
-		{
-			"path": "html/assertions/map-id-name-mismatch-novalid.html",
-			"category": "assertions",
-			"nuMessageIds": [
-				"nv-b82c4056c0a0"
-			]
-		},
-		{
-			"path": "html/assertions/meter-high-exceeds-max-novalid.html",
-			"category": "assertions",
-			"nuMessageIds": [
-				"nv-aab3a745e472"
-			]
-		},
-		{
-			"path": "html/assertions/meter-low-exceeds-high-novalid.html",
-			"category": "assertions",
-			"nuMessageIds": [
-				"nv-1db1c04c5942",
-				"nv-ee8d4b67622d",
-				"nv-eb63d19774b6",
-				"nv-ffb04c756146"
-			]
-		},
-		{
-			"path": "html/assertions/meter-min-exceeds-max-novalid.html",
-			"category": "assertions",
-			"nuMessageIds": [
-				"nv-cb1712721495",
-				"nv-a4632e9a103c"
-			]
-		},
-		{
-			"path": "html/assertions/meter-optimum-below-min-novalid.html",
-			"category": "assertions",
-			"nuMessageIds": [
-				"nv-6cd0b91f17e9",
-				"nv-8ba2ef87ac58",
-				"nv-7eea3f0d259b"
-			]
-		},
-		{
-			"path": "html/assertions/meter-optimum-exceeds-max-novalid.html",
-			"category": "assertions",
-			"nuMessageIds": [
-				"nv-8faf4e01f601"
-			]
-		},
-		{
-			"path": "html/assertions/meter-value-below-min-novalid.html",
-			"category": "assertions",
-			"nuMessageIds": [
-				"nv-0274e824921d",
-				"nv-90c96a22fabd"
-			]
-		},
-		{
-			"path": "html/assertions/meter-value-exceeds-max-novalid.html",
-			"category": "assertions",
-			"nuMessageIds": [
-				"nv-6a315801d64c"
-			]
-		},
-		{
-			"path": "html/assertions/select-multiple-selected-novalid.html",
-			"category": "assertions",
-			"nuMessageIds": [
-				"nv-0f6761c587c6"
 			]
 		},
 		{
@@ -330,13 +273,6 @@
 			"category": "global-attr",
 			"nuMessageIds": [
 				"nv-e8f89d0fb51b"
-			]
-		},
-		{
-			"path": "html/attributes/data/not-xml-serializable-novalid.html",
-			"category": "global-attr",
-			"nuMessageIds": [
-				"nv-a5c0244db6d3"
 			]
 		},
 		{
@@ -1884,20 +1820,6 @@
 			]
 		},
 		{
-			"path": "html/elements/bdo/dir-auto-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-6202c196e38a"
-			]
-		},
-		{
-			"path": "html/elements/bdo/invalid-dir-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-c7ee7c71ac1c"
-			]
-		},
-		{
 			"path": "html/elements/blockquote/cite/fragment-backslash-novalid.html",
 			"category": "invalid-attr",
 			"nuMessageIds": [
@@ -2805,13 +2727,6 @@
 			"category": "invalid-attr",
 			"nuMessageIds": [
 				"nv-3d6315d9b07f"
-			]
-		},
-		{
-			"path": "html/elements/dir/bdo-auto-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-1d99fa553238"
 			]
 		},
 		{
@@ -4034,13 +3949,6 @@
 			"category": "invalid-attr",
 			"nuMessageIds": [
 				"nv-462837b137bf"
-			]
-		},
-		{
-			"path": "html/elements/input/button-empty-value-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-a7d5ad66a316"
 			]
 		},
 		{
@@ -5690,20 +5598,6 @@
 			]
 		},
 		{
-			"path": "html/elements/label/multiple-descendants-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-b67a2c92e95b"
-			]
-		},
-		{
-			"path": "html/elements/label/multiple-labelable-descendants-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-d9811e4913c8"
-			]
-		},
-		{
 			"path": "html/elements/link/alternate-stylesheet-without-title-novalid.html",
 			"category": "invalid-attr",
 			"nuMessageIds": [
@@ -6020,13 +5914,6 @@
 			]
 		},
 		{
-			"path": "html/elements/map/id-name-mismatch-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-f287f675e24e"
-			]
-		},
-		{
 			"path": "html/elements/meta/content-security-policy/csp-invalid-directive-haswarn.html",
 			"category": "invalid-attr",
 			"nuMessageIds": [
@@ -6060,108 +5947,6 @@
 			"category": "invalid-attr",
 			"nuMessageIds": [
 				"nv-006f6fbfb136"
-			]
-		},
-		{
-			"path": "html/elements/meter/high-below-min-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-fc3772045cd4"
-			]
-		},
-		{
-			"path": "html/elements/meter/high-exceeds-max-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-b44794b47432"
-			]
-		},
-		{
-			"path": "html/elements/meter/low-below-min-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-0e4078d742d6"
-			]
-		},
-		{
-			"path": "html/elements/meter/low-exceeds-high-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-7582f7aa877e"
-			]
-		},
-		{
-			"path": "html/elements/meter/low-exceeds-max-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-0ea2edc05d4e"
-			]
-		},
-		{
-			"path": "html/elements/meter/max-below-zero-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-06d8b4ca97d0",
-				"nv-a373b730b37c"
-			]
-		},
-		{
-			"path": "html/elements/meter/min-exceeds-max-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-42ea3699c36e",
-				"nv-cc81f2c35d98",
-				"nv-8df6c3f511e7"
-			]
-		},
-		{
-			"path": "html/elements/meter/min-exceeds-one-no-max-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-8bdfc0bf20ab",
-				"nv-ad4a36e8c36d"
-			]
-		},
-		{
-			"path": "html/elements/meter/min-exceeds-value-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-b2e77b2ca402"
-			]
-		},
-		{
-			"path": "html/elements/meter/optimum-below-min-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-abea8bde3e90"
-			]
-		},
-		{
-			"path": "html/elements/meter/optimum-exceeds-max-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-d88edf520c77"
-			]
-		},
-		{
-			"path": "html/elements/meter/value-below-min-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-d4d069f89f3d"
-			]
-		},
-		{
-			"path": "html/elements/meter/value-below-zero-no-min-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-2aa240d32228"
-			]
-		},
-		{
-			"path": "html/elements/meter/value-exceeds-max-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-331806de4adb"
 			]
 		},
 		{
@@ -7720,20 +7505,6 @@
 			"category": "invalid-attr",
 			"nuMessageIds": [
 				"nv-cf9799a27fc6"
-			]
-		},
-		{
-			"path": "html/elements/select/multiple-selected-without-multiple-attr-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-62acf4b0abcf"
-			]
-		},
-		{
-			"path": "html/elements/select/multiple-selected-without-multiple-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-6943133643e7"
 			]
 		},
 		{

--- a/tests/external/snapshots/diff/summary.md
+++ b/tests/external/snapshots/diff/summary.md
@@ -1,39 +1,39 @@
 # nu-validator Benchmark Summary
 
-- generated: 2026-04-28T03:31:29.579Z
+- generated: 2026-05-08T07:14:49.330Z
 - submodule: `142931395412c00434ffb40a14d65992efd17aa8`
-- nu-validator: `ghcr.io/validator/validator@sha256:59b0e97e2664755f1597ba9b6a0ecbdc4c67bd1518d1318acd29d9a08900389b`
+- nu-validator: `ghcr.io/validator/validator@sha256:1b4aa4233d684309a74d674f83306af06d84945e51fe00e75cd2c7852e12661c`
 - markuplint: `5.0.0-rc.4`
 - node: `24.14.1`
 
 ## Totals
 
 - files: **5442**
-- match-error: **2080** (both tools flagged)
-- match-clean: **929** (neither flagged)
-- nu-only: **1430** (only nu-validator flagged; markuplint coverage candidates — open a markuplint issue after a spec read)
+- match-error: **2118** (both tools flagged)
+- match-clean: **923** (neither flagged)
+- nu-only: **1396** (only nu-validator flagged; markuplint coverage candidates — open a markuplint issue after a spec read)
 - nu-over: **28** (nu-validator errors fully covered by spec-backed excluded-ids — confirmed over-detection)
-- overall match rate: **55.3%**
+- overall match rate: **55.9%**
 - excluded-ids: 3 entries, 1 pattern(s)
 
 ## Per-Category
 
 | Category | Files | Match rate | match-error | match-clean | ml-only | nu-only | nu-over |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| aria | 780 | 80.0% | 162 | 462 | 140 | 16 | 0 |
-| assertions | 40 | 65.0% | 25 | 1 | 0 | 14 | 0 |
+| aria | 780 | 79.2% | 163 | 455 | 142 | 20 | 0 |
+| assertions | 40 | 100.0% | 39 | 1 | 0 | 0 | 0 |
 | content-model | 98 | 98.0% | 48 | 48 | 0 | 2 | 0 |
 | data-types | 56 | 71.4% | 35 | 5 | 1 | 15 | 0 |
 | deprecated | 12 | 91.7% | 11 | 0 | 1 | 0 | 0 |
-| global-attr | 57 | 75.4% | 24 | 19 | 8 | 6 | 0 |
+| global-attr | 57 | 77.2% | 24 | 20 | 8 | 5 | 0 |
 | id-duplication | 1 | 100.0% | 1 | 0 | 0 | 0 | 0 |
-| invalid-attr | 3086 | 57.9% | 1556 | 231 | 60 | 1213 | 26 |
+| invalid-attr | 3086 | 58.7% | 1579 | 231 | 60 | 1190 | 26 |
 | required-attr | 5 | 80.0% | 4 | 0 | 0 | 1 | 0 |
 | uncategorized | 1307 | 28.8% | 214 | 163 | 765 | 163 | 2 |
 
 ## Informational: ml-only
 
-**975** fixtures are flagged only by markuplint. This project does not pursue upstream nu-validator reports, so those fixtures feed a narrower audit: confirm with the spec, and if markuplint is the wrong one, fix the rule. The full list lives in `snapshots/diff/markuplint-only.json`.
+**977** fixtures are flagged only by markuplint. This project does not pursue upstream nu-validator reports, so those fixtures feed a narrower audit: confirm with the spec, and if markuplint is the wrong one, fix the rule. The full list lives in `snapshots/diff/markuplint-only.json`.
 
 ### Top ml-only rules
 
@@ -42,7 +42,7 @@
 | invalid-attr | 707 |
 | permitted-contents | 444 |
 | deprecated-attr | 354 |
-| wai-aria-disallowed-props | 120 |
+| wai-aria-disallowed-props | 121 |
 | @markuplint/ml-core | 75 |
 | link-types | 34 |
 | required-attr | 22 |

--- a/tests/external/snapshots/meta.json
+++ b/tests/external/snapshots/meta.json
@@ -1,12 +1,12 @@
 {
-	"generatedAt": "2026-04-28T03:31:29.579Z",
+	"generatedAt": "2026-05-08T07:14:49.330Z",
 	"submoduleSha": "142931395412c00434ffb40a14d65992efd17aa8",
-	"nuValidatorImage": "ghcr.io/validator/validator@sha256:59b0e97e2664755f1597ba9b6a0ecbdc4c67bd1518d1318acd29d9a08900389b",
+	"nuValidatorImage": "ghcr.io/validator/validator@sha256:1b4aa4233d684309a74d674f83306af06d84945e51fe00e75cd2c7852e12661c",
 	"markuplintVersion": "5.0.0-rc.4",
 	"nodeVersion": "24.14.1",
 	"totalFilesNu": 5442,
 	"totalFilesMl": 5442,
-	"totalNuMessages": 9735,
-	"totalMlViolations": 9792,
+	"totalNuMessages": 9756,
+	"totalMlViolations": 9852,
 	"totalNuFailures": 0
 }


### PR DESCRIPTION
## Summary

`tests/external/` の nu-validator coverage benchmark の **assertions スライス 14 fixture を nu-only から match-error にflip** することを目的にしたルール群追加 + spec data 拡張 + preset / bench config 連携。

| Metric | before | after | delta |
| --- | ---: | ---: | ---: |
| match-error | 2080 | 2118 | +38 |
| match-clean | 929 | 923 | -6 |
| ml-only | 975 | 977 | +2 |
| nu-only | 1430 | 1396 | -34 |
| nu-over | 28 | 28 | 0 |
| **assertions match rate** | **65.0%** | **100.0%** | — |

## Changes

### 6 new rules (all `defaultValue: true`, category `validation`)

| Rule | Spec source | Triggering markup |
| --- | --- | --- |
| `meter-value-bounds` | HTML LS §4.10.14 | `<meter>` whose attributes break `min ≤ value ≤ max`, `low ≤ high`, etc. |
| `no-extra-selected-options` | HTML LS §4.10.7 | `<select>` without `multiple` containing 2+ `<option selected>` |
| `map-id-name-match` | HTML LS §4.8.13 | `<map>` with `id` and `name` whose values differ (case-sensitive) |
| `label-no-multiple-controls` | HTML LS §4.10.4 | `<label>` containing 2+ form controls (button/input/meter/output/progress/select/textarea) |
| `input-file-empty-value` | HTML LS §4.10.5.1.18 | `<input type="file">` with non-empty `value` attribute |
| `input-button-non-empty-value` | nu-validator Assertions.java *(HTML LS does not state this verbatim)* | `<input type="button" value="">` |

### Spec data

- `<bdo dir="auto">` is now flagged. The `dir` enum on `<bdo>` is restricted to `["ltr", "rtl"]` per HTML LS §4.5.5: "The dir global content attribute is required on this element. The attribute's value must not be the keyword auto."

### Preset

All 6 new rules are added to `markuplint:html-standard`. The `input-button-non-empty-value` entry is `specConformance: "non-normative"` (mirrors nu-validator, not spec text); the others are `"normative"`.

### Bench config

- New rules wired into `tests/external/bench/config.ts`.
- `wai-aria-implicit-props` severity is overridden to `error` in the bench (rule default stays `warning`). Rationale: ARIA in HTML §6 ("Implicit ARIA semantics") is a MUST NOT for native↔ARIA attribute pairs; the bench surfaces it as a hard error to align with the spec text.

## Affected User-Visible Patterns

Markup that worked silently in `5.0.0-rc.4` and now reports errors:

```html
<!-- bdo dir override -->
<bdo dir="auto">x</bdo>

<!-- meter inequalities -->
<meter value="10" max="5">10 out of 5</meter>
<meter value="5" min="3" optimum="1">5</meter>
<meter value="5" low="8" high="3">5</meter>

<!-- select multi-selected -->
<select>
  <option selected>One</option>
  <option selected>Two</option>
</select>

<!-- map id/name mismatch -->
<map id="foo" name="bar"><area href="a.html" alt="A"></map>

<!-- label multiple controls -->
<label>Name: <input name="first"> <input name="last"></label>

<!-- input value type-specific -->
<input type="file" value="document.pdf">
<input type="button" value="">

<!-- ARIA-in-HTML §6 redundancy (bench severity only) -->
<input placeholder="Enter text" aria-placeholder="Enter text">
```

### Opt-out

Per-rule disable in user config:

```json
{
  "rules": {
    "meter-value-bounds": false,
    "no-extra-selected-options": false,
    "map-id-name-match": false,
    "label-no-multiple-controls": false,
    "input-file-empty-value": false,
    "input-button-non-empty-value": false
  }
}
```

`<bdo dir="auto">` is enforced at the spec-data layer (not a separate rule); switch to `dir="ltr"` / `dir="rtl"` or remove the attribute.

## Test plan

- [x] `yarn lint` (0 warnings, 0 errors)
- [x] `yarn test` (3724 tests pass, no type errors)
- [x] `yarn build` (39 projects build cleanly)
- [x] `yarn bench:update --target all --concurrency 1` — full bench regen with stable verdict
  - assertions slice: 14 nu-only → 0 (100% match rate)
  - per-rule unit tests: each new rule has both valid + invalid coverage with line/col/raw pinning
- [x] PdM + QA review applied: pretender guards on all 5 affected new rules; spec citation in `input-button-non-empty-value` README correctly attributes the assertion to nu-validator (not HTML LS).

## Notes for reviewer

- Sister `<input type="reset">` / `<input type="submit">` are intentionally NOT flagged on empty value. Reset/Submit empty-value coverage requires a separate spec read (HTML LS does not mandate non-empty there either).
- `aria-disabled-true-on-disabled-haswarn.html` flips from match-clean → ml-only in this PR. Per the bench-triage SKILL "ml-only readings", this is the case where ml is correctly stricter than nu (ARIA in HTML §6 MUST NOT) — informational, not an over-detection.
- Bench is not in CI; the inventory in `tests/external/snapshots/diff/*` is the committed snapshot from the `--concurrency 1` run.

## Suggested labels

- `Rule` (6 new rules)
- `Specs` (bdo dir enum override)
- `Config Presets` (html-standard preset additions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
