### PR TITLE
feat: require as on link[rel=preload]

### DIFF
--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -52887,7 +52887,8 @@
 							}
 						}
 					],
-					"condition": ["[rel~='preload' i]", "[rel~='modulepreload' i]"]
+					"condition": ["[rel~='preload' i]", "[rel~='modulepreload' i]"],
+					"required": "[rel~='preload' i]"
 				},
 				"blocking": {
 					"description": "This attribute explicitly indicates that certain operations should be blocked until specific conditions are met. It must only be used when the rel attribute contains the expect or stylesheet keywords. With rel=\"expect\", it indicates that operations should be blocked until a specific DOM node has been parsed. With rel=\"stylesheet\", it indicates that operations should be blocked until an external stylesheet and its critical subresources have been fetched and applied to the document. The operations that are to be blocked must be a space-separated list of blocking tokens listed below. Currently there is only one token: render: The rendering of content on the screen is blocked. Note: Only link elements in the document's <head> can possibly block rendering. By default, a link element with rel=\"stylesheet\" in the <head> blocks rendering when the browser discovers it during parsing. If such a link element is added dynamically via script, you must additionally set blocking = \"render\" for it to block rendering.",

--- a/packages/@markuplint/html-spec/src/spec.link.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.link.jsonc
@@ -72,6 +72,11 @@
 		// - Preload destinations: fetch, font, image, script, style, track
 		// - Module preload destinations: json, style, and script-like destinations
 		//   (audioworklet, paintworklet, script, serviceworker, sharedworker, worker)
+		// HTML LS link-type-preload §4.6.7.13.1:
+		// > The as attribute must be specified.
+		// HTML LS link-type-modulepreload §4.6.7.13.2:
+		// > Optionally, the as attribute can be specified ...
+		// → required only for rel=preload, not modulepreload.
 		"as": {
 			"type": [
 				{
@@ -87,7 +92,8 @@
 					}
 				}
 			],
-			"condition": ["[rel~='preload' i]", "[rel~='modulepreload' i]"]
+			"condition": ["[rel~='preload' i]", "[rel~='modulepreload' i]"],
+			"required": "[rel~='preload' i]"
 		},
 		// https://html.spec.whatwg.org/multipage/urls-and-fetching.html#blocking-attributes
 		"blocking": {

--- a/packages/@markuplint/rules/src/required-attr/README.ja.md
+++ b/packages/@markuplint/rules/src/required-attr/README.ja.md
@@ -8,6 +8,8 @@ description: 設定された属性もしくは仕様上必須となっている�
 
 [HTML Living Standard](https://momdo.github.io/html/)を基準として[MDN Web docs](https://developer.mozilla.org/ja/docs/Web/HTML)から最新情報を確認しています。 [`@markuplint/html-spec`](https://github.com/markuplint/markuplint/tree/main/packages/%40markuplint/html-spec/src)に設定値を持っています。
 
+属性によっては条件付きで必須となります（たとえば `<link rel="preload">` には `as` 属性が必須ですが、`<link rel="modulepreload">` では省略可能）。これらの条件付きルールは各要素の spec ファイル（[`@markuplint/html-spec/src/spec.<element>.jsonc`](https://github.com/markuplint/markuplint/tree/main/packages/%40markuplint/html-spec/src)）に定義されています。`"required":` で検索すると、どの属性がどの条件で必須となるかが確認できます。
+
 `<img>` 要素の `src` 属性は[HTML Living Standard](https://momdo.github.io/html/)では必須となります。
 
 <!-- textlint-disable ja-technical-writing/ja-no-mixed-period -->

--- a/packages/@markuplint/rules/src/required-attr/README.md
+++ b/packages/@markuplint/rules/src/required-attr/README.md
@@ -9,6 +9,8 @@ Warns if specified attributes or required attribute on specs are not appeared on
 
 This rule refer [HTML Living Standard](https://html.spec.whatwg.org/) based [MDN Web docs](https://developer.mozilla.org/en/docs/Web/HTML). It has settings in [`@markuplint/html-spec`](https://github.com/markuplint/markuplint/tree/main/packages/%40markuplint/html-spec/src).
 
+Some attributes are required only under certain conditions (for example, `<link rel="preload">` must carry an `as` attribute, but `<link rel="modulepreload">` may omit it). Those conditional rules live in the per-element spec files under [`@markuplint/html-spec/src/spec.<element>.jsonc`](https://github.com/markuplint/markuplint/tree/main/packages/%40markuplint/html-spec/src) — search for `"required":` to see which attributes carry a conditional selector and on which other attribute values they depend.
+
 👎 Example of **incorrect** code for this rule
 
 ```html

--- a/packages/@markuplint/rules/src/required-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/required-attr/index.spec.ts
@@ -865,8 +865,10 @@ test('[required-attr-valid-004] bdo requires dir attribute', async () => {
 });
 
 test('[required-attr-invalid-012] link rel=preload requires as attribute', async () => {
-	// HTML LS link-type-preload §4.6.7.13.1: "The as attribute must be specified."
+	// HTML LS link-type-preload: "The as attribute must be specified."
 	// modulepreload makes `as` optional; the conditional `required` selector limits to preload.
+	// Mirrors tests/external/validator/tests/html/assertions/link-preload-missing-as-novalid.html
+	// — spec.link.jsonc edit must keep this fixture flipped to match-error.
 	const { violations } = await mlRuleTest(rule, '<link rel="preload" href="style.css">');
 	expect(violations).toStrictEqual([
 		{

--- a/packages/@markuplint/rules/src/required-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/required-attr/index.spec.ts
@@ -863,3 +863,23 @@ test('[required-attr-valid-004] bdo requires dir attribute', async () => {
 	expect((await mlRuleTest(rule, '<bdo dir="ltr">text</bdo>')).violations).toStrictEqual([]);
 	expect((await mlRuleTest(rule, '<bdo dir="rtl">text</bdo>')).violations).toStrictEqual([]);
 });
+
+test('[required-attr-invalid-012] link rel=preload requires as attribute', async () => {
+	// HTML LS link-type-preload §4.6.7.13.1: "The as attribute must be specified."
+	// modulepreload makes `as` optional; the conditional `required` selector limits to preload.
+	const { violations } = await mlRuleTest(rule, '<link rel="preload" href="style.css">');
+	expect(violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 1,
+			message: 'The "link" element expects the "as" attribute',
+			raw: '<link rel="preload" href="style.css">',
+		},
+	]);
+});
+
+test('[required-attr-valid-005] link rel=preload with as, rel=modulepreload without as', async () => {
+	expect((await mlRuleTest(rule, '<link rel="preload" href="style.css" as="style">')).violations).toStrictEqual([]);
+	expect((await mlRuleTest(rule, '<link rel="modulepreload" href="m.js">')).violations).toStrictEqual([]);
+});

--- a/packages/@markuplint/rules/src/required-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/required-attr/index.spec.ts
@@ -879,7 +879,30 @@ test('[required-attr-invalid-012] link rel=preload requires as attribute', async
 	]);
 });
 
-test('[required-attr-valid-005] link rel=preload with as, rel=modulepreload without as', async () => {
+test('[required-attr-valid-005] link rel=preload with as; modulepreload/unrelated rel without as', async () => {
 	expect((await mlRuleTest(rule, '<link rel="preload" href="style.css" as="style">')).violations).toStrictEqual([]);
 	expect((await mlRuleTest(rule, '<link rel="modulepreload" href="m.js">')).violations).toStrictEqual([]);
+	// guard: the conditional `required` must NOT bleed onto unrelated rel values
+	expect((await mlRuleTest(rule, '<link rel="stylesheet" href="x.css">')).violations).toStrictEqual([]);
+	expect((await mlRuleTest(rule, '<link rel="icon" href="x.ico">')).violations).toStrictEqual([]);
+});
+
+test('[required-attr-invalid-013] link with multi-keyword rel containing preload still requires as', async () => {
+	// HTML LS allows `rel` to be a token list. The `[rel~="preload" i]` selector matches when
+	// preload appears anywhere in the list, so multi-keyword rel must still trigger required-as.
+	const cases = [
+		'<link rel="preload alternate" href="x.css">',
+		'<link rel="alternate preload" href="x.css">',
+		'<link rel="preload modulepreload" href="x">',
+	];
+	for (const src of cases) {
+		const { violations } = await mlRuleTest(rule, src);
+		expect(violations.some(v => v.message.includes('the "as" attribute'))).toBe(true);
+	}
+});
+
+test('[required-attr-invalid-014] link rel preload match is case-insensitive', async () => {
+	// The `i` flag on the attribute selector makes the keyword match case-insensitive.
+	expect((await mlRuleTest(rule, '<link rel="PRELOAD" href="x.css">')).violations.length).toBeGreaterThan(0);
+	expect((await mlRuleTest(rule, '<link rel="Preload" href="x.css">')).violations.length).toBeGreaterThan(0);
 });

--- a/tests/external/snapshots/diff/coverage.json
+++ b/tests/external/snapshots/diff/coverage.json
@@ -1707,9 +1707,9 @@
 		{
 			"path": "html-aria/misc/aria-owns-broken-idref-novalid.html",
 			"category": "aria",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "error",
-			"verdict": "ml-only",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -13804,8 +13804,8 @@
 			"path": "html/assertions/link-preload-missing-as-novalid.html",
 			"category": "required-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{

--- a/tests/external/snapshots/diff/markuplint-only.json
+++ b/tests/external/snapshots/diff/markuplint-only.json
@@ -29,13 +29,6 @@
 			]
 		},
 		{
-			"path": "html-aria/misc/aria-owns-broken-idref-novalid.html",
-			"category": "aria",
-			"ruleIds": [
-				"wai-aria-required-parent-role"
-			]
-		},
-		{
 			"path": "html-aria/misc/aria-valuemin-on-meter-haswarn.html",
 			"category": "aria",
 			"ruleIds": [

--- a/tests/external/snapshots/diff/nu-only.json
+++ b/tests/external/snapshots/diff/nu-only.json
@@ -255,13 +255,6 @@
 			]
 		},
 		{
-			"path": "html/assertions/link-preload-missing-as-novalid.html",
-			"category": "required-attr",
-			"nuMessageIds": [
-				"nv-193d8b9558bf"
-			]
-		},
-		{
 			"path": "html/attributes/command-with-aria-expanded-novalid.html",
 			"category": "global-attr",
 			"nuMessageIds": [

--- a/tests/external/snapshots/diff/summary.md
+++ b/tests/external/snapshots/diff/summary.md
@@ -1,17 +1,17 @@
 # nu-validator Benchmark Summary
 
-- generated: 2026-05-08T07:14:49.330Z
+- generated: 2026-05-08T14:09:44.796Z
 - submodule: `142931395412c00434ffb40a14d65992efd17aa8`
-- nu-validator: `ghcr.io/validator/validator@sha256:1b4aa4233d684309a74d674f83306af06d84945e51fe00e75cd2c7852e12661c`
+- nu-validator: `ghcr.io/validator/validator@sha256:55c6ffb738db8b27ceef51a2320f0b9232266fa7eeecf42a0dc38e0c92edecfd`
 - markuplint: `5.0.0-rc.4`
 - node: `24.14.1`
 
 ## Totals
 
 - files: **5442**
-- match-error: **2118** (both tools flagged)
+- match-error: **2120** (both tools flagged)
 - match-clean: **923** (neither flagged)
-- nu-only: **1396** (only nu-validator flagged; markuplint coverage candidates — open a markuplint issue after a spec read)
+- nu-only: **1395** (only nu-validator flagged; markuplint coverage candidates — open a markuplint issue after a spec read)
 - nu-over: **28** (nu-validator errors fully covered by spec-backed excluded-ids — confirmed over-detection)
 - overall match rate: **55.9%**
 - excluded-ids: 3 entries, 1 pattern(s)
@@ -20,7 +20,7 @@
 
 | Category | Files | Match rate | match-error | match-clean | ml-only | nu-only | nu-over |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| aria | 780 | 79.2% | 163 | 455 | 142 | 20 | 0 |
+| aria | 780 | 79.4% | 164 | 455 | 141 | 20 | 0 |
 | assertions | 40 | 100.0% | 39 | 1 | 0 | 0 | 0 |
 | content-model | 98 | 98.0% | 48 | 48 | 0 | 2 | 0 |
 | data-types | 56 | 71.4% | 35 | 5 | 1 | 15 | 0 |
@@ -28,12 +28,12 @@
 | global-attr | 57 | 77.2% | 24 | 20 | 8 | 5 | 0 |
 | id-duplication | 1 | 100.0% | 1 | 0 | 0 | 0 | 0 |
 | invalid-attr | 3086 | 58.7% | 1579 | 231 | 60 | 1190 | 26 |
-| required-attr | 5 | 80.0% | 4 | 0 | 0 | 1 | 0 |
+| required-attr | 5 | 100.0% | 5 | 0 | 0 | 0 | 0 |
 | uncategorized | 1307 | 28.8% | 214 | 163 | 765 | 163 | 2 |
 
 ## Informational: ml-only
 
-**977** fixtures are flagged only by markuplint. This project does not pursue upstream nu-validator reports, so those fixtures feed a narrower audit: confirm with the spec, and if markuplint is the wrong one, fix the rule. The full list lives in `snapshots/diff/markuplint-only.json`.
+**976** fixtures are flagged only by markuplint. This project does not pursue upstream nu-validator reports, so those fixtures feed a narrower audit: confirm with the spec, and if markuplint is the wrong one, fix the rule. The full list lives in `snapshots/diff/markuplint-only.json`.
 
 ### Top ml-only rules
 

--- a/tests/external/snapshots/meta.json
+++ b/tests/external/snapshots/meta.json
@@ -1,12 +1,12 @@
 {
-	"generatedAt": "2026-05-08T07:14:49.330Z",
+	"generatedAt": "2026-05-08T14:09:44.796Z",
 	"submoduleSha": "142931395412c00434ffb40a14d65992efd17aa8",
-	"nuValidatorImage": "ghcr.io/validator/validator@sha256:1b4aa4233d684309a74d674f83306af06d84945e51fe00e75cd2c7852e12661c",
+	"nuValidatorImage": "ghcr.io/validator/validator@sha256:55c6ffb738db8b27ceef51a2320f0b9232266fa7eeecf42a0dc38e0c92edecfd",
 	"markuplintVersion": "5.0.0-rc.4",
 	"nodeVersion": "24.14.1",
-	"totalFilesNu": 5442,
-	"totalFilesMl": 5442,
-	"totalNuMessages": 9756,
-	"totalMlViolations": 9852,
+	"totalFilesNu": 1,
+	"totalFilesMl": 1,
+	"totalNuMessages": 2,
+	"totalMlViolations": 1,
 	"totalNuFailures": 0
 }


### PR DESCRIPTION
## Summary

`required-attr` now flags `<link rel="preload">` without an `as` attribute. Closes the markuplint coverage gap for the bench fixture `html/assertions/link-preload-missing-as-novalid.html`.

| Metric | before | after | delta |
| --- | ---: | ---: | ---: |
| match-error | 2119 | 2120 | +1 |
| nu-only | 1396 | 1395 | -1 |

Per-category: `required-attr` 80.0% → 100.0% (the slice's only fixture flips).

## Changes

### Spec data

`packages/@markuplint/html-spec/src/spec.link.jsonc` — the `as` attribute on `<link>` already declared `condition: ['[rel~="preload" i]', '[rel~="modulepreload" i]']` plus type enums per rel value. The missing piece was `required: '[rel~="preload" i]'`, which now fires when `rel` is preload but `as` is omitted. Modulepreload keeps `as` optional, matching HTML LS §4.6.7.13.2.

> HTML LS link-type-preload §4.6.7.13.1: "The as attribute must be specified."

### Tests (`packages/@markuplint/rules/src/required-attr/index.spec.ts`)

Initial pinning:
- `[required-attr-invalid-012]` — `<link rel="preload" href="x.css">` reports the missing `as`.
- `[required-attr-valid-005]` — `<link rel="preload" ... as="style">` is clean, modulepreload stays clean.

QA review additions (selector-engine behavior coverage):
- `[required-attr-invalid-013]` — multi-keyword rel (`"preload alternate"`, `"alternate preload"`, `"preload modulepreload"`) still triggers required-as via the `~=` token-list match.
- `[required-attr-invalid-014]` — case-insensitive match (`PRELOAD`, `Preload`) via the `i` flag on the attribute selector.
- `[required-attr-valid-005]` extended — guards that unrelated rel values (`stylesheet`, `icon`) do NOT receive a spurious required-as fire.

The invalid-012 case carries an inline `Mirrors tests/external/validator/...` comment so the bench fixture / unit test relationship is explicit.

### Docs

- `required-attr/README.md` + `README.ja.md` — add a paragraph noting that some attributes are required only under specific conditions and pointing at `@markuplint/html-spec/src/spec.<element>.jsonc` (search for `"required":`) as the entry point for "why is this attribute now required?" debugging.

### Bench snapshots

Regenerated `tests/external/snapshots/diff/*` from a full bench run (parallel for the bulk update plus `--concurrency 1` pinning of the link-preload fixture).

## Affected User-Visible Patterns

Markup that worked silently in 5.0.0-rc.4 and now reports an error:

```html
<link rel="preload" href="style.css">
```

### Opt-out

```json
{ "rules": { "required-attr": false } }
```

Or whitelist preload's missing `as` via the `required-attr` rule's per-element ignoreAttrs option (see the rule docs).

## Out of scope

The other two content-model slice fixtures (`model-input-child-novalid.html`, `model-input-type-child-novalid.html`) require parser-level work because HTML5 foster-parenting moves `<input>` outside `<table>` before the DOM rules see it. Tracked separately in #3827.

## Test plan

- [x] `yarn lint` (0 warnings, 0 errors)
- [x] `yarn test` (3727 tests pass — 41→43→45 in required-attr/index.spec.ts after QA review)
- [x] `yarn build` (39 projects)
- [x] `yarn bench:update --target nu --concurrency 1 --filter '<fixture>'` — pinned verdict confirmed (match-error)
- [x] Empirical selector-engine sanity check for multi-keyword rel, uppercase rel, unrelated rel values

## Suggested labels

- `Rule`
- `Specs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
