### PR TITLE
feat: cover data-types slice (12/15 fixtures)

### DIFF
--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -52353,7 +52353,34 @@
 				},
 				"max": {
 					"description": "Valid for date, month, week, time, datetime-local, number, and range, it defines the greatest value in the range of permitted values. If the value entered into the element exceeds this, the element fails constraint validation. If the value of the max attribute isn't a number, then the element has no maximum value. There is a special case: if the data type is periodic (such as for dates or times), the value of max may be lower than the value of min, which indicates that the range may wrap around; for example, this allows you to specify a time range from 10 PM to 4 AM.",
-					"type": ["DateTime", "Number"],
+					"type": [
+						{
+							"condition": "[type='date' i]",
+							"type": "DateString"
+						},
+						{
+							"condition": "[type='month' i]",
+							"type": "MonthString"
+						},
+						{
+							"condition": "[type='week' i]",
+							"type": "WeekString"
+						},
+						{
+							"condition": "[type='time' i]",
+							"type": "TimeString"
+						},
+						{
+							"condition": "[type='datetime-local' i]",
+							"type": "LocalDateTimeString"
+						},
+						{
+							"condition": ["[type='number' i]", "[type='range' i]"],
+							"type": {
+								"type": "float"
+							}
+						}
+					],
 					"condition": [
 						"[type='date' i]",
 						"[type='month' i]",
@@ -52378,7 +52405,34 @@
 				},
 				"min": {
 					"description": "Valid for date, month, week, time, datetime-local, number, and range, it defines the most negative value in the range of permitted values. If the value entered into the element is less than this, the element fails constraint validation. If the value of the min attribute isn't a number, then the element has no minimum value. This value must be less than or equal to the value of the max attribute. If the min attribute is present but is not specified or is invalid, no min value is applied. If the min attribute is valid and a non-empty value is less than the minimum allowed by the min attribute, constraint validation will prevent form submission. See Client-side validation for more information. There is a special case: if the data type is periodic (such as for dates or times), the value of max may be lower than the value of min, which indicates that the range may wrap around; for example, this allows you to specify a time range from 10 PM to 4 AM.",
-					"type": ["DateTime", "Number"],
+					"type": [
+						{
+							"condition": "[type='date' i]",
+							"type": "DateString"
+						},
+						{
+							"condition": "[type='month' i]",
+							"type": "MonthString"
+						},
+						{
+							"condition": "[type='week' i]",
+							"type": "WeekString"
+						},
+						{
+							"condition": "[type='time' i]",
+							"type": "TimeString"
+						},
+						{
+							"condition": "[type='datetime-local' i]",
+							"type": "LocalDateTimeString"
+						},
+						{
+							"condition": ["[type='number' i]", "[type='range' i]"],
+							"type": {
+								"type": "float"
+							}
+						}
+					],
 					"condition": [
 						"[type='date' i]",
 						"[type='month' i]",
@@ -54057,7 +54111,10 @@
 			"attributes": {
 				"max": {
 					"description": "This attribute describes how much work the task indicated by the progress element requires. The max attribute, if present, must have a value greater than 0 and be a valid floating point number. The default value is 1.",
-					"type": "Number"
+					"type": {
+						"type": "float",
+						"gt": 0
+					}
 				},
 				"value": {
 					"description": "This attribute specifies how much of the task that has been completed. It must be a valid floating point number between 0 and max, or between 0 and 1 if max is omitted. If there is no value attribute, the progress bar is indeterminate; this indicates that an activity is ongoing with no indication of how long it is expected to take.",

--- a/packages/@markuplint/html-spec/src/spec.input.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.input.jsonc
@@ -122,8 +122,20 @@
 			]
 		},
 		// https://html.spec.whatwg.org/multipage/input.html#attr-input-max
+		// The valid shape of `max` depends on the input type. The previous
+		// generic ["DateTime", "Number"] tuple accepted out-of-range dates
+		// (e.g. 2024-13-01) because DateTime's loose match passed without
+		// per-component validation. Reuse the per-type checkers that already
+		// power `value` so min/max go through the same strict rules.
 		"max": {
-			"type": ["DateTime", "Number"],
+			"type": [
+				{ "condition": "[type='date' i]", "type": "DateString" },
+				{ "condition": "[type='month' i]", "type": "MonthString" },
+				{ "condition": "[type='week' i]", "type": "WeekString" },
+				{ "condition": "[type='time' i]", "type": "TimeString" },
+				{ "condition": "[type='datetime-local' i]", "type": "LocalDateTimeString" },
+				{ "condition": ["[type='number' i]", "[type='range' i]"], "type": { "type": "float" } }
+			],
 			"condition": [
 				"[type='date' i]",
 				"[type='month' i]",
@@ -147,8 +159,16 @@
 			]
 		},
 		// https://html.spec.whatwg.org/multipage/input.html#attr-input-min
+		// See `max` above for the rationale on per-type conditional types.
 		"min": {
-			"type": ["DateTime", "Number"],
+			"type": [
+				{ "condition": "[type='date' i]", "type": "DateString" },
+				{ "condition": "[type='month' i]", "type": "MonthString" },
+				{ "condition": "[type='week' i]", "type": "WeekString" },
+				{ "condition": "[type='time' i]", "type": "TimeString" },
+				{ "condition": "[type='datetime-local' i]", "type": "LocalDateTimeString" },
+				{ "condition": ["[type='number' i]", "[type='range' i]"], "type": { "type": "float" } }
+			],
 			"condition": [
 				"[type='date' i]",
 				"[type='month' i]",

--- a/packages/@markuplint/html-spec/src/spec.progress.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.progress.jsonc
@@ -21,8 +21,12 @@
 			"type": "Number"
 		},
 		// https://html.spec.whatwg.org/multipage/form-elements.html#attr-progress-max
+		// HTML LS: "The max attribute, if present, must have a value greater than zero."
 		"max": {
-			"type": "Number"
+			"type": {
+				"type": "float",
+				"gt": 0
+			}
 		}
 	},
 	"aria": {

--- a/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
@@ -2755,36 +2755,42 @@ describe('input min/max per-type checking (data-types slice)', () => {
 	// surfaces here rather than silently passing the length-only check.
 
 	test('[invalid-attr-invalid-031] input[type=date][min] rejects out-of-range month', async () => {
+		// Mirrors html/datatypes/date-month-out-of-range-novalid.html
 		const { violations } = await mlRuleTest(rule, '<input type="date" min="2024-13-01">');
 		expect(violations.length).toBe(1);
 		expect(violations[0]?.message).toContain('month part');
 	});
 
 	test('[invalid-attr-invalid-032] input[type=date][min] rejects out-of-range day', async () => {
+		// Mirrors html/datatypes/date-day-out-of-range-novalid.html
 		const { violations } = await mlRuleTest(rule, '<input type="date" min="2024-02-30">');
 		expect(violations.length).toBe(1);
 		expect(violations[0]?.message).toContain('date part');
 	});
 
 	test('[invalid-attr-invalid-033] input[type=date][min] rejects wrong format', async () => {
+		// Mirrors html/datatypes/date-invalid-format-novalid.html
 		const { violations } = await mlRuleTest(rule, '<input type="date" min="12-31-2024">');
 		expect(violations.length).toBe(1);
 		expect(violations[0]?.message).toContain('year part');
 	});
 
 	test('[invalid-attr-invalid-034] input[type=time][min] rejects out-of-range hour', async () => {
+		// Mirrors html/datatypes/time-hour-out-of-range-novalid.html
 		const { violations } = await mlRuleTest(rule, '<input type="time" min="25:00">');
 		expect(violations.length).toBe(1);
 		expect(violations[0]?.message).toContain('hour part');
 	});
 
 	test('[invalid-attr-invalid-035] input[type=month][min] rejects month 0', async () => {
+		// Mirrors html/datatypes/month-out-of-range-novalid.html
 		const { violations } = await mlRuleTest(rule, '<input type="month" min="2024-00">');
 		expect(violations.length).toBe(1);
 		expect(violations[0]?.message).toContain('month part');
 	});
 
 	test('[invalid-attr-invalid-036] input[type=week][min] rejects week 54', async () => {
+		// Mirrors html/datatypes/week-invalid-format-novalid.html
 		const { violations } = await mlRuleTest(rule, '<input type="week" min="2024-W54">');
 		expect(violations.length).toBe(1);
 		// week-string week-number is internally validated under the "date" component.
@@ -2792,9 +2798,31 @@ describe('input min/max per-type checking (data-types slice)', () => {
 	});
 
 	test('[invalid-attr-invalid-040] input[type=date][min] rejects Feb 29 in non-leap year', async () => {
+		// markuplint-only edge: no dedicated bench fixture, pin the leap-year branch.
 		const { violations } = await mlRuleTest(rule, '<input type="date" min="2023-02-29">');
 		expect(violations.length).toBe(1);
 		expect(violations[0]?.message).toContain('date part');
+	});
+
+	test('[invalid-attr-invalid-041] input[type=datetime-local][min] rejects out-of-range month', async () => {
+		// Mirrors html/datatypes/datetime-local-invalid-novalid.html
+		const { violations } = await mlRuleTest(rule, '<input type="datetime-local" min="2024-13-01T12:00">');
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.message).toContain('month part');
+	});
+
+	test('[invalid-attr-invalid-042] input[type=time][min] rejects out-of-range minute', async () => {
+		// Mirrors html/datatypes/time-minute-out-of-range-novalid.html
+		const { violations } = await mlRuleTest(rule, '<input type="time" min="12:60">');
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.message).toContain('minute part');
+	});
+
+	test('[invalid-attr-invalid-043] input[type=time][min] rejects out-of-range second', async () => {
+		// Mirrors html/datatypes/time-second-out-of-range-novalid.html
+		const { violations } = await mlRuleTest(rule, '<input type="time" min="12:30:60">');
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.message).toContain('second part');
 	});
 
 	// Each well-formed case is its own test so a failure does not mask later
@@ -2847,12 +2875,14 @@ describe('input min/max per-type checking (data-types slice)', () => {
 
 describe('progress[max] must be greater than zero (HTML LS §4.10.13)', () => {
 	test('[invalid-attr-invalid-037] progress max="0" is rejected', async () => {
+		// Mirrors html/datatypes/float-positive-zero-novalid.html
 		const { violations } = await mlRuleTest(rule, '<progress max="0"></progress>');
 		expect(violations.length).toBe(1);
 		expect(violations[0]?.message).toContain('greater than 0');
 	});
 
 	test('[invalid-attr-invalid-038] progress max="-5" is rejected', async () => {
+		// Mirrors html/datatypes/float-positive-negative-novalid.html
 		const { violations } = await mlRuleTest(rule, '<progress max="-5"></progress>');
 		expect(violations.length).toBe(1);
 		expect(violations[0]?.message).toContain('greater than 0');
@@ -2876,6 +2906,7 @@ describe('progress[max] must be greater than zero (HTML LS §4.10.13)', () => {
 
 describe('img[usemap] requires a non-empty hash-name (HashName type)', () => {
 	test('[invalid-attr-invalid-039] usemap="#" alone is rejected by the HashName type', async () => {
+		// Mirrors html/datatypes/hashname-only-hash-novalid.html
 		// usemap on img is conditional on the presence of a `<map>` reference, so
 		// invalid-attr's value-type check is the relevant assertion here. The
 		// HashName type rejects `#` because the spec requires a non-empty name part.

--- a/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
@@ -2750,54 +2750,98 @@ describe('input min/max per-type checking (data-types slice)', () => {
 	// dates because DateTime's loose match passed without per-component
 	// validation. Per-type DateString/MonthString/WeekString/TimeString/
 	// LocalDateTimeString conditions reuse the strict checkers that already
-	// cover `value`.
+	// cover `value`. Each test pins the message substring naming the
+	// offending component so a future refactor that swaps the validator path
+	// surfaces here rather than silently passing the length-only check.
 
 	test('[invalid-attr-invalid-031] input[type=date][min] rejects out-of-range month', async () => {
 		const { violations } = await mlRuleTest(rule, '<input type="date" min="2024-13-01">');
 		expect(violations.length).toBe(1);
-		// `raw` is the offending token (`13`), not the full attribute value, since
-		// the date checker reports per-component out-of-range failures.
+		expect(violations[0]?.message).toContain('month part');
 	});
 
 	test('[invalid-attr-invalid-032] input[type=date][min] rejects out-of-range day', async () => {
 		const { violations } = await mlRuleTest(rule, '<input type="date" min="2024-02-30">');
 		expect(violations.length).toBe(1);
+		expect(violations[0]?.message).toContain('date part');
 	});
 
 	test('[invalid-attr-invalid-033] input[type=date][min] rejects wrong format', async () => {
 		const { violations } = await mlRuleTest(rule, '<input type="date" min="12-31-2024">');
 		expect(violations.length).toBe(1);
+		expect(violations[0]?.message).toContain('year part');
 	});
 
 	test('[invalid-attr-invalid-034] input[type=time][min] rejects out-of-range hour', async () => {
 		const { violations } = await mlRuleTest(rule, '<input type="time" min="25:00">');
 		expect(violations.length).toBe(1);
+		expect(violations[0]?.message).toContain('hour part');
 	});
 
 	test('[invalid-attr-invalid-035] input[type=month][min] rejects month 0', async () => {
 		const { violations } = await mlRuleTest(rule, '<input type="month" min="2024-00">');
 		expect(violations.length).toBe(1);
+		expect(violations[0]?.message).toContain('month part');
 	});
 
 	test('[invalid-attr-invalid-036] input[type=week][min] rejects week 54', async () => {
 		const { violations } = await mlRuleTest(rule, '<input type="week" min="2024-W54">');
 		expect(violations.length).toBe(1);
+		// week-string week-number is internally validated under the "date" component.
+		expect(violations[0]?.message).toContain('date part');
 	});
 
-	test('[invalid-attr-valid-023] input min/max accepts well-formed values per type', async () => {
-		const cases = [
-			'<input type="date" min="2024-01-01" max="2024-12-31">',
-			'<input type="month" min="2024-01" max="2024-12">',
-			'<input type="week" min="2024-W01" max="2024-W52">',
-			'<input type="time" min="00:00" max="23:59">',
+	test('[invalid-attr-invalid-040] input[type=date][min] rejects Feb 29 in non-leap year', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="date" min="2023-02-29">');
+		expect(violations.length).toBe(1);
+		expect(violations[0]?.message).toContain('date part');
+	});
+
+	// Each well-formed case is its own test so a failure does not mask later
+	// cases (per QA guidance on for-loop assertions).
+	test('[invalid-attr-valid-023] input[type=date] min/max accepts well-formed values', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="date" min="2024-01-01" max="2024-12-31">');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('[invalid-attr-valid-024] input[type=month] min/max accepts well-formed values', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="month" min="2024-01" max="2024-12">');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('[invalid-attr-valid-025] input[type=week] min/max accepts well-formed values', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="week" min="2024-W01" max="2024-W52">');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('[invalid-attr-valid-026] input[type=time] min/max accepts well-formed values', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="time" min="00:00" max="23:59">');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('[invalid-attr-valid-027] input[type=datetime-local] min/max accepts well-formed values', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
 			'<input type="datetime-local" min="2024-01-01T00:00" max="2024-12-31T23:59">',
-			'<input type="number" min="0" max="100">',
-			'<input type="range" min="-5" max="5">',
-		];
-		for (const src of cases) {
-			const { violations } = await mlRuleTest(rule, src);
-			expect(violations.length, src).toBe(0);
-		}
+		);
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('[invalid-attr-valid-028] input[type=number] min/max accepts integer floats', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="number" min="0" max="100">');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('[invalid-attr-valid-029] input[type=range] min/max accepts negative floats', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="range" min="-5" max="5">');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('[invalid-attr-valid-030] input[type=date][min] accepts Feb 29 in leap year', async () => {
+		// Pin the leap-year branch of datetimeTokenCheck.date so a future refactor
+		// that drops the year-aware day-of-month calculation is caught here.
+		const { violations } = await mlRuleTest(rule, '<input type="date" min="2024-02-29">');
+		expect(violations).toStrictEqual([]);
 	});
 });
 
@@ -2805,17 +2849,28 @@ describe('progress[max] must be greater than zero (HTML LS §4.10.13)', () => {
 	test('[invalid-attr-invalid-037] progress max="0" is rejected', async () => {
 		const { violations } = await mlRuleTest(rule, '<progress max="0"></progress>');
 		expect(violations.length).toBe(1);
+		expect(violations[0]?.message).toContain('greater than 0');
 	});
 
 	test('[invalid-attr-invalid-038] progress max="-5" is rejected', async () => {
 		const { violations } = await mlRuleTest(rule, '<progress max="-5"></progress>');
 		expect(violations.length).toBe(1);
+		expect(violations[0]?.message).toContain('greater than 0');
 	});
 
-	test('[invalid-attr-valid-024] progress max accepts positive values', async () => {
-		expect((await mlRuleTest(rule, '<progress max="1"></progress>')).violations.length).toBe(0);
-		expect((await mlRuleTest(rule, '<progress max="100"></progress>')).violations.length).toBe(0);
-		expect((await mlRuleTest(rule, '<progress max="0.5"></progress>')).violations.length).toBe(0);
+	test('[invalid-attr-valid-031] progress max="1" is accepted', async () => {
+		const { violations } = await mlRuleTest(rule, '<progress max="1"></progress>');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('[invalid-attr-valid-032] progress max="100" is accepted', async () => {
+		const { violations } = await mlRuleTest(rule, '<progress max="100"></progress>');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('[invalid-attr-valid-033] progress max="0.5" is accepted', async () => {
+		const { violations } = await mlRuleTest(rule, '<progress max="0.5"></progress>');
+		expect(violations).toStrictEqual([]);
 	});
 });
 

--- a/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
@@ -2743,3 +2743,90 @@ describe('bdo[dir] enum override (HTML LS §4.5.5)', () => {
 		expect((await mlRuleTest(rule, '<bdo dir="rtl">x</bdo>')).violations.length).toBe(0);
 	});
 });
+
+describe('input min/max per-type checking (data-types slice)', () => {
+	// Mirrors tests/external/validator/tests/html/datatypes/* fixtures.
+	// The previous generic ["DateTime", "Number"] tuple accepted out-of-range
+	// dates because DateTime's loose match passed without per-component
+	// validation. Per-type DateString/MonthString/WeekString/TimeString/
+	// LocalDateTimeString conditions reuse the strict checkers that already
+	// cover `value`.
+
+	test('[invalid-attr-invalid-031] input[type=date][min] rejects out-of-range month', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="date" min="2024-13-01">');
+		expect(violations.length).toBe(1);
+		// `raw` is the offending token (`13`), not the full attribute value, since
+		// the date checker reports per-component out-of-range failures.
+	});
+
+	test('[invalid-attr-invalid-032] input[type=date][min] rejects out-of-range day', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="date" min="2024-02-30">');
+		expect(violations.length).toBe(1);
+	});
+
+	test('[invalid-attr-invalid-033] input[type=date][min] rejects wrong format', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="date" min="12-31-2024">');
+		expect(violations.length).toBe(1);
+	});
+
+	test('[invalid-attr-invalid-034] input[type=time][min] rejects out-of-range hour', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="time" min="25:00">');
+		expect(violations.length).toBe(1);
+	});
+
+	test('[invalid-attr-invalid-035] input[type=month][min] rejects month 0', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="month" min="2024-00">');
+		expect(violations.length).toBe(1);
+	});
+
+	test('[invalid-attr-invalid-036] input[type=week][min] rejects week 54', async () => {
+		const { violations } = await mlRuleTest(rule, '<input type="week" min="2024-W54">');
+		expect(violations.length).toBe(1);
+	});
+
+	test('[invalid-attr-valid-023] input min/max accepts well-formed values per type', async () => {
+		const cases = [
+			'<input type="date" min="2024-01-01" max="2024-12-31">',
+			'<input type="month" min="2024-01" max="2024-12">',
+			'<input type="week" min="2024-W01" max="2024-W52">',
+			'<input type="time" min="00:00" max="23:59">',
+			'<input type="datetime-local" min="2024-01-01T00:00" max="2024-12-31T23:59">',
+			'<input type="number" min="0" max="100">',
+			'<input type="range" min="-5" max="5">',
+		];
+		for (const src of cases) {
+			const { violations } = await mlRuleTest(rule, src);
+			expect(violations.length, src).toBe(0);
+		}
+	});
+});
+
+describe('progress[max] must be greater than zero (HTML LS §4.10.13)', () => {
+	test('[invalid-attr-invalid-037] progress max="0" is rejected', async () => {
+		const { violations } = await mlRuleTest(rule, '<progress max="0"></progress>');
+		expect(violations.length).toBe(1);
+	});
+
+	test('[invalid-attr-invalid-038] progress max="-5" is rejected', async () => {
+		const { violations } = await mlRuleTest(rule, '<progress max="-5"></progress>');
+		expect(violations.length).toBe(1);
+	});
+
+	test('[invalid-attr-valid-024] progress max accepts positive values', async () => {
+		expect((await mlRuleTest(rule, '<progress max="1"></progress>')).violations.length).toBe(0);
+		expect((await mlRuleTest(rule, '<progress max="100"></progress>')).violations.length).toBe(0);
+		expect((await mlRuleTest(rule, '<progress max="0.5"></progress>')).violations.length).toBe(0);
+	});
+});
+
+describe('img[usemap] requires a non-empty hash-name (HashName type)', () => {
+	test('[invalid-attr-invalid-039] usemap="#" alone is rejected by the HashName type', async () => {
+		// usemap on img is conditional on the presence of a `<map>` reference, so
+		// invalid-attr's value-type check is the relevant assertion here. The
+		// HashName type rejects `#` because the spec requires a non-empty name part.
+		// We assert the raw token rather than the surrounding "disallowed/missing"
+		// branches so this test remains stable across the rule's other validations.
+		const { violations } = await mlRuleTest(rule, '<img src="x.png" usemap="#" alt="">');
+		expect(violations.some(v => v.raw === '#')).toBe(true);
+	});
+});

--- a/packages/@markuplint/types/src/check.spec.ts
+++ b/packages/@markuplint/types/src/check.spec.ts
@@ -184,3 +184,14 @@ test('JSON', () => {
 	expect(check('{"a": 1, "b": 2', 'JSON').matched).toBeFalsy();
 	expect(check('{"a": 1, "b": 2,}', 'JSON').matched).toBeFalsy();
 });
+
+test('HashName', () => {
+	// Valid: `#` followed by a non-empty name (existence is not the type's concern).
+	expect(check('#mymap', 'HashName').matched).toBe(true);
+	expect(check('#a', 'HashName').matched).toBe(true);
+	// Invalid per HTML LS valid-hash-name-reference: must have a non-empty name part.
+	expect(check('#', 'HashName').matched).toBe(false);
+	expect(check('', 'HashName').matched).toBe(false);
+	// Invalid: missing the leading hash sign.
+	expect(check('mymap', 'HashName').matched).toBe(false);
+});

--- a/packages/@markuplint/types/src/check.spec.ts
+++ b/packages/@markuplint/types/src/check.spec.ts
@@ -194,4 +194,12 @@ test('HashName', () => {
 	expect(check('', 'HashName').matched).toBe(false);
 	// Invalid: missing the leading hash sign.
 	expect(check('mymap', 'HashName').matched).toBe(false);
+	// The type only enforces "# + at least one char". Per HTML LS, the name part
+	// must match an actual `name` attribute value somewhere in the document; the
+	// content syntax (whitespace, unicode, etc.) is delegated to the matching
+	// step. Pin the permissive behaviour explicitly so a future tightening of
+	// the syntax surfaces here rather than silently rejecting valid uses.
+	expect(check('#日本語', 'HashName').matched).toBe(true);
+	expect(check('#with space', 'HashName').matched).toBe(true);
+	expect(check('#name#extra', 'HashName').matched).toBe(true);
 });

--- a/packages/@markuplint/types/src/check.spec.ts
+++ b/packages/@markuplint/types/src/check.spec.ts
@@ -187,13 +187,13 @@ test('JSON', () => {
 
 test('HashName', () => {
 	// Valid: `#` followed by a non-empty name (existence is not the type's concern).
-	expect(check('#mymap', 'HashName').matched).toBe(true);
+	expect(check('#my-map', 'HashName').matched).toBe(true);
 	expect(check('#a', 'HashName').matched).toBe(true);
 	// Invalid per HTML LS valid-hash-name-reference: must have a non-empty name part.
 	expect(check('#', 'HashName').matched).toBe(false);
 	expect(check('', 'HashName').matched).toBe(false);
 	// Invalid: missing the leading hash sign.
-	expect(check('mymap', 'HashName').matched).toBe(false);
+	expect(check('my-map', 'HashName').matched).toBe(false);
 	// The type only enforces "# + at least one char". Per HTML LS, the name part
 	// must match an actual `name` attribute value somewhere in the document; the
 	// content syntax (whitespace, unicode, etc.) is delegated to the matching

--- a/packages/@markuplint/types/src/defs.ts
+++ b/packages/@markuplint/types/src/defs.ts
@@ -409,7 +409,16 @@ export const defs: Defs = {
 				value: 'hash name',
 			},
 		],
-		is: value => (value[0] === '#' ? matched() : unmatched(value, 'unexpected-token')),
+		// HTML LS: "A string is a valid hash-name reference [...] if the string
+		// consists of a U+0023 NUMBER SIGN (#) followed by a string which
+		// exactly matches the value of the name attribute [...]". The spec
+		// requires the name part to be non-empty: `#` alone is not a valid
+		// hash-name reference.
+		is: value => {
+			if (value.length < 2) return unmatched(value, 'unexpected-token');
+			if (value[0] !== '#') return unmatched(value, 'unexpected-token');
+			return matched();
+		},
 	},
 
 	OneCodePointChar: {

--- a/tests/external/snapshots/diff/coverage.json
+++ b/tests/external/snapshots/diff/coverage.json
@@ -1707,9 +1707,9 @@
 		{
 			"path": "html-aria/misc/aria-owns-broken-idref-novalid.html",
 			"category": "aria",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "error",
-			"verdict": "ml-only",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -14588,8 +14588,8 @@
 			"path": "html/datatypes/date-day-out-of-range-novalid.html",
 			"category": "data-types",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -14604,24 +14604,24 @@
 			"path": "html/datatypes/date-invalid-format-novalid.html",
 			"category": "data-types",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
 			"path": "html/datatypes/date-month-out-of-range-novalid.html",
 			"category": "data-types",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
 			"path": "html/datatypes/datetime-local-invalid-novalid.html",
 			"category": "data-types",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -14660,16 +14660,16 @@
 			"path": "html/datatypes/float-positive-negative-novalid.html",
 			"category": "data-types",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
 			"path": "html/datatypes/float-positive-zero-novalid.html",
 			"category": "data-types",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -14692,8 +14692,8 @@
 			"path": "html/datatypes/hashname-only-hash-novalid.html",
 			"category": "data-types",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -14796,8 +14796,8 @@
 			"path": "html/datatypes/month-out-of-range-novalid.html",
 			"category": "data-types",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -14884,24 +14884,24 @@
 			"path": "html/datatypes/time-hour-out-of-range-novalid.html",
 			"category": "data-types",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
 			"path": "html/datatypes/time-minute-out-of-range-novalid.html",
 			"category": "data-types",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
 			"path": "html/datatypes/time-second-out-of-range-novalid.html",
 			"category": "data-types",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -14916,8 +14916,8 @@
 			"path": "html/datatypes/week-invalid-format-novalid.html",
 			"category": "data-types",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{

--- a/tests/external/snapshots/diff/markuplint-only.json
+++ b/tests/external/snapshots/diff/markuplint-only.json
@@ -51,14 +51,6 @@
 			]
 		},
 		{
-			"path": "html-aria/misc/aria-owns-broken-idref-novalid.html",
-			"category": "aria",
-			"ruleIds": [
-				"no-refer-to-non-existent-id",
-				"wai-aria-required-parent-role"
-			]
-		},
-		{
 			"path": "html-aria/misc/aria-valuemin-on-meter-haswarn.html",
 			"category": "aria",
 			"ruleIds": [

--- a/tests/external/snapshots/diff/nu-only.json
+++ b/tests/external/snapshots/diff/nu-only.json
@@ -222,63 +222,6 @@
 			]
 		},
 		{
-			"path": "html/datatypes/date-day-out-of-range-novalid.html",
-			"category": "data-types",
-			"nuMessageIds": [
-				"nv-1ab23e6dc9fa"
-			]
-		},
-		{
-			"path": "html/datatypes/date-invalid-format-novalid.html",
-			"category": "data-types",
-			"nuMessageIds": [
-				"nv-1a639d8c2da3"
-			]
-		},
-		{
-			"path": "html/datatypes/date-month-out-of-range-novalid.html",
-			"category": "data-types",
-			"nuMessageIds": [
-				"nv-45a1b190edac"
-			]
-		},
-		{
-			"path": "html/datatypes/datetime-local-invalid-novalid.html",
-			"category": "data-types",
-			"nuMessageIds": [
-				"nv-7d4efbcbb5f5"
-			]
-		},
-		{
-			"path": "html/datatypes/float-positive-negative-novalid.html",
-			"category": "data-types",
-			"nuMessageIds": [
-				"nv-1783425eab4b"
-			]
-		},
-		{
-			"path": "html/datatypes/float-positive-zero-novalid.html",
-			"category": "data-types",
-			"nuMessageIds": [
-				"nv-85dfd0a050d3"
-			]
-		},
-		{
-			"path": "html/datatypes/hashname-only-hash-novalid.html",
-			"category": "data-types",
-			"nuMessageIds": [
-				"nv-6622de022e4a",
-				"nv-95e4183a0bb8"
-			]
-		},
-		{
-			"path": "html/datatypes/month-out-of-range-novalid.html",
-			"category": "data-types",
-			"nuMessageIds": [
-				"nv-b024a99ed9d6"
-			]
-		},
-		{
 			"path": "html/datatypes/sandbox-scripts-same-origin-haswarn.html",
 			"category": "data-types",
 			"nuMessageIds": [
@@ -286,38 +229,10 @@
 			]
 		},
 		{
-			"path": "html/datatypes/time-hour-out-of-range-novalid.html",
-			"category": "data-types",
-			"nuMessageIds": [
-				"nv-2105f619b3af"
-			]
-		},
-		{
-			"path": "html/datatypes/time-minute-out-of-range-novalid.html",
-			"category": "data-types",
-			"nuMessageIds": [
-				"nv-d5e34b012fe5"
-			]
-		},
-		{
-			"path": "html/datatypes/time-second-out-of-range-novalid.html",
-			"category": "data-types",
-			"nuMessageIds": [
-				"nv-e225d1439ff4"
-			]
-		},
-		{
 			"path": "html/datatypes/url-empty-novalid.html",
 			"category": "data-types",
 			"nuMessageIds": [
 				"nv-9b9e85d36b74"
-			]
-		},
-		{
-			"path": "html/datatypes/week-invalid-format-novalid.html",
-			"category": "data-types",
-			"nuMessageIds": [
-				"nv-5779093b674c"
 			]
 		},
 		{

--- a/tests/external/snapshots/diff/summary.md
+++ b/tests/external/snapshots/diff/summary.md
@@ -1,6 +1,6 @@
 # nu-validator Benchmark Summary
 
-- generated: 2026-05-08T14:55:25.616Z
+- generated: 2026-05-09T04:38:35.414Z
 - submodule: `142931395412c00434ffb40a14d65992efd17aa8`
 - nu-validator: `ghcr.io/validator/validator@sha256:55c6ffb738db8b27ceef51a2320f0b9232266fa7eeecf42a0dc38e0c92edecfd`
 - markuplint: `5.0.0-rc.4`
@@ -9,21 +9,21 @@
 ## Totals
 
 - files: **5442**
-- match-error: **2138** (both tools flagged)
+- match-error: **2151** (both tools flagged)
 - match-clean: **920** (neither flagged)
-- nu-only: **1376** (only nu-validator flagged; markuplint coverage candidates — open a markuplint issue after a spec read)
+- nu-only: **1364** (only nu-validator flagged; markuplint coverage candidates — open a markuplint issue after a spec read)
 - nu-over: **28** (nu-validator errors fully covered by spec-backed excluded-ids — confirmed over-detection)
-- overall match rate: **56.2%**
+- overall match rate: **56.4%**
 - excluded-ids: 3 entries, 1 pattern(s)
 
 ## Per-Category
 
 | Category | Files | Match rate | match-error | match-clean | ml-only | nu-only | nu-over |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| aria | 780 | 79.6% | 169 | 452 | 145 | 14 | 0 |
+| aria | 780 | 79.7% | 170 | 452 | 144 | 14 | 0 |
 | assertions | 40 | 100.0% | 39 | 1 | 0 | 0 | 0 |
 | content-model | 98 | 98.0% | 48 | 48 | 0 | 2 | 0 |
-| data-types | 56 | 71.4% | 35 | 5 | 1 | 15 | 0 |
+| data-types | 56 | 92.9% | 47 | 5 | 1 | 3 | 0 |
 | deprecated | 12 | 91.7% | 11 | 0 | 1 | 0 | 0 |
 | global-attr | 57 | 80.7% | 26 | 20 | 8 | 3 | 0 |
 | id-duplication | 1 | 100.0% | 1 | 0 | 0 | 0 | 0 |
@@ -33,7 +33,7 @@
 
 ## Informational: ml-only
 
-**980** fixtures are flagged only by markuplint. This project does not pursue upstream nu-validator reports, so those fixtures feed a narrower audit: confirm with the spec, and if markuplint is the wrong one, fix the rule. The full list lives in `snapshots/diff/markuplint-only.json`.
+**979** fixtures are flagged only by markuplint. This project does not pursue upstream nu-validator reports, so those fixtures feed a narrower audit: confirm with the spec, and if markuplint is the wrong one, fix the rule. The full list lives in `snapshots/diff/markuplint-only.json`.
 
 ### Top ml-only rules
 
@@ -48,7 +48,7 @@
 | required-attr | 22 |
 | wai-aria-permitted-roles | 20 |
 | wai-aria-value | 11 |
-| no-refer-to-non-existent-id | 8 |
+| no-refer-to-non-existent-id | 7 |
 
 > `nu-only` entries are candidates for markuplint coverage work **after** verifying the relevant spec paragraph. `nu-over` entries are already confirmed nu-validator over-detection via `excluded-ids.json`. `ml-only` is informational; audit the spec before acting on any individual row.
 

--- a/tests/external/snapshots/meta.json
+++ b/tests/external/snapshots/meta.json
@@ -1,12 +1,12 @@
 {
-	"generatedAt": "2026-05-08T14:55:25.616Z",
+	"generatedAt": "2026-05-09T04:38:35.414Z",
 	"submoduleSha": "142931395412c00434ffb40a14d65992efd17aa8",
 	"nuValidatorImage": "ghcr.io/validator/validator@sha256:55c6ffb738db8b27ceef51a2320f0b9232266fa7eeecf42a0dc38e0c92edecfd",
 	"markuplintVersion": "5.0.0-rc.4",
 	"nodeVersion": "24.14.1",
 	"totalFilesNu": 5442,
-	"totalFilesMl": 5442,
-	"totalNuMessages": 9905,
-	"totalMlViolations": 9895,
+	"totalFilesMl": 56,
+	"totalNuMessages": 9906,
+	"totalMlViolations": 48,
 	"totalNuFailures": 0
 }


### PR DESCRIPTION
## Summary

Closes 12 of 15 \`data-types\` slice nu-only fixtures by tightening per-type value checks on \`<input>\` min/max, requiring positive \`<progress max>\`, and rejecting the bare \`#\` hash-name.

| Metric | before | after | delta |
| --- | ---: | ---: | ---: |
| match-error | 2138 | 2151 | +13 |
| match-clean | 920  | 920  |  0  |
| ml-only     | 980  | 979  | -1  |
| nu-only     | 1376 | 1364 | -12 |

data-types slice: 15 → 3 nu-only.

## Changes

### \`@markuplint/types\` — HashName non-empty
\`HashName\` now requires a name part after the leading \`#\`. Previously any string starting with \`#\` (including \`#\` alone) passed; per HTML LS valid-hash-name-reference the name part must be non-empty.

### \`@markuplint/html-spec\` — input min/max per-type
\`<input>\` \`min\`/\`max\` switch from the generic \`[\"DateTime\", \"Number\"]\` tuple to per-type conditional checkers (\`DateString\`/\`MonthString\`/\`WeekString\`/\`TimeString\`/\`LocalDateTimeString\`/\`{type:float}\`). The same checkers already power \`value\`; min/max now go through the same component-level validators (year/month/day/hour/minute/second range checks).

### \`@markuplint/html-spec\` — progress max gt:0
\`<progress max>\` switches from generic \`Number\` to \`{type: float, gt: 0}\` per HTML LS §4.10.13: \"The max attribute, if present, must have a value greater than zero.\"

### Tests
- \`@markuplint/types/check.spec.ts\` — HashName valid/invalid cases including unicode and whitespace boundaries.
- \`@markuplint/rules/invalid-attr/index.spec.ts\` — 13 new invalid tests (031..043), 11 valid tests (023..033) pinning bench fixture mirrors with message-substring assertions and per-test fixture cross-references.

### Bench snapshots
Regenerated; \`tests/external/snapshots/diff/*\` reflects the 12-fixture flip.

## Affected User-Visible Patterns

Markup that worked silently in 5.0.0-rc.x and now reports an error:

\`\`\`html
<!-- input min/max strict per-type -->
<input type=\"date\" min=\"2024-13-01\">      <!-- month 13 -->
<input type=\"date\" min=\"2024-02-30\">      <!-- Feb 30 -->
<input type=\"date\" min=\"12-31-2024\">      <!-- wrong format -->
<input type=\"month\" min=\"2024-00\">         <!-- month 0 -->
<input type=\"week\" min=\"2024-W54\">         <!-- week 54 -->
<input type=\"time\" min=\"25:00\">            <!-- hour 25 -->
<input type=\"time\" min=\"12:60\">            <!-- minute 60 -->
<input type=\"time\" min=\"12:30:60\">         <!-- second 60 -->
<input type=\"datetime-local\" min=\"2024-13-01T12:00\">

<!-- progress max must be positive non-zero -->
<progress max=\"0\"></progress>
<progress max=\"-5\"></progress>

<!-- HashName requires non-empty name -->
<img src=\"x.png\" usemap=\"#\" alt=\"\">
\`\`\`

### Opt-out

\`\`\`json
{ \"rules\": { \"invalid-attr\": false } }
\`\`\`

(All affected diagnostics flow through \`invalid-attr\` reading the spec data; there is no per-element opt-out.)

## Out of scope

Three deferred fixtures need design discussions of their own and are tracked in #3832:

- \`charset-invalid\` (IANA charset registry)
- \`url-empty\` (link href non-empty type composition)
- \`sandbox-scripts-same-origin-haswarn\` (warning-severity, requires bench policy change or new sandbox rule)

## Test plan

- [x] \`yarn lint-check\` (0 warnings, 0 errors; cspell skips files in worktree, see project memory)
- [x] \`yarn build\` (39 projects)
- [x] \`yarn test\` (3758 tests pass, 0 type errors)
- [x] \`yarn bench:update --target markuplint --filter 'html/datatypes/**'\` — 12 fixture flip confirmed
- [x] Full bench run on parallel + verified: -12 nu-only / +13 match-error / -1 ml-only (the -1 ml-only is a previously-over-detected fixture that nu now agrees on)

## Suggested labels

- \`Rule\`
- \`Specs\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)