### PR TITLE
fix(astro-parser): stop surfacing non-fatal Astro diagnostics as parse errors

### DIFF
--- a/packages/@markuplint/astro-parser/src/astro-parser.spec.ts
+++ b/packages/@markuplint/astro-parser/src/astro-parser.spec.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
 
+import { ParserError } from '@markuplint/parser-utils';
 import { describe, test, expect } from 'vitest';
 
 import { astroParse } from './astro-parser.js';
@@ -532,5 +533,92 @@ describe('Issues', () => {
 				],
 			}),
 		);
+	});
+
+	/**
+	 * Astro emits a Hint (severity=4) for `<script>` tags carrying any
+	 * non-`src` attribute without an explicit `is:inline`, and Warnings
+	 * (severity=2) for things like `set:html` overwriting children. The AST
+	 * is fully populated in both cases, so markuplint must not treat them as
+	 * a parse failure (#3823). This block also pins down the negative side:
+	 * severity=Error diagnostics and raw upstream syntax errors must still
+	 * surface as ParserError, never as a silent pass-through or as a leaked
+	 * upstream error type.
+	 */
+	describe('#3823 only severity=Error Astro diagnostics are fatal', () => {
+		describe('Hint (severity=4) is non-fatal', () => {
+			test('script with define:vars', () => {
+				expect(() => astroParse('<script define:vars={{ foo: 1 }}>console.log(foo);</script>')).not.toThrow();
+				const ast = astroParse('<script define:vars={{ foo: 1 }}>console.log(foo);</script>');
+				expect(ast.children?.[0]).toEqual(
+					expect.objectContaining({
+						type: 'element',
+						name: 'script',
+					}),
+				);
+			});
+
+			test('script type="module"', () => {
+				expect(() => astroParse('<script type="module">console.log("hello");</script>')).not.toThrow();
+				const ast = astroParse('<script type="module">console.log("hello");</script>');
+				expect(ast.children?.[0]).toEqual(
+					expect.objectContaining({
+						type: 'element',
+						name: 'script',
+					}),
+				);
+			});
+
+			test('script with data-* attribute', () => {
+				expect(() => astroParse('<script data-widget="example">console.log("hello");</script>')).not.toThrow();
+				const ast = astroParse('<script data-widget="example">console.log("hello");</script>');
+				expect(ast.children?.[0]).toEqual(
+					expect.objectContaining({
+						type: 'element',
+						name: 'script',
+					}),
+				);
+			});
+
+			test('script defer', () => {
+				expect(() => astroParse('<script defer>console.log("hello");</script>')).not.toThrow();
+				const ast = astroParse('<script defer>console.log("hello");</script>');
+				expect(ast.children?.[0]).toEqual(
+					expect.objectContaining({
+						type: 'element',
+						name: 'script',
+					}),
+				);
+			});
+		});
+
+		describe('Warning (severity=2) is non-fatal', () => {
+			test('set:html with children passes through (WARNING_SET_WITH_CHILDREN, code 2006)', () => {
+				expect(() => astroParse('<div set:html="x">child</div>')).not.toThrow();
+				const ast = astroParse('<div set:html="x">child</div>');
+				expect(ast.children?.[0]).toEqual(
+					expect.objectContaining({
+						type: 'element',
+						name: 'div',
+					}),
+				);
+			});
+		});
+
+		describe('Error (severity=1) and upstream syntax errors are fatal', () => {
+			test('unterminated /* in frontmatter throws ParserError with location', () => {
+				const fn = () => astroParse('---\n/* unterminated\n---\n<div></div>');
+				expect(fn).toThrow(ParserError);
+				expect(fn).toThrow(/unterminated/i);
+			});
+
+			test('unclosed HTML comment throws ParserError (normalized from upstream SyntaxError)', () => {
+				expect(() => astroParse('<!-- not closed\n<div></div>')).toThrow(ParserError);
+			});
+
+			test('unclosed expression throws ParserError (normalized from upstream SyntaxError)', () => {
+				expect(() => astroParse('<div>{ x </div>')).toThrow(ParserError);
+			});
+		});
 	});
 });

--- a/packages/@markuplint/astro-parser/src/astro-parser.ts
+++ b/packages/@markuplint/astro-parser/src/astro-parser.ts
@@ -3,6 +3,16 @@ import type { RootNode } from '@astrojs/compiler/types';
 import { ParserError } from '@markuplint/parser-utils';
 import { parseTemplate } from 'astro-eslint-parser';
 
+/**
+ * Astro tags each diagnostic with a VS Code-style severity
+ * (1=Error, 2=Warning, 3=Information, 4=Hint). The compiler exposes the
+ * enum as types-only via `@astrojs/compiler/types` — there is no runtime
+ * value to import — so the fatal level is mirrored as a literal here.
+ *
+ * @see https://github.com/withastro/compiler/blob/main/packages/compiler/shared/types.ts
+ */
+const ASTRO_DIAGNOSTIC_SEVERITY_ERROR = 1;
+
 export type {
 	RootNode,
 	ElementNode,
@@ -15,19 +25,64 @@ export type {
 
 /**
  * Parses an Astro component source string into the Astro compiler's root AST node.
- * Delegates to astro-eslint-parser and converts any diagnostics into ParserErrors.
+ *
+ * ## Diagnostic handling policy
+ *
+ * Only **severity=Error** Astro diagnostics surface as a `ParserError`.
+ * Warning / Information / Hint diagnostics are passed through silently
+ * because the AST is still fully populated for those levels and Astro's own
+ * tooling (the language server, `astro check`) owns the user-facing message
+ * — markuplint must not surface them as fatal `parse-error`s (#3823).
+ *
+ * Concretely, the `is:inline` Hint that Astro emits for a `<script>` tag
+ * carrying any non-`src` attribute, and the `set:html` Warning for
+ * `set:html` overwriting children, both reach this wrapper but do not
+ * abort parsing.
+ *
+ * ## Error normalization
+ *
+ * `parseTemplate()` itself throws on severity=Error diagnostics and on raw
+ * template syntax errors (unterminated comments, unclosed expressions,
+ * etc.) by raising a `SyntaxError`-derived `ParseError`. Those throws are
+ * caught and normalized to `ParserError`, so the caller sees a single
+ * Tier-3 (per-file violation) error type for every parse failure rather
+ * than a Tier-1 fatal `SyntaxError` that would abort the whole lint run.
+ *
+ * The defensive `find(severity === Error)` after `parseTemplate()` is dead
+ * code today (upstream gates internally) but is retained as a safety net
+ * if a future `astro-eslint-parser` ever stops gating severity=Error.
+ *
+ * @see https://github.com/markuplint/markuplint/issues/3823
+ * @see https://docs.astro.build/en/reference/directives-reference/#isinline
+ * @see https://docs.astro.build/en/guides/client-side-scripts/#script-processing
  *
  * @param code - The raw Astro component source code
  * @returns The root AST node produced by the Astro compiler
+ * @throws {ParserError} on severity=Error Astro diagnostics or on raw upstream syntax errors
  */
 export function astroParse(code: string): RootNode {
-	const { result } = parseTemplate(code);
+	let result;
+	try {
+		({ result } = parseTemplate(code));
+	} catch (error) {
+		if (!(error instanceof SyntaxError)) {
+			throw error;
+		}
+		const { lineNumber, column } = error as SyntaxError & { lineNumber?: number; column?: number };
+		throw new ParserError(error.message, {
+			line: lineNumber ?? 1,
+			col: column ?? 0,
+		});
+	}
 
-	if (result.diagnostics[0]) {
-		const error = result.diagnostics[0];
-		throw new ParserError(error.text, {
-			line: error.location.line,
-			col: error.location.column,
+	// Defensive: if a future `astro-eslint-parser` stops gating severity=Error
+	// diagnostics internally, surface them here so they never silently leak
+	// past the wrapper as a non-fatal pass-through.
+	const fatal = result.diagnostics.find(d => d.severity === ASTRO_DIAGNOSTIC_SEVERITY_ERROR);
+	if (fatal) {
+		throw new ParserError(fatal.text, {
+			line: fatal.location.line,
+			col: fatal.location.column,
 		});
 	}
 

--- a/packages/@markuplint/astro-parser/src/parser.spec.ts
+++ b/packages/@markuplint/astro-parser/src/parser.spec.ts
@@ -663,4 +663,34 @@ describe('Issue', () => {
 `);
 		expect(ast).toBeTruthy();
 	});
+
+	describe('#3823 script tag diagnostics are not fatal', () => {
+		test('script type="module" parses to a script element', () => {
+			const ast = parse('<script type="module">console.log("hello");</script>');
+			expect(ast.parseError).toBeUndefined();
+			const map = nodeListToDebugMaps(ast.nodeList);
+			expect(map[0]).toBe('[1:1]>[1:23](0,22)script: <script␣type="module">');
+		});
+
+		test('script defer parses to a script element', () => {
+			const ast = parse('<script defer>console.log("hello");</script>');
+			expect(ast.parseError).toBeUndefined();
+			const map = nodeListToDebugMaps(ast.nodeList);
+			expect(map[0]).toBe('[1:1]>[1:15](0,14)script: <script␣defer>');
+		});
+
+		test('script with data-* attribute parses to a script element', () => {
+			const ast = parse('<script data-widget="example">console.log("hello");</script>');
+			expect(ast.parseError).toBeUndefined();
+			const map = nodeListToDebugMaps(ast.nodeList);
+			expect(map[0]).toBe('[1:1]>[1:31](0,30)script: <script␣data-widget="example">');
+		});
+
+		test('script with define:vars parses to a script element', () => {
+			const ast = parse('<script define:vars={{ foo: 1 }}>console.log(foo);</script>');
+			expect(ast.parseError).toBeUndefined();
+			const map = nodeListToDebugMaps(ast.nodeList);
+			expect(map[0]).toBe('[1:1]>[1:34](0,33)script: <script␣define:vars={{␣foo:␣1␣}}>');
+		});
+	});
 });

--- a/packages/@markuplint/ml-core/src/index.spec.ts
+++ b/packages/@markuplint/ml-core/src/index.spec.ts
@@ -1283,4 +1283,24 @@ key: value
 		expect(createTestDocument(contents[1]).toString()).toBe(contents[1]);
 		expect(createTestDocument(contents[2]).toString()).toBe(contents[2]);
 	});
+
+	test('#3823 — Astro <script> with non-src attributes is parseable end-to-end', async () => {
+		// Reproduces https://github.com/markuplint/markuplint/issues/3823: in
+		// previous versions the Astro compiler's `is:inline` Hint reached
+		// markuplint as a fatal `parse-error`. The fix lives in
+		// `@markuplint/astro-parser`; this test pins the contract at the
+		// document-creation boundary so a regression in the parser package is
+		// caught at the integration seam, not just in the parser unit tests.
+		const parser = await import('@markuplint/astro-parser');
+		const cases = [
+			'<script define:vars={{ foo: 1 }}>console.log(foo);</script>',
+			'<script type="module">console.log("hello");</script>',
+			'<script data-widget="example">console.log("hello");</script>',
+			'<script defer>console.log("hello");</script>',
+		];
+		for (const code of cases) {
+			const doc = createTestDocument(code, { parser });
+			expect(doc.querySelector('script')).not.toBeNull();
+		}
+	});
 });


### PR DESCRIPTION
## Summary

- Fixes #3823. Astro tags each diagnostic with a VS Code-style severity (1=Error, 2=Warning, 3=Information, 4=Hint). The wrapper used to throw `ParserError` on the first diagnostic of any severity, which turned the `is:inline` Hint emitted for `<script>` tags carrying any non-`src` attribute into a fatal markuplint parse-error. Severity Warning / Information / Hint now pass through silently because the AST is fully populated and Astro's own tooling owns those advisory messages.
- Upstream `parseTemplate()` itself throws on severity=Error and on raw template syntax errors (unterminated comments, unclosed expressions, ...). Those `SyntaxError`-class throws are now caught and normalized to `ParserError`, so callers see a single Tier-3 (per-file violation) error type instead of a Tier-1 fatal that would abort the whole lint run.
- Adds regression coverage at three layers: `astroParse()` unit, `AstroParser.parse()` integration, and `createTestDocument()` cross-package boundary in `ml-core`.

## Test plan

- [x] `yarn lint-check` passes (eslint + prettier)
- [x] `yarn build` succeeds for all 37 packages
- [x] `yarn test` — 142 files / 1447 tests pass / 1 skipped
- [x] New `astro-parser.spec.ts` cases prove Hint (`script type="module"` etc.), Warning (`set:html` with children), and Error (unterminated `/*`, unclosed comment, unclosed expression) paths all behave correctly
- [x] Cross-package `ml-core` test covers the original report's four `<script>` shapes via `createTestDocument`

## References

- Issue: #3823
- Astro `is:inline` directive: https://docs.astro.build/en/reference/directives-reference/#isinline
- Astro script processing: https://docs.astro.build/en/guides/client-side-scripts/#script-processing