### PR TITLE
fix(html-spec): forbid nested svg|a per SVG2 §17.6

### DIFF
--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -57342,14 +57342,14 @@
 						"condition": "svg|switch > svg|a",
 						"contents": [
 							{
-								"transparent": "*"
+								"transparent": ":not(svg|a, :has(svg|a))"
 							}
 						]
 					}
 				],
 				"contents": [
 					{
-						"transparent": "*, :model(SVGDescriptive):not(svg|a, :has(svg|a))"
+						"transparent": ":not(svg|a, :has(svg|a))"
 					}
 				]
 			},

--- a/packages/@markuplint/html-spec/src/spec.svg_a.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.svg_a.jsonc
@@ -7,14 +7,17 @@
 				"condition": "svg|switch > svg|a",
 				"contents": [
 					{
-						"transparent": "*"
+						// SVG2 §17.6 — "may contain any element that its parent
+						// may contain, except itself".
+						"transparent": ":not(svg|a, :has(svg|a))"
 					}
 				]
 			}
 		],
 		"contents": [
 			{
-				"transparent": "*, :model(SVGDescriptive):not(svg|a, :has(svg|a))"
+				// SVG2 §17.6 — same self-exclusion applies outside <svg|switch>.
+				"transparent": ":not(svg|a, :has(svg|a))"
 			}
 		]
 	},

--- a/packages/@markuplint/html-spec/src/spec.svg_a.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.svg_a.jsonc
@@ -2,6 +2,11 @@
 // https://www.w3.org/TR/svg-aam-1.0/#details-id-0
 {
 	"contentModel": {
+		// The `svg|switch > svg|a` branch is functionally equivalent to the
+		// default branch today, but is preserved so future svg|switch-specific
+		// constraints can be expressed without restructuring spec consumers
+		// that walk this `conditional` shape (e.g., the rules engine and the
+		// generated `index.json`).
 		"conditional": [
 			{
 				"condition": "svg|switch > svg|a",

--- a/packages/@markuplint/rules/src/permitted-contents/index.spec.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/index.spec.ts
@@ -716,31 +716,65 @@ describe('verify', () => {
 			},
 		]);
 
-		// Transitive nesting (via <g>) must also be rejected. The inner <a>
-		// is reported directly through transparent self-exclusion; its text
-		// descendant then surfaces as a follow-up violation through <g>'s
-		// own transparent model.
+		// Transitive nesting (via <g>) must also be rejected. The primary
+		// violation is the inner <a>: the spec change (`:has(svg|a)` in the
+		// transparent expression) is what catches it. The follow-up text
+		// violation is INCIDENTAL — it falls out of how the engine surfaces
+		// children of a transparent-rejected node, and may shift if that
+		// propagation logic changes. Treat only the first entry as the
+		// load-bearing assertion for this PR.
 		const { violations: violations4 } = await mlRuleTest(
 			rule,
 			'<svg><a href="#"><g><a href="#">nested</a></g></a></svg>',
 		);
-		expect(violations4).toStrictEqual([
-			{
-				severity: 'error',
-				line: 1,
-				col: 21,
-				message: 'The "a" element is a transparent model but also disallows the "a" element in this context',
-				raw: '<a href="#">',
-			},
-			{
-				severity: 'error',
-				line: 1,
-				col: 33,
-				message:
-					'The text node is not allowed in the "g" element through the transparent model in this context',
-				raw: 'nested',
-			},
-		]);
+		expect(violations4[0]).toStrictEqual({
+			severity: 'error',
+			line: 1,
+			col: 21,
+			message: 'The "a" element is a transparent model but also disallows the "a" element in this context',
+			raw: '<a href="#">',
+		});
+	});
+
+	test('[permitted-contents-valid-002] svg:a wrapping <g> without nested <a>', async () => {
+		// Regression guard: the `:has(svg|a)` constraint added for
+		// invalid-017 must not over-fire on wrappers that legitimately do
+		// not contain another <a>.
+		const { violations } = await mlRuleTest(
+			rule,
+			'<svg><a href="#"><g><rect width="10" height="10"/></g></a></svg>',
+		);
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('[permitted-contents-invalid-030] svg:a self-nesting inside svg:switch', async () => {
+		// Covers the conditional `svg|switch > svg|a` branch of spec.svg_a.jsonc.
+		// SVG2 §17.6's self-exclusion applies in this context too; without this
+		// test, deleting the conditional-branch fix would not break any test.
+		const { violations } = await mlRuleTest(
+			rule,
+			'<svg><switch><a href="#"><a href="#">nested</a></a></switch></svg>',
+		);
+		expect(violations[0]).toStrictEqual({
+			severity: 'error',
+			line: 1,
+			col: 26,
+			message: 'The "a" element is a transparent model but also disallows the "a" element in this context',
+			raw: '<a href="#">',
+		});
+	});
+
+	test('[permitted-contents-invalid-031] svg:a self-nesting via svg:defs wrapper', async () => {
+		// Wrapper-agnostic check: `:has(svg|a)` should reject any element that
+		// contains an <a>, regardless of which container is used.
+		const { violations } = await mlRuleTest(rule, '<svg><a href="#"><defs><a href="#">nested</a></defs></a></svg>');
+		expect(violations[0]).toStrictEqual({
+			severity: 'error',
+			line: 1,
+			col: 24,
+			message: 'The "a" element is a transparent model but also disallows the "a" element in this context',
+			raw: '<a href="#">',
+		});
 	});
 
 	test('[permitted-contents-invalid-018] svg:foreignObject', async () => {

--- a/packages/@markuplint/rules/src/permitted-contents/index.spec.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/index.spec.ts
@@ -702,6 +702,45 @@ describe('verify', () => {
 				raw: '<feBlend />',
 			},
 		]);
+
+		// SVG2 §17.6 — "may contain any element that its parent may contain,
+		// except itself". Direct nested <svg|a> must be rejected.
+		const { violations: violations3 } = await mlRuleTest(rule, '<svg><a href="#"><a href="#">nested</a></a></svg>');
+		expect(violations3).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 18,
+				message: 'The "a" element is a transparent model but also disallows the "a" element in this context',
+				raw: '<a href="#">',
+			},
+		]);
+
+		// Transitive nesting (via <g>) must also be rejected. The inner <a>
+		// is reported directly through transparent self-exclusion; its text
+		// descendant then surfaces as a follow-up violation through <g>'s
+		// own transparent model.
+		const { violations: violations4 } = await mlRuleTest(
+			rule,
+			'<svg><a href="#"><g><a href="#">nested</a></g></a></svg>',
+		);
+		expect(violations4).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 21,
+				message: 'The "a" element is a transparent model but also disallows the "a" element in this context',
+				raw: '<a href="#">',
+			},
+			{
+				severity: 'error',
+				line: 1,
+				col: 33,
+				message:
+					'The text node is not allowed in the "g" element through the transparent model in this context',
+				raw: 'nested',
+			},
+		]);
 	});
 
 	test('[permitted-contents-invalid-018] svg:foreignObject', async () => {

--- a/tests/external/snapshots/diff/coverage.json
+++ b/tests/external/snapshots/diff/coverage.json
@@ -13060,8 +13060,8 @@
 			"path": "html-svg/svg-a-nested-in-svg-a-novalid.html",
 			"category": "uncategorized",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{

--- a/tests/external/snapshots/diff/nu-only.json
+++ b/tests/external/snapshots/diff/nu-only.json
@@ -144,13 +144,6 @@
 			]
 		},
 		{
-			"path": "html-svg/svg-a-nested-in-svg-a-novalid.html",
-			"category": "uncategorized",
-			"nuMessageIds": [
-				"nv-da8c90c8321b"
-			]
-		},
-		{
 			"path": "html/attributes/command-with-aria-expanded-novalid.html",
 			"category": "global-attr",
 			"nuMessageIds": [

--- a/tests/external/snapshots/diff/summary.md
+++ b/tests/external/snapshots/diff/summary.md
@@ -1,6 +1,6 @@
 # nu-validator Benchmark Summary
 
-- generated: 2026-05-09T15:23:33.619Z
+- generated: 2026-05-10T01:00:24.409Z
 - submodule: `142931395412c00434ffb40a14d65992efd17aa8`
 - nu-validator: `ghcr.io/validator/validator@sha256:9746b8663542cb5bded271fea08a3cc04ca12af6232f014baa341fccc01d3a21`
 - markuplint: `5.0.0-rc.4`
@@ -9,11 +9,11 @@
 ## Totals
 
 - files: **5442**
-- match-error: **2168** (both tools flagged)
+- match-error: **2169** (both tools flagged)
 - match-clean: **920** (neither flagged)
-- nu-only: **1346** (only nu-validator flagged; markuplint coverage candidates — open a markuplint issue after a spec read)
+- nu-only: **1345** (only nu-validator flagged; markuplint coverage candidates — open a markuplint issue after a spec read)
 - nu-over: **28** (nu-validator errors fully covered by spec-backed excluded-ids — confirmed over-detection)
-- overall match rate: **56.7%**
+- overall match rate: **56.8%**
 - excluded-ids: 3 entries, 1 pattern(s)
 
 ## Per-Category
@@ -29,7 +29,7 @@
 | id-duplication | 1 | 100.0% | 1 | 0 | 0 | 0 | 0 |
 | invalid-attr | 3086 | 59.1% | 1592 | 231 | 60 | 1177 | 26 |
 | required-attr | 5 | 100.0% | 5 | 0 | 0 | 0 | 0 |
-| uncategorized | 1307 | 29.6% | 224 | 163 | 765 | 153 | 2 |
+| uncategorized | 1307 | 29.7% | 225 | 163 | 765 | 152 | 2 |
 
 ## Informational: ml-only
 

--- a/tests/external/snapshots/meta.json
+++ b/tests/external/snapshots/meta.json
@@ -1,5 +1,5 @@
 {
-	"generatedAt": "2026-05-09T15:23:33.619Z",
+	"generatedAt": "2026-05-10T01:00:24.409Z",
 	"submoduleSha": "142931395412c00434ffb40a14d65992efd17aa8",
 	"nuValidatorImage": "ghcr.io/validator/validator@sha256:9746b8663542cb5bded271fea08a3cc04ca12af6232f014baa341fccc01d3a21",
 	"markuplintVersion": "5.0.0-rc.4",
@@ -7,6 +7,6 @@
 	"totalFilesNu": 5442,
 	"totalFilesMl": 5442,
 	"totalNuMessages": 9905,
-	"totalMlViolations": 9941,
+	"totalMlViolations": 9942,
 	"totalNuFailures": 0
 }


### PR DESCRIPTION
## Summary

- **Bug**: SVG2 §17.6 forbids `<svg|a>` from containing another `<svg|a>` ("may contain any element that its parent may contain, except itself"), but `spec.svg_a.jsonc` allowed it. The unconditional `*` admitted every element including `svg|a`, and the `:model(SVGDescriptive):not(svg|a, :has(svg|a))` constraint only covered the descriptive-content branch.
- **Fix**: tighten both transparent expressions (the conditional `svg|switch > svg|a` branch and the default branch) to `:not(svg|a, :has(svg|a))`, mirroring the pattern that HTML `<a>` already uses.
- **Coverage**: extends `[permitted-contents-invalid-017]` with direct nesting (`<svg><a><a>`) and transitive nesting (`<svg><a><g><a>`) cases.
- **Bench**: `html-svg/svg-a-nested-in-svg-a-novalid.html` flips nu-only → match-error. No other verdict changes.

Cumulative nu-only triage: 1346 → 1345 (-1).

## Test plan

- [x] `yarn lint-check` — 0 errors / 0 warnings
- [x] `yarn build` — all 39 packages succeed
- [x] `yarn test` — 248/248 test files, 3788 tests pass
- [x] `permitted-contents-invalid-017` covers direct + transitive svg|a nesting
- [x] `tests/external/snapshots/diff/summary.md` shows 1 nu-only → match-error flip with no regressions
- [ ] CI all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)