### PR TITLE
test: register coverage Issues in bench-xref + SKILL fact-check gate

### DIFF
--- a/.claude/skills/bench-triage/SKILL.md
+++ b/.claude/skills/bench-triage/SKILL.md
@@ -187,6 +187,36 @@ yarn bench:compare
 If the verdict flipped, the original observation was parallel-run
 flicker, not a real signal.
 
+## Step 7: Fact-check the Issue body before filing
+
+When the verdict points at "open or extend an Issue" and the Issue
+body cites specific repository assets — file paths, package names,
+spec data files, helper libraries — every reference MUST be verified
+to exist in the current tree before the Issue is filed. Implementers
+read the Issue first; a wrong path sends them to a dead end.
+
+Required pre-filing checks:
+
+1. **File paths**: every quoted path resolves (`ls <path>` or open in editor).
+2. **"Add new file" claims**: confirm the file is actually missing
+   (`find packages/... -name '<pattern>'`). If a file with the same
+   role already exists, change the wording to "extend" instead of
+   "add" and list the existing files explicitly.
+3. **Recommended npm libraries**: package exists and is currently
+   maintained (`npm view <pkg>` or check the npm/registry page).
+   Do not write `(or similar)` placeholders.
+4. **Spec section numbers**: dereference the cited URL once before
+   pasting; section numbers shift between drafts.
+5. **bench-xref registration**: when the Issue is `primary` (i.e.,
+   bench fixtures back its claim), add a mapping in
+   `tests/external/bench/issue-xref.config.ts` so `bench-xref` keeps
+   the body in sync on each release-prep cycle.
+
+Skipping any of these is the same failure mode as filing without a
+spec quote: it pollutes the inventory with stale or false references
+that other agents and humans will then act on. Treat it as a hard
+gate, not a polish step.
+
 ## Audit log of message-substring decisions
 
 Each row is a conclusion reached by reading the cited paragraph

--- a/tests/external/bench/issue-xref.config.ts
+++ b/tests/external/bench/issue-xref.config.ts
@@ -64,6 +64,41 @@ export const xrefMappings: readonly XrefMapping[] = [
 		note:
 			'Two distinct gaps surface here: (A) `parse5` onParseError signals (HTML LS §13.2.5 tokenizer errors — bogus comment/doctype, EOF inside comment/doctype/system-id, character-reference malformations, U+0000/U+000B forbidden code points, unquoted-attr edge cases) are not surfaced as violations by `@markuplint/html-parser`; (B) `isDocumentFragment` heuristic treats any source not starting with `<!doctype html>` or `<html>` as a fragment, so the `doctype` rule skips full documents that begin with `<meta>`/`<title>` (`no-doctype`, `eof-without-doctype`, `bogus-doctype`, `nameless-doctype`, etc.). Closing both is a prerequisite for completing nu-validator parser-error coverage.',
 	},
+	{
+		kind: 'primary',
+		issue: 3848,
+		filter: /^html\/(invalid-attr|microdata\/(itemid|itemtype))\//,
+		note:
+			'URL Living Standard validator implementation. Largest single residual: 1246 nu-only fixtures (invalid-attr 1177 + microdata/itemid 39 + microdata/itemtype 30). Single implementation project in `packages/@markuplint/types/src/whatwg/check-url.ts` unlocks all of them at once. Confirmed nu-correct error categories (per bench-triage SKILL audit log): invalid-credentials, special-scheme-missing-following-solidus, invalid-reverse-solidus, invalid-URL-unit, file-invalid-Windows-drive-letter.',
+	},
+	{
+		kind: 'primary',
+		issue: 3849,
+		filter: /^html-math\//,
+		note:
+			'MathML Core content model constraints. 12 fixtures (mfrac/mover/mroot/msub/msup/msubsup/munder/munderover arity, mprescripts/mtr/annotation parent restrictions, math-in-head). Per-element spec data files already exist as `spec.mml_*.jsonc` (32 files); the gap is expressing arity / parent constraints inside them. `spec.svg_a.jsonc` is the conditional-branch precedent.',
+	},
+	{
+		kind: 'primary',
+		issue: 3850,
+		filter: /^html\/media-queries\//,
+		note:
+			'CSS Media Queries Level 4/5 syntax validation in `media=` attribute. 13 fixtures (unrecognized media, missing units, deprecated features). Add a new typed checker under `packages/@markuplint/types/src/whatwg/` following the `check-mime-type` / `check-link-type` pattern.',
+	},
+	{
+		kind: 'primary',
+		issue: 3851,
+		filter: /^html\/mime-types\//,
+		note:
+			'MIME type quoted-string parameter parsing. 2 fixtures (unfinished quoted string in `text/html;charset="..."`). Extend the existing `packages/@markuplint/types/src/whatwg/check-mime-type.ts` to validate parameter quoted-string termination per RFC 9110 §5.6.6.',
+	},
+	{
+		kind: 'primary',
+		issue: 3852,
+		filter: /^html\/microdata\/(itemprop-not-in-item|itemref-redundant|itemtype-empty)/,
+		note:
+			'Microdata semantic constraints. 3 fixtures: itemprop without itemscope ancestor (HTML LS §5.2.4), duplicate ids in itemref (§5.2.2), empty itemtype value (§5.2.1). Three small focused rules — distinct from the URL-syntax work in #3848.',
+	},
 
 	// === 2 次群: bench では裏取れない Issue（ステルブロック） ===
 	{


### PR DESCRIPTION
## Summary

Two follow-ups to the recent uncategorized triage cycle:

- **Register Issues #3848 / #3849 / #3850 / #3851 / #3852 as `primary` mappings** in `tests/external/bench/issue-xref.config.ts`. Without registration, the freshly-filed coverage Issues stay invisible to `bench-xref`'s `<!-- bench-xref:begin v1 -->` synchronization and to the pre-release checklist. Each filter regex matches only the fixture sub-tree the Issue is responsible for.
- **Add Step 7 to the `bench-triage` SKILL** ("Fact-check the Issue body before filing"). Triggered by an incident where four newly-filed Issues each cited at least one wrong path or missed an existing spec data file. Documents the hard gate so future agents and contributors do not repeat the same mistake.

No code-path or runtime-behaviour changes; both edits are pure documentation / config-as-code.

## Test plan

- [x] `yarn lint-check` — 0 errors / 0 warnings
- [x] `npx vitest run tests/external/bench` — 107/107 tests pass (covers `xref-issue.ts` consumers of `issue-xref.config.ts`)
- [x] `tsc` typecheck via vitest — `XrefMapping` shape satisfied for all 5 new entries
- [x] Each new `filter` regex matches only the intended sub-tree (verified against current `nu-only.json` fixture paths)
- [ ] CI all green
- [ ] After merge, run `yarn bench:xref` once to confirm the bench-xref blocks land on Issues #3848-#3852

🤖 Generated with [Claude Code](https://claude.com/claude-code)