### PR TITLE
fix(types): reject unterminated quoted-string in MIME type parameters

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -169,6 +169,7 @@
 
 		// Specs
 		"closedby",
+		"DQUOTE",
 		"khern",
 		"mathml",
 		"tref",

--- a/packages/@markuplint/types/src/whatwg/check-mime-type.spec.ts
+++ b/packages/@markuplint/types/src/whatwg/check-mime-type.spec.ts
@@ -50,6 +50,54 @@ test('quoted-string parameter properly terminated stays valid', () => {
 	expect(check('text/html;charset="\\""').matched).toBe(true);
 });
 
+test('empty quoted-string parameter (`""`) is valid', () => {
+	// Inner loop sees the closing DQUOTE on its very first iteration; the
+	// terminated flag is set immediately. Regression guard for the refactor
+	// that introduced the explicit `terminated` boolean.
+	expect(check('text/html;charset=""').matched).toBe(true);
+});
+
+test('escaped backslash inside a quoted string does not consume the closing DQUOTE', () => {
+	// JS `'\\\\'` is the two-character string `\\`, which after MIME-type
+	// quoted-string unescaping is the single character `\`. The `\` escape
+	// must consume the next `\`, not the trailing `"`.
+	expect(check('text/html;a="b\\\\"').matched).toBe(true);
+});
+
+test('only the second parameter is unterminated', () => {
+	// Confirms the outer loop continues past a properly-terminated parameter
+	// before reaching the unterminated one — exercises the multi-parameter
+	// state machine that the bench fixtures (008/009) do not cover.
+	expect(check('text/html;a="x";b="y')).toStrictEqual({
+		column: 19,
+		expects: [{ type: 'format', value: 'MIME Type' }],
+		length: 2,
+		line: 1,
+		matched: false,
+		offset: 18,
+		raw: '"y',
+		reason: 'syntax-error',
+		ref: null,
+	});
+});
+
+test('semicolon inside an unterminated quoted-string is consumed as content, not a separator', () => {
+	// `"x;b=y` is one unterminated quoted-string; the `;` does NOT split off
+	// `b=y` as a new parameter because it falls inside the unterminated
+	// DQUOTE region. Verifies the inner loop's separator rules.
+	expect(check('text/html;a="x;b=y')).toStrictEqual({
+		column: 13,
+		expects: [{ type: 'format', value: 'MIME Type' }],
+		length: 6,
+		line: 1,
+		matched: false,
+		offset: 12,
+		raw: '"x;b=y',
+		reason: 'syntax-error',
+		ref: null,
+	});
+});
+
 test('excrescence-token', () => {
 	expect(check('xy;')).toStrictEqual({
 		column: 1,

--- a/packages/@markuplint/types/src/whatwg/check-mime-type.spec.ts
+++ b/packages/@markuplint/types/src/whatwg/check-mime-type.spec.ts
@@ -10,6 +10,46 @@ test('valid', () => {
 	expect(check('x/y;a=b;c=D;E="F"').matched).toBe(true);
 });
 
+test('unterminated quoted-string parameter (no closing DQUOTE)', () => {
+	// Mirrors `tests/external/validator/tests/html/mime-types/008-novalid.html`.
+	// `whatwg-mimetype` would parse this as `text/html; charset=utf-8` (silently
+	// dropping the missing terminator), so the check must short-circuit.
+	expect(check('text/html;charset="utf-8')).toStrictEqual({
+		column: 19,
+		expects: [{ type: 'format', value: 'MIME Type' }],
+		length: 6,
+		line: 1,
+		matched: false,
+		offset: 18,
+		raw: '"utf-8',
+		reason: 'syntax-error',
+		ref: null,
+	});
+});
+
+test('unterminated quoted-string parameter ending with backslash escape', () => {
+	// Mirrors `tests/external/validator/tests/html/mime-types/009-novalid.html`.
+	// The trailing `\` consumes the would-be terminator and leaves the value
+	// unterminated; nu-validator reports "Unfinished quoted string."
+	expect(check('text/html;charset="u\\')).toStrictEqual({
+		column: 19,
+		expects: [{ type: 'format', value: 'MIME Type' }],
+		length: 3,
+		line: 1,
+		matched: false,
+		offset: 18,
+		raw: '"u\\',
+		reason: 'syntax-error',
+		ref: null,
+	});
+});
+
+test('quoted-string parameter properly terminated stays valid', () => {
+	expect(check('text/html;charset="utf-8"').matched).toBe(true);
+	// Escaped DQUOTE inside a properly-terminated quoted string is fine.
+	expect(check('text/html;charset="\\""').matched).toBe(true);
+});
+
 test('excrescence-token', () => {
 	expect(check('xy;')).toStrictEqual({
 		column: 1,

--- a/packages/@markuplint/types/src/whatwg/check-mime-type.ts
+++ b/packages/@markuplint/types/src/whatwg/check-mime-type.ts
@@ -18,10 +18,18 @@ const expects = (withoutParameters: boolean) => [
  * unterminated (no closing DQUOTE before end-of-string), or `null` when every
  * quoted-string is properly closed.
  *
- * RFC 9110 §5.6.6 requires the closing DQUOTE in `quoted-string`; the WHATWG
- * MIME Sniffing parser tolerates the missing terminator and returns a partial
- * value (so `MIMEType.parse` cannot surface this conformance error). We do
- * the structural scan ourselves and run it before invoking the parser.
+ * [RFC 9110 §5.6.6](https://www.rfc-editor.org/rfc/rfc9110#name-parameters)
+ * requires the closing DQUOTE in `quoted-string`; the
+ * [WHATWG MIME Sniffing](https://mimesniff.spec.whatwg.org/#parse-a-mime-type)
+ * parser tolerates the missing terminator and returns a partial value (so
+ * `MIMEType.parse` cannot surface this conformance error). We do the
+ * structural scan ourselves and run it before invoking the parser.
+ *
+ * **Limitation:** the scan assumes the opening DQUOTE immediately follows
+ * the `=` byte. RFC 9110 allows OWS (optional whitespace) around `=`, but
+ * WHATWG MIME Sniffing's tokenizer (and every nu-validator-known input
+ * today) closes that gap. If a future fixture exercises `; charset = "..."`
+ * style spacing, extend this scan to skip OWS before checking for `"`.
  *
  * @param value Raw attribute value to scan.
  * @returns The offset of the opening DQUOTE of the unterminated parameter, or `null`.

--- a/packages/@markuplint/types/src/whatwg/check-mime-type.ts
+++ b/packages/@markuplint/types/src/whatwg/check-mime-type.ts
@@ -39,6 +39,7 @@ function findUnterminatedQuotedString(value: string): { readonly offset: number 
 		if (i >= value.length || value[i] !== '"') continue;
 		const start = i;
 		i++;
+		let terminated = false;
 		while (i < value.length) {
 			if (value[i] === '\\') {
 				i += 2;
@@ -46,11 +47,12 @@ function findUnterminatedQuotedString(value: string): { readonly offset: number 
 			}
 			if (value[i] === '"') {
 				i++;
+				terminated = true;
 				break;
 			}
 			i++;
 		}
-		if (i > value.length || (i === value.length && value[i - 1] !== '"')) {
+		if (!terminated) {
 			return { offset: start };
 		}
 	}

--- a/packages/@markuplint/types/src/whatwg/check-mime-type.ts
+++ b/packages/@markuplint/types/src/whatwg/check-mime-type.ts
@@ -14,6 +14,50 @@ const expects = (withoutParameters: boolean) => [
 ];
 
 /**
+ * Locates the start position of a parameter whose quoted-string value is
+ * unterminated (no closing DQUOTE before end-of-string), or `null` when every
+ * quoted-string is properly closed.
+ *
+ * RFC 9110 §5.6.6 requires the closing DQUOTE in `quoted-string`; the WHATWG
+ * MIME Sniffing parser tolerates the missing terminator and returns a partial
+ * value (so `MIMEType.parse` cannot surface this conformance error). We do
+ * the structural scan ourselves and run it before invoking the parser.
+ *
+ * @param value Raw attribute value to scan.
+ * @returns The offset of the opening DQUOTE of the unterminated parameter, or `null`.
+ */
+function findUnterminatedQuotedString(value: string): { readonly offset: number } | null {
+	for (let i = 0; i < value.length; ) {
+		if (value[i] !== ';') {
+			i++;
+			continue;
+		}
+		i++;
+		while (i < value.length && value[i] !== '=' && value[i] !== ';') i++;
+		if (i >= value.length || value[i] === ';') continue;
+		i++;
+		if (i >= value.length || value[i] !== '"') continue;
+		const start = i;
+		i++;
+		while (i < value.length) {
+			if (value[i] === '\\') {
+				i += 2;
+				continue;
+			}
+			if (value[i] === '"') {
+				i++;
+				break;
+			}
+			i++;
+		}
+		if (i > value.length || (i === value.length && value[i - 1] !== '"')) {
+			return { offset: start };
+		}
+	}
+	return null;
+}
+
+/**
  * Validates a MIME type string according to the WHATWG MIME Sniffing specification.
  *
  * Optionally restricts to MIME types with no parameters.
@@ -29,6 +73,13 @@ export const checkMIMEType: CustomSyntaxChecker<{
 	const withoutParameters = options?.withoutParameters ?? false;
 	if (!value) {
 		return unmatched(value, 'empty-token', { expects: expects(withoutParameters) });
+	}
+	const unterminated = findUnterminatedQuotedString(value);
+	if (unterminated) {
+		return new Token(value.slice(unterminated.offset), unterminated.offset, value).unmatched({
+			reason: 'syntax-error',
+			expects: expects(withoutParameters),
+		});
 	}
 	const mimeType = MIMEType.parse(value);
 	if (mimeType) {

--- a/tests/external/snapshots/diff/coverage.json
+++ b/tests/external/snapshots/diff/coverage.json
@@ -42382,8 +42382,8 @@
 			"path": "html/mime-types/008-novalid.html",
 			"category": "uncategorized",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -42398,8 +42398,8 @@
 			"path": "html/mime-types/009-novalid.html",
 			"category": "uncategorized",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{

--- a/tests/external/snapshots/diff/nu-only.json
+++ b/tests/external/snapshots/diff/nu-only.json
@@ -9056,20 +9056,6 @@
 			]
 		},
 		{
-			"path": "html/mime-types/008-novalid.html",
-			"category": "uncategorized",
-			"nuMessageIds": [
-				"nv-acac3ee7c070"
-			]
-		},
-		{
-			"path": "html/mime-types/009-novalid.html",
-			"category": "uncategorized",
-			"nuMessageIds": [
-				"nv-b80decc691d5"
-			]
-		},
-		{
 			"path": "html/parser/astral-nonchar-in-stream-novalid.html",
 			"category": "uncategorized",
 			"nuMessageIds": [

--- a/tests/external/snapshots/diff/summary.md
+++ b/tests/external/snapshots/diff/summary.md
@@ -1,6 +1,6 @@
 # nu-validator Benchmark Summary
 
-- generated: 2026-05-10T01:00:24.409Z
+- generated: 2026-05-10T02:41:44.869Z
 - submodule: `142931395412c00434ffb40a14d65992efd17aa8`
 - nu-validator: `ghcr.io/validator/validator@sha256:9746b8663542cb5bded271fea08a3cc04ca12af6232f014baa341fccc01d3a21`
 - markuplint: `5.0.0-rc.4`
@@ -9,9 +9,9 @@
 ## Totals
 
 - files: **5442**
-- match-error: **2169** (both tools flagged)
+- match-error: **2171** (both tools flagged)
 - match-clean: **920** (neither flagged)
-- nu-only: **1345** (only nu-validator flagged; markuplint coverage candidates — open a markuplint issue after a spec read)
+- nu-only: **1343** (only nu-validator flagged; markuplint coverage candidates — open a markuplint issue after a spec read)
 - nu-over: **28** (nu-validator errors fully covered by spec-backed excluded-ids — confirmed over-detection)
 - overall match rate: **56.8%**
 - excluded-ids: 3 entries, 1 pattern(s)
@@ -29,7 +29,7 @@
 | id-duplication | 1 | 100.0% | 1 | 0 | 0 | 0 | 0 |
 | invalid-attr | 3086 | 59.1% | 1592 | 231 | 60 | 1177 | 26 |
 | required-attr | 5 | 100.0% | 5 | 0 | 0 | 0 | 0 |
-| uncategorized | 1307 | 29.7% | 225 | 163 | 765 | 152 | 2 |
+| uncategorized | 1307 | 29.8% | 227 | 163 | 765 | 150 | 2 |
 
 ## Informational: ml-only
 

--- a/tests/external/snapshots/meta.json
+++ b/tests/external/snapshots/meta.json
@@ -1,5 +1,5 @@
 {
-	"generatedAt": "2026-05-10T01:00:24.409Z",
+	"generatedAt": "2026-05-10T02:41:44.869Z",
 	"submoduleSha": "142931395412c00434ffb40a14d65992efd17aa8",
 	"nuValidatorImage": "ghcr.io/validator/validator@sha256:9746b8663542cb5bded271fea08a3cc04ca12af6232f014baa341fccc01d3a21",
 	"markuplintVersion": "5.0.0-rc.4",
@@ -7,6 +7,6 @@
 	"totalFilesNu": 5442,
 	"totalFilesMl": 5442,
 	"totalNuMessages": 9905,
-	"totalMlViolations": 9942,
+	"totalMlViolations": 9944,
 	"totalNuFailures": 0
 }


### PR DESCRIPTION
## Summary

Closes the bench fixture portion of #3851.

- **Bug**: `whatwg-mimetype` (the WHATWG MIME Sniffing parser) tolerates an unterminated `quoted-string` parameter value and returns a partial value silently, so `text/html;charset="utf-8` (no closing DQUOTE) and `text/html;charset="u\` (escape consumes the would-be terminator) passed `MIMEType.parse`. RFC 9110 §5.6.6 requires the closing DQUOTE — these are conformance errors.
- **Fix**: a structural pre-scan in `check-mime-type.ts` walks parameter quoted-strings (handling `\` escapes) and short-circuits with `syntax-error` when any opening DQUOTE has no matching closing DQUOTE before end-of-string. Runs before invoking `MIMEType.parse`.
- **Tests**: 3 new cases — both bench fixtures (008, 009) plus a positive guard that properly-terminated quoted-strings (`"utf-8"`, `"\""`) stay valid.
- **Bench**: `html/mime-types/008-novalid.html` and `009-novalid.html` flip nu-only → match-error. No other verdict changes.

Cumulative nu-only triage: 1345 → 1343 (-2).

## Test plan

- [x] `yarn lint-check` — 0 errors / 0 warnings
- [x] `yarn build` — all 39 packages succeed
- [x] `yarn test` — 248/248 test files, 3812 tests pass
- [x] `check-mime-type.spec.ts` covers: unterminated DQUOTE (008), backslash-escape-EOF (009), properly-terminated DQUOTE positive cases
- [x] `tests/external/snapshots/diff/summary.md` shows the expected 2-fixture flip with no regressions
- [ ] CI all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)