### PR TITLE
fix(astro-parser): preserve spread attributes containing TypeScript and expression-child siblings

### DIFF
--- a/packages/@markuplint/astro-parser/ARCHITECTURE.ja.md
+++ b/packages/@markuplint/astro-parser/ARCHITECTURE.ja.md
@@ -33,6 +33,7 @@ flowchart TD
         astroParser["AstroParser\nextends Parser‹Node›"]
         astroParseFn["astroParse()\nastro-eslint-parser ラッパー"]
         detectBlock["detectBlockBehavior()\n.map()/.filter() 検出"]
+        spreadAttr["extractSpreadAttribute()\n波括弧対応スプレッド抽出器"]
         compScanner["componentScanner\n(サブパス: ./component-scanner)"]
     end
 
@@ -47,6 +48,7 @@ flowchart TD
     astroCompiler -->|"Node 型"| astroParseFn
     astroParseFn -->|"RootNode.children"| astroParser
     detectBlock -->|"blockBehavior"| astroParser
+    spreadAttr -->|"visitAttr() の spread プリパス"| astroParser
     astroParser -->|"MLASTDocument を生成"| mlCore
     astroParser -->|"parse()"| compScanner
     compScanner -->|"ComponentScanResult"| pretenders
@@ -185,6 +187,8 @@ Astro テンプレートディレクティブは `name:modifier` 構文を使用
 - 波括弧を含む正規表現リテラル（例: `{...x.match(/}/) ? a : b}`）は認識しません。`/` は常に除算演算子として扱われます。遭遇した場合は変数に切り出して回避してください。
 
 **撤去条件**: `parser-utils/script-parser.ts` が TypeScript 構文を理解し、かつスプレッドの `}` を超えて伸びないように改善された場合、本パッケージの `src/spread-attr.ts` と `visitAttr()` のプリパスは削除し、基底パーサーのパスに戻すことが可能です。
+
+**`detectBlockBehavior()` との独立性**: スプレッドのプリパスは属性トークンに対して動作し、`detectBlockBehavior()` は `expression` AST ノードに対して走るため、両者は状態を共有しません。両者の相互作用は `parser.spec.ts` の `<Comp {...rest}>{list.map(...)}</Comp>` リグレッションテストで保証されています。
 
 ## jsx-parser との比較
 

--- a/packages/@markuplint/astro-parser/ARCHITECTURE.ja.md
+++ b/packages/@markuplint/astro-parser/ARCHITECTURE.ja.md
@@ -164,20 +164,42 @@ Astro テンプレートディレクティブは `name:modifier` 構文を使用
 - ショートハンド属性: `{prop}`
 - ネストされた式: `style={{ a: b }}`
 
+### スプレッド属性
+
+スプレッド属性（`{...EXPR}`）は、基底の `Parser.visitAttr()` に委譲する **前**に、`visitAttr()` 内の波括弧対応プリパス（`src/spread-attr.ts` 参照）で抽出されます。プリパスは生のトークンを 1 文字ずつ走査し、以下を考慮します:
+
+- 文字列リテラル（`'`、`"`）
+- `${}` 補間付きテンプレートリテラル
+- 行コメント（`//`）とブロックコメント（`/* */`）
+- バックスラッシュでエスケープされたクォート（連続するバックスラッシュの偶奇判定）
+
+スプレッドトークンに対しては上流の `safeScriptParser`（espree ベース）を意図的に回避します。理由:
+
+1. espree は `{...x as any}` のような TypeScript 構文を理解せず、`as` の手前でスプレッドを誤って終端させる。
+2. espree は「valid な JS プレフィックス」をスプレッドの閉じ `}` を超えて貪欲に伸ばすことがあり、例えば `{...props}>{label}` を二項 `>` 式として解釈してしまい、次の兄弟ノードを呑み込み `Invalid tag syntax` エラーになる。
+
+両方とも v4 では [#3824](https://github.com/markuplint/markuplint/issues/3824) として、dev では [#3856](https://github.com/markuplint/markuplint/issues/3856) として追跡されています。プリパスは `{...}` 境界を純粋な波括弧マッチング問題として扱うことで両方を解消します。
+
+**波括弧マッチャの既知の制限**:
+
+- 波括弧を含む正規表現リテラル（例: `{...x.match(/}/) ? a : b}`）は認識しません。`/` は常に除算演算子として扱われます。遭遇した場合は変数に切り出して回避してください。
+
+**撤去条件**: `parser-utils/script-parser.ts` が TypeScript 構文を理解し、かつスプレッドの `}` を超えて伸びないように改善された場合、本パッケージの `src/spread-attr.ts` と `visitAttr()` のプリパスは削除し、基底パーサーのパスに戻すことが可能です。
+
 ## jsx-parser との比較
 
-| 機能                           | `astro-parser`                         | `jsx-parser`                                      |
-| ------------------------------ | -------------------------------------- | ------------------------------------------------- |
-| **トークナイザ**               | `astro-eslint-parser`                  | TypeScript ESTree（`@typescript-eslint/parser`）  |
-| **フロントマター**             | サポート（`---...---` psblock）        | 該当なし                                          |
-| **式の構文**                   | `{expr}` を MustacheTag psblock として | `{expr}` を JSXExpressionContainer psblock として |
-| **テンプレートディレクティブ** | `class:list`、`set:html` 等            | 該当なし                                          |
-| **名前空間管理**               | 基底 `Parser` に委譲                   | html-parser の `getNamespace()` に委譲            |
-| **コンポーネント検出**         | `/^[A-Z]/` パターン                    | `/^[A-Z]/` パターン                               |
-| **自己閉じタイプ**             | `html+xml`                             | デフォルト（XML のみ）                            |
-| **booleanish 属性**            | 未設定                                 | `booleanish: true`                                |
-| **名前なしフラグメント**       | `<>...</>` サポート                    | `<>...</>` サポート                               |
-| **スプレッド属性**             | 基底パーサーで処理                     | カスタム `visitSpreadAttr()` で IDL ルックアップ  |
+| 機能                           | `astro-parser`                                  | `jsx-parser`                                      |
+| ------------------------------ | ----------------------------------------------- | ------------------------------------------------- |
+| **トークナイザ**               | `astro-eslint-parser`                           | TypeScript ESTree（`@typescript-eslint/parser`）  |
+| **フロントマター**             | サポート（`---...---` psblock）                 | 該当なし                                          |
+| **式の構文**                   | `{expr}` を MustacheTag psblock として          | `{expr}` を JSXExpressionContainer psblock として |
+| **テンプレートディレクティブ** | `class:list`、`set:html` 等                     | 該当なし                                          |
+| **名前空間管理**               | 基底 `Parser` に委譲                            | html-parser の `getNamespace()` に委譲            |
+| **コンポーネント検出**         | `/^[A-Z]/` パターン                             | `/^[A-Z]/` パターン                               |
+| **自己閉じタイプ**             | `html+xml`                                      | デフォルト（XML のみ）                            |
+| **booleanish 属性**            | 未設定                                          | `booleanish: true`                                |
+| **名前なしフラグメント**       | `<>...</>` サポート                             | `<>...</>` サポート                               |
+| **スプレッド属性**             | `visitAttr()` 内の波括弧対応プリパス（TS 対応） | カスタム `visitSpreadAttr()` で IDL ルックアップ  |
 
 ## バージョン互換性
 
@@ -195,6 +217,7 @@ astro-eslint-parser → @astrojs/compiler → Astro 構文サポート
 | ---------------------- | ------------------------------------------------------------------------------------------------------------- |
 | `parser.ts`            | `AstroParser` クラス — 全オーバーライドメソッドと名前空間スコーピング                                         |
 | `astro-parser.ts`      | `astroParse()` ラッパー — `astro-eslint-parser` に委譲し、診断を `ParserError` に変換                         |
+| `spread-attr.ts`       | `visitAttr()` が使用する波括弧対応スプレッド属性抽出器（上記「スプレッド属性」を参照）                        |
 | `index.ts`             | 公開 API — シングルトン `parser` インスタンスを再エクスポート                                                 |
 | `component-scanner.ts` | `@markuplint/pretenders` 自動スキャン用コンポーネントスキャナー（サブパスエクスポート `./component-scanner`） |
 

--- a/packages/@markuplint/astro-parser/ARCHITECTURE.md
+++ b/packages/@markuplint/astro-parser/ARCHITECTURE.md
@@ -33,6 +33,7 @@ flowchart TD
         astroParser["AstroParser\nextends Parser‹Node›"]
         astroParseFn["astroParse()\nastro-eslint-parser wrapper"]
         detectBlock["detectBlockBehavior()\n.map()/.filter() detection"]
+        spreadAttr["extractSpreadAttribute()\nbrace-aware spread extractor"]
         compScanner["componentScanner\n(subpath: ./component-scanner)"]
     end
 
@@ -47,6 +48,7 @@ flowchart TD
     astroCompiler -->|"Node types"| astroParseFn
     astroParseFn -->|"RootNode.children"| astroParser
     detectBlock -->|"blockBehavior"| astroParser
+    spreadAttr -->|"spread pre-pass in visitAttr()"| astroParser
     astroParser -->|"produces MLASTDocument"| mlCore
     astroParser -->|"parse()"| compScanner
     compScanner -->|"ComponentScanResult"| pretenders
@@ -185,6 +187,8 @@ Both failure modes were reported in [#3824](https://github.com/markuplint/markup
 - Regular-expression literals containing braces (e.g. `{...x.match(/}/) ? a : b}`) are not recognised — `/` is always treated as a division operator. Rewrite via a variable indirection if encountered.
 
 **Retraction condition**: if `parser-utils/script-parser.ts` is upgraded to handle TypeScript syntax and to stop extending past the spread's `}`, this package's `src/spread-attr.ts` and the `visitAttr()` pre-pass can be removed and the base parser path restored.
+
+**Independence from `detectBlockBehavior()`**: the spread pre-pass operates on attribute tokens, while `detectBlockBehavior()` runs over `expression` AST nodes — they share no state. The interaction is locked down by the `<Comp {...rest}>{list.map(...)}</Comp>` regression test in `parser.spec.ts`.
 
 ## Comparison with jsx-parser
 

--- a/packages/@markuplint/astro-parser/ARCHITECTURE.md
+++ b/packages/@markuplint/astro-parser/ARCHITECTURE.md
@@ -164,20 +164,42 @@ Any attribute whose start quote is `{` gets `isDynamicValue: true`. This applies
 - Shorthand attributes: `{prop}`
 - Nested expressions: `style={{ a: b }}`
 
+### Spread Attributes
+
+Spread attributes (`{...EXPR}`) are extracted by a brace-aware pre-pass in `visitAttr()` (see `src/spread-attr.ts`) **before** delegating to the base `Parser.visitAttr()`. The pre-pass walks the raw token character by character with awareness of:
+
+- string literals (`'`, `"`)
+- template literals with `${}` interpolation
+- line (`//`) and block (`/* */`) comments
+- backslash-escaped quotes (counting consecutive backslashes for parity)
+
+This bypasses the upstream `safeScriptParser` (espree-based) for spread tokens because espree:
+
+1. Does not understand TypeScript syntax such as `{...x as any}` and would terminate the spread early at `as`.
+2. May greedily extend a "valid JS prefix" past the spread's closing `}` into surrounding HTML — for example `{...props}>{label}` is interpreted as a binary `>` expression, swallowing the next sibling and producing `Invalid tag syntax`.
+
+Both failure modes were reported in [#3824](https://github.com/markuplint/markuplint/issues/3824) (v4) and tracked on dev as [#3856](https://github.com/markuplint/markuplint/issues/3856). The pre-pass solves them by treating the `{...}` boundary as a pure brace-matching problem.
+
+**Known limitations** of the brace matcher:
+
+- Regular-expression literals containing braces (e.g. `{...x.match(/}/) ? a : b}`) are not recognised — `/` is always treated as a division operator. Rewrite via a variable indirection if encountered.
+
+**Retraction condition**: if `parser-utils/script-parser.ts` is upgraded to handle TypeScript syntax and to stop extending past the spread's `}`, this package's `src/spread-attr.ts` and the `visitAttr()` pre-pass can be removed and the base parser path restored.
+
 ## Comparison with jsx-parser
 
-| Feature                   | `astro-parser`                  | `jsx-parser`                                    |
-| ------------------------- | ------------------------------- | ----------------------------------------------- |
-| **Tokenizer**             | `astro-eslint-parser`           | TypeScript ESTree (`@typescript-eslint/parser`) |
-| **Frontmatter**           | Supported (`---...---` psblock) | Not applicable                                  |
-| **Expression syntax**     | `{expr}` as MustacheTag psblock | `{expr}` as JSXExpressionContainer psblock      |
-| **Template directives**   | `class:list`, `set:html`, etc.  | Not applicable                                  |
-| **Namespace management**  | Delegates to base `Parser`      | Delegates to `getNamespace()` from html-parser  |
-| **Component detection**   | `/^[A-Z]/` pattern              | `/^[A-Z]/` pattern                              |
-| **Self-close type**       | `html+xml`                      | Default (XML-only)                              |
-| **Booleanish attributes** | Not configured                  | `booleanish: true`                              |
-| **Nameless fragments**    | `<>...</>` supported            | `<>...</>` supported                            |
-| **Spread attributes**     | Handled by base parser          | Custom `visitSpreadAttr()` with IDL lookup      |
+| Feature                   | `astro-parser`                                   | `jsx-parser`                                    |
+| ------------------------- | ------------------------------------------------ | ----------------------------------------------- |
+| **Tokenizer**             | `astro-eslint-parser`                            | TypeScript ESTree (`@typescript-eslint/parser`) |
+| **Frontmatter**           | Supported (`---...---` psblock)                  | Not applicable                                  |
+| **Expression syntax**     | `{expr}` as MustacheTag psblock                  | `{expr}` as JSXExpressionContainer psblock      |
+| **Template directives**   | `class:list`, `set:html`, etc.                   | Not applicable                                  |
+| **Namespace management**  | Delegates to base `Parser`                       | Delegates to `getNamespace()` from html-parser  |
+| **Component detection**   | `/^[A-Z]/` pattern                               | `/^[A-Z]/` pattern                              |
+| **Self-close type**       | `html+xml`                                       | Default (XML-only)                              |
+| **Booleanish attributes** | Not configured                                   | `booleanish: true`                              |
+| **Nameless fragments**    | `<>...</>` supported                             | `<>...</>` supported                            |
+| **Spread attributes**     | Brace-aware pre-pass in `visitAttr()` (TS-aware) | Custom `visitSpreadAttr()` with IDL lookup      |
 
 ## Version Compatibility
 
@@ -195,6 +217,7 @@ astro-eslint-parser → @astrojs/compiler → Astro syntax support
 | ---------------------- | -------------------------------------------------------------------------------------------------- |
 | `parser.ts`            | `AstroParser` class — all override methods and namespace scoping                                   |
 | `astro-parser.ts`      | `astroParse()` wrapper — delegates to `astro-eslint-parser`, converts diagnostics to `ParserError` |
+| `spread-attr.ts`       | Brace-aware spread-attribute extractor used by `visitAttr()` (see Spread Attributes above)         |
 | `index.ts`             | Public API — re-exports the singleton `parser` instance                                            |
 | `component-scanner.ts` | Component scanner for `@markuplint/pretenders` auto scan (subpath export `./component-scanner`)    |
 

--- a/packages/@markuplint/astro-parser/docs/maintenance.ja.md
+++ b/packages/@markuplint/astro-parser/docs/maintenance.ja.md
@@ -122,6 +122,13 @@ yarn upgrade @astrojs/compiler --scope @markuplint/astro-parser --dev
 yarn build --scope @markuplint/astro-parser && yarn test --scope @markuplint/astro-parser
 ```
 
+### v4 からの fix を forward-port するとき
+
+`v4` ブランチの `astro-parser` 修正を `dev` に持ってくる場合、`Token` のフィールド名 rename に注意:
+v4 は `startOffset` / `startLine` / `startCol`、dev は短縮形の `offset` / `line` / `col` を使用します。
+この rename は `*.spec.ts` でアサートしている AST ノードプロパティにも当てはまります。
+ビルド時に該当プロパティが `TS2339` で落ちるので、それを目印にすぐ気付けます。
+
 ## トラブルシューティング
 
 ### フロントマターが認識されない

--- a/packages/@markuplint/astro-parser/docs/maintenance.ja.md
+++ b/packages/@markuplint/astro-parser/docs/maintenance.ja.md
@@ -102,11 +102,12 @@ expect(debugMaps).toStrictEqual([
 
 上流パッケージの変更がこのパーサーに影響を与える可能性があります:
 
-| パッケージ                 | 影響                                                        |
-| -------------------------- | ----------------------------------------------------------- |
-| `@markuplint/parser-utils` | 基底 `Parser` クラスの変更は全オーバーライドメソッドに影響  |
-| `@markuplint/ml-ast`       | AST 型の変更は `nodeize()` の戻り値の型に影響               |
-| `astro-eslint-parser`      | パーサー出力形式の変更は `tokenize()` と `nodeize()` に影響 |
+| パッケージ                               | 影響                                                                                                  |
+| ---------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `@markuplint/parser-utils`               | 基底 `Parser` クラスの変更は全オーバーライドメソッドに影響                                            |
+| `@markuplint/parser-utils/script-parser` | TS 対応と非貪欲なパースが上流に入った場合、`src/spread-attr.ts` と `visitAttr()` のプリパスは削除可能 |
+| `@markuplint/ml-ast`                     | AST 型の変更は `nodeize()` の戻り値の型に影響                                                         |
+| `astro-eslint-parser`                    | パーサー出力形式の変更は `tokenize()` と `nodeize()` に影響                                           |
 
 `astro-eslint-parser` を更新する場合:
 
@@ -170,3 +171,20 @@ yarn build --scope @markuplint/astro-parser && yarn test --scope @markuplint/ast
 1. 属性名の形式を確認 — 正規表現はコロンが1つだけで、両側に空でない部分が必要
 2. `switch (lowerCaseDirectiveName)` を確認 — ディレクティブプレフィックスがケースにマッチする必要がある
 3. 新しいディレクティブプレフィックスの場合は、新しいケースを追加（レシピ #1 参照）
+
+### スプレッド属性が途中で切れる、または `{...EXPR}` の直後に式の子があると `Invalid tag syntax` が発生する
+
+**症状:** 次のいずれか:
+
+- `{...{ command: 'close' } as any}` が部分的なスプレッドと不正な `as` / `any}` 属性に分割される。
+- `<div {...props}>{label}</div>`（または `{label}` のような式の子をスプレッド属性の直後に持つ要素）が `SyntaxError: Invalid tag syntax: ...` をスローする。
+
+**原因:** 要素の生トークンが、`src/spread-attr.ts` の波括弧対応抽出器ではなく `parser-utils/safeScriptParser`（espree ベース）にルーティングされている。`safeScriptParser` は TypeScript 構文（`as`）を理解せず、また「valid な JS プレフィックス」をスプレッドの `}` を超えて周囲の HTML まで伸ばすことがある（`{...props}>{label}` を二項 `>` 式として解釈）。
+
+**解決策:**
+
+1. `src/parser.ts` の `visitAttr()` が `super.visitAttr()` の **前**に `./spread-attr.js` の `extractSpreadAttribute()` を呼んでいることを確認。順序が重要 — 基底パスにフォールスルーするとバグが発動する。
+2. 新しいエッジケースが報告されたら、`src/spread-attr.spec.ts` で `findMatchingBrace()` のユニットテストとして再現し、波括弧マッチャに追加のエスケープルール（文字列 / テンプレート / コメント / バックスラッシュ）が必要かを判断。
+3. 既知の制限は `src/spread-attr.ts` の JSDoc に記載 — 波括弧を含む正規表現リテラルは扱えない。新たな制限が見つかったらそこに追記。
+
+オリジナルの報告とスプレッド属性を `parser-utils` ではなく本パッケージで処理する根拠については [#3824](https://github.com/markuplint/markuplint/issues/3824)（v4）と [#3856](https://github.com/markuplint/markuplint/issues/3856)（dev/v5）を参照。

--- a/packages/@markuplint/astro-parser/docs/maintenance.ja.md
+++ b/packages/@markuplint/astro-parser/docs/maintenance.ja.md
@@ -98,6 +98,20 @@ expect(debugMaps).toStrictEqual([
    });
    ```
 
+### 4. スプレッド属性の波括弧マッチャを更新する
+
+`{...EXPR}` のパースで新たなエッジケース（未考慮の文字列構文、コメント形式、エスケープシーケンス等）が報告された場合:
+
+1. エッジケースを `src/spread-attr.spec.ts` の `findMatchingBrace()` ユニットテストとして再現する。修正前は失敗するテストにする。
+2. 修正の置き場所を判断する:
+   - **文字列 / テンプレート / クォート処理** → `findMatchingBrace()` の `inString` 分岐を拡張
+   - **コメント処理** → `//` / `/* */` の分岐を拡張
+   - **エスケープシーケンスの偶奇判定** → `countPrecedingBackslashes()` を拡張
+3. 失敗ユニットテストが green になる最小の修正に留める。完全な JavaScript レキサーを実装してはいけない。
+4. 新しいケースが単体テストで自然に表現できない場合、`parser.spec.ts` の `#3856` describe に統合テストを追加する。
+5. マッチャがそのケースに対応できない場合（例: 正規表現リテラル）、`src/spread-attr.ts` の JSDoc の **Known limitations** に追記する。
+6. 検証: `yarn build --scope @markuplint/astro-parser && yarn test --scope @markuplint/astro-parser && yarn lint`。
+
 ## 上流影響チェックリスト
 
 上流パッケージの変更がこのパーサーに影響を与える可能性があります:

--- a/packages/@markuplint/astro-parser/docs/maintenance.md
+++ b/packages/@markuplint/astro-parser/docs/maintenance.md
@@ -102,11 +102,12 @@ Namespace resolution is currently handled by the base `Parser` class from `@mark
 
 Changes to upstream packages can affect this parser:
 
-| Package                    | Impact                                                           |
-| -------------------------- | ---------------------------------------------------------------- |
-| `@markuplint/parser-utils` | Base `Parser` class changes affect all override methods          |
-| `@markuplint/ml-ast`       | AST type changes affect `nodeize()` return types                 |
-| `astro-eslint-parser`      | Parser output format changes affect `tokenize()` and `nodeize()` |
+| Package                                  | Impact                                                                                                             |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `@markuplint/parser-utils`               | Base `Parser` class changes affect all override methods                                                            |
+| `@markuplint/parser-utils/script-parser` | If TS support and non-greedy parsing land here, `src/spread-attr.ts` and the `visitAttr()` pre-pass can be removed |
+| `@markuplint/ml-ast`                     | AST type changes affect `nodeize()` return types                                                                   |
+| `astro-eslint-parser`                    | Parser output format changes affect `tokenize()` and `nodeize()`                                                   |
 
 When updating `astro-eslint-parser`:
 
@@ -170,3 +171,20 @@ yarn build --scope @markuplint/astro-parser && yarn test --scope @markuplint/ast
 1. Verify the attribute name format — the regex requires exactly one colon with non-empty parts on both sides
 2. Check the `switch (lowerCaseDirectiveName)` — the directive prefix must match a case
 3. If it is a new directive prefix, add a new case (see Recipe #1)
+
+### Spread attribute is truncated, or `Invalid tag syntax` is thrown for `{...EXPR}` followed by an expression child
+
+**Symptom:** Either of the following:
+
+- `{...{ command: 'close' } as any}` is split into a partial spread plus bogus `as` / `any}` attributes.
+- `<div {...props}>{label}</div>` (or any element with a spread attribute followed immediately by an expression child like `{label}`) throws `SyntaxError: Invalid tag syntax: ...`.
+
+**Cause:** The element's raw token is being routed through `parser-utils/safeScriptParser` (espree-based) instead of the brace-aware extractor in `src/spread-attr.ts`. `safeScriptParser` does not understand TypeScript syntax (`as`) and may extend a "valid JS prefix" past the spread's `}` into the surrounding HTML (interpreting `{...props}>{label}` as a binary `>` expression).
+
+**Solution:**
+
+1. Confirm `src/parser.ts` `visitAttr()` calls `extractSpreadAttribute()` from `./spread-attr.js` _before_ `super.visitAttr()`. The order matters — falling through to the base path is what triggers the bug.
+2. If a new edge case is reported, reproduce it as a unit test in `src/spread-attr.spec.ts` with `findMatchingBrace()` and decide whether the brace matcher needs an additional escape rule (string / template / comment / backslash).
+3. Known limitations are listed in `src/spread-attr.ts` JSDoc — regular-expression literals containing braces are not handled. Document any additional limitations there.
+
+See [#3824](https://github.com/markuplint/markuplint/issues/3824) (v4) and [#3856](https://github.com/markuplint/markuplint/issues/3856) (dev/v5) for the original report and the rationale for handling spread attributes locally instead of in `parser-utils`.

--- a/packages/@markuplint/astro-parser/docs/maintenance.md
+++ b/packages/@markuplint/astro-parser/docs/maintenance.md
@@ -122,6 +122,14 @@ yarn upgrade @astrojs/compiler --scope @markuplint/astro-parser --dev
 yarn build --scope @markuplint/astro-parser && yarn test --scope @markuplint/astro-parser
 ```
 
+### Porting fixes from v4
+
+When forward-porting an `astro-parser` fix from the `v4` branch to `dev`, beware
+the `Token` field rename: v4 uses `startOffset` / `startLine` / `startCol`;
+dev uses the short forms `offset` / `line` / `col`. The same rename also
+applies to AST node properties asserted in `*.spec.ts`. Build will surface
+the issue as `TS2339` on the renamed properties.
+
 ## Troubleshooting
 
 ### Frontmatter is not recognized

--- a/packages/@markuplint/astro-parser/docs/maintenance.md
+++ b/packages/@markuplint/astro-parser/docs/maintenance.md
@@ -98,6 +98,26 @@ Namespace resolution is currently handled by the base `Parser` class from `@mark
    });
    ```
 
+### 4. Updating the spread-attribute brace matcher
+
+When a new edge case is reported for `{...EXPR}` parsing (a previously
+unconsidered string syntax, comment style, or escape sequence):
+
+1. Reproduce the edge case as a `findMatchingBrace()` unit test in
+   `src/spread-attr.spec.ts` — the test should fail before any fix.
+2. Decide where the fix belongs:
+   - **String / template / quote handling** → extend the `inString` switch in
+     `findMatchingBrace()`
+   - **Comment handling** → extend the `//` / `/* */` branches
+   - **Escape sequence parity** → extend `countPrecedingBackslashes()`
+3. Apply the minimum change that turns the failing unit test green; avoid
+   introducing a full JavaScript lexer.
+4. If the new case is not naturally expressible as a standalone unit test,
+   add an integration test in `parser.spec.ts` under the `#3856` describe.
+5. Update the **Known limitations** list in `src/spread-attr.ts` JSDoc if the
+   matcher still cannot handle the case (e.g., regex literals).
+6. Verify: `yarn build --scope @markuplint/astro-parser && yarn test --scope @markuplint/astro-parser && yarn lint`.
+
 ## Upstream Impact Checklist
 
 Changes to upstream packages can affect this parser:

--- a/packages/@markuplint/astro-parser/src/parser.spec.ts
+++ b/packages/@markuplint/astro-parser/src/parser.spec.ts
@@ -792,6 +792,19 @@ describe('Issue', () => {
 			expect(spread.col).toBe(3);
 			expect(spread.raw).toBe('{...rest}');
 		});
+
+		test('spread attribute on component with block-behavior expression child (dev-specific)', () => {
+			// Guards the interaction between the new spread pre-pass (#3856) and
+			// dev's `detectBlockBehavior()` for `.map()` expression children.
+			const ast = parse('<Comp {...rest}>{list.map(item => <li>{item}</li>)}</Comp>');
+			expect(ast.parseError).toBeUndefined();
+			const start = findStartTag(ast);
+			const spreads = start.attributes.filter((a: any) => a.type === 'spread');
+			expect(spreads).toHaveLength(1);
+			expect(spreads[0].raw).toBe('{...rest}');
+			const debugMaps = nodeListToDebugMaps(ast.nodeList);
+			expect(debugMaps.some(line => line.includes('#ps:MustacheTag (each)'))).toBe(true);
+		});
 	});
 });
 

--- a/packages/@markuplint/astro-parser/src/parser.spec.ts
+++ b/packages/@markuplint/astro-parser/src/parser.spec.ts
@@ -684,6 +684,115 @@ describe('Issue', () => {
 			expect(map[0]).toBe('[1:1]>[1:34](0,33)script: <script␣define:vars={{␣foo:␣1␣}}>');
 		});
 	});
+
+	describe('#3856 spread attribute parsing (v5 mirror of #3824)', () => {
+		const findStartTag = (ast: any) => ast.nodeList.find((n: any) => n.type === 'starttag');
+
+		test('TypeScript assertion in spread attribute', () => {
+			const ast = parse(
+				'<button type="button" {...{ command: "close" } as any} commandfor="dialog-id">close</button>',
+			);
+			expect(ast.parseError).toBeUndefined();
+			const start = findStartTag(ast);
+			const spreads = start.attributes.filter((a: any) => a.type === 'spread');
+			expect(spreads).toHaveLength(1);
+			expect(spreads[0].raw).toBe('{...{ command: "close" } as any}');
+			const attrNames = start.attributes.filter((a: any) => a.type === 'attr').map((a: any) => a.nodeName);
+			expect(attrNames).toEqual(['type', 'commandfor']);
+		});
+
+		test('spread attribute with expression child on same element', () => {
+			const ast = parse('<div {...props}>{label}</div>');
+			expect(ast.parseError).toBeUndefined();
+			const start = findStartTag(ast);
+			const spreads = start.attributes.filter((a: any) => a.type === 'spread');
+			expect(spreads).toHaveLength(1);
+			expect(spreads[0].raw).toBe('{...props}');
+		});
+
+		test('dynamic tag (PascalCase) with spread + expression child', () => {
+			const ast = parse('<ContainerTag class="container" {...containerProps}>{title}</ContainerTag>');
+			expect(ast.parseError).toBeUndefined();
+			const start = findStartTag(ast);
+			const spreads = start.attributes.filter((a: any) => a.type === 'spread');
+			expect(spreads).toHaveLength(1);
+			expect(spreads[0].raw).toBe('{...containerProps}');
+		});
+
+		test('textarea with conditional spread + expression child', () => {
+			const ast = parse(
+				"<textarea {...fieldSizingContent ? { 'data-field-sizing': 'content' } : {}}>{value}</textarea>",
+			);
+			expect(ast.parseError).toBeUndefined();
+			const start = findStartTag(ast);
+			const spreads = start.attributes.filter((a: any) => a.type === 'spread');
+			expect(spreads).toHaveLength(1);
+			expect(spreads[0].raw).toBe("{...fieldSizingContent ? { 'data-field-sizing': 'content' } : {}}");
+		});
+
+		test('multiple spread attributes on dynamic tag with expression child', () => {
+			const ast = parse(`<Element
+  {...iconOnly ? { title: label } : {}}
+  {...rest}
+>
+  {label}
+</Element>`);
+			expect(ast.parseError).toBeUndefined();
+			const start = findStartTag(ast);
+			const spreads = start.attributes.filter((a: any) => a.type === 'spread');
+			expect(spreads).toHaveLength(2);
+			expect(spreads[0].raw).toBe('{...iconOnly ? { title: label } : {}}');
+			expect(spreads[1].raw).toBe('{...rest}');
+		});
+
+		test('component with conditional spread and descendant expression child', () => {
+			const ast = parse(`<Comp {...enabled ? { title: title } : {}}>
+  <div>{title}</div>
+</Comp>`);
+			expect(ast.parseError).toBeUndefined();
+			const start = findStartTag(ast);
+			const spreads = start.attributes.filter((a: any) => a.type === 'spread');
+			expect(spreads).toHaveLength(1);
+			expect(spreads[0].raw).toBe('{...enabled ? { title: title } : {}}');
+		});
+
+		test('static spread + text child still works (regression guard)', () => {
+			const ast = parse('<div {...props}>text</div>');
+			expect(ast.parseError).toBeUndefined();
+			const start = findStartTag(ast);
+			const spreads = start.attributes.filter((a: any) => a.type === 'spread');
+			expect(spreads).toHaveLength(1);
+			expect(spreads[0].raw).toBe('{...props}');
+		});
+
+		test('simple spread shorthand still works (regression guard)', () => {
+			const ast = parse('<div {a} {...b} />');
+			expect(ast.parseError).toBeUndefined();
+			const start = findStartTag(ast);
+			const spreads = start.attributes.filter((a: any) => a.type === 'spread');
+			expect(spreads).toHaveLength(1);
+			expect(spreads[0].raw).toBe('{...b}');
+		});
+
+		test('multi-line spread reports correct line, column, and offset', () => {
+			const ast = parse('<Element\n  {...rest}\n/>');
+			const start = findStartTag(ast);
+			const spread = start.attributes.find((a: any) => a.type === 'spread');
+			expect(spread.line).toBe(2);
+			expect(spread.col).toBe(3);
+			expect(spread.offset).toBe(11);
+			expect(spread.raw).toBe('{...rest}');
+		});
+
+		test('CRLF line endings preserve correct line, column, and offset', () => {
+			const ast = parse('<Element\r\n  {...rest}\r\n/>');
+			const start = findStartTag(ast);
+			const spread = start.attributes.find((a: any) => a.type === 'spread');
+			expect(spread.line).toBe(2);
+			expect(spread.col).toBe(3);
+			expect(spread.raw).toBe('{...rest}');
+		});
+	});
 });
 
 describe('Directives', () => {

--- a/packages/@markuplint/astro-parser/src/parser.ts
+++ b/packages/@markuplint/astro-parser/src/parser.ts
@@ -248,8 +248,8 @@ class AstroParser extends Parser<Node> {
 	 * Visits an attribute token, handling Astro-specific syntax including
 	 * curly-brace expression values, shorthand attributes (`{name}`),
 	 * spread attributes (`{...expr}`, including TypeScript and nested
-	 * expressions, see #3856), and template directives (e.g., `class:list`,
-	 * `set:html`).
+	 * expressions, see #3856; root cause originally reported as #3824),
+	 * and template directives (e.g., `class:list`, `set:html`).
 	 *
 	 * @param token - The token representing the attribute
 	 * @returns The parsed attribute node with Astro-specific metadata

--- a/packages/@markuplint/astro-parser/src/parser.ts
+++ b/packages/@markuplint/astro-parser/src/parser.ts
@@ -6,6 +6,7 @@ import { AttrState, Parser, ParserError } from '@markuplint/parser-utils';
 
 import { astroParse } from './astro-parser.js';
 import { detectBlockBehavior } from './detect-block-behavior.js';
+import { extractSpreadAttribute } from './spread-attr.js';
 
 /**
  * Parser implementation for Astro component templates.
@@ -246,12 +247,41 @@ class AstroParser extends Parser<Node> {
 	/**
 	 * Visits an attribute token, handling Astro-specific syntax including
 	 * curly-brace expression values, shorthand attributes (`{name}`),
-	 * and template directives (e.g., `class:list`, `set:html`).
+	 * spread attributes (`{...expr}`, including TypeScript and nested
+	 * expressions, see #3856), and template directives (e.g., `class:list`,
+	 * `set:html`).
 	 *
 	 * @param token - The token representing the attribute
 	 * @returns The parsed attribute node with Astro-specific metadata
 	 */
 	visitAttr(token: Token) {
+		const spreadHit = extractSpreadAttribute(token.raw);
+		if (spreadHit) {
+			let spreadLine = token.line;
+			let spreadCol = token.col;
+			for (const c of spreadHit.leadingSpace) {
+				if (c === '\n') {
+					spreadLine++;
+					spreadCol = 1;
+				} else {
+					spreadCol++;
+				}
+			}
+			const spread = super.visitSpreadAttr({
+				raw: spreadHit.spreadRaw,
+				offset: token.offset + spreadHit.leadingSpace.length,
+				line: spreadLine,
+				col: spreadCol,
+			});
+			// `extractSpreadAttribute` already validates the `{...EXPR}` shape
+			// so `super.visitSpreadAttr` is expected to return a node here.
+			// Falling through to the generic attr path is a defensive safeguard
+			// against future shape changes in the parent class.
+			if (spread) {
+				return spreadHit.leftover ? { ...spread, __rightText: spreadHit.leftover } : spread;
+			}
+		}
+
 		const attr = super.visitAttr(token, {
 			quoteSet: [
 				{ start: '"', end: '"', type: 'string' },

--- a/packages/@markuplint/astro-parser/src/spread-attr.spec.ts
+++ b/packages/@markuplint/astro-parser/src/spread-attr.spec.ts
@@ -1,0 +1,119 @@
+import { describe, test, expect } from 'vitest';
+
+import { extractSpreadAttribute, findMatchingBrace } from './spread-attr.js';
+
+describe('findMatchingBrace', () => {
+	test('returns -1 when start char is not `{`', () => {
+		expect(findMatchingBrace('foo', 0)).toBe(-1);
+	});
+
+	test('matches simple `{...x}`', () => {
+		expect(findMatchingBrace('{...x}', 0)).toBe(5);
+	});
+
+	test('matches nested object literal `{...{ a: 1 }}`', () => {
+		const raw = '{...{ a: 1 }}';
+		expect(findMatchingBrace(raw, 0)).toBe(raw.length - 1);
+	});
+
+	test('respects double-quoted string containing `}`', () => {
+		const raw = '{...{ s: "}" }}';
+		expect(findMatchingBrace(raw, 0)).toBe(raw.length - 1);
+	});
+
+	test('respects single-quoted string containing `}`', () => {
+		const raw = "{...{ s: '}' }}";
+		expect(findMatchingBrace(raw, 0)).toBe(raw.length - 1);
+	});
+
+	test('respects template literal `${expr}` interpolation', () => {
+		const raw = '{...{ s: `${a}}` }}';
+		expect(findMatchingBrace(raw, 0)).toBe(raw.length - 1);
+	});
+
+	test('respects line comment containing `}`', () => {
+		const raw = '{...x // }\n}';
+		expect(findMatchingBrace(raw, 0)).toBe(raw.length - 1);
+	});
+
+	test('respects block comment containing `}`', () => {
+		const raw = '{...x /* } */ }';
+		expect(findMatchingBrace(raw, 0)).toBe(raw.length - 1);
+	});
+
+	test('does not advance past intended `}` for HTML siblings', () => {
+		// Only the spread itself; the `>{label}</div>` part is HTML and must stay outside.
+		const raw = '{...props}>{label}</div>';
+		expect(findMatchingBrace(raw, 0)).toBe(9);
+	});
+
+	test('returns -1 when braces are unbalanced', () => {
+		expect(findMatchingBrace('{...{ a: 1 }', 0)).toBe(-1);
+	});
+
+	test('matches when start index is non-zero', () => {
+		const raw = 'prefix {...x}';
+		expect(findMatchingBrace(raw, 7)).toBe(12);
+	});
+
+	test('treats `\\\\"` as escaped-backslash followed by string-closing quote', () => {
+		// String content is one backslash, then the `"` closes the string.
+		// Even count of preceding backslashes => quote is NOT escaped.
+		const raw = '{...{ s: "\\\\" }}';
+		expect(findMatchingBrace(raw, 0)).toBe(raw.length - 1);
+	});
+
+	test('treats `\\"` as escaped quote that does not close the string', () => {
+		// Odd count of preceding backslashes => quote IS escaped.
+		const raw = '{...{ s: "a\\"b" }}';
+		expect(findMatchingBrace(raw, 0)).toBe(raw.length - 1);
+	});
+});
+
+describe('extractSpreadAttribute', () => {
+	test('returns null for non-spread token', () => {
+		expect(extractSpreadAttribute(' foo="bar"')).toBeNull();
+		expect(extractSpreadAttribute(' {name}')).toBeNull();
+	});
+
+	test('extracts simple spread', () => {
+		expect(extractSpreadAttribute(' {...props}')).toEqual({
+			leadingSpace: ' ',
+			spreadRaw: '{...props}',
+			leftover: '',
+		});
+	});
+
+	test('preserves leftover HTML after spread', () => {
+		expect(extractSpreadAttribute(' {...props}>{label}</div>')).toEqual({
+			leadingSpace: ' ',
+			spreadRaw: '{...props}',
+			leftover: '>{label}</div>',
+		});
+	});
+
+	test('handles TypeScript assertion inside spread', () => {
+		expect(extractSpreadAttribute(' {...{ command: "close" } as any} commandfor="dialog-id">')).toEqual({
+			leadingSpace: ' ',
+			spreadRaw: '{...{ command: "close" } as any}',
+			leftover: ' commandfor="dialog-id">',
+		});
+	});
+
+	test('handles conditional spread expression', () => {
+		expect(extractSpreadAttribute(' {...c ? { x: 1 } : {}}>{value}')).toEqual({
+			leadingSpace: ' ',
+			spreadRaw: '{...c ? { x: 1 } : {}}',
+			leftover: '>{value}',
+		});
+	});
+
+	test('handles multi-line leading whitespace', () => {
+		const result = extractSpreadAttribute('\n  {...rest}\n');
+		expect(result).toEqual({
+			leadingSpace: '\n  ',
+			spreadRaw: '{...rest}',
+			leftover: '\n',
+		});
+	});
+});

--- a/packages/@markuplint/astro-parser/src/spread-attr.ts
+++ b/packages/@markuplint/astro-parser/src/spread-attr.ts
@@ -1,0 +1,123 @@
+/**
+ * Counts consecutive backslashes immediately before position `i` in `raw`.
+ * An odd count means the character at `i` is escaped; an even count means
+ * the preceding backslashes are themselves paired escapes.
+ */
+function countPrecedingBackslashes(raw: string, i: number): number {
+	let n = 0;
+	let j = i - 1;
+	while (j >= 0 && raw[j] === '\\') {
+		n++;
+		j--;
+	}
+	return n;
+}
+
+/**
+ * Locates the matching closing brace for a JS-like expression that starts at
+ * `raw[start]` (which must be `{`), respecting string literals (`'`, `"`),
+ * template literals with `${}` interpolation, and line/block comments.
+ *
+ * Returns the index of the matching `}`, or -1 if no match is found.
+ *
+ * Why this exists: `safeScriptParser` (espree-based) does not understand
+ * TypeScript syntax such as `{...x as any}` and may also extend a "valid JS
+ * prefix" past the spread's closing brace into surrounding HTML
+ * (e.g. `{...props}>{label}` is parsed as a binary `>` expression),
+ * misclassifying both the spread end and any expression-child siblings.
+ * See https://github.com/markuplint/markuplint/issues/3824.
+ *
+ * Known limitation: regular-expression literals containing braces
+ * (e.g. `{...x.match(/}/) ? a : b}`) are not recognised — `/` is always
+ * treated as a division operator. Such patterns are vanishingly rare in
+ * Astro spread attributes; rewrite via a variable indirection if needed.
+ */
+export function findMatchingBrace(raw: string, start: number): number {
+	if (raw[start] !== '{') return -1;
+
+	let depth = 0;
+	let inString: '"' | "'" | '`' | null = null;
+	const templateBraceStack: number[] = [];
+
+	for (let i = start; i < raw.length; i++) {
+		const c = raw[i];
+
+		if (inString) {
+			if (inString === '`') {
+				if (c === '`' && countPrecedingBackslashes(raw, i) % 2 === 0) {
+					inString = null;
+				} else if (c === '$' && raw[i + 1] === '{') {
+					templateBraceStack.push(depth);
+					inString = null;
+					depth++;
+					i++;
+				}
+			} else if (c === inString && countPrecedingBackslashes(raw, i) % 2 === 0) {
+				inString = null;
+			}
+			continue;
+		}
+
+		if (c === '/' && raw[i + 1] === '/') {
+			while (i < raw.length && raw[i] !== '\n') i++;
+			continue;
+		}
+
+		if (c === '/' && raw[i + 1] === '*') {
+			i += 2;
+			while (i < raw.length - 1 && !(raw[i] === '*' && raw[i + 1] === '/')) i++;
+			i++;
+			continue;
+		}
+
+		if (c === '"' || c === "'" || c === '`') {
+			inString = c;
+			continue;
+		}
+
+		if (c === '{') {
+			depth++;
+		} else if (c === '}') {
+			depth--;
+			if (depth === 0) return i;
+			if (templateBraceStack.length > 0 && depth === templateBraceStack.at(-1)) {
+				templateBraceStack.pop();
+				inString = '`';
+			}
+		}
+	}
+
+	return -1;
+}
+
+/**
+ * Detects whether the given attribute token starts with an Astro spread
+ * attribute (`{...EXPR}`) and, if so, returns the spread's exact slice plus
+ * the leading whitespace and any leftover trailing text after the spread.
+ *
+ * Returns null when the token is not a spread attribute.
+ *
+ * Exported so the brace-matching logic can be unit-tested independently of
+ * the parser pipeline.
+ */
+export function extractSpreadAttribute(
+	raw: string,
+): { leadingSpace: string; spreadRaw: string; leftover: string } | null {
+	const leadingMatch = /^\s*/.exec(raw);
+	const leadingSpace = leadingMatch?.[0] ?? '';
+	const remaining = raw.slice(leadingSpace.length);
+
+	// eslint-disable-next-line regexp/strict
+	if (!/^{\s*\.{3}[^.]/.test(remaining)) {
+		return null;
+	}
+
+	const end = findMatchingBrace(remaining, 0);
+	if (end < 0) return null;
+
+	return {
+		leadingSpace,
+		spreadRaw: remaining.slice(0, end + 1),
+		leftover: remaining.slice(end + 1),
+	};
+}

--- a/packages/@markuplint/astro-parser/src/spread-attr.ts
+++ b/packages/@markuplint/astro-parser/src/spread-attr.ts
@@ -25,7 +25,8 @@ function countPrecedingBackslashes(raw: string, i: number): number {
  * prefix" past the spread's closing brace into surrounding HTML
  * (e.g. `{...props}>{label}` is parsed as a binary `>` expression),
  * misclassifying both the spread end and any expression-child siblings.
- * See https://github.com/markuplint/markuplint/issues/3824.
+ * See https://github.com/markuplint/markuplint/issues/3824 (v4) and
+ * https://github.com/markuplint/markuplint/issues/3856 (dev/v5).
  *
  * Known limitation: regular-expression literals containing braces
  * (e.g. `{...x.match(/}/) ? a : b}`) are not recognised — `/` is always


### PR DESCRIPTION
## Summary

- Forward-port of #3854 (v4) to dev (v5 RC). Fixes the same Astro spread-attribute parsing bug as Issue #3824 but on dev, tracked as #3856.
- Adds a brace-aware extractor in `astro-parser` (`src/spread-attr.ts`) that respects string literals, template `${}` interpolation, line/block comments, and escaped quotes — runs as a pre-pass in `visitAttr()` before the base parser.
- Sidesteps the upstream `safeScriptParser` (espree-based), which truncates TS syntax (`as`) and greedily extends past the spread's `}` into surrounding HTML.
- Documents the rationale, known limitations (regex literals containing braces), and retraction conditions in ARCHITECTURE / maintenance docs (EN/JA), with the spread node visible in the architecture diagram.

Closes #3856

## v4 vs dev port notes

- Token field rename on dev (`startLine`/`startCol`/`startOffset` → `line`/`col`/`offset`) — applied to the new `visitAttr()` pre-pass and the position assertions in the regression tests. A "Porting fixes from v4" section in `docs/maintenance.md` records this so the next port hits the build error early.
- Lint stack on dev is oxlint/oxfmt (not ESLint/Prettier), so the v4 follow-up commits for those linters are not needed here. Husky/lint-staged ran cleanly on the worktree.
- dev has `detectBlockBehavior()` (no v4 counterpart). Independence between the new spread pre-pass and that path is locked down by a regression test (`<Comp {...rest}>{list.map(...)}</Comp>`).

## Test plan

- [x] `yarn build` — 39 packages success
- [x] `yarn test` — 3838 passed / 1 skipped
- [x] astro-parser tests — 96 passed (33 spread-related)
- [x] All Issue #3824 reproduction cases parse without error on dev:
  - [x] TS assertion in spread attribute
  - [x] Spread + expression child (static / dynamic tag / textarea conditional / multi-line / component descendant)
- [x] Multi-line and CRLF spread position assertions (line/col/offset using v5 short field names)
- [x] dev-specific: spread + `.map()` block-behavior interaction
- [x] Unit tests for brace matcher: nested, string-`}`, template `${}`, line/block comment, unbalanced, start-offset, escape parity (`\\\\` vs `\\"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)