### PR TITLE
fix(html-spec): tighten MathML element content models per MathML Core

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -172,6 +172,12 @@
 		"DQUOTE",
 		"khern",
 		"mathml",
+		"mfrac",
+		"mover",
+		"mprescripts",
+		"msubsup",
+		"munder",
+		"munderover",
 		"tref",
 		"vkern",
 

--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -56143,16 +56143,7 @@
 			"contentModel": {
 				"contents": [
 					{
-						"zeroOrMore": [
-							":model(MathMLPresentation)",
-							"mml|semantics",
-							"mml|annotation",
-							"mml|annotation-xml",
-							"mml|mtr",
-							"mml|mtd",
-							"mml|mprescripts",
-							"#text"
-						]
+						"zeroOrMore": [":model(MathMLPresentation)", "mml|semantics", "#text"]
 					}
 				]
 			},
@@ -56314,7 +56305,8 @@
 			"contentModel": {
 				"contents": [
 					{
-						"oneOrMore": [":model(MathMLPresentation)", "mml|semantics", "#text"],
+						"require": [":model(MathMLPresentation)", "mml|semantics", "#text"],
+						"min": 2,
 						"max": 2
 					}
 				]
@@ -56566,13 +56558,14 @@
 			"contentModel": {
 				"contents": [
 					{
-						"oneOrMore": [
+						"require": [
 							":model(MathMLPresentation)",
 							"mml|semantics",
 							"mml|annotation",
 							"mml|annotation-xml",
 							"#text"
 						],
+						"min": 2,
 						"max": 2
 					}
 				]
@@ -56710,7 +56703,8 @@
 			"contentModel": {
 				"contents": [
 					{
-						"oneOrMore": [":model(MathMLPresentation)", "mml|semantics", "#text"],
+						"require": [":model(MathMLPresentation)", "mml|semantics", "#text"],
+						"min": 2,
 						"max": 2
 					}
 				]
@@ -56917,13 +56911,14 @@
 			"contentModel": {
 				"contents": [
 					{
-						"oneOrMore": [
+						"require": [
 							":model(MathMLPresentation)",
 							"mml|semantics",
 							"mml|annotation",
 							"mml|annotation-xml",
 							"#text"
 						],
+						"min": 2,
 						"max": 2
 					}
 				]
@@ -56955,13 +56950,14 @@
 			"contentModel": {
 				"contents": [
 					{
-						"oneOrMore": [
+						"require": [
 							":model(MathMLPresentation)",
 							"mml|semantics",
 							"mml|annotation",
 							"mml|annotation-xml",
 							"#text"
 						],
+						"min": 3,
 						"max": 3
 					}
 				]
@@ -56998,13 +56994,14 @@
 			"contentModel": {
 				"contents": [
 					{
-						"oneOrMore": [
+						"require": [
 							":model(MathMLPresentation)",
 							"mml|semantics",
 							"mml|annotation",
 							"mml|annotation-xml",
 							"#text"
 						],
+						"min": 2,
 						"max": 2
 					}
 				]
@@ -57221,13 +57218,14 @@
 			"contentModel": {
 				"contents": [
 					{
-						"oneOrMore": [
+						"require": [
 							":model(MathMLPresentation)",
 							"mml|semantics",
 							"mml|annotation",
 							"mml|annotation-xml",
 							"#text"
 						],
+						"min": 2,
 						"max": 2
 					}
 				]
@@ -57261,13 +57259,14 @@
 			"contentModel": {
 				"contents": [
 					{
-						"oneOrMore": [
+						"require": [
 							":model(MathMLPresentation)",
 							"mml|semantics",
 							"mml|annotation",
 							"mml|annotation-xml",
 							"#text"
 						],
+						"min": 3,
 						"max": 3
 					}
 				]

--- a/packages/@markuplint/html-spec/src/spec.mml_math.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.mml_math.jsonc
@@ -5,10 +5,11 @@
 			{
 				// MathML Core §2.1.1 — only Presentation MathML and <semantics>
 				// are valid direct children of <math>. Parent-restricted
-				// elements (`<mtr>`/`<mtd>` only inside `<mtable>`,
-				// `<mprescripts>` only inside `<mmultiscripts>`,
-				// `<annotation>`/`<annotation-xml>` only inside `<semantics>`)
-				// are intentionally absent here so misplacement fires.
+				// elements (`<mtr>` §3.5.2 / `<mtd>` §3.5.3 only inside
+				// `<mtable>` §3.5.1, `<mprescripts>` §3.4.3 only inside
+				// `<mmultiscripts>`, `<annotation>` / `<annotation-xml>`
+				// §3.7 only inside `<semantics>`) are intentionally absent
+				// here so misplacement fires.
 				"zeroOrMore": [
 					":model(MathMLPresentation)",
 					"mml|semantics",

--- a/packages/@markuplint/html-spec/src/spec.mml_math.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.mml_math.jsonc
@@ -3,14 +3,15 @@
 	"contentModel": {
 		"contents": [
 			{
+				// MathML Core §2.1.1 — only Presentation MathML and <semantics>
+				// are valid direct children of <math>. Parent-restricted
+				// elements (`<mtr>`/`<mtd>` only inside `<mtable>`,
+				// `<mprescripts>` only inside `<mmultiscripts>`,
+				// `<annotation>`/`<annotation-xml>` only inside `<semantics>`)
+				// are intentionally absent here so misplacement fires.
 				"zeroOrMore": [
 					":model(MathMLPresentation)",
 					"mml|semantics",
-					"mml|annotation",
-					"mml|annotation-xml",
-					"mml|mtr",
-					"mml|mtd",
-					"mml|mprescripts",
 					"#text"
 				]
 			}

--- a/packages/@markuplint/html-spec/src/spec.mml_mfrac.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.mml_mfrac.jsonc
@@ -3,11 +3,14 @@
 	"contentModel": {
 		"contents": [
 			{
-				"oneOrMore": [
+				// MathML Core §3.5.6 — mfrac requires exactly two children
+				// (numerator and denominator).
+				"require": [
 					":model(MathMLPresentation)",
 					"mml|semantics",
 					"#text"
 				],
+				"min": 2,
 				"max": 2
 			}
 		]

--- a/packages/@markuplint/html-spec/src/spec.mml_mfrac.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.mml_mfrac.jsonc
@@ -3,7 +3,7 @@
 	"contentModel": {
 		"contents": [
 			{
-				// MathML Core §3.5.6 — mfrac requires exactly two children
+				// MathML Core §3.3.2 — mfrac requires exactly two children
 				// (numerator and denominator).
 				"require": [
 					":model(MathMLPresentation)",

--- a/packages/@markuplint/html-spec/src/spec.mml_mover.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.mml_mover.jsonc
@@ -3,7 +3,7 @@
 	"contentModel": {
 		"contents": [
 			{
-				// MathML Core §3.6.2 — mover requires exactly two children
+				// MathML Core §3.4.2 — mover requires exactly two children
 				// (base and overscript).
 				"require": [
 					":model(MathMLPresentation)",

--- a/packages/@markuplint/html-spec/src/spec.mml_mover.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.mml_mover.jsonc
@@ -3,13 +3,16 @@
 	"contentModel": {
 		"contents": [
 			{
-				"oneOrMore": [
+				// MathML Core §3.6.2 — mover requires exactly two children
+				// (base and overscript).
+				"require": [
 					":model(MathMLPresentation)",
 					"mml|semantics",
 					"mml|annotation",
 					"mml|annotation-xml",
 					"#text"
 				],
+				"min": 2,
 				"max": 2
 			}
 		]

--- a/packages/@markuplint/html-spec/src/spec.mml_mroot.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.mml_mroot.jsonc
@@ -3,7 +3,7 @@
 	"contentModel": {
 		"contents": [
 			{
-				// MathML Core §3.5.7 — mroot requires exactly two children
+				// MathML Core §3.3.3 — mroot requires exactly two children
 				// (base and index).
 				"require": [
 					":model(MathMLPresentation)",

--- a/packages/@markuplint/html-spec/src/spec.mml_mroot.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.mml_mroot.jsonc
@@ -3,11 +3,14 @@
 	"contentModel": {
 		"contents": [
 			{
-				"oneOrMore": [
+				// MathML Core §3.5.7 — mroot requires exactly two children
+				// (base and index).
+				"require": [
 					":model(MathMLPresentation)",
 					"mml|semantics",
 					"#text"
 				],
+				"min": 2,
 				"max": 2
 			}
 		]

--- a/packages/@markuplint/html-spec/src/spec.mml_msub.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.mml_msub.jsonc
@@ -3,7 +3,7 @@
 	"contentModel": {
 		"contents": [
 			{
-				// MathML Core §3.6.1 — msub requires exactly two children
+				// MathML Core §3.4.1 — msub requires exactly two children
 				// (base and subscript).
 				"require": [
 					":model(MathMLPresentation)",

--- a/packages/@markuplint/html-spec/src/spec.mml_msub.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.mml_msub.jsonc
@@ -3,13 +3,16 @@
 	"contentModel": {
 		"contents": [
 			{
-				"oneOrMore": [
+				// MathML Core §3.6.1 — msub requires exactly two children
+				// (base and subscript).
+				"require": [
 					":model(MathMLPresentation)",
 					"mml|semantics",
 					"mml|annotation",
 					"mml|annotation-xml",
 					"#text"
 				],
+				"min": 2,
 				"max": 2
 			}
 		]

--- a/packages/@markuplint/html-spec/src/spec.mml_msubsup.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.mml_msubsup.jsonc
@@ -3,7 +3,7 @@
 	"contentModel": {
 		"contents": [
 			{
-				// MathML Core §3.6.1 — msubsup requires exactly three children
+				// MathML Core §3.4.1 — msubsup requires exactly three children
 				// (base, subscript, superscript).
 				"require": [
 					":model(MathMLPresentation)",

--- a/packages/@markuplint/html-spec/src/spec.mml_msubsup.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.mml_msubsup.jsonc
@@ -3,13 +3,16 @@
 	"contentModel": {
 		"contents": [
 			{
-				"oneOrMore": [
+				// MathML Core §3.6.1 — msubsup requires exactly three children
+				// (base, subscript, superscript).
+				"require": [
 					":model(MathMLPresentation)",
 					"mml|semantics",
 					"mml|annotation",
 					"mml|annotation-xml",
 					"#text"
 				],
+				"min": 3,
 				"max": 3
 			}
 		]

--- a/packages/@markuplint/html-spec/src/spec.mml_msup.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.mml_msup.jsonc
@@ -3,7 +3,7 @@
 	"contentModel": {
 		"contents": [
 			{
-				// MathML Core §3.6.1 — msup requires exactly two children
+				// MathML Core §3.4.1 — msup requires exactly two children
 				// (base and superscript).
 				"require": [
 					":model(MathMLPresentation)",

--- a/packages/@markuplint/html-spec/src/spec.mml_msup.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.mml_msup.jsonc
@@ -3,13 +3,16 @@
 	"contentModel": {
 		"contents": [
 			{
-				"oneOrMore": [
+				// MathML Core §3.6.1 — msup requires exactly two children
+				// (base and superscript).
+				"require": [
 					":model(MathMLPresentation)",
 					"mml|semantics",
 					"mml|annotation",
 					"mml|annotation-xml",
 					"#text"
 				],
+				"min": 2,
 				"max": 2
 			}
 		]

--- a/packages/@markuplint/html-spec/src/spec.mml_munder.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.mml_munder.jsonc
@@ -3,7 +3,7 @@
 	"contentModel": {
 		"contents": [
 			{
-				// MathML Core §3.6.2 — munder requires exactly two children
+				// MathML Core §3.4.2 — munder requires exactly two children
 				// (base and underscript).
 				"require": [
 					":model(MathMLPresentation)",

--- a/packages/@markuplint/html-spec/src/spec.mml_munder.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.mml_munder.jsonc
@@ -3,13 +3,16 @@
 	"contentModel": {
 		"contents": [
 			{
-				"oneOrMore": [
+				// MathML Core §3.6.2 — munder requires exactly two children
+				// (base and underscript).
+				"require": [
 					":model(MathMLPresentation)",
 					"mml|semantics",
 					"mml|annotation",
 					"mml|annotation-xml",
 					"#text"
 				],
+				"min": 2,
 				"max": 2
 			}
 		]

--- a/packages/@markuplint/html-spec/src/spec.mml_munderover.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.mml_munderover.jsonc
@@ -3,13 +3,16 @@
 	"contentModel": {
 		"contents": [
 			{
-				"oneOrMore": [
+				// MathML Core §3.6.2 — munderover requires exactly three children
+				// (base, underscript, overscript).
+				"require": [
 					":model(MathMLPresentation)",
 					"mml|semantics",
 					"mml|annotation",
 					"mml|annotation-xml",
 					"#text"
 				],
+				"min": 3,
 				"max": 3
 			}
 		]

--- a/packages/@markuplint/html-spec/src/spec.mml_munderover.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.mml_munderover.jsonc
@@ -3,7 +3,7 @@
 	"contentModel": {
 		"contents": [
 			{
-				// MathML Core §3.6.2 — munderover requires exactly three children
+				// MathML Core §3.4.2 — munderover requires exactly three children
 				// (base, underscript, overscript).
 				"require": [
 					":model(MathMLPresentation)",

--- a/packages/@markuplint/rules/src/permitted-contents/index.spec.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/index.spec.ts
@@ -826,12 +826,46 @@ describe('verify', () => {
 		// NG: 3 children (too many)
 		const { violations: v2 } = await mlRuleTest(rule, '<math><mfrac><mi>a</mi><mi>b</mi><mi>c</mi></mfrac></math>');
 		expect(v2.length).toBeGreaterThan(0);
+
+		// NG: 1 child (MathML Core §3.5.6 — mfrac requires exactly two children).
+		// The previous spec used `oneOrMore` with `max: 2`, which silently
+		// allowed a single child. Locks down the require/min:2 fix.
+		const { violations: v3 } = await mlRuleTest(rule, '<math><mfrac><mi>a</mi></mfrac></math>');
+		expect(v3.length).toBeGreaterThan(0);
 	});
 
 	test('[permitted-contents-invalid-021] mml:math', async () => {
 		// OK: MathML presentation elements
 		const { violations: v1 } = await mlRuleTest(rule, '<math><mi>x</mi><mo>+</mo><mn>1</mn></math>');
 		expect(v1).toStrictEqual([]);
+
+		// NG: <mtr> is parent-restricted to <mtable> (MathML Core §3.5.6)
+		// and must not appear directly under <math>.
+		const { violations: v2 } = await mlRuleTest(rule, '<math><mtr><mtd><mn>1</mn></mtd></mtr></math>');
+		expect(v2.length).toBeGreaterThan(0);
+
+		// NG: <annotation> is parent-restricted to <semantics> (MathML Core §3.7.1)
+		// and must not appear directly under <math>.
+		const { violations: v3 } = await mlRuleTest(rule, '<math><annotation>note</annotation></math>');
+		expect(v3.length).toBeGreaterThan(0);
+
+		// NG: <mprescripts> is parent-restricted to <mmultiscripts> (MathML Core §3.6.5).
+		const { violations: v4 } = await mlRuleTest(rule, '<math><mprescripts/></math>');
+		expect(v4.length).toBeGreaterThan(0);
+
+		// OK regression: properly wrapped <annotation> inside <semantics>.
+		const { violations: v5 } = await mlRuleTest(
+			rule,
+			'<math><semantics><mrow><mi>x</mi></mrow><annotation>x</annotation></semantics></math>',
+		);
+		expect(v5).toStrictEqual([]);
+
+		// OK regression: properly wrapped <mtr> inside <mtable>.
+		const { violations: v6 } = await mlRuleTest(
+			rule,
+			'<math><mtable><mtr><mtd><mn>1</mn></mtd></mtr></mtable></math>',
+		);
+		expect(v6).toStrictEqual([]);
 	});
 
 	test('[permitted-contents-valid-001] The SVG <image> element and the HTML obsolete <image> element', async () => {

--- a/packages/@markuplint/rules/src/permitted-contents/index.spec.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/index.spec.ts
@@ -835,7 +835,7 @@ describe('verify', () => {
 			},
 		]);
 
-		// NG: 1 child (MathML Core §3.5.6 — mfrac requires exactly two children).
+		// NG: 1 child (MathML Core §3.3.2 — mfrac requires exactly two children).
 		// The previous spec used `oneOrMore` with `max: 2`, which silently
 		// allowed a single child. Locks down the require/min:2 fix.
 		const { violations: v3 } = await mlRuleTest(rule, '<math><mfrac><mi>a</mi></mfrac></math>');
@@ -855,7 +855,7 @@ describe('verify', () => {
 		const { violations: v1 } = await mlRuleTest(rule, '<math><mi>x</mi><mo>+</mo><mn>1</mn></math>');
 		expect(v1).toStrictEqual([]);
 
-		// NG: <mtr> is parent-restricted to <mtable> (MathML Core §3.5.6)
+		// NG: <mtr> is parent-restricted to <mtable> (MathML Core §3.5.2)
 		// and must not appear directly under <math>.
 		const { violations: v2 } = await mlRuleTest(rule, '<math><mtr><mtd><mn>1</mn></mtd></mtr></math>');
 		expect(v2).toStrictEqual([
@@ -868,7 +868,7 @@ describe('verify', () => {
 			},
 		]);
 
-		// NG: <annotation> is parent-restricted to <semantics> (MathML Core §3.7.1)
+		// NG: <annotation> is parent-restricted to <semantics> (MathML Core §3.7)
 		// and must not appear directly under <math>.
 		const { violations: v3 } = await mlRuleTest(rule, '<math><annotation>note</annotation></math>');
 		expect(v3).toStrictEqual([
@@ -881,7 +881,7 @@ describe('verify', () => {
 			},
 		]);
 
-		// NG: <mprescripts> is parent-restricted to <mmultiscripts> (MathML Core §3.6.5).
+		// NG: <mprescripts> is parent-restricted to <mmultiscripts> (MathML Core §3.4.3).
 		const { violations: v4 } = await mlRuleTest(rule, '<math><mprescripts/></math>');
 		expect(v4).toStrictEqual([
 			{
@@ -915,7 +915,7 @@ describe('verify', () => {
 	});
 
 	test('[permitted-contents-invalid-032] mml:msubsup arity (exactly 3 children)', async () => {
-		// MathML Core §3.6.1 — msubsup requires exactly three children
+		// MathML Core §3.4.1 — msubsup requires exactly three children
 		// (base, subscript, superscript). Representative spec test for the
 		// arity-3 group (covers munderover by analogy).
 
@@ -955,7 +955,7 @@ describe('verify', () => {
 	});
 
 	test('[permitted-contents-invalid-033] mml:mover arity (broader selector with annotation)', async () => {
-		// MathML Core §3.6.2 — mover requires exactly two children. Distinct
+		// MathML Core §3.4.2 — mover requires exactly two children. Distinct
 		// from mfrac in that the permitted-content selector also accepts
 		// `mml|annotation` and `mml|annotation-xml`. Guards against a future
 		// edit that removes either selector by mistake.

--- a/packages/@markuplint/rules/src/permitted-contents/index.spec.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/index.spec.ts
@@ -823,15 +823,31 @@ describe('verify', () => {
 		const { violations: v1 } = await mlRuleTest(rule, '<math><mfrac><mi>a</mi><mi>b</mi></mfrac></math>');
 		expect(v1).toStrictEqual([]);
 
-		// NG: 3 children (too many)
+		// NG: 3 children (too many) — third child triggers the max overflow.
 		const { violations: v2 } = await mlRuleTest(rule, '<math><mfrac><mi>a</mi><mi>b</mi><mi>c</mi></mfrac></math>');
-		expect(v2.length).toBeGreaterThan(0);
+		expect(v2).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 34,
+				message: 'There is more content than it needs. the max number of elements required is two',
+				raw: '<mi>',
+			},
+		]);
 
 		// NG: 1 child (MathML Core §3.5.6 — mfrac requires exactly two children).
 		// The previous spec used `oneOrMore` with `max: 2`, which silently
 		// allowed a single child. Locks down the require/min:2 fix.
 		const { violations: v3 } = await mlRuleTest(rule, '<math><mfrac><mi>a</mi></mfrac></math>');
-		expect(v3.length).toBeGreaterThan(0);
+		expect(v3).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 7,
+				message: 'Require an element. (Need ":model(MathMLPresentation)")',
+				raw: '<mfrac>',
+			},
+		]);
 	});
 
 	test('[permitted-contents-invalid-021] mml:math', async () => {
@@ -842,16 +858,40 @@ describe('verify', () => {
 		// NG: <mtr> is parent-restricted to <mtable> (MathML Core §3.5.6)
 		// and must not appear directly under <math>.
 		const { violations: v2 } = await mlRuleTest(rule, '<math><mtr><mtd><mn>1</mn></mtd></mtr></math>');
-		expect(v2.length).toBeGreaterThan(0);
+		expect(v2).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 7,
+				message: 'The "mtr" element is not allowed in the "math" element in this context',
+				raw: '<mtr>',
+			},
+		]);
 
 		// NG: <annotation> is parent-restricted to <semantics> (MathML Core §3.7.1)
 		// and must not appear directly under <math>.
 		const { violations: v3 } = await mlRuleTest(rule, '<math><annotation>note</annotation></math>');
-		expect(v3.length).toBeGreaterThan(0);
+		expect(v3).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 7,
+				message: 'The "annotation" element is not allowed in the "math" element in this context',
+				raw: '<annotation>',
+			},
+		]);
 
 		// NG: <mprescripts> is parent-restricted to <mmultiscripts> (MathML Core §3.6.5).
 		const { violations: v4 } = await mlRuleTest(rule, '<math><mprescripts/></math>');
-		expect(v4.length).toBeGreaterThan(0);
+		expect(v4).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 7,
+				message: 'The "mprescripts" element is not allowed in the "math" element in this context',
+				raw: '<mprescripts/>',
+			},
+		]);
 
 		// OK regression: properly wrapped <annotation> inside <semantics>.
 		const { violations: v5 } = await mlRuleTest(
@@ -866,6 +906,87 @@ describe('verify', () => {
 			'<math><mtable><mtr><mtd><mn>1</mn></mtd></mtr></mtable></math>',
 		);
 		expect(v6).toStrictEqual([]);
+
+		// Note: `<math>` directly inside `<head>` (the html-math/math-in-head
+		// fixture) is NOT covered here. The HTML5 parser auto-corrects the
+		// `<math>` element out of `<head>` into `<body>` before rule
+		// evaluation, so a content-model fix at the `<head>` spec data level
+		// cannot reach it. Tracked under #3844 (parser-level error gap).
+	});
+
+	test('[permitted-contents-invalid-032] mml:msubsup arity (exactly 3 children)', async () => {
+		// MathML Core §3.6.1 — msubsup requires exactly three children
+		// (base, subscript, superscript). Representative spec test for the
+		// arity-3 group (covers munderover by analogy).
+
+		// OK: exactly 3 children
+		const { violations: v1 } = await mlRuleTest(
+			rule,
+			'<math><msubsup><mi>x</mi><mn>0</mn><mn>1</mn></msubsup></math>',
+		);
+		expect(v1).toStrictEqual([]);
+
+		// NG: 2 children (one short)
+		const { violations: v2 } = await mlRuleTest(rule, '<math><msubsup><mi>x</mi><mn>0</mn></msubsup></math>');
+		expect(v2).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 7,
+				message: 'Require an element. (Need ":model(MathMLPresentation)")',
+				raw: '<msubsup>',
+			},
+		]);
+
+		// NG: 4 children (one over)
+		const { violations: v3 } = await mlRuleTest(
+			rule,
+			'<math><msubsup><mi>x</mi><mn>0</mn><mn>1</mn><mn>2</mn></msubsup></math>',
+		);
+		expect(v3).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 46,
+				message: 'There is more content than it needs. the max number of elements required is three',
+				raw: '<mn>',
+			},
+		]);
+	});
+
+	test('[permitted-contents-invalid-033] mml:mover arity (broader selector with annotation)', async () => {
+		// MathML Core §3.6.2 — mover requires exactly two children. Distinct
+		// from mfrac in that the permitted-content selector also accepts
+		// `mml|annotation` and `mml|annotation-xml`. Guards against a future
+		// edit that removes either selector by mistake.
+
+		// OK: exactly 2 children
+		const { violations: v1 } = await mlRuleTest(rule, '<math><mover><mi>x</mi><mo>~</mo></mover></math>');
+		expect(v1).toStrictEqual([]);
+
+		// NG: 1 child
+		const { violations: v2 } = await mlRuleTest(rule, '<math><mover><mi>x</mi></mover></math>');
+		expect(v2).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 7,
+				message: 'Require an element. (Need ":model(MathMLPresentation)")',
+				raw: '<mover>',
+			},
+		]);
+
+		// NG: 3 children
+		const { violations: v3 } = await mlRuleTest(rule, '<math><mover><mi>x</mi><mo>~</mo><mi>y</mi></mover></math>');
+		expect(v3).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 34,
+				message: 'There is more content than it needs. the max number of elements required is two',
+				raw: '<mi>',
+			},
+		]);
 	});
 
 	test('[permitted-contents-valid-001] The SVG <image> element and the HTML obsolete <image> element', async () => {

--- a/tests/external/snapshots/diff/coverage.json
+++ b/tests/external/snapshots/diff/coverage.json
@@ -1707,9 +1707,9 @@
 		{
 			"path": "html-aria/misc/aria-owns-broken-idref-novalid.html",
 			"category": "aria",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "error",
-			"verdict": "ml-only",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -6964,8 +6964,8 @@
 			"path": "html-math/annotation-outside-semantics-novalid.html",
 			"category": "uncategorized",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -7084,8 +7084,8 @@
 			"path": "html-math/mfrac-wrong-children-novalid.html",
 			"category": "uncategorized",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -7140,8 +7140,8 @@
 			"path": "html-math/mover-wrong-children-novalid.html",
 			"category": "uncategorized",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -7164,8 +7164,8 @@
 			"path": "html-math/mprescripts-outside-mmultiscripts-novalid.html",
 			"category": "uncategorized",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -7180,8 +7180,8 @@
 			"path": "html-math/mroot-wrong-children-novalid.html",
 			"category": "uncategorized",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -7228,8 +7228,8 @@
 			"path": "html-math/msub-wrong-children-novalid.html",
 			"category": "uncategorized",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -7244,8 +7244,8 @@
 			"path": "html-math/msubsup-wrong-children-novalid.html",
 			"category": "uncategorized",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -7260,8 +7260,8 @@
 			"path": "html-math/msup-wrong-children-novalid.html",
 			"category": "uncategorized",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -7292,8 +7292,8 @@
 			"path": "html-math/mtr-outside-mtable-novalid.html",
 			"category": "uncategorized",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -7308,8 +7308,8 @@
 			"path": "html-math/munder-wrong-children-novalid.html",
 			"category": "uncategorized",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -7324,8 +7324,8 @@
 			"path": "html-math/munderover-wrong-children-novalid.html",
 			"category": "uncategorized",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{

--- a/tests/external/snapshots/diff/markuplint-only.json
+++ b/tests/external/snapshots/diff/markuplint-only.json
@@ -51,14 +51,6 @@
 			]
 		},
 		{
-			"path": "html-aria/misc/aria-owns-broken-idref-novalid.html",
-			"category": "aria",
-			"ruleIds": [
-				"no-refer-to-non-existent-id",
-				"wai-aria-required-parent-role"
-			]
-		},
-		{
 			"path": "html-aria/misc/aria-valuemin-on-meter-haswarn.html",
 			"category": "aria",
 			"ruleIds": [

--- a/tests/external/snapshots/diff/nu-only.json
+++ b/tests/external/snapshots/diff/nu-only.json
@@ -59,88 +59,11 @@
 			]
 		},
 		{
-			"path": "html-math/annotation-outside-semantics-novalid.html",
-			"category": "uncategorized",
-			"nuMessageIds": [
-				"nv-6db259cf12d0"
-			]
-		},
-		{
 			"path": "html-math/math-in-head-novalid.html",
 			"category": "uncategorized",
 			"nuMessageIds": [
 				"nv-0c86320f6630",
 				"nv-8aff5b8981a2"
-			]
-		},
-		{
-			"path": "html-math/mfrac-wrong-children-novalid.html",
-			"category": "uncategorized",
-			"nuMessageIds": [
-				"nv-040639226b3a"
-			]
-		},
-		{
-			"path": "html-math/mover-wrong-children-novalid.html",
-			"category": "uncategorized",
-			"nuMessageIds": [
-				"nv-53183604e0dd"
-			]
-		},
-		{
-			"path": "html-math/mprescripts-outside-mmultiscripts-novalid.html",
-			"category": "uncategorized",
-			"nuMessageIds": [
-				"nv-9b9bc9ec3935"
-			]
-		},
-		{
-			"path": "html-math/mroot-wrong-children-novalid.html",
-			"category": "uncategorized",
-			"nuMessageIds": [
-				"nv-2515d13ecb23"
-			]
-		},
-		{
-			"path": "html-math/msub-wrong-children-novalid.html",
-			"category": "uncategorized",
-			"nuMessageIds": [
-				"nv-94f048f5b5f2"
-			]
-		},
-		{
-			"path": "html-math/msubsup-wrong-children-novalid.html",
-			"category": "uncategorized",
-			"nuMessageIds": [
-				"nv-0229f9179fba"
-			]
-		},
-		{
-			"path": "html-math/msup-wrong-children-novalid.html",
-			"category": "uncategorized",
-			"nuMessageIds": [
-				"nv-938f077237f4"
-			]
-		},
-		{
-			"path": "html-math/mtr-outside-mtable-novalid.html",
-			"category": "uncategorized",
-			"nuMessageIds": [
-				"nv-40d1c6012443"
-			]
-		},
-		{
-			"path": "html-math/munder-wrong-children-novalid.html",
-			"category": "uncategorized",
-			"nuMessageIds": [
-				"nv-619086335546"
-			]
-		},
-		{
-			"path": "html-math/munderover-wrong-children-novalid.html",
-			"category": "uncategorized",
-			"nuMessageIds": [
-				"nv-041ffbaa3a4c"
 			]
 		},
 		{

--- a/tests/external/snapshots/diff/summary.md
+++ b/tests/external/snapshots/diff/summary.md
@@ -1,6 +1,6 @@
 # nu-validator Benchmark Summary
 
-- generated: 2026-05-10T02:41:44.869Z
+- generated: 2026-05-10T05:44:24.996Z
 - submodule: `142931395412c00434ffb40a14d65992efd17aa8`
 - nu-validator: `ghcr.io/validator/validator@sha256:9746b8663542cb5bded271fea08a3cc04ca12af6232f014baa341fccc01d3a21`
 - markuplint: `5.0.0-rc.4`
@@ -9,18 +9,18 @@
 ## Totals
 
 - files: **5442**
-- match-error: **2171** (both tools flagged)
+- match-error: **2183** (both tools flagged)
 - match-clean: **920** (neither flagged)
-- nu-only: **1343** (only nu-validator flagged; markuplint coverage candidates — open a markuplint issue after a spec read)
+- nu-only: **1332** (only nu-validator flagged; markuplint coverage candidates — open a markuplint issue after a spec read)
 - nu-over: **28** (nu-validator errors fully covered by spec-backed excluded-ids — confirmed over-detection)
-- overall match rate: **56.8%**
+- overall match rate: **57.0%**
 - excluded-ids: 3 entries, 1 pattern(s)
 
 ## Per-Category
 
 | Category | Files | Match rate | match-error | match-clean | ml-only | nu-only | nu-over |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| aria | 780 | 80.4% | 175 | 452 | 145 | 8 | 0 |
+| aria | 780 | 80.5% | 176 | 452 | 144 | 8 | 0 |
 | assertions | 40 | 100.0% | 39 | 1 | 0 | 0 | 0 |
 | content-model | 98 | 98.0% | 48 | 48 | 0 | 2 | 0 |
 | data-types | 56 | 92.9% | 47 | 5 | 1 | 3 | 0 |
@@ -29,11 +29,11 @@
 | id-duplication | 1 | 100.0% | 1 | 0 | 0 | 0 | 0 |
 | invalid-attr | 3086 | 59.1% | 1592 | 231 | 60 | 1177 | 26 |
 | required-attr | 5 | 100.0% | 5 | 0 | 0 | 0 | 0 |
-| uncategorized | 1307 | 29.8% | 227 | 163 | 765 | 150 | 2 |
+| uncategorized | 1307 | 30.7% | 238 | 163 | 765 | 139 | 2 |
 
 ## Informational: ml-only
 
-**980** fixtures are flagged only by markuplint. This project does not pursue upstream nu-validator reports, so those fixtures feed a narrower audit: confirm with the spec, and if markuplint is the wrong one, fix the rule. The full list lives in `snapshots/diff/markuplint-only.json`.
+**979** fixtures are flagged only by markuplint. This project does not pursue upstream nu-validator reports, so those fixtures feed a narrower audit: confirm with the spec, and if markuplint is the wrong one, fix the rule. The full list lives in `snapshots/diff/markuplint-only.json`.
 
 ### Top ml-only rules
 
@@ -48,7 +48,7 @@
 | required-attr | 22 |
 | wai-aria-permitted-roles | 20 |
 | wai-aria-value | 11 |
-| no-refer-to-non-existent-id | 8 |
+| no-refer-to-non-existent-id | 7 |
 
 > `nu-only` entries are candidates for markuplint coverage work **after** verifying the relevant spec paragraph. `nu-over` entries are already confirmed nu-validator over-detection via `excluded-ids.json`. `ml-only` is informational; audit the spec before acting on any individual row.
 

--- a/tests/external/snapshots/meta.json
+++ b/tests/external/snapshots/meta.json
@@ -1,12 +1,12 @@
 {
-	"generatedAt": "2026-05-10T02:41:44.869Z",
+	"generatedAt": "2026-05-10T05:44:24.996Z",
 	"submoduleSha": "142931395412c00434ffb40a14d65992efd17aa8",
 	"nuValidatorImage": "ghcr.io/validator/validator@sha256:9746b8663542cb5bded271fea08a3cc04ca12af6232f014baa341fccc01d3a21",
 	"markuplintVersion": "5.0.0-rc.4",
 	"nodeVersion": "24.14.1",
 	"totalFilesNu": 5442,
 	"totalFilesMl": 5442,
-	"totalNuMessages": 9905,
-	"totalMlViolations": 9944,
+	"totalNuMessages": 9906,
+	"totalMlViolations": 9955,
 	"totalNuFailures": 0
 }


### PR DESCRIPTION
## Summary

Closes 11 of 12 nu-only fixtures under \`html-math/\` (Issue #3849).

- **Strict arity** for elements that need an exact child count, by switching from `oneOrMore + max: N` to `require + min/max`:
  - `mfrac`, `mover`, `mroot`, `msub`, `msup`, `munder` — exactly 2 children
  - `msubsup`, `munderover` — exactly 3 children
  Previously `oneOrMore + max: 2` silently allowed 1..2 children, so a single-child `<mfrac>` passed.

- **Removes parent-restricted elements from `<math>`'s direct child list**:
  - `mtr` (only inside `<mtable>` per MathML Core §3.5.2) / `mtd` (only inside `<mtr>` per §3.5.3)
  - `mprescripts` (only inside `<mmultiscripts>` per §3.4.3)
  - `annotation` / `annotation-xml` (only inside `<semantics>` per §3.7)
  Their valid wrappers already include them, so legitimate constructs (mtable-isvalid, annotation-xml-isvalid, etc.) are unaffected.

- **Out of scope (deferred)**: `math-in-head-novalid.html`. HTML5's parser auto-corrects `<math>` out of `<head>` into `<body>` before rule evaluation, so a content-model fix at the `<head>` spec data level cannot reach it. Tracked under #3844 (parser-level error gap).

## Bench impact

- Before: nu-only 1343
- After: nu-only 1332 (-11 expected MathML flips)
- Plus an unrelated flicker on `html-aria/misc/aria-owns-broken-idref-novalid.html` (nu-validator non-determinism, documented in `bench-triage` SKILL).

## Test plan

- [x] `yarn lint-check` — 0 errors / 0 warnings
- [x] `yarn build` — all 39 packages succeed
- [x] `yarn test` — 248/248 test files, 3816 tests pass
- [x] `permitted-contents-invalid-020` — mfrac with 1, 2, 3 children (1 and 3 fire, 2 valid)
- [x] `permitted-contents-invalid-021` — mtr/annotation/mprescripts misplaced under `<math>` (fire), and the same elements valid when wrapped in their proper parents (mtable, semantics)
- [x] `tests/external/snapshots/diff/summary.md` shows 11 expected flips with no real regressions
- [x] `index.json` `nonStandard: true` count unchanged from `dev` (drift from `yarn up:gen` reverted to keep diff scoped)
- [ ] CI all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
