### PR TITLE
feat(rules): add itemprop-requires-itemscope + tighten itemref/itemtype spec data

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -170,6 +170,10 @@
 		// Specs
 		"closedby",
 		"DQUOTE",
+		"itemprop",
+		"itemref",
+		"itemscope",
+		"itemtype",
 		"khern",
 		"mathml",
 		"mfrac",

--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -377,6 +377,7 @@
 				"itemref": {
 					"type": {
 						"token": "DOMID",
+						"unique": true,
 						"separator": "space"
 					},
 					"condition": "[itemscope]"
@@ -389,6 +390,7 @@
 						"token": "AbsoluteURL",
 						"ordered": false,
 						"unique": true,
+						"allowEmpty": false,
 						"separator": "space"
 					},
 					"condition": "[itemscope]"

--- a/packages/@markuplint/html-spec/src/spec-common.attributes.jsonc
+++ b/packages/@markuplint/html-spec/src/spec-common.attributes.jsonc
@@ -153,9 +153,9 @@
 		"itemref": {
 			"type": {
 				"token": "DOMID",
-				// HTML LS §5.2.2 — itemref value is "an unordered set of unique
-				// space-separated tokens that are case-sensitive". Without
-				// `unique`, `itemref="ref1 ref1"` silently passed.
+				// HTML LS §5.2.2 (Items) — itemref value is "an unordered set
+				// of unique space-separated tokens that are case-sensitive".
+				// Without `unique`, `itemref="ref1 ref1"` silently passed.
 				"unique": true,
 				"separator": "space"
 			},
@@ -171,10 +171,10 @@
 				"token": "AbsoluteURL",
 				"ordered": false,
 				"unique": true,
-				// HTML LS §5.2.1 — when itemtype is specified its value must
-				// be "an unordered set of unique tokens that are case-sensitive,
-				// each of which is a valid absolute URL". An empty value has
-				// no tokens at all and is non-conforming.
+				// HTML LS §5.2.2 (Items) — when itemtype is specified its
+				// value must be "an unordered set of unique tokens that are
+				// case-sensitive, each of which is a valid absolute URL".
+				// An empty value has no tokens at all and is non-conforming.
 				"allowEmpty": false,
 				"separator": "space"
 			},

--- a/packages/@markuplint/html-spec/src/spec-common.attributes.jsonc
+++ b/packages/@markuplint/html-spec/src/spec-common.attributes.jsonc
@@ -153,6 +153,10 @@
 		"itemref": {
 			"type": {
 				"token": "DOMID",
+				// HTML LS §5.2.2 — itemref value is "an unordered set of unique
+				// space-separated tokens that are case-sensitive". Without
+				// `unique`, `itemref="ref1 ref1"` silently passed.
+				"unique": true,
 				"separator": "space"
 			},
 			"condition": "[itemscope]"
@@ -167,6 +171,11 @@
 				"token": "AbsoluteURL",
 				"ordered": false,
 				"unique": true,
+				// HTML LS §5.2.1 — when itemtype is specified its value must
+				// be "an unordered set of unique tokens that are case-sensitive,
+				// each of which is a valid absolute URL". An empty value has
+				// no tokens at all and is non-conforming.
+				"allowEmpty": false,
 				"separator": "space"
 			},
 			// HTML LS §5.7.4: itemtype must not be specified on elements that

--- a/packages/@markuplint/rules/schema.json
+++ b/packages/@markuplint/rules/schema.json
@@ -69,6 +69,9 @@
 				"invalid-attr": {
 					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/invalid-attr/schema.json"
 				},
+				"itemprop-requires-itemscope": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/itemprop-requires-itemscope/schema.json"
+				},
 				"label-has-control": {
 					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/label-has-control/schema.json"
 				},

--- a/packages/@markuplint/rules/src/index.ts
+++ b/packages/@markuplint/rules/src/index.ts
@@ -30,6 +30,7 @@ import IneffectiveAttr from './ineffective-attr/index.js';
 import InputButtonNonEmptyValue from './input-button-non-empty-value/index.js';
 import InputFileEmptyValue from './input-file-empty-value/index.js';
 import InvalidAttr from './invalid-attr/index.js';
+import ItempropRequiresItemscope from './itemprop-requires-itemscope/index.js';
 import LabelHasControl from './label-has-control/index.js';
 import LabelNoMultipleControls from './label-no-multiple-controls/index.js';
 import LandmarkRoles from './landmark-roles/index.js';
@@ -107,6 +108,7 @@ const rules = {
 	'input-button-non-empty-value': InputButtonNonEmptyValue,
 	'input-file-empty-value': InputFileEmptyValue,
 	'invalid-attr': InvalidAttr,
+	'itemprop-requires-itemscope': ItempropRequiresItemscope,
 	'label-has-control': LabelHasControl,
 	'label-no-multiple-controls': LabelNoMultipleControls,
 	'landmark-roles': LandmarkRoles,

--- a/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
@@ -2915,4 +2915,30 @@ describe('img[usemap] requires a non-empty hash-name (HashName type)', () => {
 		const { violations } = await mlRuleTest(rule, '<img src="x.png" usemap="#" alt="">');
 		expect(violations.some(v => v.raw === '#')).toBe(true);
 	});
+
+	test('[invalid-attr-invalid-040] itemref token list rejects duplicate ids (HTML LS §5.2.2)', async () => {
+		// Mirrors html/microdata/itemref-redundant-novalid.html. Locks down the
+		// `unique: true` flag added to the itemref token spec.
+		const { violations } = await mlRuleTest(
+			rule,
+			'<div itemscope itemref="ref1 ref1"></div><div id="ref1" itemprop="name">x</div>',
+		);
+		expect(
+			violations.some(v => v.raw === 'ref1' && typeof v.message === 'string' && v.message.includes('duplicated')),
+		).toBe(true);
+	});
+
+	test('[invalid-attr-invalid-041] itemtype="" rejects empty token set (HTML LS §5.2.1)', async () => {
+		// Mirrors html/microdata/itemtype-empty-novalid.html. Locks down the
+		// `allowEmpty: false` flag added to the itemtype token spec.
+		const { violations } = await mlRuleTest(rule, '<div itemtype="" itemscope></div>');
+		expect(
+			violations.some(
+				v =>
+					typeof v.message === 'string' &&
+					v.message.includes('itemtype') &&
+					v.message.includes('must not be empty'),
+			),
+		).toBe(true);
+	});
 });

--- a/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
@@ -2916,7 +2916,7 @@ describe('img[usemap] requires a non-empty hash-name (HashName type)', () => {
 		expect(violations.some(v => v.raw === '#')).toBe(true);
 	});
 
-	test('[invalid-attr-invalid-040] itemref token list rejects duplicate ids (HTML LS §5.2.2)', async () => {
+	test('[invalid-attr-invalid-040] itemref token list rejects duplicate ids (HTML LS §5.2.2 Items)', async () => {
 		// Mirrors html/microdata/itemref-redundant-novalid.html. Locks down the
 		// `unique: true` flag added to the itemref token spec.
 		// Uses substring-only `.some(...)` (matches the invalid-039 pattern)
@@ -2931,7 +2931,7 @@ describe('img[usemap] requires a non-empty hash-name (HashName type)', () => {
 		).toBe(true);
 	});
 
-	test('[invalid-attr-invalid-041] itemtype="" rejects empty token set (HTML LS §5.2.1)', async () => {
+	test('[invalid-attr-invalid-041] itemtype="" rejects empty token set (HTML LS §5.2.2 Items)', async () => {
 		// Mirrors html/microdata/itemtype-empty-novalid.html. Locks down the
 		// `allowEmpty: false` flag added to the itemtype token spec.
 		// Uses substring-only match (see invalid-040 for rationale).

--- a/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
@@ -2919,6 +2919,9 @@ describe('img[usemap] requires a non-empty hash-name (HashName type)', () => {
 	test('[invalid-attr-invalid-040] itemref token list rejects duplicate ids (HTML LS §5.2.2)', async () => {
 		// Mirrors html/microdata/itemref-redundant-novalid.html. Locks down the
 		// `unique: true` flag added to the itemref token spec.
+		// Uses substring-only `.some(...)` (matches the invalid-039 pattern)
+		// so the test stays stable when invalid-attr's surrounding wording is
+		// tuned elsewhere.
 		const { violations } = await mlRuleTest(
 			rule,
 			'<div itemscope itemref="ref1 ref1"></div><div id="ref1" itemprop="name">x</div>',
@@ -2931,6 +2934,7 @@ describe('img[usemap] requires a non-empty hash-name (HashName type)', () => {
 	test('[invalid-attr-invalid-041] itemtype="" rejects empty token set (HTML LS §5.2.1)', async () => {
 		// Mirrors html/microdata/itemtype-empty-novalid.html. Locks down the
 		// `allowEmpty: false` flag added to the itemtype token spec.
+		// Uses substring-only match (see invalid-040 for rationale).
 		const { violations } = await mlRuleTest(rule, '<div itemtype="" itemscope></div>');
 		expect(
 			violations.some(

--- a/packages/@markuplint/rules/src/itemprop-requires-itemscope/README.ja.md
+++ b/packages/@markuplint/rules/src/itemprop-requires-itemscope/README.ja.md
@@ -1,0 +1,41 @@
+---
+description: itemprop が必ずアイテムに属していることを要求します。
+---
+
+# `itemprop-requires-itemscope`
+
+<!-- textlint-disable ja-technical-writing/ja-no-mixed-period -->
+
+どのアイテムにも property を貢献していない `itemprop` 属性を警告します。
+
+> アイテムに属さない要素の `itemprop` 属性はエラーです。
+
+[HTML Living Standard §5.2.4 — Names: the itemprop attribute](https://html.spec.whatwg.org/multipage/microdata.html#names:-the-itemprop-attribute) より引用
+
+要素がアイテムに属しているのは、次の **いずれか** を満たす場合です:
+
+- 祖先要素が `itemscope` 属性を持っている
+- 自要素の `id` が、どこかの `itemscope` 要素の `itemref` トークンリストから参照されている
+
+<!-- prettier-ignore-end -->
+
+❌ 間違ったコード例
+
+```html
+<span itemprop="name">孤立したプロパティ</span>
+```
+
+✅ 正しいコード例
+
+```html
+<!-- itemscope を持つ祖先がある -->
+<div itemscope>
+  <span itemprop="name">アイテム内</span>
+</div>
+
+<!-- itemref で参照されている -->
+<div itemscope itemref="ref-name"></div>
+<span id="ref-name" itemprop="name">itemref 経由で到達可能</span>
+```
+
+<!-- textlint-enable ja-technical-writing/ja-no-mixed-period -->

--- a/packages/@markuplint/rules/src/itemprop-requires-itemscope/README.ja.md
+++ b/packages/@markuplint/rules/src/itemprop-requires-itemscope/README.ja.md
@@ -8,9 +8,9 @@ description: itemprop が必ずアイテムに属していることを要求し�
 
 どのアイテムにも property を貢献していない `itemprop` 属性を警告します。
 
-> アイテムに属さない要素の `itemprop` 属性はエラーです。
+> 文書には、その文書のアイテムのいずれの property としても見つからない `itemprop` 属性を持つ要素を含めてはならない。
 
-[HTML Living Standard §5.2.4 — Names: the itemprop attribute](https://html.spec.whatwg.org/multipage/microdata.html#names:-the-itemprop-attribute) より引用
+[HTML Living Standard §5.2.5 — Associating names with items](https://html.spec.whatwg.org/multipage/microdata.html#associating-names-with-items) より引用 (拙訳)。`itemprop` 属性自体の定義は [§5.2.3 — Names: the itemprop attribute](https://html.spec.whatwg.org/multipage/microdata.html#names:-the-itemprop-attribute) にあります。
 
 要素がアイテムに属しているのは、次の **いずれか** を満たす場合です:
 

--- a/packages/@markuplint/rules/src/itemprop-requires-itemscope/README.md
+++ b/packages/@markuplint/rules/src/itemprop-requires-itemscope/README.md
@@ -1,0 +1,38 @@
+---
+id: itemprop-requires-itemscope
+description: Require every itemprop to belong to an item.
+---
+
+# `itemprop-requires-itemscope`
+
+Warns about an `itemprop` attribute that does not contribute a property to any item.
+
+> For elements with no item, an `itemprop` attribute is in error.
+
+Cite: [HTML Living Standard §5.2.4 — Names: the itemprop attribute](https://html.spec.whatwg.org/multipage/microdata.html#names:-the-itemprop-attribute)
+
+An element belongs to an item if **either** of the following holds:
+
+- it has an ancestor element with an `itemscope` attribute, or
+- its `id` is referenced by some `itemscope` element's `itemref` token list.
+
+<!-- prettier-ignore-end -->
+
+❌ Examples of **incorrect** code for this rule
+
+```html
+<span itemprop="name">Orphan property</span>
+```
+
+✅ Examples of **correct** code for this rule
+
+```html
+<!-- An ancestor has itemscope -->
+<div itemscope>
+  <span itemprop="name">Inside an item</span>
+</div>
+
+<!-- Reachable via itemref -->
+<div itemscope itemref="ref-name"></div>
+<span id="ref-name" itemprop="name">Reachable via itemref</span>
+```

--- a/packages/@markuplint/rules/src/itemprop-requires-itemscope/README.md
+++ b/packages/@markuplint/rules/src/itemprop-requires-itemscope/README.md
@@ -7,9 +7,9 @@ description: Require every itemprop to belong to an item.
 
 Warns about an `itemprop` attribute that does not contribute a property to any item.
 
-> For elements with no item, an `itemprop` attribute is in error.
+> A document must not contain any elements that have an `itemprop` attribute that would not be found to be a property of any of the items in that document.
 
-Cite: [HTML Living Standard §5.2.4 — Names: the itemprop attribute](https://html.spec.whatwg.org/multipage/microdata.html#names:-the-itemprop-attribute)
+Cite: [HTML Living Standard §5.2.5 — Associating names with items](https://html.spec.whatwg.org/multipage/microdata.html#associating-names-with-items). The `itemprop` attribute itself is defined in [§5.2.3 — Names: the itemprop attribute](https://html.spec.whatwg.org/multipage/microdata.html#names:-the-itemprop-attribute).
 
 An element belongs to an item if **either** of the following holds:
 

--- a/packages/@markuplint/rules/src/itemprop-requires-itemscope/index.spec.ts
+++ b/packages/@markuplint/rules/src/itemprop-requires-itemscope/index.spec.ts
@@ -27,6 +27,27 @@ describe('verify', () => {
 		expect(violations).toStrictEqual([]);
 	});
 
+	test('[itemprop-requires-itemscope-valid-004] whitespace-only itemref contributes no entries; would-be target stays orphan', async () => {
+		// `itemref="  "` yields zero non-empty tokens, so the host claims no
+		// id at all. Exercises the `if (token)` filter inside the token-
+		// collection loop. The standalone span is therefore not reachable
+		// via itemref and falls into the orphan branch.
+		const { violations } = await mlRuleTest(
+			rule,
+			'<div itemscope itemref="  "></div><span id="ref-name" itemprop="name">y</span>',
+		);
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 35,
+				message:
+					'The element must belong to an item via an ancestor `itemscope` or be referenced by an `itemref`',
+				raw: '<span id="ref-name" itemprop="name">',
+			},
+		]);
+	});
+
 	test('[itemprop-requires-itemscope-invalid-001] orphan itemprop with no ancestor itemscope and no itemref', async () => {
 		const { violations } = await mlRuleTest(rule, '<span itemprop="name">orphan</span>');
 		expect(violations).toStrictEqual([
@@ -62,8 +83,27 @@ describe('verify', () => {
 
 	test('[itemprop-requires-itemscope-invalid-003] each orphan in a sequence fires independently', async () => {
 		// Loop must process every [itemprop] match, not stop at the first.
+		// Pin both violations so a future change that accidentally narrows
+		// the loop (or fires for the wrong reason) is caught.
 		const { violations } = await mlRuleTest(rule, '<span itemprop="name">a</span><span itemprop="email">b</span>');
-		expect(violations).toHaveLength(2);
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 1,
+				message:
+					'The element must belong to an item via an ancestor `itemscope` or be referenced by an `itemref`',
+				raw: '<span itemprop="name">',
+			},
+			{
+				severity: 'error',
+				line: 1,
+				col: 31,
+				message:
+					'The element must belong to an item via an ancestor `itemscope` or be referenced by an `itemref`',
+				raw: '<span itemprop="email">',
+			},
+		]);
 	});
 
 	test('[itemprop-requires-itemscope-invalid-004] explicit empty id falls into the orphan branch', async () => {

--- a/packages/@markuplint/rules/src/itemprop-requires-itemscope/index.spec.ts
+++ b/packages/@markuplint/rules/src/itemprop-requires-itemscope/index.spec.ts
@@ -1,0 +1,84 @@
+import { mlRuleTest } from 'markuplint';
+import { describe, test, expect } from 'vitest';
+
+import rule from './index.js';
+
+describe('verify', () => {
+	test('[itemprop-requires-itemscope-valid-001] itemprop inside an itemscope ancestor', async () => {
+		const { violations } = await mlRuleTest(rule, '<div itemscope><span itemprop="name">x</span></div>');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('[itemprop-requires-itemscope-valid-002] itemprop reachable via itemref', async () => {
+		// HTML LS does not require the referenced element to be a descendant
+		// of the itemscope element. Sibling reachability is sufficient.
+		const { violations } = await mlRuleTest(
+			rule,
+			'<div itemscope itemref="ref-name"></div><span id="ref-name" itemprop="name">y</span>',
+		);
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('[itemprop-requires-itemscope-valid-003] element with both itemscope and itemprop is valid (self-as-scope)', async () => {
+		// HTML LS allows an element to be both an item host and contribute a
+		// property to an enclosing item. closest('[itemscope]') must include
+		// self so the inner element is not flagged as an orphan.
+		const { violations } = await mlRuleTest(rule, '<div itemscope><div itemscope itemprop="address">x</div></div>');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('[itemprop-requires-itemscope-invalid-001] orphan itemprop with no ancestor itemscope and no itemref', async () => {
+		const { violations } = await mlRuleTest(rule, '<span itemprop="name">orphan</span>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 1,
+				message:
+					'The element must belong to an item via an ancestor `itemscope` or be referenced by an `itemref`',
+				raw: '<span itemprop="name">',
+			},
+		]);
+	});
+
+	test('[itemprop-requires-itemscope-invalid-002] itemref token does not match the orphan element id', async () => {
+		// `itemref` lists `ref-other` but the orphan span has `id="ref-name"`,
+		// so the orphan is NOT reachable via itemref.
+		const { violations } = await mlRuleTest(
+			rule,
+			'<div itemscope itemref="ref-other"></div><span id="ref-name" itemprop="name">orphan</span>',
+		);
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 42,
+				message:
+					'The element must belong to an item via an ancestor `itemscope` or be referenced by an `itemref`',
+				raw: '<span id="ref-name" itemprop="name">',
+			},
+		]);
+	});
+
+	test('[itemprop-requires-itemscope-invalid-003] each orphan in a sequence fires independently', async () => {
+		// Loop must process every [itemprop] match, not stop at the first.
+		const { violations } = await mlRuleTest(rule, '<span itemprop="name">a</span><span itemprop="email">b</span>');
+		expect(violations).toHaveLength(2);
+	});
+
+	test('[itemprop-requires-itemscope-invalid-004] explicit empty id falls into the orphan branch', async () => {
+		// `id=""` is not a valid identifier and cannot be an itemref target;
+		// the rule must treat such an element the same as having no id at all.
+		const { violations } = await mlRuleTest(rule, '<span id="" itemprop="name">orphan</span>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 1,
+				message:
+					'The element must belong to an item via an ancestor `itemscope` or be referenced by an `itemref`',
+				raw: '<span id="" itemprop="name">',
+			},
+		]);
+	});
+});

--- a/packages/@markuplint/rules/src/itemprop-requires-itemscope/index.ts
+++ b/packages/@markuplint/rules/src/itemprop-requires-itemscope/index.ts
@@ -1,0 +1,54 @@
+import { createRule } from '@markuplint/ml-core';
+
+import meta from './meta.js';
+
+/**
+ * Rule that requires every `itemprop` to belong to an item.
+ *
+ * Per HTML LS §5.2.4 ("Names: the itemprop attribute"), an element with
+ * an `itemprop` attribute is in error unless one of the following is true:
+ *
+ * - it has an ancestor element with an `itemscope` attribute, or
+ * - its `id` is referenced by some `itemscope` element's `itemref` token list.
+ *
+ * Either path makes the element part of an item; without either, the
+ * `itemprop` is orphaned and contributes no property to any item.
+ *
+ * @see https://html.spec.whatwg.org/multipage/microdata.html#names:-the-itemprop-attribute
+ */
+export default createRule<boolean, null>({
+	meta,
+	verify({ document, report, t }) {
+		// Build the set of element ids referenced by some `[itemscope] [itemref]`.
+		// HTML LS does not require `itemref` to point to a descendant — any
+		// element in the same tree may be claimed via id, so we collect ids
+		// once and then check each `[itemprop]` against the union set.
+		// `itemref="  "` (whitespace-only) yields zero tokens and contributes
+		// no entries to the set; orphans referencing such a host stay orphans.
+		const itemrefIds = new Set<string>();
+		const itemrefHosts = document.querySelectorAll('[itemscope][itemref]');
+		for (const host of itemrefHosts) {
+			const value = host.getAttribute('itemref') ?? '';
+			for (const token of value.split(/\s+/)) {
+				if (token) itemrefIds.add(token);
+			}
+		}
+
+		const itempropEls = document.querySelectorAll('[itemprop]');
+		for (const el of itempropEls) {
+			const hasAncestorScope = el.closest('[itemscope]') != null;
+			const id = el.getAttribute('id');
+			const isItemrefTarget = id != null && id !== '' && itemrefIds.has(id);
+			if (!hasAncestorScope && !isItemrefTarget) {
+				report({
+					scope: el,
+					message: t(
+						'{0} must {1}',
+						t('the {0}', 'element'),
+						'belong to an item via an ancestor `itemscope` or be referenced by an `itemref`',
+					),
+				});
+			}
+		}
+	},
+});

--- a/packages/@markuplint/rules/src/itemprop-requires-itemscope/index.ts
+++ b/packages/@markuplint/rules/src/itemprop-requires-itemscope/index.ts
@@ -5,8 +5,12 @@ import meta from './meta.js';
 /**
  * Rule that requires every `itemprop` to belong to an item.
  *
- * Per HTML LS §5.2.4 ("Names: the itemprop attribute"), an element with
- * an `itemprop` attribute is in error unless one of the following is true:
+ * The `itemprop` attribute is defined in HTML LS §5.2.3 ("Names: the
+ * itemprop attribute"). The conformance constraint behind this rule sits
+ * under §5.2.5: a document must not contain an `itemprop` element that
+ * would not be found to be a property of any of its items. Practically,
+ * an element with `itemprop` belongs to an item when one of the following
+ * is true:
  *
  * - it has an ancestor element with an `itemscope` attribute, or
  * - its `id` is referenced by some `itemscope` element's `itemref` token list.
@@ -15,6 +19,7 @@ import meta from './meta.js';
  * `itemprop` is orphaned and contributes no property to any item.
  *
  * @see https://html.spec.whatwg.org/multipage/microdata.html#names:-the-itemprop-attribute
+ * @see https://html.spec.whatwg.org/multipage/microdata.html#associating-names-with-items
  */
 export default createRule<boolean, null>({
 	meta,

--- a/packages/@markuplint/rules/src/itemprop-requires-itemscope/meta.ts
+++ b/packages/@markuplint/rules/src/itemprop-requires-itemscope/meta.ts
@@ -1,0 +1,4 @@
+/** Rule metadata for `itemprop-requires-itemscope`: categorized as a validation rule. */
+export default {
+	category: 'validation',
+} as const;

--- a/packages/@markuplint/rules/src/itemprop-requires-itemscope/schema.json
+++ b/packages/@markuplint/rules/src/itemprop-requires-itemscope/schema.json
@@ -1,0 +1,29 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"value": {
+			"type": "boolean",
+			"description": "Reports an `itemprop` that does not belong to any item.",
+			"description:ja": "どのアイテムにも属していない `itemprop` を警告します。"
+		}
+	},
+	"oneOf": [
+		{
+			"$ref": "#/definitions/value"
+		},
+		{
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"value": { "$ref": "#/definitions/value" },
+				"severity": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/ml-config/schema.json#/definitions/severity",
+					"default": "error"
+				},
+				"reason": {
+					"type": "string"
+				}
+			}
+		}
+	]
+}

--- a/packages/markuplint/src/cli/init/get-default-rules.spec.ts
+++ b/packages/markuplint/src/cli/init/get-default-rules.spec.ts
@@ -89,6 +89,10 @@ test('default-rules', () => {
 			category: 'validation',
 			defaultValue: true,
 		},
+		'itemprop-requires-itemscope': {
+			category: 'validation',
+			defaultValue: true,
+		},
 		'label-has-control': {
 			category: 'a11y',
 			defaultValue: false,

--- a/tests/external/bench/config.ts
+++ b/tests/external/bench/config.ts
@@ -44,7 +44,8 @@ export const benchmarkConfig: Config = {
 		'attr-duplication': true,
 		// Catches missing/legacy/quirky DOCTYPE (HTML LS §13.2 — non-`<!DOCTYPE html>` declarations).
 		doctype: true,
-		// Catches an `[itemprop]` element that is not part of any item (HTML LS §5.2.4).
+		// Catches an `[itemprop]` element that is not part of any item
+		// (HTML LS §5.2.3 attribute def + §5.2.5 conformance constraint).
 		'itemprop-requires-itemscope': true,
 		'no-extra-selected-options': true,
 		'no-orphaned-end-tag': true,

--- a/tests/external/bench/config.ts
+++ b/tests/external/bench/config.ts
@@ -44,6 +44,8 @@ export const benchmarkConfig: Config = {
 		'attr-duplication': true,
 		// Catches missing/legacy/quirky DOCTYPE (HTML LS §13.2 — non-`<!DOCTYPE html>` declarations).
 		doctype: true,
+		// Catches an `[itemprop]` element that is not part of any item (HTML LS §5.2.4).
+		'itemprop-requires-itemscope': true,
 		'no-extra-selected-options': true,
 		'no-orphaned-end-tag': true,
 		'srcset-sizes-constraint': true,

--- a/tests/external/bench/issue-xref.config.ts
+++ b/tests/external/bench/issue-xref.config.ts
@@ -95,9 +95,10 @@ export const xrefMappings: readonly XrefMapping[] = [
 	{
 		kind: 'primary',
 		issue: 3852,
-		filter: /^html\/microdata\/(itemprop-not-in-item|itemref-redundant|itemtype-empty)/,
+		filter:
+			/^(html\/microdata\/(itemprop-not-in-item|itemref-redundant|itemtype-empty)|html\/elements\/(link|meta)\/itemprop-with-)/,
 		note:
-			'Microdata semantic constraints. 3 fixtures: itemprop without itemscope ancestor (HTML LS §5.2.4), duplicate ids in itemref (§5.2.2), empty itemtype value (§5.2.1). Three small focused rules — distinct from the URL-syntax work in #3848.',
+			'Microdata semantic constraints. 5 fixtures: itemprop without itemscope ancestor (HTML LS §5.2.3 attribute def + §5.2.5 conformance constraint) — covers `html/microdata/itemprop-not-in-item` plus the bonus `html/elements/link/itemprop-with-rel` and `html/elements/meta/itemprop-with-name` orphan cases — duplicate ids in itemref (§5.2.2 Items), empty itemtype value (§5.2.2 Items). Distinct from the URL-syntax work in #3848.',
 	},
 
 	// === 2 次群: bench では裏取れない Issue（ステルブロック） ===

--- a/tests/external/snapshots/diff/coverage.json
+++ b/tests/external/snapshots/diff/coverage.json
@@ -30942,8 +30942,8 @@
 			"path": "html/elements/link/itemprop-with-rel-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -31406,8 +31406,8 @@
 			"path": "html/elements/meta/itemprop-with-name-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -41548,8 +41548,8 @@
 			"path": "html/microdata/itemprop-not-in-item-novalid.html",
 			"category": "uncategorized",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -41564,8 +41564,8 @@
 			"path": "html/microdata/itemref-redundant-novalid.html",
 			"category": "uncategorized",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -41580,8 +41580,8 @@
 			"path": "html/microdata/itemtype-empty-novalid.html",
 			"category": "uncategorized",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{

--- a/tests/external/snapshots/diff/nu-only.json
+++ b/tests/external/snapshots/diff/nu-only.json
@@ -5541,14 +5541,6 @@
 			]
 		},
 		{
-			"path": "html/elements/link/itemprop-with-rel-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-a7c721263c03",
-				"nv-714e7c410510"
-			]
-		},
-		{
 			"path": "html/elements/meta/content-security-policy/csp-invalid-directive-haswarn.html",
 			"category": "invalid-attr",
 			"nuMessageIds": [
@@ -5567,14 +5559,6 @@
 			"category": "invalid-attr",
 			"nuMessageIds": [
 				"nv-f76bf04a85bb"
-			]
-		},
-		{
-			"path": "html/elements/meta/itemprop-with-name-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-e421b32ec6be",
-				"nv-4fc0d9c94280"
 			]
 		},
 		{
@@ -8744,27 +8728,6 @@
 			"category": "uncategorized",
 			"nuMessageIds": [
 				"nv-f17ac3205810"
-			]
-		},
-		{
-			"path": "html/microdata/itemprop-not-in-item-novalid.html",
-			"category": "uncategorized",
-			"nuMessageIds": [
-				"nv-daf1fa858f68"
-			]
-		},
-		{
-			"path": "html/microdata/itemref-redundant-novalid.html",
-			"category": "uncategorized",
-			"nuMessageIds": [
-				"nv-b36b432a5bb7"
-			]
-		},
-		{
-			"path": "html/microdata/itemtype-empty-novalid.html",
-			"category": "uncategorized",
-			"nuMessageIds": [
-				"nv-056325bb7b3f"
 			]
 		},
 		{

--- a/tests/external/snapshots/diff/summary.md
+++ b/tests/external/snapshots/diff/summary.md
@@ -1,6 +1,6 @@
 # nu-validator Benchmark Summary
 
-- generated: 2026-05-10T05:44:24.996Z
+- generated: 2026-05-10T07:03:04.647Z
 - submodule: `142931395412c00434ffb40a14d65992efd17aa8`
 - nu-validator: `ghcr.io/validator/validator@sha256:9746b8663542cb5bded271fea08a3cc04ca12af6232f014baa341fccc01d3a21`
 - markuplint: `5.0.0-rc.4`
@@ -9,11 +9,11 @@
 ## Totals
 
 - files: **5442**
-- match-error: **2183** (both tools flagged)
+- match-error: **2188** (both tools flagged)
 - match-clean: **920** (neither flagged)
-- nu-only: **1332** (only nu-validator flagged; markuplint coverage candidates — open a markuplint issue after a spec read)
+- nu-only: **1327** (only nu-validator flagged; markuplint coverage candidates — open a markuplint issue after a spec read)
 - nu-over: **28** (nu-validator errors fully covered by spec-backed excluded-ids — confirmed over-detection)
-- overall match rate: **57.0%**
+- overall match rate: **57.1%**
 - excluded-ids: 3 entries, 1 pattern(s)
 
 ## Per-Category
@@ -27,9 +27,9 @@
 | deprecated | 12 | 91.7% | 11 | 0 | 1 | 0 | 0 |
 | global-attr | 57 | 80.7% | 26 | 20 | 8 | 3 | 0 |
 | id-duplication | 1 | 100.0% | 1 | 0 | 0 | 0 | 0 |
-| invalid-attr | 3086 | 59.1% | 1592 | 231 | 60 | 1177 | 26 |
+| invalid-attr | 3086 | 59.1% | 1594 | 231 | 60 | 1175 | 26 |
 | required-attr | 5 | 100.0% | 5 | 0 | 0 | 0 | 0 |
-| uncategorized | 1307 | 30.7% | 238 | 163 | 765 | 139 | 2 |
+| uncategorized | 1307 | 30.9% | 241 | 163 | 765 | 136 | 2 |
 
 ## Informational: ml-only
 

--- a/tests/external/snapshots/meta.json
+++ b/tests/external/snapshots/meta.json
@@ -1,5 +1,5 @@
 {
-	"generatedAt": "2026-05-10T05:44:24.996Z",
+	"generatedAt": "2026-05-10T07:03:04.647Z",
 	"submoduleSha": "142931395412c00434ffb40a14d65992efd17aa8",
 	"nuValidatorImage": "ghcr.io/validator/validator@sha256:9746b8663542cb5bded271fea08a3cc04ca12af6232f014baa341fccc01d3a21",
 	"markuplintVersion": "5.0.0-rc.4",
@@ -7,6 +7,6 @@
 	"totalFilesNu": 5442,
 	"totalFilesMl": 5442,
 	"totalNuMessages": 9906,
-	"totalMlViolations": 9955,
+	"totalMlViolations": 9965,
 	"totalNuFailures": 0
 }


### PR DESCRIPTION
## Summary

Closes the bench fixture portion of #3852, plus 2 bonus orphan-itemprop fixtures.

- **New rule `itemprop-requires-itemscope`** — catches the HTML LS §5.2.5 conformance constraint that an `itemprop` element must belong to an item, either via an ancestor `itemscope` or via reachability from some `itemscope` element's `itemref` token list. The attribute itself is defined in §5.2.3.
- **Spec data tightening** in `spec-common.attributes.jsonc` — `itemref` gains `unique: true` (HTML LS §5.2.2 unordered set of unique tokens) and `itemtype` gains `allowEmpty: false` (HTML LS §5.2.2 — empty token set is non-conforming). Both surfaced via the existing `invalid-attr` rule; new tests pin them.
- **Bench impact: 5 nu-only → match-error, 0 regressions**:
  - `html/microdata/itemprop-not-in-item-novalid.html` (rule)
  - `html/microdata/itemref-redundant-novalid.html` (spec data)
  - `html/microdata/itemtype-empty-novalid.html` (spec data)
  - `html/elements/link/itemprop-with-rel-novalid.html` (rule, bonus)
  - `html/elements/meta/itemprop-with-name-novalid.html` (rule, bonus)
- **bench-xref** filter for #3852 extended so the two `<link>` / `<meta>` bonus flips are tracked under the same Issue.

Cumulative nu-only triage: 1332 → 1327 (-5).

## Test plan

- [x] `yarn lint-check` — 0 errors / 0 warnings
- [x] `yarn build` — all 39 packages succeed
- [x] `yarn test` — 248/248 test files, 3858 tests pass
- [x] `itemprop-requires-itemscope` unit tests cover: ancestor itemscope (valid-001), itemref reachability (valid-002), self-as-scope (valid-003), whitespace-only itemref (valid-004), orphan with no id (invalid-001), itemref token mismatch (invalid-002), multiple orphans (invalid-003), explicit empty id (invalid-004)
- [x] `invalid-attr-invalid-040 / 041` pin the spec data tweaks (itemref unique, itemtype allowEmpty)
- [x] `markuplint:get-default-rules` snapshot includes the new rule
- [x] `tests/external/snapshots/diff/summary.md` shows the expected 5-fixture flip with no real regressions
- [x] `index.json` `nonStandard: true` count unchanged from `dev` (drift from `yarn up:gen` reverted to keep diff scoped)
- [ ] CI all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)