### PR TITLE
fix(parser-utils): handle <script>/<style> raw-text body in parseCodeFragment per HTML LS §13.2.5.1 (v4 backport of #3825)

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -176,6 +176,7 @@
 		// Specs
 		"closedby",
 		"khern",
+		"rcdata",
 		"tref",
 		"vkern",
 

--- a/packages/@markuplint/astro-parser/ARCHITECTURE.ja.md
+++ b/packages/@markuplint/astro-parser/ARCHITECTURE.ja.md
@@ -213,6 +213,12 @@ Astro テンプレートディレクティブは `name:modifier` 構文を使用
 
 **撤去条件**: `parser-utils/script-parser.ts` が TypeScript 構文を理解し、かつスプレッドの `}` を超えて伸びないように改善された場合、本パッケージの `src/spread-attr.ts` と `visitAttr()` のプリパスは削除し、基底パーサーのパスに戻すことが可能です。
 
+### Raw-text 要素の本文（`<script>`、`<style>`）
+
+`AstroParser.visitElement()` は **要素全体（本文・終了タグを含む）の raw 文字列**を `parser-utils` の `parseCodeFragment()` に渡し、最初のノードを開始タグ、最後のノードを終了タグとして使います。`<script>` や `<style>` の本文をそのまま再トークナイズすると、`/<br\s*\/?>/gi` のような正規表現がタグとして誤読され `Invalid tag syntax` で失敗します（[#3860](https://github.com/markuplint/markuplint/issues/3860)、[#3825](https://github.com/markuplint/markuplint/issues/3825) の v4 backport）。
+
+raw-text の安全性は `parser-utils` 側に委譲しています。`parseCodeFragment()` は `rawTextElements`（既定 `['style', 'script']`）を認識し、本文を次に現れる ASCII 大文字小文字非依存の `</tagName`（タブ/LF/FF/CR/空白/`>` /`/` のいずれかが続く）まで丸ごと消費します（[HTML LS §13.2.5.1](https://html.spec.whatwg.org/multipage/syntax.html#cdata-rcdata-restrictions)）。`astro-parser` 側に専用分岐は不要で、`parsedNodes[0]` と `parsedNodes[-1]` がそれぞれ開始タグ・終了タグになる既存フローのまま動作します。
+
 ## jsx-parser との比較
 
 | 機能                           | `astro-parser`                                  | `jsx-parser`                                      |

--- a/packages/@markuplint/astro-parser/ARCHITECTURE.md
+++ b/packages/@markuplint/astro-parser/ARCHITECTURE.md
@@ -213,6 +213,12 @@ Both failure modes were reported in [#3824](https://github.com/markuplint/markup
 
 **Retraction condition**: if `parser-utils/script-parser.ts` is upgraded to handle TypeScript syntax and to stop extending past the spread's `}`, this package's `src/spread-attr.ts` and the `visitAttr()` pre-pass can be removed and the base parser path restored.
 
+### Raw-text Element Bodies (`<script>`, `<style>`)
+
+`AstroParser.visitElement()` hands the **entire element source** (including body and end tag) to `parser-utils`'s `parseCodeFragment()` and uses the first parsed node as the start tag and the last as the end tag. For `<script>` and `<style>`, the body would otherwise be re-tokenized as HTML — and a regex such as `/<br\s*\/?>/gi` inside a script body would be misread as a tag, causing `Invalid tag syntax` ([#3860](https://github.com/markuplint/markuplint/issues/3860), v4 backport of [#3825](https://github.com/markuplint/markuplint/issues/3825)).
+
+Raw-text safety is delegated to `parser-utils`: `parseCodeFragment()` recognizes `rawTextElements` (default `['style', 'script']`) and consumes the body verbatim until the next ASCII-case-insensitive `</tagName` followed by a tab/LF/FF/CR/space/`>` /`/`, per [HTML LS §13.2.5.1](https://html.spec.whatwg.org/multipage/syntax.html#cdata-rcdata-restrictions). `astro-parser` requires no special-case branch — the existing `visitElement()` flow continues to work because the start tag and end tag still occupy `parsedNodes[0]` and `parsedNodes[-1]` respectively.
+
 ## Comparison with jsx-parser
 
 | Feature                   | `astro-parser`                                   | `jsx-parser`                                    |

--- a/packages/@markuplint/astro-parser/docs/maintenance.ja.md
+++ b/packages/@markuplint/astro-parser/docs/maintenance.ja.md
@@ -132,6 +132,23 @@ yarn upgrade @astrojs/compiler --scope @markuplint/astro-parser --dev
 yarn build --scope @markuplint/astro-parser && yarn test --scope @markuplint/astro-parser
 ```
 
+## dev (v5 RC) からの fix port 手順
+
+`dev` と `v4` は自動マージ不可 — 両方に当てる必要がある fix は手動で port する。最も頻発する port hazard は `Token` のフィールド名差:
+
+| v4 (本ブランチ)                                | dev (v5 RC)                                                 |
+| ---------------------------------------------- | ----------------------------------------------------------- |
+| `token.startOffset` / `startLine` / `startCol` | `token.offset` / `line` / `col`                             |
+| `token.endOffset` / `endLine` / `endCol`       | `#getEndLocation()` ヘルパが `{ offset, line, col }` を返す |
+| `MLASTText` は `parentNode` のみ               | `MLASTText` は `parentNodeUuid` も持つ                      |
+
+dev fix を port する手順:
+
+1. dev のソース変更とテストを両方読む。`token.line` / `token.col` / `token.offset` で assert しているテストは v4 では `startLine` / `startCol` / `startOffset` に書き換える。
+2. v4 のフィールド名でソース変更を適用。`yarn build` で `TS2339` が出れば見落としを fail-fast に検出できる。
+3. dev と同じ `#NNNN` describe id を v4 でも使う — id を揃えると後から両ブランチを grep で対比しやすい。
+4. JSDoc / `parser-class.md` / 該当パッケージの `maintenance.md` Troubleshooting に dev / v4 の Issue・PR を相互リンク。次に port する人が関係を再発見しなくて済む。
+
 ## トラブルシューティング
 
 ### フロントマターが認識されない
@@ -212,4 +229,4 @@ yarn build --scope @markuplint/astro-parser && yarn test --scope @markuplint/ast
 2. 修正は `astro-parser` 内ではない。`packages/@markuplint/parser-utils/src/parser.ts` の `parseCodeFragment()` を見て raw-text 分岐が無傷か、close-tag 正規表現が仕様の文字クラスにまだ一致するかを確認する。
 3. 別の上流 parser が `astro-parser` と同様に要素全体の raw を `parseCodeFragment` に渡すケースが追加された場合、追加配線は不要 — 同じ parser-utils 分岐がそのままカバーする。
 
-オリジナルの報告は [#3860](https://github.com/markuplint/markuplint/issues/3860)（[#3825](https://github.com/markuplint/markuplint/issues/3825) の v4 backport）を参照。
+オリジナルの報告は [#3860](https://github.com/markuplint/markuplint/issues/3860)（[#3825](https://github.com/markuplint/markuplint/issues/3825) の v4 backport）を参照。dev (v5 RC) には [#3859](https://github.com/markuplint/markuplint/pull/3859) が先行マージされている。今後 raw-text 周りの変更を port する際は両 PR を diff 比較すること。

--- a/packages/@markuplint/astro-parser/docs/maintenance.ja.md
+++ b/packages/@markuplint/astro-parser/docs/maintenance.ja.md
@@ -199,3 +199,17 @@ yarn build --scope @markuplint/astro-parser && yarn test --scope @markuplint/ast
 3. 既知の制限は `src/spread-attr.ts` の JSDoc に記載 — 波括弧を含む正規表現リテラルは扱えない。新たな制限が見つかったらそこに追記。
 
 オリジナルの報告とスプレッド属性を `parser-utils` ではなく本パッケージで処理する根拠については [#3824](https://github.com/markuplint/markuplint/issues/3824) を参照。
+
+### `<script>` または `<style>` の本文で `Invalid tag syntax` が throw する
+
+**症状:** `<script>` 本文の JS/TS に HTML 風の部分文字列（典型的には `/<br\s*\/?>/gi` や `/<\/?p>/gi` のような正規表現）が含まれると `ParserError: SyntaxError: Invalid tag syntax: "..."` で落ちる。`<style>` 本文中の `/* <br = */` のような CSS コメントでも同種の症状が出る。
+
+**原因:** `AstroParser.visitElement()` は要素全体（本文を含む）の raw 文字列を `parser-utils` の `parseCodeFragment()` に渡している。raw-text 認識がないと `parseCodeFragment()` は本文を HTML として再トークナイズし、正規表現中の `<br...>` をタグ開始と解釈、続く `\s`（リテラルなバックスラッシュ）を属性名とみなして throw する。
+
+**解決策:** raw-text の安全性は `parser-utils/parser.ts` の `parseCodeFragment()` 内に実装されている。自閉でない開始タグの `nodeName.toLowerCase()` が `rawTextElements` に含まれる場合、本文は次に現れる ASCII 大文字小文字非依存の `</tagName`（タブ/LF/FF/CR/空白/`>` /`/` のいずれかが続く）まで丸ごと消費される（HTML LS §13.2.5.1）。リグレッションが疑われたら:
+
+1. `npx vitest run packages/@markuplint/astro-parser/src/parser.spec.ts -t "#3860"` で失敗フィクスチャがまだ再現するかを確認。
+2. 修正は `astro-parser` 内ではない。`packages/@markuplint/parser-utils/src/parser.ts` の `parseCodeFragment()` を見て raw-text 分岐が無傷か、close-tag 正規表現が仕様の文字クラスにまだ一致するかを確認する。
+3. 別の上流 parser が `astro-parser` と同様に要素全体の raw を `parseCodeFragment` に渡すケースが追加された場合、追加配線は不要 — 同じ parser-utils 分岐がそのままカバーする。
+
+オリジナルの報告は [#3860](https://github.com/markuplint/markuplint/issues/3860)（[#3825](https://github.com/markuplint/markuplint/issues/3825) の v4 backport）を参照。

--- a/packages/@markuplint/astro-parser/docs/maintenance.md
+++ b/packages/@markuplint/astro-parser/docs/maintenance.md
@@ -199,3 +199,17 @@ yarn build --scope @markuplint/astro-parser && yarn test --scope @markuplint/ast
 3. Known limitations are listed in `src/spread-attr.ts` JSDoc — regular-expression literals containing braces are not handled. Document any additional limitations there.
 
 See [#3824](https://github.com/markuplint/markuplint/issues/3824) for the original report and the rationale for handling spread attributes locally instead of in `parser-utils`.
+
+### `<script>` or `<style>` body throws `Invalid tag syntax`
+
+**Symptom:** A `<script>` body containing JavaScript / TypeScript with HTML-like substrings (most commonly a regex such as `/<br\s*\/?>/gi` or `/<\/?p>/gi`) throws `ParserError: SyntaxError: Invalid tag syntax: "..."`. Same for `<style>` bodies that include CSS comments such as `/* <br = */`.
+
+**Cause:** `AstroParser.visitElement()` passes the entire element source (including body) to `parser-utils`'s `parseCodeFragment()`. Without raw-text awareness, `parseCodeFragment()` would treat the body as HTML and try to tokenize the regex's `<br...>` as a start tag, hitting `\s` (literal backslash) where an attribute name is expected.
+
+**Solution:** Raw-text safety lives in `parser-utils/parser.ts` `parseCodeFragment()` — after a non-self-closing start tag whose `nodeName.toLowerCase()` matches `rawTextElements`, the body is consumed verbatim until the next ASCII-case-insensitive `</tagName` followed by a tab/LF/FF/CR/space/`>` /`/` (HTML LS §13.2.5.1). If a regression appears here:
+
+1. Verify the failing fixture still reproduces by running `npx vitest run packages/@markuplint/astro-parser/src/parser.spec.ts -t "#3860"`.
+2. The fix is _not_ inside `astro-parser` — inspect `packages/@markuplint/parser-utils/src/parser.ts` `parseCodeFragment()` to confirm the raw-text branch is intact and the close-tag regex still matches the spec character class.
+3. If a different upstream parser is added that hands the full element raw to `parseCodeFragment` (similar to `astro-parser`), no extra wiring is needed — the same parser-utils branch covers it.
+
+See [#3860](https://github.com/markuplint/markuplint/issues/3860) (v4 backport of [#3825](https://github.com/markuplint/markuplint/issues/3825)) for the original report.

--- a/packages/@markuplint/astro-parser/docs/maintenance.md
+++ b/packages/@markuplint/astro-parser/docs/maintenance.md
@@ -132,6 +132,23 @@ yarn upgrade @astrojs/compiler --scope @markuplint/astro-parser --dev
 yarn build --scope @markuplint/astro-parser && yarn test --scope @markuplint/astro-parser
 ```
 
+## Porting Fixes from dev (v5 RC)
+
+`dev` and `v4` cannot be merged automatically — fixes that need to land on both branches are ported manually. The most common port hazard is the `Token` field rename:
+
+| v4 (this branch)                               | dev (v5 RC)                                                                  |
+| ---------------------------------------------- | ---------------------------------------------------------------------------- |
+| `token.startOffset` / `startLine` / `startCol` | `token.offset` / `line` / `col`                                              |
+| `token.endOffset` / `endLine` / `endCol`       | computed via `#getEndLocation()` helper that returns `{ offset, line, col }` |
+| `MLASTText` has only `parentNode`              | `MLASTText` adds `parentNodeUuid`                                            |
+
+Procedure when porting a dev fix:
+
+1. Read both the dev source change and the dev tests, including any test that asserts on `token.line` / `token.col` / `token.offset` — those need to become `startLine` / `startCol` / `startOffset` on v4.
+2. Apply the source change with the v4 field names. `yarn build` should fail fast with `TS2339` on any field you missed.
+3. Re-run the v4 test fixtures against the same `#NNNN` describe id used on dev — keeping the id stable lets future maintainers grep across both branches.
+4. Cross-link both Issues / PRs in the JSDoc, `parser-class.md`, and the package's `maintenance.md` Troubleshooting entry so the next porter doesn't have to re-discover the relationship.
+
 ## Troubleshooting
 
 ### Frontmatter is not recognized
@@ -212,4 +229,4 @@ See [#3824](https://github.com/markuplint/markuplint/issues/3824) for the origin
 2. The fix is _not_ inside `astro-parser` — inspect `packages/@markuplint/parser-utils/src/parser.ts` `parseCodeFragment()` to confirm the raw-text branch is intact and the close-tag regex still matches the spec character class.
 3. If a different upstream parser is added that hands the full element raw to `parseCodeFragment` (similar to `astro-parser`), no extra wiring is needed — the same parser-utils branch covers it.
 
-See [#3860](https://github.com/markuplint/markuplint/issues/3860) (v4 backport of [#3825](https://github.com/markuplint/markuplint/issues/3825)) for the original report.
+See [#3860](https://github.com/markuplint/markuplint/issues/3860) (v4 backport of [#3825](https://github.com/markuplint/markuplint/issues/3825)) for the original report. The dev (v5 RC) implementation landed first via [#3859](https://github.com/markuplint/markuplint/pull/3859) — diff-compare both PRs when porting future raw-text changes.

--- a/packages/@markuplint/astro-parser/src/parser.spec.ts
+++ b/packages/@markuplint/astro-parser/src/parser.spec.ts
@@ -841,9 +841,7 @@ const title = 'Script HTML-like regex';
 		});
 
 		test('script with attributes + body containing regex', () => {
-			const ast = parse(
-				'<script type="module" is:inline>const t = s.replace(/<br\\s*\\/?>/gi, " ");</script>',
-			);
+			const ast = parse('<script type="module" is:inline>const t = s.replace(/<br\\s*\\/?>/gi, " ");</script>');
 			expect(ast.parseError).toBeUndefined();
 			const map = nodeListToDebugMaps(ast.nodeList);
 			expect(map[0]).toBe('[1:1]>[1:33](0,32)script: <script␣type="module"␣is:inline>');

--- a/packages/@markuplint/astro-parser/src/parser.spec.ts
+++ b/packages/@markuplint/astro-parser/src/parser.spec.ts
@@ -802,4 +802,127 @@ describe('Issue', () => {
 			expect(spread.raw).toBe('{...rest}');
 		});
 	});
+
+	describe('#3860 raw-text element body (script/style) — v4 backport of #3825', () => {
+		test('script body with HTML-like regex parses without parseError', () => {
+			const ast = parse('<script>const t = s.replace(/<br\\s*\\/?>/gi, " ");</script>');
+			expect(ast.parseError).toBeUndefined();
+			const tags = ast.nodeList.filter((n: any) => n.type === 'starttag' || n.type === 'endtag');
+			expect(tags.map((t: any) => `${t.type}:${t.nodeName}`)).toEqual(['starttag:script', 'endtag:script']);
+		});
+
+		test('issue example with frontmatter, title, and TS regex script', () => {
+			const ast = parse(`---
+const title = 'Script HTML-like regex';
+---
+
+<h1>{title}</h1>
+
+<script>
+  function normalizeDescription(source: string): string {
+    return source.replace(/<br\\s*\\/?>/gi, ' ');
+  }
+
+  console.log(normalizeDescription('line<br>break'));
+</script>`);
+			expect(ast.parseError).toBeUndefined();
+			const tags = ast.nodeList.filter((n: any) => n.type === 'starttag' || n.type === 'endtag');
+			const tagSig = tags.map((t: any) => `${t.type}:${t.nodeName}`);
+			// Strict equality: an extra phantom <script> or a swallowed <h1> would silently
+			// pass under `toContain`.
+			expect(tagSig).toEqual(['starttag:h1', 'endtag:h1', 'starttag:script', 'endtag:script']);
+		});
+
+		test('style body with HTML-like content parses without parseError', () => {
+			const ast = parse('<style>/* <br = */ a { color: red; }</style>');
+			expect(ast.parseError).toBeUndefined();
+			const tags = ast.nodeList.filter((n: any) => n.type === 'starttag' || n.type === 'endtag');
+			expect(tags.map((t: any) => `${t.type}:${t.nodeName}`)).toEqual(['starttag:style', 'endtag:style']);
+		});
+
+		test('script with attributes + body containing regex', () => {
+			const ast = parse(
+				'<script type="module" is:inline>const t = s.replace(/<br\\s*\\/?>/gi, " ");</script>',
+			);
+			expect(ast.parseError).toBeUndefined();
+			const map = nodeListToDebugMaps(ast.nodeList);
+			expect(map[0]).toBe('[1:1]>[1:33](0,32)script: <script␣type="module"␣is:inline>');
+			// End tag must still be emitted; without this guard a regression that
+			// drops the close tag would silently pass since `map[0]` only checks
+			// the start tag.
+			expect(map.at(-1)).toMatch(/script: <\/script>$/);
+		});
+
+		test('self-closing script (regression guard)', () => {
+			const ast = parse('<script src="x.js" />');
+			expect(ast.parseError).toBeUndefined();
+			const tags = ast.nodeList.filter((n: any) => n.type === 'starttag');
+			expect(tags).toHaveLength(1);
+			expect(tags[0].nodeName).toBe('script');
+		});
+
+		test('empty script (regression guard)', () => {
+			const ast = parse('<script></script>');
+			expect(ast.parseError).toBeUndefined();
+			const tags = ast.nodeList.filter((n: any) => n.type === 'starttag' || n.type === 'endtag');
+			expect(tags.map((t: any) => `${t.type}:${t.nodeName}`)).toEqual(['starttag:script', 'endtag:script']);
+		});
+
+		test('multi-line script body reports correct end tag position', () => {
+			const ast = parse(`<script>
+const t = s.replace(/<br\\s*\\/?>/gi, " ");
+</script>`);
+			expect(ast.parseError).toBeUndefined();
+			const endTag = ast.nodeList.find((n: any) => n.type === 'endtag' && n.nodeName === 'script');
+			expect(endTag).toBeDefined();
+			expect(endTag!.startLine).toBe(3);
+			expect(endTag!.startCol).toBe(1);
+			expect(endTag!.raw).toBe('</script>');
+		});
+
+		test('script close tag is matched ASCII-case-insensitively (uppercase close)', () => {
+			// Note: the reverse pairing (`<SCRIPT>...</script>`) is not testable here
+			// because Astro upstream classifies `<SCRIPT>` as a component (PascalCase
+			// component-name rule), not the HTML script element — its body is then
+			// parsed as JSX-style children, not raw text. Case-insensitive close-tag
+			// matching is a parser-utils concern, locked in only for the
+			// lowercase-open + uppercase-close direction here.
+			const ast = parse('<script>const t = "<br>";</SCRIPT>');
+			expect(ast.parseError).toBeUndefined();
+			const endTag = ast.nodeList.find((n: any) => n.type === 'endtag');
+			expect(endTag).toBeDefined();
+			expect(endTag!.raw).toBe('</SCRIPT>');
+		});
+
+		test('a different raw-text tag in the body does not terminate the script', () => {
+			// `</style>` inside a script string must NOT close the `<script>` because
+			// the tag names differ. Locks in the per-tag-name match in
+			// `parseCodeFragment`'s raw-text close pattern.
+			//
+			// Note: the stricter HTML LS §13.2.5.1 lookahead variant — `</scripts>`
+			// (same prefix + extra char) must not close — is not testable via Astro
+			// because the Astro upstream tokenizer rejects `</scriptX>` substrings
+			// inside script bodies before markuplint sees them.
+			const ast = parse('<script>const x = "</style>";</script>');
+			expect(ast.parseError).toBeUndefined();
+			const endTags = ast.nodeList.filter((n: any) => n.type === 'endtag' && n.nodeName === 'script');
+			expect(endTags).toHaveLength(1);
+			expect(endTags[0].raw).toBe('</script>');
+		});
+
+		test('unterminated script body falls back to the legacy parse path', () => {
+			// No </script> in the body — the raw-text short-circuit MUST NOT consume the
+			// body and MUST let the existing "unclosed tag" handling run.
+			// Locks in the `if (match)` else branch of `parseCodeFragment`'s raw-text guard.
+			expect(() => parse('<script>const x = 1;')).not.toThrow();
+		});
+
+		test('plain script body (no HTML-like content) still parses correctly (regression)', () => {
+			const ast = parse('<script>const x = 1;</script>');
+			expect(ast.parseError).toBeUndefined();
+			const map = nodeListToDebugMaps(ast.nodeList);
+			expect(map[0]).toBe('[1:1]>[1:9](0,8)script: <script>');
+			expect(map.at(-1)).toBe('[1:21]>[1:30](20,29)script: </script>');
+		});
+	});
 });

--- a/packages/@markuplint/jsx-parser/src/index.spec.ts
+++ b/packages/@markuplint/jsx-parser/src/index.spec.ts
@@ -773,4 +773,35 @@ const C = () => {
 			'[8:1]>[8:8](155,162)html: </html>',
 		]);
 	});
+
+	describe('#3860 raw-text element body via JSX expression child (v4 backport of #3825)', () => {
+		// Note: JSX's <script>{`...`}</script> path does NOT exercise parser-utils'
+		// raw-text branch in `parseCodeFragment` — the body is a JSXExpressionContainer
+		// child and never re-tokenized. The primary value of these tests is to lock in
+		// the upstream invariant "TypeScript ESTree rejects bare `<` in element body
+		// before markuplint sees it", so a future upstream relaxation can't silently
+		// change observed JSX tag emissions.
+
+		test('script body wrapped in template literal expression child', () => {
+			const doc = parse('<div><script>{`const t = s.replace(/<br\\s*\\/?>/gi, " ");`}</script></div>');
+			const tags = doc.nodeList.filter((n: any) => n.type === 'starttag' || n.type === 'endtag');
+			expect(tags.map((t: any) => `${t.type}:${t.nodeName}`)).toEqual([
+				'starttag:div',
+				'starttag:script',
+				'endtag:script',
+				'endtag:div',
+			]);
+		});
+
+		test('style body wrapped in template literal expression child', () => {
+			const doc = parse('<div><style>{`/* <br = */ a{color:red}`}</style></div>');
+			const tags = doc.nodeList.filter((n: any) => n.type === 'starttag' || n.type === 'endtag');
+			expect(tags.map((t: any) => `${t.type}:${t.nodeName}`)).toEqual([
+				'starttag:div',
+				'starttag:style',
+				'endtag:style',
+				'endtag:div',
+			]);
+		});
+	});
 });

--- a/packages/@markuplint/parser-utils/SKILL.md
+++ b/packages/@markuplint/parser-utils/SKILL.md
@@ -46,6 +46,7 @@ Create a new parser extending the abstract Parser class. Follow recipe #1 in `do
 2. Implement `tokenize()` -- invoke the language-specific tokenizer on `this.rawCode`
 3. Implement `nodeize()` -- convert each AST node using visitor methods
 4. Set constructor options (`endTagType`, `tagNameCaseSensitive`, `ignoreTags`, etc.)
+   - The default `rawTextElements` is `['style', 'script']` (HTML LS §13.2.5.1). If your language treats additional elements as raw text, override it; if your language does NOT (e.g., `<script>` body is parsed as language-specific syntax), pass an empty array.
 
 ### Step 3: Export the parser module
 

--- a/packages/@markuplint/parser-utils/docs/maintenance.ja.md
+++ b/packages/@markuplint/parser-utils/docs/maintenance.ja.md
@@ -132,14 +132,14 @@ IDL属性マップは `src/idl-attributes.ts` で定義されています。新�
 
 このパッケージへの変更は下流のすべてのパーサーに影響します:
 
-| パッケージ                  | 主な依存関係                                                                                                                                       |
-| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `@markuplint/html-parser`   | Parser 基底クラス、researchTags を使用した visitText                                                                                               |
-| `@markuplint/jsx-parser`    | Parser 基底クラス、quoteSet を使用した visitAttr、detectElementType、parseCodeFragment                                                             |
-| `@markuplint/vue-parser`    | Parser 基底クラス、visitAttr、flattenNodes、detectElementType                                                                                      |
-| `@markuplint/svelte-parser` | Parser 基底クラス、visitText、visitPsBlock、visitChildren、ignoreTags                                                                              |
+| パッケージ                  | 主な依存関係                                                                                                                                           |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `@markuplint/html-parser`   | Parser 基底クラス、researchTags を使用した visitText                                                                                                   |
+| `@markuplint/jsx-parser`    | Parser 基底クラス、quoteSet を使用した visitAttr、detectElementType、parseCodeFragment                                                                 |
+| `@markuplint/vue-parser`    | Parser 基底クラス、visitAttr、flattenNodes、detectElementType                                                                                          |
+| `@markuplint/svelte-parser` | Parser 基底クラス、visitText、visitPsBlock、visitChildren、ignoreTags                                                                                  |
 | `@markuplint/astro-parser`  | Parser 基底クラス（直接）、visitElement、**parseCodeFragment に要素全体の raw を渡す唯一の caller — raw-text element 本文の short-circuit 経路を踏む** |
-| `@markuplint/pug-parser`    | Parser 基底クラス                                                                                                                                  |
+| `@markuplint/pug-parser`    | Parser 基底クラス                                                                                                                                      |
 
 Parser クラスを変更する際は、必ずすべてのパーサーパッケージでテストを実行してください:
 

--- a/packages/@markuplint/parser-utils/docs/maintenance.ja.md
+++ b/packages/@markuplint/parser-utils/docs/maintenance.ja.md
@@ -189,4 +189,6 @@ yarn test --scope @markuplint/html-parser --scope @markuplint/jsx-parser \
 2. `parseCodeFragment()` を確認 — raw-text 分岐が無傷か、`#getRawTextCloseTagPattern()` のキャッシュが参照されているか、close-tag 正規表現がまだ仕様の文字クラス `[\t\n\f\r >/]` を使っているかをチェック。
 3. `#3860 raw-text element body via JSX expression child` の jsx 防衛テストは上流 invariant の lock-in が目的で、parser-utils の raw-text 分岐自体は経由しない（本文が expression child として処理されるため）。
 
+dev (v5 RC) には [#3859](https://github.com/markuplint/markuplint/pull/3859) が先行マージされている。今後の変更を port する際は両 PR を diff 比較すること。
+
 **Escapable raw text 要素 (`<title>`, `<textarea>`) について**: 既定の `rawTextElements` には含めていません。HTML LS では escapable raw text として分類され、本文中の文字参照（`&amp;` 等）の展開が要求されますが、本ブランチではその展開を実装していません。意図的に `rawTextElements` に追加する場合は、本文中の文字参照が decode されず raw のまま渡されることを許容してください。

--- a/packages/@markuplint/parser-utils/docs/maintenance.ja.md
+++ b/packages/@markuplint/parser-utils/docs/maintenance.ja.md
@@ -130,16 +130,16 @@ IDL属性マップは `src/idl-attributes.ts` で定義されています。新�
 
 ## 下流影響チェックリスト
 
-このパッケージへの変更は、下流の6つのパーサーパッケージすべてに影響を与える可能性があります:
+このパッケージへの変更は下流のすべてのパーサーに影響します:
 
-| パッケージ                  | 主な依存関係                                                          |
-| --------------------------- | --------------------------------------------------------------------- |
-| `@markuplint/html-parser`   | Parser 基底クラス、researchTags を使用した visitText                  |
-| `@markuplint/jsx-parser`    | Parser 基底クラス、quoteSet を使用した visitAttr、detectElementType   |
-| `@markuplint/vue-parser`    | Parser 基底クラス、visitAttr、flattenNodes、detectElementType         |
-| `@markuplint/svelte-parser` | Parser 基底クラス、visitText、visitPsBlock、visitChildren、ignoreTags |
-| `@markuplint/astro-parser`  | Parser 基底クラス（html-parser 経由）                                 |
-| `@markuplint/pug-parser`    | Parser 基底クラス                                                     |
+| パッケージ                  | 主な依存関係                                                                                                                                       |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@markuplint/html-parser`   | Parser 基底クラス、researchTags を使用した visitText                                                                                               |
+| `@markuplint/jsx-parser`    | Parser 基底クラス、quoteSet を使用した visitAttr、detectElementType、parseCodeFragment                                                             |
+| `@markuplint/vue-parser`    | Parser 基底クラス、visitAttr、flattenNodes、detectElementType                                                                                      |
+| `@markuplint/svelte-parser` | Parser 基底クラス、visitText、visitPsBlock、visitChildren、ignoreTags                                                                              |
+| `@markuplint/astro-parser`  | Parser 基底クラス（直接）、visitElement、**parseCodeFragment に要素全体の raw を渡す唯一の caller — raw-text element 本文の short-circuit 経路を踏む** |
+| `@markuplint/pug-parser`    | Parser 基底クラス                                                                                                                                  |
 
 Parser クラスを変更する際は、必ずすべてのパーサーパッケージでテストを実行してください:
 
@@ -148,6 +148,8 @@ yarn test --scope @markuplint/html-parser --scope @markuplint/jsx-parser \
   --scope @markuplint/vue-parser --scope @markuplint/svelte-parser \
   --scope @markuplint/astro-parser --scope @markuplint/pug-parser
 ```
+
+`parseCodeFragment`（特に raw-text element 分岐）に手を入れる場合は、`astro-parser` が最も影響を受けやすい caller — まずそこから確認してください。
 
 ## トラブルシューティング
 
@@ -174,3 +176,17 @@ yarn test --scope @markuplint/html-parser --scope @markuplint/jsx-parser \
 **原因:** パースオプションで `ignoreFrontMatter` が有効になっていない。
 
 **解決策:** `parse()` を呼び出す際に `options.ignoreFrontMatter` が `true` であることを確認する。注意: Svelte はこれを明示的に無効にしています。
+
+### `<script>` または `<style>` 本文で `parseCodeFragment` が `Invalid tag syntax` を throw する
+
+**症状:** 要素全体の raw を `parseCodeFragment()` に渡すサブクラス（例: `astro-parser`）で、script/style 本文に HTML 風部分文字列（`/<br\s*\/?>/gi` や `/* <br = */` など）が含まれると `SyntaxError: Invalid tag syntax: "..."` が throw する。[#3825](https://github.com/markuplint/markuplint/issues/3825) の v4 backport で、[#3860](https://github.com/markuplint/markuplint/issues/3860) として追跡。
+
+**原因:** raw-text 認識がないと `parseCodeFragment()` は本文を再トークナイズし、正規表現中の `<br...>` をタグ開始と解釈、続く `\s`（リテラルなバックスラッシュ）を属性名とみなして throw する。
+
+**解決策:** 修正は `parseCodeFragment()`（`src/parser.ts`）内に住んでいる。自閉でない開始タグの `nodeName.toLowerCase()` が `rawTextElements` に含まれる場合、本文は次に現れる ASCII 大文字小文字非依存の `</tagName`（タブ/LF/FF/CR/空白/`>` /`/` のいずれかが続く）まで丸ごと消費される（[HTML Living Standard §13.2.5.1](https://html.spec.whatwg.org/multipage/syntax.html#cdata-rcdata-restrictions)）。リグレッションが疑われたら:
+
+1. リグレッションスイートを再実行: `npx vitest run packages/@markuplint/astro-parser/src/parser.spec.ts -t "#3860"`。
+2. `parseCodeFragment()` を確認 — raw-text 分岐が無傷か、`#getRawTextCloseTagPattern()` のキャッシュが参照されているか、close-tag 正規表現がまだ仕様の文字クラス `[\t\n\f\r >/]` を使っているかをチェック。
+3. `#3860 raw-text element body via JSX expression child` の jsx 防衛テストは上流 invariant の lock-in が目的で、parser-utils の raw-text 分岐自体は経由しない（本文が expression child として処理されるため）。
+
+**Escapable raw text 要素 (`<title>`, `<textarea>`) について**: 既定の `rawTextElements` には含めていません。HTML LS では escapable raw text として分類され、本文中の文字参照（`&amp;` 等）の展開が要求されますが、本ブランチではその展開を実装していません。意図的に `rawTextElements` に追加する場合は、本文中の文字参照が decode されず raw のまま渡されることを許容してください。

--- a/packages/@markuplint/parser-utils/docs/maintenance.md
+++ b/packages/@markuplint/parser-utils/docs/maintenance.md
@@ -189,4 +189,6 @@ When touching `parseCodeFragment` (especially the raw-text element branch), `ast
 2. Inspect `parseCodeFragment()` — confirm the raw-text branch is intact, the `#getRawTextCloseTagPattern()` cache is being consulted, and the close-tag regex still uses the spec character class `[\t\n\f\r >/]`.
 3. The defensive jsx tests under `#3860 raw-text element body via JSX expression child` exist to lock in upstream invariants — they do **not** exercise the parser-utils raw-text branch directly (their bodies are expression children, not raw element source).
 
+The dev (v5 RC) implementation landed first via [#3859](https://github.com/markuplint/markuplint/pull/3859) — diff-compare both PRs when porting future changes.
+
 **Note on escapable raw text elements (`<title>`, `<textarea>`):** these are NOT in the default `rawTextElements`. HTML LS classifies them as escapable raw text — they require character-reference (`&amp;`) expansion that this branch does not implement. Add them to a parser's `rawTextElements` only if you accept that character refs in their body will be passed through verbatim instead of decoded.

--- a/packages/@markuplint/parser-utils/docs/maintenance.md
+++ b/packages/@markuplint/parser-utils/docs/maintenance.md
@@ -132,14 +132,14 @@ The IDL attribute map is defined in `src/idl-attributes.ts`. To add a new mappin
 
 Changes to this package can affect every downstream parser:
 
-| Package                     | Key Dependencies                                                                                                                                              |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `@markuplint/html-parser`   | Parser base class, visitText with researchTags                                                                                                                |
-| `@markuplint/jsx-parser`    | Parser base class, visitAttr with quoteSet, detectElementType, parseCodeFragment                                                                              |
-| `@markuplint/vue-parser`    | Parser base class, visitAttr, flattenNodes, detectElementType                                                                                                 |
-| `@markuplint/svelte-parser` | Parser base class, visitText, visitPsBlock, visitChildren, ignoreTags                                                                                         |
+| Package                     | Key Dependencies                                                                                                                                               |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@markuplint/html-parser`   | Parser base class, visitText with researchTags                                                                                                                 |
+| `@markuplint/jsx-parser`    | Parser base class, visitAttr with quoteSet, detectElementType, parseCodeFragment                                                                               |
+| `@markuplint/vue-parser`    | Parser base class, visitAttr, flattenNodes, detectElementType                                                                                                  |
+| `@markuplint/svelte-parser` | Parser base class, visitText, visitPsBlock, visitChildren, ignoreTags                                                                                          |
 | `@markuplint/astro-parser`  | Parser base class (direct), visitElement, **parseCodeFragment with full element raw — the only caller that exercises the raw-text element body short-circuit** |
-| `@markuplint/pug-parser`    | Parser base class                                                                                                                                             |
+| `@markuplint/pug-parser`    | Parser base class                                                                                                                                              |
 
 Always run tests across all parser packages when modifying the Parser class:
 

--- a/packages/@markuplint/parser-utils/docs/maintenance.md
+++ b/packages/@markuplint/parser-utils/docs/maintenance.md
@@ -130,16 +130,16 @@ The IDL attribute map is defined in `src/idl-attributes.ts`. To add a new mappin
 
 ## Downstream Impact Checklist
 
-Changes to this package can affect all 6 downstream parser packages:
+Changes to this package can affect every downstream parser:
 
-| Package                     | Key Dependencies                                                      |
-| --------------------------- | --------------------------------------------------------------------- |
-| `@markuplint/html-parser`   | Parser base class, visitText with researchTags                        |
-| `@markuplint/jsx-parser`    | Parser base class, visitAttr with quoteSet, detectElementType         |
-| `@markuplint/vue-parser`    | Parser base class, visitAttr, flattenNodes, detectElementType         |
-| `@markuplint/svelte-parser` | Parser base class, visitText, visitPsBlock, visitChildren, ignoreTags |
-| `@markuplint/astro-parser`  | Parser base class (via html-parser)                                   |
-| `@markuplint/pug-parser`    | Parser base class                                                     |
+| Package                     | Key Dependencies                                                                                                                                              |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@markuplint/html-parser`   | Parser base class, visitText with researchTags                                                                                                                |
+| `@markuplint/jsx-parser`    | Parser base class, visitAttr with quoteSet, detectElementType, parseCodeFragment                                                                              |
+| `@markuplint/vue-parser`    | Parser base class, visitAttr, flattenNodes, detectElementType                                                                                                 |
+| `@markuplint/svelte-parser` | Parser base class, visitText, visitPsBlock, visitChildren, ignoreTags                                                                                         |
+| `@markuplint/astro-parser`  | Parser base class (direct), visitElement, **parseCodeFragment with full element raw — the only caller that exercises the raw-text element body short-circuit** |
+| `@markuplint/pug-parser`    | Parser base class                                                                                                                                             |
 
 Always run tests across all parser packages when modifying the Parser class:
 
@@ -148,6 +148,8 @@ yarn test --scope @markuplint/html-parser --scope @markuplint/jsx-parser \
   --scope @markuplint/vue-parser --scope @markuplint/svelte-parser \
   --scope @markuplint/astro-parser --scope @markuplint/pug-parser
 ```
+
+When touching `parseCodeFragment` (especially the raw-text element branch), `astro-parser` is the most sensitive caller — start there.
 
 ## Troubleshooting
 
@@ -174,3 +176,17 @@ yarn test --scope @markuplint/html-parser --scope @markuplint/jsx-parser \
 **Cause:** `ignoreFrontMatter` is not enabled in parse options.
 
 **Solution:** Ensure `options.ignoreFrontMatter` is `true` when calling `parse()`. Note: Svelte explicitly disables this.
+
+### `<script>` or `<style>` body throws `Invalid tag syntax` from `parseCodeFragment`
+
+**Symptom:** A subclass that hands the full element raw to `parseCodeFragment()` (e.g., `astro-parser`) throws `SyntaxError: Invalid tag syntax: "..."` when the script/style body contains HTML-like substrings such as `/<br\s*\/?>/gi` or `/* <br = */`. v4 backport of [#3825](https://github.com/markuplint/markuplint/issues/3825), tracked as [#3860](https://github.com/markuplint/markuplint/issues/3860).
+
+**Cause:** Without raw-text awareness, `parseCodeFragment()` re-tokenizes the body and tries to parse the regex's `<br...>` as a start tag, hitting the `\s` (literal backslash) where an attribute name is expected.
+
+**Solution:** The fix lives in `parseCodeFragment()` (`src/parser.ts`). After parsing a non-self-closing start tag whose `nodeName.toLowerCase()` matches `rawTextElements`, the body is consumed verbatim until the next ASCII-case-insensitive `</tagName` followed by a tab/LF/FF/CR/space/`>` /`/`, per [HTML Living Standard §13.2.5.1](https://html.spec.whatwg.org/multipage/syntax.html#cdata-rcdata-restrictions). If a regression is suspected:
+
+1. Re-run the regression suite: `npx vitest run packages/@markuplint/astro-parser/src/parser.spec.ts -t "#3860"`.
+2. Inspect `parseCodeFragment()` — confirm the raw-text branch is intact, the `#getRawTextCloseTagPattern()` cache is being consulted, and the close-tag regex still uses the spec character class `[\t\n\f\r >/]`.
+3. The defensive jsx tests under `#3860 raw-text element body via JSX expression child` exist to lock in upstream invariants — they do **not** exercise the parser-utils raw-text branch directly (their bodies are expression children, not raw element source).
+
+**Note on escapable raw text elements (`<title>`, `<textarea>`):** these are NOT in the default `rawTextElements`. HTML LS classifies them as escapable raw text — they require character-reference (`&amp;`) expansion that this branch does not implement. Add them to a parser's `rawTextElements` only if you accept that character refs in their body will be passed through verbatim instead of decoded.

--- a/packages/@markuplint/parser-utils/docs/parser-class.ja.md
+++ b/packages/@markuplint/parser-utils/docs/parser-class.ja.md
@@ -245,6 +245,8 @@ parseCodeFragment(
 
 **Escapable raw text 要素 (`<title>`, `<textarea>`) は既定の `rawTextElements` に含めていません**。HTML LS では escapable raw text として分類され、本文中の文字参照（`&amp;` 等）の decode が要求されますが、上記 short-circuit はその decode を実装していません。意図的に `rawTextElements` に追加する場合は、本文中の文字参照が decode されず raw のまま渡されることを許容してください。
 
+この分岐は v4 では [#3860](https://github.com/markuplint/markuplint/issues/3860)（[#3825](https://github.com/markuplint/markuplint/issues/3825) の backport）で追加された。dev (v5 RC) には [#3859](https://github.com/markuplint/markuplint/pull/3859) が先行マージされている。今後 raw-text 周りに変更を加える際は両 PR を diff 比較すること。
+
 ### visitComment()
 
 ```ts

--- a/packages/@markuplint/parser-utils/docs/parser-class.ja.md
+++ b/packages/@markuplint/parser-utils/docs/parser-class.ja.md
@@ -70,15 +70,15 @@ constructor(options?: ParserOptions, defaultState?: State)
 
 コンストラクタは `ParserOptions` オブジェクトとオプションのデフォルト状態値を受け取ります。
 
-| オプション             | 型                     | デフォルト                      | 説明                                                                                     |
-| ---------------------- | ---------------------- | ------------------------------- | ---------------------------------------------------------------------------------------- |
-| `booleanish`           | `boolean`              | `false`                         | 省略された属性値を `true` として扱う（例: JSX `<Component aria-hidden />`）              |
-| `endTagType`           | `EndTagType`           | `'omittable'`                   | `'xml'`: 終了タグ必須またはセルフクローズ; `'omittable'`: 省略可; `'never'`: 不要        |
-| `ignoreTags`           | `readonly IgnoreTag[]` | `[]`                            | パース前にマスクするコードブロックのパターン（例: テンプレート式）                       |
-| `maskChar`             | `string`               | `'\uE000'` (MASK_CHAR)          | マスクされたコードブロックを置換するために使用する文字                                   |
-| `tagNameCaseSensitive` | `boolean`              | `false`                         | タグ名の比較で大文字小文字を区別するか（例: JSX、Svelte）                                |
-| `selfCloseType`        | `SelfCloseType`        | `'html'`                        | `'html'`: void 要素のみセルフクローズ; `'xml'`: スラッシュで判定; `'html+xml'`: いずれか |
-| `spaceChars`           | `readonly string[]`    | `['\t', '\n', '\f', '\r', ' ']` | タグのパース時に空白として扱う文字                                                       |
+| オプション             | 型                     | デフォルト                      | 説明                                                                                                                   |
+| ---------------------- | ---------------------- | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `booleanish`           | `boolean`              | `false`                         | 省略された属性値を `true` として扱う（例: JSX `<Component aria-hidden />`）                                            |
+| `endTagType`           | `EndTagType`           | `'omittable'`                   | `'xml'`: 終了タグ必須またはセルフクローズ; `'omittable'`: 省略可; `'never'`: 不要                                      |
+| `ignoreTags`           | `readonly IgnoreTag[]` | `[]`                            | パース前にマスクするコードブロックのパターン（例: テンプレート式）                                                     |
+| `maskChar`             | `string`               | `'\uE000'` (MASK_CHAR)          | マスクされたコードブロックを置換するために使用する文字                                                                 |
+| `tagNameCaseSensitive` | `boolean`              | `false`                         | タグ名の比較で大文字小文字を区別するか（例: JSX、Svelte）                                                              |
+| `selfCloseType`        | `SelfCloseType`        | `'html'`                        | `'html'`: void 要素のみセルフクローズ; `'xml'`: スラッシュで判定; `'html+xml'`: いずれか                               |
+| `spaceChars`           | `readonly string[]`    | `['\t', '\n', '\f', '\r', ' ']` | タグのパース時に空白として扱う文字                                                                                     |
 | `rawTextElements`      | `readonly string[]`    | `['style', 'script']`           | 子要素をトラバースせず、本文を `parseCodeFragment` が再トークナイズしない要素（HTML LS §13.2.5.1 の raw-text element） |
 
 ## パースパイプライン

--- a/packages/@markuplint/parser-utils/docs/parser-class.ja.md
+++ b/packages/@markuplint/parser-utils/docs/parser-class.ja.md
@@ -79,7 +79,7 @@ constructor(options?: ParserOptions, defaultState?: State)
 | `tagNameCaseSensitive` | `boolean`              | `false`                         | タグ名の比較で大文字小文字を区別するか（例: JSX、Svelte）                                |
 | `selfCloseType`        | `SelfCloseType`        | `'html'`                        | `'html'`: void 要素のみセルフクローズ; `'xml'`: スラッシュで判定; `'html+xml'`: いずれか |
 | `spaceChars`           | `readonly string[]`    | `['\t', '\n', '\f', '\r', ' ']` | タグのパース時に空白として扱う文字                                                       |
-| `rawTextElements`      | `readonly string[]`    | `['style', 'script']`           | 子要素をトラバースしない要素（生テキストコンテンツ）                                     |
+| `rawTextElements`      | `readonly string[]`    | `['style', 'script']`           | 子要素をトラバースせず、本文を `parseCodeFragment` が再トークナイズしない要素（HTML LS §13.2.5.1 の raw-text element） |
 
 ## パースパイプライン
 
@@ -227,6 +227,23 @@ visitText(
 ```
 
 テキストノードを作成します。`researchTags` が true の場合、`parseCodeFragment()` を通じてテキストを再パースし、埋め込まれた HTML タグを発見します。`invalidTagAsText` も true の場合、発見された開始タグによりコンテンツ全体が単一のテキストノードとして扱われます。
+
+### parseCodeFragment()
+
+```ts
+parseCodeFragment(
+  token: ChildToken,
+  options?: { namelessFragment?: boolean }
+): readonly (MLASTTag | MLASTText)[]
+```
+
+タグとテキストが混在した raw fragment を `MLASTTag` / `MLASTText` の列に再トークナイズします。サブクラス（例: `astro-parser` の `visitElement`）が、上流トークナイザーから要素全体に対する単一の raw 文字列しか得られないときに、開始タグ・本文・終了タグへ分解する目的で利用します。
+
+**Raw-text element の本文処理**: 自閉でない開始タグの `nodeName.toLowerCase()` が `rawTextElements`（既定値 `['style', 'script']`）に含まれる場合、本文は次に現れる ASCII 大文字小文字を問わない `</tagName`（タブ/LF/FF/CR/空白/`>` /`/` のいずれかが続く）まで丸ごと消費されます（[HTML Living Standard §13.2.5.1](https://html.spec.whatwg.org/multipage/syntax.html#cdata-rcdata-restrictions)）。本文は単一の `#text` ノードとなり、**再トークナイズはしません**。これがないと、`<script>` 本文中の `<br\s*\/?>` のような正規表現がタグとして解釈され `Invalid tag syntax` で throw します。
+
+このガードは、上流トークナイザーが要素本文中の裸の `<` をすでに弾く parser（TypeScript ESTree を使う `jsx-parser`）では dormant ですが、要素全体の raw を `parseCodeFragment` に渡す parser（例: `astro-parser`）では必須です。
+
+**Escapable raw text 要素 (`<title>`, `<textarea>`) は既定の `rawTextElements` に含めていません**。HTML LS では escapable raw text として分類され、本文中の文字参照（`&amp;` 等）の decode が要求されますが、上記 short-circuit はその decode を実装していません。意図的に `rawTextElements` に追加する場合は、本文中の文字参照が decode されず raw のまま渡されることを許容してください。
 
 ### visitComment()
 

--- a/packages/@markuplint/parser-utils/docs/parser-class.md
+++ b/packages/@markuplint/parser-utils/docs/parser-class.md
@@ -245,6 +245,8 @@ This guard is dormant for parsers whose upstream tokenizer already rejects bare 
 
 **Escapable raw text elements (`<title>`, `<textarea>`)** are NOT in the default `rawTextElements`. HTML LS classifies them as escapable raw text — they require character-reference (`&amp;` etc.) decoding inside the body, which the short-circuit above does not implement. Add them to `rawTextElements` only if you accept that character references will be passed through verbatim instead of decoded.
 
+This branch was added in v4 via [#3860](https://github.com/markuplint/markuplint/issues/3860) (backport of [#3825](https://github.com/markuplint/markuplint/issues/3825)) — the dev (v5 RC) implementation landed first via [#3859](https://github.com/markuplint/markuplint/pull/3859). Diff-compare both PRs when porting future raw-text changes.
+
 ### visitComment()
 
 ```ts

--- a/packages/@markuplint/parser-utils/docs/parser-class.md
+++ b/packages/@markuplint/parser-utils/docs/parser-class.md
@@ -79,7 +79,7 @@ The constructor accepts a `ParserOptions` object and an optional default state v
 | `tagNameCaseSensitive` | `boolean`              | `false`                         | Whether tag name comparisons are case-sensitive (e.g., JSX, Svelte)                        |
 | `selfCloseType`        | `SelfCloseType`        | `'html'`                        | `'html'`: only void elements self-close; `'xml'`: solidus determines; `'html+xml'`: either |
 | `spaceChars`           | `readonly string[]`    | `['\t', '\n', '\f', '\r', ' ']` | Characters treated as whitespace in tag parsing                                            |
-| `rawTextElements`      | `readonly string[]`    | `['style', 'script']`           | Elements whose children are not traversed (raw text content)                               |
+| `rawTextElements`      | `readonly string[]`    | `['style', 'script']`           | Elements whose children are not traversed and whose body bypasses `parseCodeFragment` re-tokenization (raw text content per HTML LS §13.2.5.1) |
 
 ## Parse Pipeline
 
@@ -227,6 +227,23 @@ visitText(
 ```
 
 Creates a text node. When `researchTags` is true, re-parses the text via `parseCodeFragment()` to discover embedded HTML tags. If `invalidTagAsText` is also true, any discovered start tags cause the entire content to be treated as a single text node.
+
+### parseCodeFragment()
+
+```ts
+parseCodeFragment(
+  token: ChildToken,
+  options?: { namelessFragment?: boolean }
+): readonly (MLASTTag | MLASTText)[]
+```
+
+Re-tokenizes a raw fragment that may contain a mix of tags and text into a sequence of `MLASTTag` and `MLASTText` nodes. Used by subclasses (e.g., `astro-parser`'s `visitElement`) when the upstream tokenizer produces a single raw blob covering an entire element — the subclass needs the start tag, body, and end tag to be split apart.
+
+**Raw-text element handling.** After parsing a non-self-closing start tag whose `nodeName.toLowerCase()` matches an entry in `rawTextElements` (default `['style', 'script']`), the body is consumed verbatim until the next ASCII-case-insensitive `</tagName` followed by a tab/LF/FF/CR/space/`>` /`/` (per [HTML Living Standard §13.2.5.1](https://html.spec.whatwg.org/multipage/syntax.html#cdata-rcdata-restrictions)). The body becomes a single `#text` node and is **not** re-tokenized — `<br\s*\/?>` inside a script body would otherwise be interpreted as a tag and throw `Invalid tag syntax`.
+
+This guard is dormant for parsers whose upstream tokenizer already rejects bare `<` in element body (`jsx-parser` via TypeScript ESTree) but is critical for parsers that hand the full raw element to `parseCodeFragment` (e.g., `astro-parser`).
+
+**Escapable raw text elements (`<title>`, `<textarea>`)** are NOT in the default `rawTextElements`. HTML LS classifies them as escapable raw text — they require character-reference (`&amp;` etc.) decoding inside the body, which the short-circuit above does not implement. Add them to `rawTextElements` only if you accept that character references will be passed through verbatim instead of decoded.
 
 ### visitComment()
 

--- a/packages/@markuplint/parser-utils/docs/parser-class.md
+++ b/packages/@markuplint/parser-utils/docs/parser-class.md
@@ -70,15 +70,15 @@ constructor(options?: ParserOptions, defaultState?: State)
 
 The constructor accepts a `ParserOptions` object and an optional default state value:
 
-| Option                 | Type                   | Default                         | Description                                                                                |
-| ---------------------- | ---------------------- | ------------------------------- | ------------------------------------------------------------------------------------------ |
-| `booleanish`           | `boolean`              | `false`                         | Treat omitted attribute values as `true` (e.g., JSX `<Component aria-hidden />`)           |
-| `endTagType`           | `EndTagType`           | `'omittable'`                   | `'xml'`: end tag required or self-close; `'omittable'`: may omit; `'never'`: never need    |
-| `ignoreTags`           | `readonly IgnoreTag[]` | `[]`                            | Patterns for code blocks to mask before parsing (e.g., template expressions)               |
-| `maskChar`             | `string`               | `'\uE000'` (MASK_CHAR)          | Character used to replace masked code blocks                                               |
-| `tagNameCaseSensitive` | `boolean`              | `false`                         | Whether tag name comparisons are case-sensitive (e.g., JSX, Svelte)                        |
-| `selfCloseType`        | `SelfCloseType`        | `'html'`                        | `'html'`: only void elements self-close; `'xml'`: solidus determines; `'html+xml'`: either |
-| `spaceChars`           | `readonly string[]`    | `['\t', '\n', '\f', '\r', ' ']` | Characters treated as whitespace in tag parsing                                            |
+| Option                 | Type                   | Default                         | Description                                                                                                                                    |
+| ---------------------- | ---------------------- | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `booleanish`           | `boolean`              | `false`                         | Treat omitted attribute values as `true` (e.g., JSX `<Component aria-hidden />`)                                                               |
+| `endTagType`           | `EndTagType`           | `'omittable'`                   | `'xml'`: end tag required or self-close; `'omittable'`: may omit; `'never'`: never need                                                        |
+| `ignoreTags`           | `readonly IgnoreTag[]` | `[]`                            | Patterns for code blocks to mask before parsing (e.g., template expressions)                                                                   |
+| `maskChar`             | `string`               | `'\uE000'` (MASK_CHAR)          | Character used to replace masked code blocks                                                                                                   |
+| `tagNameCaseSensitive` | `boolean`              | `false`                         | Whether tag name comparisons are case-sensitive (e.g., JSX, Svelte)                                                                            |
+| `selfCloseType`        | `SelfCloseType`        | `'html'`                        | `'html'`: only void elements self-close; `'xml'`: solidus determines; `'html+xml'`: either                                                     |
+| `spaceChars`           | `readonly string[]`    | `['\t', '\n', '\f', '\r', ' ']` | Characters treated as whitespace in tag parsing                                                                                                |
 | `rawTextElements`      | `readonly string[]`    | `['style', 'script']`           | Elements whose children are not traversed and whose body bypasses `parseCodeFragment` re-tokenization (raw text content per HTML LS §13.2.5.1) |
 
 ## Parse Pipeline

--- a/packages/@markuplint/parser-utils/src/parser.ts
+++ b/packages/@markuplint/parser-utils/src/parser.ts
@@ -877,7 +877,9 @@ export abstract class Parser<Node extends {} = {}, State extends unknown = null>
 	 * @param options - Controls whether nameless fragments (JSX `<>`) are recognized
 	 * @returns An array of tag and text AST nodes discovered in the code fragment
 	 * @see https://html.spec.whatwg.org/multipage/syntax.html#cdata-rcdata-restrictions
-	 * @see https://github.com/markuplint/markuplint/issues/3860
+	 * @see https://github.com/markuplint/markuplint/issues/3860 (v4 backport tracking issue)
+	 * @see https://github.com/markuplint/markuplint/issues/3825 (original dev report)
+	 * @see https://github.com/markuplint/markuplint/pull/3859 (dev fix that landed first)
 	 */
 	parseCodeFragment(
 		token: ChildToken,

--- a/packages/@markuplint/parser-utils/src/parser.ts
+++ b/packages/@markuplint/parser-utils/src/parser.ts
@@ -69,6 +69,13 @@ export abstract class Parser<Node extends {} = {}, State extends unknown = null>
 	readonly #selfCloseType: SelfCloseType = 'html';
 	readonly #spaceChars: readonly string[] = defaultSpaces;
 	readonly #rawTextElements: readonly string[] = ['style', 'script'];
+	/**
+	 * Compiled close-tag patterns for `#rawTextElements`, populated lazily on first
+	 * use and reused across every starttag in the same parse. Keyed by the original
+	 * tag name (as authored in source) so a `tagNameCaseSensitive` parser that
+	 * preserves casing reuses the same `RegExp` for every occurrence.
+	 */
+	readonly #rawTextCloseTagPatternCache = new Map<string, RegExp>();
 	#authoredElementName?: ParserAuthoredElementNameDistinguishing;
 	#originalRawCode = '';
 	#rawCode = '';
@@ -855,11 +862,22 @@ export abstract class Parser<Node extends {} = {}, State extends unknown = null>
 	/**
 	 * Re-parses a text token to discover embedded HTML/XML tags within it,
 	 * splitting the content into a sequence of tag and text AST nodes.
-	 * Handles self-closing detection, depth tracking, and void element recognition.
+	 * Handles self-closing detection, depth tracking, void element recognition,
+	 * and the raw-text element body short-circuit (HTML LS §13.2.5.1).
+	 *
+	 * Raw-text element handling only covers the elements listed in
+	 * `rawTextElements` (default `['style', 'script']`). HTML LS *escapable* raw
+	 * text elements — `<title>` and `<textarea>` — are intentionally NOT in the
+	 * default. They allow character references (`&amp;` etc.) in their body, and
+	 * decoding is not implemented in this short-circuit. A subclass that adds
+	 * them via the `rawTextElements` option will see character references passed
+	 * through verbatim.
 	 *
 	 * @param token - The child token containing the code fragment to re-parse
 	 * @param options - Controls whether nameless fragments (JSX `<>`) are recognized
 	 * @returns An array of tag and text AST nodes discovered in the code fragment
+	 * @see https://html.spec.whatwg.org/multipage/syntax.html#cdata-rcdata-restrictions
+	 * @see https://github.com/markuplint/markuplint/issues/3860
 	 */
 	parseCodeFragment(
 		token: ChildToken,
@@ -969,6 +987,54 @@ export abstract class Parser<Node extends {} = {}, State extends unknown = null>
 
 				nodes.push(tag);
 			}
+
+			/**
+			 * Raw-text element body short-circuit (HTML Living Standard §13.2.5.1
+			 * — "Restrictions on the contents of raw text and escapable raw text
+			 * elements". The spec section anchor is `cdata-rcdata-restrictions`,
+			 * where RCDATA stands for "Raw text + Character REF data" — the broader
+			 * class that covers escapable raw text such as `<title>` / `<textarea>`).
+			 *
+			 * Per spec, the contents of `<script>` / `<style>` (and any caller-supplied
+			 * raw-text element) are NOT re-tokenized as HTML — the only thing that
+			 * terminates the body is `</tagName` followed by a tab/LF/FF/CR/space/`>`
+			 * /`/`. Without this guard, fragments like `<script>const t = s.replace(
+			 * /<br\s*\/?>/gi, " ");</script>` would feed the regex to `#parseTag`,
+			 * which would try to parse `<br\s*\/?>` as a tag and throw on the
+			 * backslash (#3860 / dev mirror #3825).
+			 *
+			 * This is dormant for `jsx-parser` and `mdx-parser` because their upstream
+			 * tokenizers reject bare `<` in element body before reaching here, but the
+			 * fix keeps `parseCodeFragment` honest for any future caller.
+			 *
+			 * @see https://html.spec.whatwg.org/multipage/syntax.html#cdata-rcdata-restrictions
+			 * @see https://github.com/markuplint/markuplint/issues/3860
+			 */
+			if (tag.type === 'starttag' && !isSelfClose && this.#rawTextElements.includes(tag.nodeName.toLowerCase())) {
+				const closeTagPattern = this.#getRawTextCloseTagPattern(tag.nodeName);
+				const match = closeTagPattern.exec(raw);
+				if (match) {
+					const bodyRaw = raw.slice(0, match.index);
+					if (bodyRaw) {
+						const bodyToken = this.createToken(bodyRaw, startOffset, startLine, startCol);
+						const bodyNode: MLASTText = {
+							...bodyToken,
+							type: 'text',
+							depth,
+							nodeName: '#text',
+							parentNode: null,
+						};
+						nodes.push(bodyNode);
+						const bodyEnd = this.#getEndLocation(bodyToken);
+						startOffset = bodyEnd.endOffset;
+						startLine = bodyEnd.endLine;
+						startCol = bodyEnd.endCol;
+					}
+					raw = raw.slice(match.index);
+				}
+				// If no matching close tag is found, fall through to the generic loop
+				// so the existing "unclosed tag" handling remains in effect.
+			}
 		}
 		return nodes;
 	}
@@ -980,7 +1046,7 @@ export abstract class Parser<Node extends {} = {}, State extends unknown = null>
 	 * @param node - The AST node whose location should be updated
 	 * @param props - The new position and depth values to apply (only provided values are changed)
 	 */
-	updateLocation(
+updateLocation(
 		node: MLASTNodeTreeItem,
 		props: Partial<Pick<MLASTNodeTreeItem, 'startOffset' | 'startLine' | 'startCol' | 'depth'>>,
 	) {
@@ -995,7 +1061,7 @@ export abstract class Parser<Node extends {} = {}, State extends unknown = null>
 		});
 	}
 
-	/**
+/**
 	 * Set new raw code to target node.
 	 *
 	 * Replace the raw code and update the start/end offset/line/column.
@@ -1003,7 +1069,7 @@ export abstract class Parser<Node extends {} = {}, State extends unknown = null>
 	 * @param node target node
 	 * @param raw new raw code
 	 */
-	updateRaw(node: MLASTToken, raw: string) {
+updateRaw(node: MLASTToken, raw: string) {
 		const startOffset = node.startOffset;
 		const startLine = node.startLine;
 		const startCol = node.startCol;
@@ -1022,20 +1088,20 @@ export abstract class Parser<Node extends {} = {}, State extends unknown = null>
 		});
 	}
 
-	/**
+/**
 	 * Updates the node name and/or element type of an element or close tag AST node.
 	 * Useful for renaming elements or changing their classification after initial parsing.
 	 *
 	 * @param el - The element or close tag AST node to update
 	 * @param props - The properties to overwrite on the element
 	 */
-	updateElement(el: MLASTElement, props: Partial<Pick<MLASTElement, 'nodeName' | 'elementType'>>): void;
-	updateElement(el: MLASTElementCloseTag, props: Partial<Pick<MLASTElementCloseTag, 'nodeName'>>): void;
-	updateElement(el: MLASTTag, props: Partial<Pick<MLASTElement, 'nodeName' | 'elementType'>>): void {
+updateElement(el: MLASTElement, props: Partial<Pick<MLASTElement, 'nodeName' | 'elementType'>>): void;
+updateElement(el: MLASTElementCloseTag, props: Partial<Pick<MLASTElementCloseTag, 'nodeName'>>): void;
+updateElement(el: MLASTTag, props: Partial<Pick<MLASTElement, 'nodeName' | 'elementType'>>): void {
 		Object.assign(el, props);
 	}
 
-	/**
+/**
 	 * Updates metadata properties on an HTML attribute AST node, such as marking
 	 * it as a directive, dynamic value, or setting its potential name/value
 	 * for preprocessor-specific attribute transformations.
@@ -1043,7 +1109,7 @@ export abstract class Parser<Node extends {} = {}, State extends unknown = null>
 	 * @param attr - The HTML attribute AST node to update
 	 * @param props - The metadata properties to overwrite on the attribute
 	 */
-	updateAttr(
+updateAttr(
 		attr: MLASTHTMLAttr,
 		props: Partial<
 			Pick<
@@ -1061,7 +1127,7 @@ export abstract class Parser<Node extends {} = {}, State extends unknown = null>
 		Object.assign(attr, props);
 	}
 
-	/**
+/**
 	 * Determines the element type (e.g., "html", "web-component", "authored") for a
 	 * given tag name, using the parser's authored element name distinguishing pattern.
 	 *
@@ -1069,11 +1135,11 @@ export abstract class Parser<Node extends {} = {}, State extends unknown = null>
 	 * @param defaultPattern - A fallback pattern if no authored element name pattern is set
 	 * @returns The element type classification
 	 */
-	detectElementType(nodeName: string, defaultPattern?: ParserAuthoredElementNameDistinguishing): ElementType {
+detectElementType(nodeName: string, defaultPattern?: ParserAuthoredElementNameDistinguishing): ElementType {
 		return detectElementType(nodeName, this.#authoredElementName, defaultPattern);
 	}
 
-	/**
+/**
 	 * Creates a new MLASTToken with a generated UUID and computed end position.
 	 * Accepts either a Token object or a raw string with explicit start coordinates.
 	 *
@@ -1083,9 +1149,9 @@ export abstract class Parser<Node extends {} = {}, State extends unknown = null>
 	 * @param startCol - The column number where the token starts (required when token is a string)
 	 * @returns A fully populated AST token with UUID, start/end positions, and raw content
 	 */
-	createToken(token: Token): MLASTToken;
-	createToken(token: string, startOffset: number, startLine: number, startCol: number): MLASTToken;
-	createToken(token: string | Token, startOffset?: number, startLine?: number, startCol?: number): MLASTToken {
+createToken(token: Token): MLASTToken;
+createToken(token: string, startOffset: number, startLine: number, startCol: number): MLASTToken;
+createToken(token: string | Token, startOffset?: number, startLine?: number, startCol?: number): MLASTToken {
 		const props =
 			typeof token === 'string'
 				? {
@@ -1414,6 +1480,27 @@ export abstract class Parser<Node extends {} = {}, State extends unknown = null>
 			endLine: getEndLine(token.raw, token.startLine),
 			endCol: getEndCol(token.raw, token.startCol),
 		} as const;
+	}
+
+	/**
+	 * Returns a cached close-tag pattern for a raw-text element, building it on first
+	 * use. The pattern matches `</tagName` followed by a tab/LF/FF/CR/space/`>`/`/`
+	 * (HTML LS §13.2.5.1) ASCII-case-insensitively. Caching avoids recompiling the
+	 * `RegExp` for every `<script>` / `<style>` start tag in large documents.
+	 */
+	#getRawTextCloseTagPattern(tagName: string): RegExp {
+		const cached = this.#rawTextCloseTagPatternCache.get(tagName);
+		if (cached) {
+			return cached;
+		}
+		const escapedName = tagName.replaceAll(/[$()*+.?[\\\]^{|}]/g, '\\$&');
+		// `regexp/strict` cannot statically verify a pattern built from the
+		// dynamic `escapedName` interpolation; the escape above is the contract
+		// that makes this safe for any caller-supplied `rawTextElements` value.
+		 
+		const pattern = new RegExp(`</${escapedName}(?=[\\t\\n\\f\\r >/])`, 'i');
+		this.#rawTextCloseTagPatternCache.set(tagName, pattern);
+		return pattern;
 	}
 
 	#orphanEndTagToBogusMark(nodeList: readonly MLASTNodeTreeItem[]) {

--- a/packages/@markuplint/parser-utils/src/parser.ts
+++ b/packages/@markuplint/parser-utils/src/parser.ts
@@ -1046,7 +1046,7 @@ export abstract class Parser<Node extends {} = {}, State extends unknown = null>
 	 * @param node - The AST node whose location should be updated
 	 * @param props - The new position and depth values to apply (only provided values are changed)
 	 */
-updateLocation(
+	updateLocation(
 		node: MLASTNodeTreeItem,
 		props: Partial<Pick<MLASTNodeTreeItem, 'startOffset' | 'startLine' | 'startCol' | 'depth'>>,
 	) {
@@ -1061,7 +1061,7 @@ updateLocation(
 		});
 	}
 
-/**
+	/**
 	 * Set new raw code to target node.
 	 *
 	 * Replace the raw code and update the start/end offset/line/column.
@@ -1069,7 +1069,7 @@ updateLocation(
 	 * @param node target node
 	 * @param raw new raw code
 	 */
-updateRaw(node: MLASTToken, raw: string) {
+	updateRaw(node: MLASTToken, raw: string) {
 		const startOffset = node.startOffset;
 		const startLine = node.startLine;
 		const startCol = node.startCol;
@@ -1088,20 +1088,20 @@ updateRaw(node: MLASTToken, raw: string) {
 		});
 	}
 
-/**
+	/**
 	 * Updates the node name and/or element type of an element or close tag AST node.
 	 * Useful for renaming elements or changing their classification after initial parsing.
 	 *
 	 * @param el - The element or close tag AST node to update
 	 * @param props - The properties to overwrite on the element
 	 */
-updateElement(el: MLASTElement, props: Partial<Pick<MLASTElement, 'nodeName' | 'elementType'>>): void;
-updateElement(el: MLASTElementCloseTag, props: Partial<Pick<MLASTElementCloseTag, 'nodeName'>>): void;
-updateElement(el: MLASTTag, props: Partial<Pick<MLASTElement, 'nodeName' | 'elementType'>>): void {
+	updateElement(el: MLASTElement, props: Partial<Pick<MLASTElement, 'nodeName' | 'elementType'>>): void;
+	updateElement(el: MLASTElementCloseTag, props: Partial<Pick<MLASTElementCloseTag, 'nodeName'>>): void;
+	updateElement(el: MLASTTag, props: Partial<Pick<MLASTElement, 'nodeName' | 'elementType'>>): void {
 		Object.assign(el, props);
 	}
 
-/**
+	/**
 	 * Updates metadata properties on an HTML attribute AST node, such as marking
 	 * it as a directive, dynamic value, or setting its potential name/value
 	 * for preprocessor-specific attribute transformations.
@@ -1109,7 +1109,7 @@ updateElement(el: MLASTTag, props: Partial<Pick<MLASTElement, 'nodeName' | 'elem
 	 * @param attr - The HTML attribute AST node to update
 	 * @param props - The metadata properties to overwrite on the attribute
 	 */
-updateAttr(
+	updateAttr(
 		attr: MLASTHTMLAttr,
 		props: Partial<
 			Pick<
@@ -1127,7 +1127,7 @@ updateAttr(
 		Object.assign(attr, props);
 	}
 
-/**
+	/**
 	 * Determines the element type (e.g., "html", "web-component", "authored") for a
 	 * given tag name, using the parser's authored element name distinguishing pattern.
 	 *
@@ -1135,11 +1135,11 @@ updateAttr(
 	 * @param defaultPattern - A fallback pattern if no authored element name pattern is set
 	 * @returns The element type classification
 	 */
-detectElementType(nodeName: string, defaultPattern?: ParserAuthoredElementNameDistinguishing): ElementType {
+	detectElementType(nodeName: string, defaultPattern?: ParserAuthoredElementNameDistinguishing): ElementType {
 		return detectElementType(nodeName, this.#authoredElementName, defaultPattern);
 	}
 
-/**
+	/**
 	 * Creates a new MLASTToken with a generated UUID and computed end position.
 	 * Accepts either a Token object or a raw string with explicit start coordinates.
 	 *
@@ -1149,9 +1149,9 @@ detectElementType(nodeName: string, defaultPattern?: ParserAuthoredElementNameDi
 	 * @param startCol - The column number where the token starts (required when token is a string)
 	 * @returns A fully populated AST token with UUID, start/end positions, and raw content
 	 */
-createToken(token: Token): MLASTToken;
-createToken(token: string, startOffset: number, startLine: number, startCol: number): MLASTToken;
-createToken(token: string | Token, startOffset?: number, startLine?: number, startCol?: number): MLASTToken {
+	createToken(token: Token): MLASTToken;
+	createToken(token: string, startOffset: number, startLine: number, startCol: number): MLASTToken;
+	createToken(token: string | Token, startOffset?: number, startLine?: number, startCol?: number): MLASTToken {
 		const props =
 			typeof token === 'string'
 				? {
@@ -1497,7 +1497,7 @@ createToken(token: string | Token, startOffset?: number, startLine?: number, sta
 		// `regexp/strict` cannot statically verify a pattern built from the
 		// dynamic `escapedName` interpolation; the escape above is the contract
 		// that makes this safe for any caller-supplied `rawTextElements` value.
-		 
+
 		const pattern = new RegExp(`</${escapedName}(?=[\\t\\n\\f\\r >/])`, 'i');
 		this.#rawTextCloseTagPatternCache.set(tagName, pattern);
 		return pattern;


### PR DESCRIPTION
## Summary

v4 backport of [#3825](https://github.com/markuplint/markuplint/issues/3825), tracked as [#3860](https://github.com/markuplint/markuplint/issues/3860). The dev (v5 RC) implementation landed first via [#3859](https://github.com/markuplint/markuplint/pull/3859). This PR ports the same fix to v4 (stable).

- Fix: Astro `<script>` / `<style>` body containing HTML-like substrings (e.g. `/<br\s*\/?>/gi`, `/* <br = */`) no longer throws `SyntaxError: Invalid tag syntax`.
- The fix lives in `@markuplint/parser-utils` `parseCodeFragment()`. After parsing a non-self-closing start tag whose `nodeName.toLowerCase()` matches `rawTextElements` (default `['style', 'script']`), the body is consumed verbatim until the next ASCII-case-insensitive `</tagName` followed by tab/LF/FF/CR/space/`>` /`/`, per [HTML LS §13.2.5.1](https://html.spec.whatwg.org/multipage/syntax.html#cdata-rcdata-restrictions).
- Dormant for `jsx-parser` (its upstream tokenizer rejects bare `<` in element body); a defensive test is added to lock in that invariant.
- Close-tag patterns are cached per `tagName` so `RegExp` is not recompiled for every starttag.

## v4-specific adjustments vs dev

- Token field names are kept as v4's long form (`startOffset` / `startLine` / `startCol`).
- `MLASTText` shape on v4 has only `parentNode` (no `parentNodeUuid`).
- Lint stack is ESLint + Prettier (not oxlint + oxfmt) — included a separate `style` commit to recover from a mid-stream Prettier compliance break (see Commits below).
- v4 has no `mdx-parser` package, so only `jsx-parser` defensive tests are added.

## Commits

| # | Type | Subject |
|---|---|---|
| 1 | chore | register `rcdata` in cspell dictionary |
| 2 | fix(parser-utils) | handle raw-text element body in `parseCodeFragment` per HTML LS §13.2.5.1 |
| 3 | docs(parser-utils) | document raw-text behavior, downstream impact, and escapable raw text scope |
| 4 | test(astro-parser) | cover script/style raw-text body cases for #3860 |
| 5 | docs(astro-parser) | note raw-text safety delegation and add #3860 troubleshooting |
| 6 | test(jsx-parser) | pin upstream raw-text invariant for #3860 |
| 7 | style | apply Prettier formatting to v4 backport files |
| 8 | docs | cross-link v4 backport with dev #3825/#3859 and add port guide |

> **Audit note**: commit 7 (`style`) restores tab indentation that was stripped from six `parser-utils/src/parser.ts` method signatures during the merge-conflict resolution earlier on this branch. TypeScript build/test passed (whitespace-irrelevant) but Prettier would have failed on CI. Caught during the QA review pass before PR creation.

## Test plan

- [x] `yarn build` — 37 packages clean
- [x] `yarn test` — 1493 / 1494 pass (1 skip)
- [x] `yarn lint:eslint` — 0 errors, 0 warnings
- [x] `yarn lint:prettier` — clean
- [x] `#3860` regression suite: astro 11 + jsx 2 = 13 passing
- [ ] CI green

## Risks / Compatibility

- **No breaking change** — patch-level bug fix on stable v4. CHANGELOG auto-generated from `fix(parser-utils)` commit.
- For internal parsers (`html`, `jsx`, `astro`): no observable behavior change. astro-parser's `visitElement` already discards intermediate text nodes from `parseCodeFragment`; the new body text node is silently dropped (verified by existing snapshot tests).
- For external consumers of `@markuplint/parser-utils`: `parseCodeFragment()` previously could throw for raw-text bodies; now it returns a text node + close-tag instead. API shape (`(MLASTTag | MLASTText)[]`) unchanged. Treated as a fix.
- No migration guide needed.

## Related

- Original report: #3825
- v4 backport tracking: #3860
- dev fix: #3859 (merged)

## Closes

Closes #3860

🤖 Generated with [Claude Code](https://claude.com/claude-code)