### PR TITLE
ci: switch pnpm build approval to pnpm-workspace.yaml allowBuilds (v4 backport)

### DIFF
--- a/test/isolated-env/ts-config-ts/pnpm-workspace.yaml
+++ b/test/isolated-env/ts-config-ts/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/test/isolated-env/ts/pnpm-workspace.yaml
+++ b/test/isolated-env/ts/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
## Summary

Fix the `isolated-env (ubuntu-latest, pnpm, ts)` and `(pnpm, ts-config-ts)` CI legs that have been failing on every recent v4 PR (#3854, #3862, etc.) with `[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild@0.27.7`.

pnpm 11 refuses to run lifecycle scripts of dependencies unless explicitly approved. Without esbuild's postinstall, the native binary is not installed, `tsx` fails to load the test entry, and the install step exits non-zero.

The fix is a 2-line `pnpm-workspace.yaml` per affected sandbox root:

```yaml
allowBuilds:
  esbuild: true
```

## v4 backport context

dev (v5 RC) landed the same fix via `78062cfb0` after confirming experimentally:

- `pnpm-workspace.yaml` `allowBuilds` is the only mechanism pnpm 11 honours.
- `package.json` `pnpm.onlyBuiltDependencies` is silently ignored.
- The `--allow-build=<pkg>` CLI flag is rejected as `Unknown option`.

The `esm` leg does not need this file because its entry (`node ./index.js`) doesn't load `tsx`.

## Test plan

- [x] Confirmed dev's identical fix (`78062cfb0`) keeps the pnpm legs green on dev (`origin/dev` HEAD CI).
- [ ] CI on this PR shows `isolated-env (ubuntu-latest, pnpm, ts)` and `(pnpm, ts-config-ts)` passing.
- Local repro is impractical because the failure surfaces only in CI's sandbox layout (`../sandbox/test/isolated-env/<env>` with `file:` deps pointing at sibling `markuplint/packages/`); a local `pnpm install` exits 0 with only a warning.

## Risks / Compatibility

- npm and yarn legs ignore the new `pnpm-workspace.yaml` file — no impact.
- No code change, no dependency change. CI-only config.
- No CHANGELOG entry needed (`ci:` scope).

## References

- Dev fix commit: `78062cfb0 ci: switch pnpm build approval to pnpm-workspace.yaml allowBuilds`
- Pre-existing failure flagged in #3862 PR body
- pnpm docs: https://pnpm.io/9.x/cli/approve-builds (note: pnpm 11 only reads `allowBuilds` map, not the older `onlyBuiltDependencies`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)