### PR TITLE
chore: refresh nu-validator bench snapshots after #3874

### DIFF
--- a/tests/external/snapshots/diff/coverage.json
+++ b/tests/external/snapshots/diff/coverage.json
@@ -14908,8 +14908,8 @@
 			"path": "html/datatypes/url-empty-novalid.html",
 			"category": "data-types",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -17210,8 +17210,8 @@
 			"path": "html/elements/base/href-and-target-missing-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -19254,8 +19254,8 @@
 			"path": "html/elements/button/formaction-empty-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -19270,8 +19270,8 @@
 			"path": "html/elements/button/formaction-whitespace-only-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -22716,8 +22716,8 @@
 			"path": "html/elements/form/action-empty-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -22732,8 +22732,8 @@
 			"path": "html/elements/form/action-whitespace-only-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -25514,8 +25514,8 @@
 			"path": "html/elements/input/image-without-alt-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -25770,8 +25770,8 @@
 			"path": "html/elements/input/type-image-formaction-empty-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -25786,8 +25786,8 @@
 			"path": "html/elements/input/type-image-formaction-whitespace-only-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -27102,8 +27102,8 @@
 			"path": "html/elements/input/type-submit-formaction-empty-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -27118,8 +27118,8 @@
 			"path": "html/elements/input/type-submit-formaction-whitespace-only-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -30204,8 +30204,8 @@
 			"path": "html/elements/link/href-empty-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -30228,8 +30228,8 @@
 			"path": "html/elements/link/href-whitespace-only-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -31716,8 +31716,8 @@
 			"path": "html/elements/object/data-empty-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -31740,8 +31740,8 @@
 			"path": "html/elements/object/data-whitespace-only-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -39134,8 +39134,8 @@
 			"path": "html/elements/video/poster-empty-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -39150,8 +39150,8 @@
 			"path": "html/elements/video/poster-whitespace-only-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{

--- a/tests/external/snapshots/diff/nu-only.json
+++ b/tests/external/snapshots/diff/nu-only.json
@@ -103,13 +103,6 @@
 			]
 		},
 		{
-			"path": "html/datatypes/url-empty-novalid.html",
-			"category": "data-types",
-			"nuMessageIds": [
-				"nv-9b9e85d36b74"
-			]
-		},
-		{
 			"path": "html/elements/a/with-href-button-descendant-novalid.html",
 			"category": "invalid-attr",
 			"nuMessageIds": [
@@ -121,13 +114,6 @@
 			"category": "invalid-attr",
 			"nuMessageIds": [
 				"nv-f3f919789208"
-			]
-		},
-		{
-			"path": "html/elements/base/href-and-target-missing-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-920b4fb50a87"
 			]
 		},
 		{
@@ -145,20 +131,6 @@
 			]
 		},
 		{
-			"path": "html/elements/button/formaction-empty-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-acb1eb6a08be"
-			]
-		},
-		{
-			"path": "html/elements/button/formaction-whitespace-only-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-4c60cd9da2dd"
-			]
-		},
-		{
 			"path": "html/elements/dl/div-multiple-groups-novalid.html",
 			"category": "invalid-attr",
 			"nuMessageIds": [
@@ -166,20 +138,6 @@
 				"nv-8488d87fd201",
 				"nv-c85c578225cf",
 				"nv-4f10aadba99f"
-			]
-		},
-		{
-			"path": "html/elements/form/action-empty-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-70b66927decd"
-			]
-		},
-		{
-			"path": "html/elements/form/action-whitespace-only-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-ea6dd43cac43"
 			]
 		},
 		{
@@ -225,13 +183,6 @@
 			]
 		},
 		{
-			"path": "html/elements/input/image-without-alt-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-83e76d8a6f6a"
-			]
-		},
-		{
 			"path": "html/elements/input/list-not-datalist-novalid.html",
 			"category": "invalid-attr",
 			"nuMessageIds": [
@@ -264,34 +215,6 @@
 			"category": "invalid-attr",
 			"nuMessageIds": [
 				"nv-9d1d24e3ba6b"
-			]
-		},
-		{
-			"path": "html/elements/input/type-image-formaction-empty-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-d18149ab1fa5"
-			]
-		},
-		{
-			"path": "html/elements/input/type-image-formaction-whitespace-only-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-ed23c549bb56"
-			]
-		},
-		{
-			"path": "html/elements/input/type-submit-formaction-empty-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-881990d6aa38"
-			]
-		},
-		{
-			"path": "html/elements/input/type-submit-formaction-whitespace-only-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-47e40872fbb5"
 			]
 		},
 		{
@@ -337,20 +260,6 @@
 			]
 		},
 		{
-			"path": "html/elements/link/href-empty-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-cf93c616422f"
-			]
-		},
-		{
-			"path": "html/elements/link/href-whitespace-only-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-a37edadf3318"
-			]
-		},
-		{
 			"path": "html/elements/meta/content-security-policy/csp-invalid-directive-haswarn.html",
 			"category": "invalid-attr",
 			"nuMessageIds": [
@@ -376,20 +285,6 @@
 			"category": "invalid-attr",
 			"nuMessageIds": [
 				"nv-006f6fbfb136"
-			]
-		},
-		{
-			"path": "html/elements/object/data-empty-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-e834128eb2ef"
-			]
-		},
-		{
-			"path": "html/elements/object/data-whitespace-only-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-7f4c749291c0"
 			]
 		},
 		{
@@ -1184,20 +1079,6 @@
 			"nuMessageIds": [
 				"nv-826f9d9b348e",
 				"nv-10d5998bc50c"
-			]
-		},
-		{
-			"path": "html/elements/video/poster-empty-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-b0077457c547"
-			]
-		},
-		{
-			"path": "html/elements/video/poster-whitespace-only-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-528c1af6ff8f"
 			]
 		},
 		{

--- a/tests/external/snapshots/diff/summary.md
+++ b/tests/external/snapshots/diff/summary.md
@@ -1,6 +1,6 @@
 # nu-validator Benchmark Summary
 
-- generated: 2026-05-14T12:02:22.151Z
+- generated: 2026-05-15T03:19:36.200Z
 - submodule: `142931395412c00434ffb40a14d65992efd17aa8`
 - nu-validator: `ghcr.io/validator/validator@sha256:d16a53211ea8617b13a0c7f87e9d0cf4058e4ab729482dd3dfebade9bb4b6671`
 - markuplint: `5.0.0-rc.4`
@@ -9,11 +9,11 @@
 ## Totals
 
 - files: **5442**
-- match-error: **3340** (both tools flagged)
+- match-error: **3357** (both tools flagged)
 - match-clean: **919** (neither flagged)
-- nu-only: **174** (only nu-validator flagged; markuplint coverage candidates — open a markuplint issue after a spec read)
+- nu-only: **157** (only nu-validator flagged; markuplint coverage candidates — open a markuplint issue after a spec read)
 - nu-over: **28** (nu-validator errors fully covered by spec-backed excluded-ids — confirmed over-detection)
-- overall match rate: **78.3%**
+- overall match rate: **78.6%**
 - excluded-ids: 3 entries, 1 pattern(s)
 
 ## Per-Category
@@ -23,11 +23,11 @@
 | aria | 780 | 80.4% | 175 | 452 | 145 | 8 | 0 |
 | assertions | 40 | 100.0% | 39 | 1 | 0 | 0 | 0 |
 | content-model | 98 | 98.0% | 48 | 48 | 0 | 2 | 0 |
-| data-types | 56 | 92.9% | 47 | 5 | 1 | 3 | 0 |
+| data-types | 56 | 94.6% | 48 | 5 | 1 | 2 | 0 |
 | deprecated | 12 | 91.7% | 11 | 0 | 1 | 0 | 0 |
 | global-attr | 57 | 80.7% | 26 | 20 | 8 | 3 | 0 |
 | id-duplication | 1 | 100.0% | 1 | 0 | 0 | 0 | 0 |
-| invalid-attr | 3086 | 92.3% | 2617 | 230 | 61 | 152 | 26 |
+| invalid-attr | 3086 | 92.8% | 2633 | 230 | 61 | 136 | 26 |
 | required-attr | 5 | 100.0% | 5 | 0 | 0 | 0 | 0 |
 | uncategorized | 1307 | 40.9% | 371 | 163 | 765 | 6 | 2 |
 

--- a/tests/external/snapshots/meta.json
+++ b/tests/external/snapshots/meta.json
@@ -1,5 +1,5 @@
 {
-	"generatedAt": "2026-05-14T12:02:22.151Z",
+	"generatedAt": "2026-05-15T03:19:36.200Z",
 	"submoduleSha": "142931395412c00434ffb40a14d65992efd17aa8",
 	"nuValidatorImage": "ghcr.io/validator/validator@sha256:d16a53211ea8617b13a0c7f87e9d0cf4058e4ab729482dd3dfebade9bb4b6671",
 	"markuplintVersion": "5.0.0-rc.4",
@@ -7,6 +7,6 @@
 	"totalFilesNu": 5442,
 	"totalFilesMl": 5442,
 	"totalNuMessages": 9905,
-	"totalMlViolations": 11227,
+	"totalMlViolations": 11244,
 	"totalNuFailures": 0
 }


### PR DESCRIPTION
## Summary

Refresh nu-validator coverage benchmark snapshots to reflect the effects of #3874 (URL non-empty + required-attr tightening).

## Bench delta

| Metric | Before | After | Δ |
| --- | ---: | ---: | ---: |
| match-error | 3340 | 3357 | **+17** |
| nu-only | 174 | 157 | **-17** |
| match-clean | 919 | 919 | 0 |
| ml-only | 981 | 981 | 0 |
| nu-over | 28 | 28 | 0 |
| totalMlViolations | 11227 | 11244 | +17 |
| **match rate** | **78.3%** | **78.6%** | +0.3pp |

- **+17 match-error / -17 nu-only**: 12 directly targeted fixtures (5 attrs × URL empty/whitespace + base + input[type=image] alt) plus 5 collateral hits where one fixture carried multiple nu messages
- **No ml-only regression**: tightening did not introduce false positives on adjacent elements

## Test plan

- [x] `yarn bench:update --target nu --concurrency 1` (Docker full regen)
- [x] `yarn bench:update --target markuplint` (ml side)
- [x] `yarn bench:compare` (diff regenerated)
- [x] `yarn bench:verify` -- 5442/5442 pass