### PR TITLE
fix(types): reject duplicate descriptors in Srcset checker

### DIFF
--- a/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
@@ -3298,3 +3298,36 @@ describe('input[name] must not be "isindex" (HTML LS §4.10.18.2)', () => {
 		expect(violations.length).toBeGreaterThan(0);
 	});
 });
+
+describe('srcset descriptors must be unique (HTML LS §4.8.4.4.1)', () => {
+	test('[invalid-attr-valid-047] srcset with distinct densities is accepted', async () => {
+		const { violations } = await mlRuleTest(rule, '<img src="x.jpg" srcset="a.jpg 1x, b.jpg 2x" alt="">');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('[invalid-attr-invalid-070] srcset with duplicate density (omitted + 1x) is rejected', async () => {
+		// Mirrors html/elements/picture/srcset-microsyntax-unique-descriptors-1x-and-omitted-novalid.html.
+		// Omitted descriptor implies density 1x; pairing with explicit 1x is a duplicate.
+		const { violations } = await mlRuleTest(rule, '<img srcset="x 1x, y" src="x" alt="">');
+		expect(violations.length).toBeGreaterThan(0);
+	});
+
+	test('[invalid-attr-invalid-071] srcset with duplicate explicit density is rejected', async () => {
+		// Mirrors html/elements/picture/srcset-microsyntax-unique-descriptors-2x-novalid.html.
+		const { violations } = await mlRuleTest(rule, '<img srcset="x 2x, y 2x" src="x" alt="">');
+		expect(violations.length).toBeGreaterThan(0);
+	});
+
+	test('[invalid-attr-invalid-072] srcset with integer and decimal density equal in value is rejected', async () => {
+		// Mirrors html/elements/picture/srcset-microsyntax-unique-descriptors-integer-and-decimals-x-novalid.html.
+		// 1x and 1.0x normalise to the same numeric pixel density.
+		const { violations } = await mlRuleTest(rule, '<img srcset="x 1x, y 1.0x" src="x" alt="">');
+		expect(violations.length).toBeGreaterThan(0);
+	});
+
+	test('[invalid-attr-invalid-073] srcset with duplicate width descriptor is rejected', async () => {
+		// Mirrors html/elements/picture/srcset-microsyntax-unique-descriptors-w-novalid.html.
+		const { violations } = await mlRuleTest(rule, '<img srcset="x 1w, y 1w" sizes="100vw" src="x" alt="">');
+		expect(violations.length).toBeGreaterThan(0);
+	});
+});

--- a/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
@@ -3330,4 +3330,27 @@ describe('srcset descriptors must be unique (HTML LS §4.8.4.4.1)', () => {
 		const { violations } = await mlRuleTest(rule, '<img srcset="x 1w, y 1w" sizes="100vw" src="x" alt="">');
 		expect(violations.length).toBeGreaterThan(0);
 	});
+
+	test('[invalid-attr-invalid-074] srcset with explicit "1x, 1x" duplicate is rejected', async () => {
+		// The simplest duplicate-density case — most common shape that real
+		// projects accidentally hit. No nu fixture pins this directly (only
+		// `1x, y` / `2x, 2x` / `1x, 1.0x` are in the corpus), but the rule
+		// guarantee should fire on the canonical shape too.
+		const { violations } = await mlRuleTest(rule, '<img srcset="a.jpg 1x, b.jpg 1x" src="a.jpg" alt="">');
+		expect(violations.length).toBeGreaterThan(0);
+	});
+
+	test('[invalid-attr-invalid-075] srcset with decimal-only duplicate density is rejected', async () => {
+		// Pins the decimal-equality branch independently from the
+		// integer-vs-decimal normalisation case (invalid-072).
+		const { violations } = await mlRuleTest(rule, '<img srcset="a.jpg 0.5x, b.jpg 0.5x" src="a.jpg" alt="">');
+		expect(violations.length).toBeGreaterThan(0);
+	});
+
+	test('[invalid-attr-invalid-076] srcset with duplicate density at end of 3-entry list is rejected', async () => {
+		// Duplicate detection must trip on the third entry, not only on the
+		// adjacent pair. Pins that the Set is checked for every entry.
+		const { violations } = await mlRuleTest(rule, '<img srcset="a.jpg 1x, b.jpg 2x, c.jpg 1x" src="a.jpg" alt="">');
+		expect(violations.length).toBeGreaterThan(0);
+	});
 });

--- a/packages/@markuplint/types/src/check.spec.ts
+++ b/packages/@markuplint/types/src/check.spec.ts
@@ -89,7 +89,6 @@ test('Srcset', () => {
 	// Descriptor consistency
 	expect(check('a.jpg 480w, b.jpg 1024w', 'Srcset').matched).toBe(true);
 	expect(check('a.jpg 1x, b.jpg 2x', 'Srcset').matched).toBe(true);
-	expect(check('a.jpg, b.jpg', 'Srcset').matched).toBe(true);
 	expect(check('a.jpg, b.jpg 2x', 'Srcset').matched).toBe(true);
 	expect(check('a.jpg 480w, b.jpg', 'Srcset').matched).toBe(false);
 	expect(check('a.jpg 480w, b.jpg 2x', 'Srcset').matched).toBe(false);
@@ -102,6 +101,18 @@ test('Srcset', () => {
 	expect(check('a.jpg 0x', 'Srcset').matched).toBe(false);
 	expect(check('a.jpg 0.0x', 'Srcset').matched).toBe(false);
 	expect(check('a.jpg -1x', 'Srcset').matched).toBe(false);
+
+	// Spec: "An invalid image candidate string is one with [...] a duplicate
+	// descriptor." Track normalised numeric values so 1x / 1.0x / omitted
+	// descriptor (implicit 1x) all collide on the same density slot.
+	expect(check('a.jpg 1x, b.jpg 1x', 'Srcset').matched).toBe(false);
+	expect(check('a.jpg 1x, b.jpg 1.0x', 'Srcset').matched).toBe(false);
+	expect(check('a.jpg, b.jpg', 'Srcset').matched).toBe(false);
+	expect(check('a.jpg 1x, b.jpg', 'Srcset').matched).toBe(false);
+	expect(check('a.jpg 480w, b.jpg 480w', 'Srcset').matched).toBe(false);
+	// Sanity: distinct densities / widths still accepted.
+	expect(check('a.jpg 1x, b.jpg 1.5x, c.jpg 2x', 'Srcset').matched).toBe(true);
+	expect(check('a.jpg 320w, b.jpg 640w, c.jpg 1280w', 'Srcset').matched).toBe(true);
 });
 
 test('IconSize', () => {

--- a/packages/@markuplint/types/src/check.spec.ts
+++ b/packages/@markuplint/types/src/check.spec.ts
@@ -113,6 +113,11 @@ test('Srcset', () => {
 	// Sanity: distinct densities / widths still accepted.
 	expect(check('a.jpg 1x, b.jpg 1.5x, c.jpg 2x', 'Srcset').matched).toBe(true);
 	expect(check('a.jpg 320w, b.jpg 640w, c.jpg 1280w', 'Srcset').matched).toBe(true);
+
+	// Numeric normalisation: `1e0` and `1` resolve to the same Number(); the
+	// duplicate detection key uses Number() so different lexical forms of the
+	// same density still collide.
+	expect(check('a.jpg 1e0x, b.jpg 1x', 'Srcset').matched).toBe(false);
 });
 
 test('IconSize', () => {

--- a/packages/@markuplint/types/src/defs.ts
+++ b/packages/@markuplint/types/src/defs.ts
@@ -710,6 +710,12 @@ export const defs: Defs = {
 			const images = value.split(',');
 			let hasWidth = false;
 			let hasDensity = false;
+			// Spec: "Let candidates be an initially empty source set. ... If candidates already has an
+			// entry whose descriptor's width is equal to width [or pixel density], then a parse error
+			// must be reported." Track normalised numeric values so 1x / 1.0x / omitted-descriptor
+			// (implicit 1x) all collide.
+			const usedWidths = new Set<number>();
+			const usedDensities = new Set<number>();
 
 			for (const image of images) {
 				// image candidate string
@@ -744,6 +750,13 @@ export const defs: Defs = {
 									],
 								});
 							}
+							const w = Number(num);
+							if (usedWidths.has(w)) {
+								return unmatched(value, 'duplicated', {
+									expects: [{ type: 'format', value: 'unique width descriptor' }],
+								});
+							}
+							usedWidths.add(w);
 							hasWidth = true;
 							break;
 						}
@@ -759,6 +772,13 @@ export const defs: Defs = {
 									],
 								});
 							}
+							const d = Number(num);
+							if (usedDensities.has(d)) {
+								return unmatched(value, 'duplicated', {
+									expects: [{ type: 'format', value: 'unique pixel density descriptor' }],
+								});
+							}
+							usedDensities.add(d);
 							hasDensity = true;
 							break;
 						}
@@ -778,7 +798,14 @@ export const defs: Defs = {
 						}
 					}
 				} else {
-					// No descriptor implies 1x (density descriptor)
+					// Spec: "If image candidate's descriptor is the empty string, [...] add an
+					// image source with a pixel density of 1.0."
+					if (usedDensities.has(1)) {
+						return unmatched(value, 'duplicated', {
+							expects: [{ type: 'format', value: 'unique pixel density descriptor' }],
+						});
+					}
+					usedDensities.add(1);
 					hasDensity = true;
 				}
 

--- a/website/docs/migration/v4-to-v5/rules/invalid-attr.md
+++ b/website/docs/migration/v4-to-v5/rules/invalid-attr.md
@@ -171,6 +171,7 @@ Each row cites the issue where the validation was introduced and the HTML / URL 
 | `<input type=image>` requires alt  | `<input type="image" src="b.png">`              | —                                                             | [HTML LS — input image button](<https://html.spec.whatwg.org/multipage/input.html#image-button-state-(type=image)>)                                 |
 | Standalone `autocomplete=webauthn` | `<input autocomplete="webauthn">`               | —                                                             | [HTML LS — `webauthn` token](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-autocomplete-webauthn)                 |
 | `input[name="isindex"]` forbidden  | `<input type="text" name="isindex">`            | —                                                             | [HTML LS — the `name` attribute](https://html.spec.whatwg.org/multipage/forms.html#attr-fe-name)                                                    |
+| `srcset` duplicate descriptors     | `<img srcset="a 1x, b 1x">`                     | —                                                             | [HTML LS — `srcset` attributes](https://html.spec.whatwg.org/multipage/images.html#srcset-attributes)                                               |
 
 ### Patterns now flagged on URL-typed attributes (`href`, `src`, `action`, `cite`, `itemid`, `itemtype`, ...)
 
@@ -195,6 +196,7 @@ Beyond the generic URL LS pipeline above, three specialised URL types tighten fu
 - **`<input type="image">` must have an `alt` attribute** (HTML LS §4.10.5.1.18). The `required-attr` rule now fires when `type="image"` is present without `alt`.
 - **`autocomplete="webauthn"` alone is non-conforming** (HTML LS §4.10.18.7). The `webauthn` token "must appear along with at least one other token". `<input autocomplete="webauthn">` now raises a violation; combinations like `autocomplete="name webauthn"` remain valid.
 - **`<input name="isindex">` is reserved** (HTML LS §4.10.18.2). The literal value `isindex` was kept reserved when the obsolete `<isindex>` element was removed; the `name` attribute on `<input>` now flags it. The check is case-sensitive (matches the spec literal).
+- **`srcset` duplicate descriptors are non-conforming** (HTML LS §4.8.4.4.1). "An invalid image candidate string is one with [...] a duplicate descriptor." The `Srcset` type checker now rejects repeats in either the density slot (`1x, 1x`, `1x, 1.0x`, or an omitted descriptor — implicit 1x — combined with `1x`) or the width slot (`480w, 480w`). Numeric equality is used so different lexical forms of the same value still collide.
 - **`<base href>`** now runs the full URL LS validator (in addition to the existing `data:` / `javascript:` scheme prohibition). Previously the type accepted any non-`data:`/`javascript:` value without further checks.
 - **`<input type="url" value>`** now uses an absolute-URL variant that accepts empty values (per HTML LS §4.10.5.1.7 "if specified and not empty") but rejects relative URLs. Use a full `https://…` form or leave the attribute empty.
 

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/migration/v4-to-v5/rules/invalid-attr.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/migration/v4-to-v5/rules/invalid-attr.md
@@ -171,6 +171,7 @@ v5 では、これまで `Any` として素通りしていた領域について 
 | `<input type=image>` の alt 必須      | `<input type="image" src="b.png">`              | —                                                             | [HTML LS — input image button](<https://html.spec.whatwg.org/multipage/input.html#image-button-state-(type=image)>)                                 |
 | 単独の `autocomplete=webauthn` 禁止   | `<input autocomplete="webauthn">`               | —                                                             | [HTML LS — `webauthn` token](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-autocomplete-webauthn)                 |
 | `input[name="isindex"]` 禁止          | `<input type="text" name="isindex">`            | —                                                             | [HTML LS — the `name` attribute](https://html.spec.whatwg.org/multipage/forms.html#attr-fe-name)                                                    |
+| `srcset` の descriptor 重複禁止       | `<img srcset="a 1x, b 1x">`                     | —                                                             | [HTML LS — `srcset` attributes](https://html.spec.whatwg.org/multipage/images.html#srcset-attributes)                                               |
 
 ### URL 系属性 (`href` / `src` / `action` / `cite` / `itemid` / `itemtype` 等) で新たに違反となるパターン
 
@@ -195,6 +196,7 @@ v5 では、これまで `Any` として素通りしていた領域について 
 - **`<input type="image">` は `alt` 属性を必須化** (HTML LS §4.10.5.1.18)。`type="image"` で `alt` が無い場合に `required-attr` ルールが発火します。
 - **単独の `autocomplete="webauthn"` は非適合** (HTML LS §4.10.18.7)。`webauthn` トークンは「他のトークンと組み合わせて使われなければならない」とされており、`<input autocomplete="webauthn">` のような単独使用は v5 で違反となります。`autocomplete="name webauthn"` のような組み合わせは引き続き有効です。
 - **`<input name="isindex">` は予約値** (HTML LS §4.10.18.2)。廃止された `<isindex>` 要素の名残として、リテラル値 `isindex` は予約されています。v5 では `name` 属性が `isindex` (大文字小文字区別) のときに違反となります。
+- **`srcset` の descriptor 重複は非適合** (HTML LS §4.8.4.4.1)。仕様は「重複した descriptor を持つ image candidate string は invalid」と定義しています。`Srcset` 型チェッカーは密度スロット (`1x, 1x`、`1x, 1.0x`、または省略 = 暗黙 1x と `1x` の組み合わせ) と幅スロット (`480w, 480w`) いずれの重複も拒否します。判定は数値比較なので、同じ値の異なる表記 (`1` vs `1.0` 等) も衝突します。
 - **`<base href>`** は既存の `data:`/`javascript:` スキーム禁止に加え、URL LS の完全な検証も実行するようになりました。以前は `data:`/`javascript:` 以外なら無検査で受理していました。
 - **`<input type="url" value>`** は絶対 URL 限定の variant を使うようになりました。空の値は受理 (HTML LS §4.10.5.1.7 「指定されかつ非空なら」) ですが、相対 URL は拒否します。完全な `https://…` 形式を使うか、属性を空にしてください。
 


### PR DESCRIPTION
## Summary

Tighten the `Srcset` checker so duplicate descriptors are flagged per HTML LS §4.8.4.4.1.

### Fix

- Track normalised numeric values for both the width and pixel density slots.
- `1x`, `1.0x`, `1e0x`, and an omitted descriptor (implicit 1x) all collide on the same density slot.
- `Nw` collisions are tracked separately for width descriptors.

### Companion change

The existing assertion `check('a.jpg, b.jpg', 'Srcset').matched === true` was spec-incorrect — both candidates reduce to implicit 1x. It is now `false`.

## Bench delta (verified locally)

| Metric | Before | After | Δ |
| --- | ---: | ---: | ---: |
| match-error | 3362 | 3366 | +4 |
| nu-only | 151 | 147 | **-4** |
| ml-only | 981 | 981 | 0 |

Affected fixtures (all under `html/elements/picture/`):

- `srcset-microsyntax-unique-descriptors-1x-and-omitted-novalid.html`
- `srcset-microsyntax-unique-descriptors-2x-novalid.html`
- `srcset-microsyntax-unique-descriptors-integer-and-decimals-x-novalid.html`
- `srcset-microsyntax-unique-descriptors-w-novalid.html`

No ml-only regression.

## Test plan

- [x] `check.spec.ts` — duplicate-detection unit tests + exponent-form (`1e0x`) normalisation
- [x] `invalid-attr/index.spec.ts` — 7 tests covering all 4 fixture shapes plus explicit \`1x, 1x\`, decimal-only (\`0.5x, 0.5x\`), and end-of-list duplicate (\`1x, 2x, 1x\`)
- [x] Migration guide entry + bullet (en/ja)
- [x] \`yarn lint\` / \`yarn build\` / \`yarn test\` / \`yarn site:build\` all pass locally