### PR TITLE
chore: exclude Speculation Rules JSON-content nu messages (out of HTML LS scope, tracks #3882)

### DIFF
--- a/.claude/skills/bench-triage/SKILL.md
+++ b/.claude/skills/bench-triage/SKILL.md
@@ -116,9 +116,16 @@ For a `nu-only` fixture, the spec verdict gives a binary action:
 
 | Spec on the markup | Conclusion | Action |
 | --- | --- | --- |
-| **Forbidden** | nu correct, markuplint has a coverage gap. | Add or extend a markuplint rule. Open an Issue if the work is non-trivial. After fix, `yarn bench:update:ml` — fixture should flip to `match-error`. |
-| **Permitted** | nu over-detecting. | Record in `excluded-ids.json` (per-ID or pattern; see below). After edit, `yarn bench:compare` — fixture should flip to `nu-over`. |
+| **Forbidden (HTML LS / ARIA / URL LS)** | nu correct, markuplint has a coverage gap. | Add or extend a markuplint rule. Open an Issue if the work is non-trivial. After fix, `yarn bench:update:ml` — fixture should flip to `match-error`. |
+| **Forbidden, but spec is outside markuplint's reference scope** (e.g. WICG draft, vendor extension) | nu is enforcing a spec that markuplint deliberately does not track. Open an Issue for future coverage AND record the messages in `excluded-ids.json` so the bench can focus on actionable HTML LS gaps. | Issue + `excluded-ids.json` pattern. Reason field must explicitly note `deferred-WICG / deferred-<spec>` so future readers can distinguish from regular nu-over. Tracking Issue # MUST be in the reason. |
+| **Permitted by HTML LS** | nu over-detecting. | Record in `excluded-ids.json` (per-ID or pattern; see below). After edit, `yarn bench:compare` — fixture should flip to `nu-over`. |
 | **Ambiguous / under discussion** | Spec issue or PR ongoing. | Note the spec-tracker URL in `snapshots/diff/summary.md` follow-up. Do not silently close. |
+
+markuplint's reference scope is HTML Living Standard + WAI-ARIA +
+URL Living Standard. Anything nu enforces from a WICG draft, a
+vendor extension, or any other spec outside that set is treated
+as deferred coverage — eligible for `excluded-ids.json` only if
+an Issue tracks the future implementation.
 
 When the spec disagrees with **both** tools (recent normative
 revision neither has adopted), open one Issue per tool but pursue
@@ -164,6 +171,15 @@ When the same diagnostic hits many fixtures, use `patterns[]`
 
 `specUrl` is required on patterns — they are the most load-bearing
 exclusion. If you cannot cite a paragraph, use a per-`id` entry.
+
+Patterns trade compactness for stability: per-`id` entries pin the
+nu message-ID hash, so a wording shift in nu surfaces as a stale
+entry on the next bench refresh (the entry stops matching and the
+fixture reappears in `nu-only`). Patterns key on message text, so
+a wording shift silently drops them out of effect. For deferred-spec
+batches (10+ fixtures driven by an Issue), prefer patterns but record
+the expected `nu-over` headcount in the reason field so pre-release
+bench refreshes can spot drift.
 
 After editing `excluded-ids.json`:
 

--- a/tests/external/snapshots/diff/coverage.json
+++ b/tests/external/snapshots/diff/coverage.json
@@ -6187,9 +6187,9 @@
 		{
 			"path": "html-aria/setsize-posinset-level/testcase-769.html",
 			"category": "aria",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "error",
-			"verdict": "match-error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -15701,9 +15701,9 @@
 		{
 			"path": "html/elements/area/download-isvalid.html",
 			"category": "invalid-attr",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "error",
-			"verdict": "ml-only",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -24496,8 +24496,8 @@
 			"path": "html/elements/img/sizes-without-srcset-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -25322,8 +25322,8 @@
 			"path": "html/elements/input/autocomplete-webauthn-only-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -25554,8 +25554,8 @@
 			"path": "html/elements/input/name-isindex-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -30156,8 +30156,8 @@
 			"path": "html/elements/link/alternate-stylesheet-without-title-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -30188,8 +30188,8 @@
 			"path": "html/elements/link/disabled-without-stylesheet-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -32405,10 +32405,12 @@
 		{
 			"path": "html/elements/object/type-only-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-785400222871"
+			]
 		},
 		{
 			"path": "html/elements/ol/model-isvalid.html",
@@ -32782,8 +32784,8 @@
 			"path": "html/elements/picture/img-with-sizes-no-srcset-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -34062,32 +34064,32 @@
 			"path": "html/elements/picture/srcset-microsyntax-unique-descriptors-1x-and-omitted-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
 			"path": "html/elements/picture/srcset-microsyntax-unique-descriptors-2x-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
 			"path": "html/elements/picture/srcset-microsyntax-unique-descriptors-integer-and-decimals-x-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
 			"path": "html/elements/picture/srcset-microsyntax-unique-descriptors-w-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -34254,8 +34256,8 @@
 			"path": "html/elements/progress/value-negative-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -35511,18 +35513,22 @@
 		{
 			"path": "html/elements/script/speculationrules-and-empty-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-2d05eb740ea1"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules-and-not-array-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-ffb7b0802b96"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules-complex-with-arrays-isvalid.html",
@@ -35535,26 +35541,32 @@
 		{
 			"path": "html/elements/script/speculationrules-document-missing-where-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-eba9b39992b3"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules-document-with-urls-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-e4f280547930"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules-eagerness-not-string-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-1aa1a7651199"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules-href-matches-array-isvalid.html",
@@ -35567,26 +35579,32 @@
 		{
 			"path": "html/elements/script/speculationrules-href-matches-empty-array-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-91eedf90678b"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules-href-matches-empty-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-3726177f55dd"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules-href-matches-not-string-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-7b3a72419899"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules-inferred-source-document-isvalid.html",
@@ -35615,98 +35633,122 @@
 		{
 			"path": "html/elements/script/speculationrules-invalid-eagerness-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-56a4bd14c073"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules-invalid-json-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-67ce6bae6dfa"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules-invalid-property-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-db1dd7e71b6d"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules-invalid-source-value-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-9272f3df3931"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules-list-missing-urls-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-6e918dafe95a"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules-list-with-where-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-2bed56dc7103"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules-missing-prefetch-prerender-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-ed4428d7c7b8"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules-missing-source-urls-where-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-897112884fef"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules-not-object-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-c4dbbb29b496"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules-prefetch-not-array-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-a0733157f4a6"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules-rule-invalid-property-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-5aceb9ca670f"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules-rule-not-object-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-f06c2faed408"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules-selector-matches-array-isvalid.html",
@@ -35719,58 +35761,72 @@
 		{
 			"path": "html/elements/script/speculationrules-selector-matches-empty-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-69d0c3ff01f7"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules-selector-matches-not-string-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-9a27f02ee3f4"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules-source-not-string-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-11f6ff44ec77"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules-urls-empty-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-ab2ce085d332"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules-urls-empty-string-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-49dc77882497"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules-urls-item-not-string-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-12de65ecfe17"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules-urls-not-array-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-f5ad73f01a88"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules-valid-document-isvalid.html",
@@ -35791,26 +35847,32 @@
 		{
 			"path": "html/elements/script/speculationrules-where-empty-predicate-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-b389111680c0"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules-where-multiple-predicates-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-064d4ab3a71a"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules-where-not-object-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-1f5bbec4e8d6"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules-with-async-novalid.html",
@@ -35882,7 +35944,9 @@
 			"nu": "error",
 			"ml": "error",
 			"verdict": "match-error",
-			"excludedIds": []
+			"excludedIds": [
+				"nv-ff2842bef763"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules/async-novalid.html",
@@ -35935,34 +35999,42 @@
 		{
 			"path": "html/elements/script/speculationrules/document-without-where-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-8d601bd4f3eb"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules/empty-and-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-14bc386f66c5"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules/empty-object-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-e61699ad5ac8"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules/empty-urls-array-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-3a085f550de4"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules/fetchpriority-novalid.html",
@@ -35999,50 +36071,62 @@
 		{
 			"path": "html/elements/script/speculationrules/invalid-eagerness-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-e0ae7e3c0f58"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules/invalid-property-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-ad54379a20df"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules/invalid-source-value-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-9200aa197c81"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules/list-with-where-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-ac8241a880ba"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules/list-without-urls-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-615f9e6076b5"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules/multiple-predicates-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-356357ce7aa5"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules/nomodule-novalid.html",
@@ -36055,10 +36139,12 @@
 		{
 			"path": "html/elements/script/speculationrules/not-json-novalid.html",
 			"category": "invalid-attr",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "clean",
-			"verdict": "nu-only",
-			"excludedIds": []
+			"verdict": "nu-over",
+			"excludedIds": [
+				"nv-4e1c6d820ff7"
+			]
 		},
 		{
 			"path": "html/elements/script/speculationrules/prefetch-list-valid.html",
@@ -36130,7 +36216,9 @@
 			"nu": "error",
 			"ml": "error",
 			"verdict": "match-error",
-			"excludedIds": []
+			"excludedIds": [
+				"nv-be060635eed1"
+			]
 		},
 		{
 			"path": "html/elements/script/src-empty-novalid.html",

--- a/tests/external/snapshots/diff/markuplint-only.json
+++ b/tests/external/snapshots/diff/markuplint-only.json
@@ -1019,6 +1019,13 @@
 			]
 		},
 		{
+			"path": "html-aria/setsize-posinset-level/testcase-769.html",
+			"category": "aria",
+			"ruleIds": [
+				"wai-aria-required-parent-role"
+			]
+		},
+		{
 			"path": "html-its/allowedcharacters/html/allowedcharacters1html.html",
 			"category": "uncategorized",
 			"ruleIds": [
@@ -7124,13 +7131,6 @@
 			"category": "invalid-attr",
 			"ruleIds": [
 				"deprecated-attr"
-			]
-		},
-		{
-			"path": "html/elements/area/download-isvalid.html",
-			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
 			]
 		},
 		{

--- a/tests/external/snapshots/diff/nu-only.json
+++ b/tests/external/snapshots/diff/nu-only.json
@@ -4,7 +4,7 @@
 			"path": "html-aria/author-requirements/574.html",
 			"category": "aria",
 			"nuMessageIds": [
-				"nv-374285ecf319"
+				"nv-73b3fce3b363"
 			]
 		},
 		{
@@ -155,13 +155,6 @@
 			]
 		},
 		{
-			"path": "html/elements/img/sizes-without-srcset-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-a671e8696e31"
-			]
-		},
-		{
 			"path": "html/elements/img/usemap-invalid-reference-novalid.html",
 			"category": "invalid-attr",
 			"nuMessageIds": [
@@ -176,13 +169,6 @@
 			]
 		},
 		{
-			"path": "html/elements/input/autocomplete-webauthn-only-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-462837b137bf"
-			]
-		},
-		{
 			"path": "html/elements/input/list-not-datalist-novalid.html",
 			"category": "invalid-attr",
 			"nuMessageIds": [
@@ -194,13 +180,6 @@
 			"category": "invalid-attr",
 			"nuMessageIds": [
 				"nv-5b40a940f6c9"
-			]
-		},
-		{
-			"path": "html/elements/input/name-isindex-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-7ddc0016467c"
 			]
 		},
 		{
@@ -246,20 +225,6 @@
 			]
 		},
 		{
-			"path": "html/elements/link/alternate-stylesheet-without-title-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-ae73b462598b"
-			]
-		},
-		{
-			"path": "html/elements/link/disabled-without-stylesheet-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-26b90eaa8207"
-			]
-		},
-		{
 			"path": "html/elements/meta/content-security-policy/csp-invalid-directive-haswarn.html",
 			"category": "invalid-attr",
 			"nuMessageIds": [
@@ -285,13 +250,6 @@
 			"category": "invalid-attr",
 			"nuMessageIds": [
 				"nv-006f6fbfb136"
-			]
-		},
-		{
-			"path": "html/elements/object/type-only-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-785400222871"
 			]
 		},
 		{
@@ -349,13 +307,6 @@
 			"nuMessageIds": [
 				"nv-3ade6b2bf3d6",
 				"nv-aca994a28b46"
-			]
-		},
-		{
-			"path": "html/elements/picture/img-with-sizes-no-srcset-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-f12d9461757f"
 			]
 		},
 		{
@@ -423,34 +374,6 @@
 			]
 		},
 		{
-			"path": "html/elements/picture/srcset-microsyntax-unique-descriptors-1x-and-omitted-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-8f1eb639ef74"
-			]
-		},
-		{
-			"path": "html/elements/picture/srcset-microsyntax-unique-descriptors-2x-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-f16ee35b7cae"
-			]
-		},
-		{
-			"path": "html/elements/picture/srcset-microsyntax-unique-descriptors-integer-and-decimals-x-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-5b3ec352d449"
-			]
-		},
-		{
-			"path": "html/elements/picture/srcset-microsyntax-unique-descriptors-w-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-902400df810a"
-			]
-		},
-		{
 			"path": "html/elements/progress/value-exceeds-max-novalid.html",
 			"category": "invalid-attr",
 			"nuMessageIds": [
@@ -462,13 +385,6 @@
 			"category": "invalid-attr",
 			"nuMessageIds": [
 				"nv-077fa3dae0ce"
-			]
-		},
-		{
-			"path": "html/elements/progress/value-negative-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-077a46fbc254"
 			]
 		},
 		{
@@ -647,216 +563,6 @@
 			]
 		},
 		{
-			"path": "html/elements/script/speculationrules-and-empty-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-2d05eb740ea1"
-			]
-		},
-		{
-			"path": "html/elements/script/speculationrules-and-not-array-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-ffb7b0802b96"
-			]
-		},
-		{
-			"path": "html/elements/script/speculationrules-document-missing-where-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-eba9b39992b3"
-			]
-		},
-		{
-			"path": "html/elements/script/speculationrules-document-with-urls-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-e4f280547930"
-			]
-		},
-		{
-			"path": "html/elements/script/speculationrules-eagerness-not-string-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-1aa1a7651199"
-			]
-		},
-		{
-			"path": "html/elements/script/speculationrules-href-matches-empty-array-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-91eedf90678b"
-			]
-		},
-		{
-			"path": "html/elements/script/speculationrules-href-matches-empty-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-3726177f55dd"
-			]
-		},
-		{
-			"path": "html/elements/script/speculationrules-href-matches-not-string-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-7b3a72419899"
-			]
-		},
-		{
-			"path": "html/elements/script/speculationrules-invalid-eagerness-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-56a4bd14c073"
-			]
-		},
-		{
-			"path": "html/elements/script/speculationrules-invalid-json-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-67ce6bae6dfa"
-			]
-		},
-		{
-			"path": "html/elements/script/speculationrules-invalid-property-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-db1dd7e71b6d"
-			]
-		},
-		{
-			"path": "html/elements/script/speculationrules-invalid-source-value-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-9272f3df3931"
-			]
-		},
-		{
-			"path": "html/elements/script/speculationrules-list-missing-urls-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-6e918dafe95a"
-			]
-		},
-		{
-			"path": "html/elements/script/speculationrules-list-with-where-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-2bed56dc7103"
-			]
-		},
-		{
-			"path": "html/elements/script/speculationrules-missing-prefetch-prerender-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-ed4428d7c7b8"
-			]
-		},
-		{
-			"path": "html/elements/script/speculationrules-missing-source-urls-where-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-897112884fef"
-			]
-		},
-		{
-			"path": "html/elements/script/speculationrules-not-object-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-c4dbbb29b496"
-			]
-		},
-		{
-			"path": "html/elements/script/speculationrules-prefetch-not-array-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-a0733157f4a6"
-			]
-		},
-		{
-			"path": "html/elements/script/speculationrules-rule-invalid-property-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-5aceb9ca670f"
-			]
-		},
-		{
-			"path": "html/elements/script/speculationrules-rule-not-object-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-f06c2faed408"
-			]
-		},
-		{
-			"path": "html/elements/script/speculationrules-selector-matches-empty-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-69d0c3ff01f7"
-			]
-		},
-		{
-			"path": "html/elements/script/speculationrules-selector-matches-not-string-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-9a27f02ee3f4"
-			]
-		},
-		{
-			"path": "html/elements/script/speculationrules-source-not-string-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-11f6ff44ec77"
-			]
-		},
-		{
-			"path": "html/elements/script/speculationrules-urls-empty-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-ab2ce085d332"
-			]
-		},
-		{
-			"path": "html/elements/script/speculationrules-urls-empty-string-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-49dc77882497"
-			]
-		},
-		{
-			"path": "html/elements/script/speculationrules-urls-item-not-string-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-12de65ecfe17"
-			]
-		},
-		{
-			"path": "html/elements/script/speculationrules-urls-not-array-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-f5ad73f01a88"
-			]
-		},
-		{
-			"path": "html/elements/script/speculationrules-where-empty-predicate-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-b389111680c0"
-			]
-		},
-		{
-			"path": "html/elements/script/speculationrules-where-multiple-predicates-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-064d4ab3a71a"
-			]
-		},
-		{
-			"path": "html/elements/script/speculationrules-where-not-object-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-1f5bbec4e8d6"
-			]
-		},
-		{
 			"path": "html/elements/script/speculationrules-with-crossorigin-novalid.html",
 			"category": "invalid-attr",
 			"nuMessageIds": [
@@ -878,87 +584,10 @@
 			]
 		},
 		{
-			"path": "html/elements/script/speculationrules/document-without-where-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-8d601bd4f3eb"
-			]
-		},
-		{
-			"path": "html/elements/script/speculationrules/empty-and-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-14bc386f66c5"
-			]
-		},
-		{
-			"path": "html/elements/script/speculationrules/empty-object-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-e61699ad5ac8"
-			]
-		},
-		{
-			"path": "html/elements/script/speculationrules/empty-urls-array-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-3a085f550de4"
-			]
-		},
-		{
 			"path": "html/elements/script/speculationrules/fetchpriority-novalid.html",
 			"category": "invalid-attr",
 			"nuMessageIds": [
 				"nv-81b907c64826"
-			]
-		},
-		{
-			"path": "html/elements/script/speculationrules/invalid-eagerness-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-e0ae7e3c0f58"
-			]
-		},
-		{
-			"path": "html/elements/script/speculationrules/invalid-property-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-ad54379a20df"
-			]
-		},
-		{
-			"path": "html/elements/script/speculationrules/invalid-source-value-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-9200aa197c81"
-			]
-		},
-		{
-			"path": "html/elements/script/speculationrules/list-with-where-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-ac8241a880ba"
-			]
-		},
-		{
-			"path": "html/elements/script/speculationrules/list-without-urls-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-615f9e6076b5"
-			]
-		},
-		{
-			"path": "html/elements/script/speculationrules/multiple-predicates-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-356357ce7aa5"
-			]
-		},
-		{
-			"path": "html/elements/script/speculationrules/not-json-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-4e1c6d820ff7"
 			]
 		},
 		{

--- a/tests/external/snapshots/diff/nu-over.json
+++ b/tests/external/snapshots/diff/nu-over.json
@@ -141,10 +141,304 @@
 			]
 		},
 		{
+			"path": "html/elements/object/type-only-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-785400222871"
+			]
+		},
+		{
 			"path": "html/elements/q/cite/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
 			"nuMessageIds": [
 				"nv-3cd607b1d358"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules-and-empty-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-2d05eb740ea1"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules-and-not-array-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-ffb7b0802b96"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules-document-missing-where-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-eba9b39992b3"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules-document-with-urls-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-e4f280547930"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules-eagerness-not-string-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-1aa1a7651199"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules-href-matches-empty-array-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-91eedf90678b"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules-href-matches-empty-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-3726177f55dd"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules-href-matches-not-string-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-7b3a72419899"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules-invalid-eagerness-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-56a4bd14c073"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules-invalid-json-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-67ce6bae6dfa"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules-invalid-property-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-db1dd7e71b6d"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules-invalid-source-value-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-9272f3df3931"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules-list-missing-urls-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-6e918dafe95a"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules-list-with-where-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-2bed56dc7103"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules-missing-prefetch-prerender-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-ed4428d7c7b8"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules-missing-source-urls-where-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-897112884fef"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules-not-object-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-c4dbbb29b496"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules-prefetch-not-array-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-a0733157f4a6"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules-rule-invalid-property-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-5aceb9ca670f"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules-rule-not-object-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-f06c2faed408"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules-selector-matches-empty-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-69d0c3ff01f7"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules-selector-matches-not-string-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-9a27f02ee3f4"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules-source-not-string-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-11f6ff44ec77"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules-urls-empty-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-ab2ce085d332"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules-urls-empty-string-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-49dc77882497"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules-urls-item-not-string-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-12de65ecfe17"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules-urls-not-array-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-f5ad73f01a88"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules-where-empty-predicate-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-b389111680c0"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules-where-multiple-predicates-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-064d4ab3a71a"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules-where-not-object-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-1f5bbec4e8d6"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules/document-without-where-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-8d601bd4f3eb"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules/empty-and-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-14bc386f66c5"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules/empty-object-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-e61699ad5ac8"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules/empty-urls-array-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-3a085f550de4"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules/invalid-eagerness-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-e0ae7e3c0f58"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules/invalid-property-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-ad54379a20df"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules/invalid-source-value-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-9200aa197c81"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules/list-with-where-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-ac8241a880ba"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules/list-without-urls-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-615f9e6076b5"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules/multiple-predicates-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-356357ce7aa5"
+			]
+		},
+		{
+			"path": "html/elements/script/speculationrules/not-json-novalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-4e1c6d820ff7"
 			]
 		},
 		{

--- a/tests/external/snapshots/diff/summary.md
+++ b/tests/external/snapshots/diff/summary.md
@@ -1,33 +1,33 @@
 # nu-validator Benchmark Summary
 
-- generated: 2026-05-15T03:19:36.200Z
+- generated: 2026-05-17T03:23:23.494Z
 - submodule: `142931395412c00434ffb40a14d65992efd17aa8`
-- nu-validator: `ghcr.io/validator/validator@sha256:d16a53211ea8617b13a0c7f87e9d0cf4058e4ab729482dd3dfebade9bb4b6671`
+- nu-validator: `ghcr.io/validator/validator@sha256:b36e0da34a71a21e742a7336198a3404b6d737401098eaf9c945024bb51ae5be`
 - markuplint: `5.0.0-rc.4`
 - node: `24.14.1`
 
 ## Totals
 
 - files: **5442**
-- match-error: **3357** (both tools flagged)
+- match-error: **3368** (both tools flagged)
 - match-clean: **919** (neither flagged)
-- nu-only: **157** (only nu-validator flagged; markuplint coverage candidates — open a markuplint issue after a spec read)
-- nu-over: **28** (nu-validator errors fully covered by spec-backed excluded-ids — confirmed over-detection)
-- overall match rate: **78.6%**
-- excluded-ids: 3 entries, 1 pattern(s)
+- nu-only: **104** (only nu-validator flagged; markuplint coverage candidates — open a markuplint issue after a spec read)
+- nu-over: **70** (nu-validator errors fully covered by spec-backed excluded-ids — confirmed over-detection)
+- overall match rate: **78.8%**
+- excluded-ids: 4 entries, 8 pattern(s)
 
 ## Per-Category
 
 | Category | Files | Match rate | match-error | match-clean | ml-only | nu-only | nu-over |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| aria | 780 | 80.4% | 175 | 452 | 145 | 8 | 0 |
+| aria | 780 | 80.3% | 174 | 452 | 146 | 8 | 0 |
 | assertions | 40 | 100.0% | 39 | 1 | 0 | 0 | 0 |
 | content-model | 98 | 98.0% | 48 | 48 | 0 | 2 | 0 |
 | data-types | 56 | 94.6% | 48 | 5 | 1 | 2 | 0 |
 | deprecated | 12 | 91.7% | 11 | 0 | 1 | 0 | 0 |
 | global-attr | 57 | 80.7% | 26 | 20 | 8 | 3 | 0 |
 | id-duplication | 1 | 100.0% | 1 | 0 | 0 | 0 | 0 |
-| invalid-attr | 3086 | 92.8% | 2633 | 230 | 61 | 136 | 26 |
+| invalid-attr | 3086 | 93.2% | 2645 | 230 | 60 | 83 | 68 |
 | required-attr | 5 | 100.0% | 5 | 0 | 0 | 0 | 0 |
 | uncategorized | 1307 | 40.9% | 371 | 163 | 765 | 6 | 2 |
 
@@ -39,7 +39,7 @@
 
 | Rule | Count |
 | --- | ---: |
-| invalid-attr | 708 |
+| invalid-attr | 707 |
 | permitted-contents | 444 |
 | deprecated-attr | 354 |
 | wai-aria-disallowed-props | 121 |

--- a/tests/external/snapshots/excluded-ids.json
+++ b/tests/external/snapshots/excluded-ids.json
@@ -48,7 +48,7 @@
 		},
 		{
 			"messageContains": "speculation rule",
-			"reason": "Speculation Rules is a WICG draft (https://wicg.github.io/nav-speculation/speculation-rules.html), not part of HTML Living Standard. markuplint's reference scope is HTML LS + ARIA + URL LS, so nu-validator enforcing the WICG schema counts as over-detection from markuplint's perspective. Coverage is tracked at https://github.com/markuplint/markuplint/issues/3882 — once implemented, this pattern should be removed.",
+			"reason": "Speculation Rules is a WICG draft (https://wicg.github.io/nav-speculation/speculation-rules.html), not part of HTML Living Standard. markuplint's reference scope is HTML LS + ARIA + URL LS, so nu-validator enforcing the WICG schema counts as over-detection from markuplint's perspective. This adds a deferred-WICG subclass of `nu-over` (distinct from the existing `nu-over` cases where nu over-interprets HTML LS itself). Coverage tracked at https://github.com/markuplint/markuplint/issues/3882 — when implementation lands, **remove all 7 SR-related patterns** (`speculation rule`, `document rule`, `“speculationrules” must have valid JSON`, `“speculationrules” must contain a JSON`, `“prefetch” array`, `“prefetch” property within`, `in the “urls” array`) and the 41 fixtures will flip to `match-error`. Stale-detection note: patterns match message text, so if nu changes wording the patterns silently fall out of effect — confirm `nu-over` SR count stays ~41 in pre-release bench refreshes.",
 			"specUrl": "https://wicg.github.io/nav-speculation/speculation-rules.html",
 			"addedAt": "2026-05-17",
 			"addedBy": "hirao"

--- a/tests/external/snapshots/excluded-ids.json
+++ b/tests/external/snapshots/excluded-ids.json
@@ -45,6 +45,55 @@
 			"specUrl": "https://url.spec.whatwg.org/#url-writing",
 			"addedAt": "2026-04-23",
 			"addedBy": "hirao"
+		},
+		{
+			"messageContains": "speculation rule",
+			"reason": "Speculation Rules is a WICG draft (https://wicg.github.io/nav-speculation/speculation-rules.html), not part of HTML Living Standard. markuplint's reference scope is HTML LS + ARIA + URL LS, so nu-validator enforcing the WICG schema counts as over-detection from markuplint's perspective. Coverage is tracked at https://github.com/markuplint/markuplint/issues/3882 — once implemented, this pattern should be removed.",
+			"specUrl": "https://wicg.github.io/nav-speculation/speculation-rules.html",
+			"addedAt": "2026-05-17",
+			"addedBy": "hirao"
+		},
+		{
+			"messageContains": "document rule",
+			"reason": "Speculation Rules `where` predicate terminology — see the Speculation Rules pattern above for the full rationale and tracking issue.",
+			"specUrl": "https://wicg.github.io/nav-speculation/speculation-rules.html",
+			"addedAt": "2026-05-17",
+			"addedBy": "hirao"
+		},
+		{
+			"messageContains": "“speculationrules” must have valid JSON",
+			"reason": "Catches `<script type=speculationrules>` JSON syntax errors (`must have valid JSON content`). Distinct from `must not have a ... attribute` which is HTML LS scope. See the Speculation Rules pattern above for rationale and tracking issue.",
+			"specUrl": "https://wicg.github.io/nav-speculation/speculation-rules.html",
+			"addedAt": "2026-05-17",
+			"addedBy": "hirao"
+		},
+		{
+			"messageContains": "“speculationrules” must contain a JSON",
+			"reason": "Catches `<script type=speculationrules>` JSON shape errors (`must contain a JSON object with...`). See the Speculation Rules pattern above for rationale and tracking issue.",
+			"specUrl": "https://wicg.github.io/nav-speculation/speculation-rules.html",
+			"addedAt": "2026-05-17",
+			"addedBy": "hirao"
+		},
+		{
+			"messageContains": "“prefetch” array",
+			"reason": "Speculation Rules top-level `prefetch` array shape validation — see the Speculation Rules pattern above for rationale and tracking issue.",
+			"specUrl": "https://wicg.github.io/nav-speculation/speculation-rules.html",
+			"addedAt": "2026-05-17",
+			"addedBy": "hirao"
+		},
+		{
+			"messageContains": "“prefetch” property within",
+			"reason": "Speculation Rules `prefetch` property type validation (must be a JSON array) — see the Speculation Rules pattern above for rationale and tracking issue.",
+			"specUrl": "https://wicg.github.io/nav-speculation/speculation-rules.html",
+			"addedAt": "2026-05-17",
+			"addedBy": "hirao"
+		},
+		{
+			"messageContains": "in the “urls” array",
+			"reason": "Speculation Rules `urls` array item-type validation (non-empty string) — see the Speculation Rules pattern above for rationale and tracking issue.",
+			"specUrl": "https://wicg.github.io/nav-speculation/speculation-rules.html",
+			"addedAt": "2026-05-17",
+			"addedBy": "hirao"
 		}
 	]
 }

--- a/tests/external/snapshots/meta.json
+++ b/tests/external/snapshots/meta.json
@@ -1,12 +1,12 @@
 {
-	"generatedAt": "2026-05-15T03:19:36.200Z",
+	"generatedAt": "2026-05-17T03:23:23.494Z",
 	"submoduleSha": "142931395412c00434ffb40a14d65992efd17aa8",
-	"nuValidatorImage": "ghcr.io/validator/validator@sha256:d16a53211ea8617b13a0c7f87e9d0cf4058e4ab729482dd3dfebade9bb4b6671",
+	"nuValidatorImage": "ghcr.io/validator/validator@sha256:b36e0da34a71a21e742a7336198a3404b6d737401098eaf9c945024bb51ae5be",
 	"markuplintVersion": "5.0.0-rc.4",
 	"nodeVersion": "24.14.1",
 	"totalFilesNu": 5442,
 	"totalFilesMl": 5442,
-	"totalNuMessages": 9905,
-	"totalMlViolations": 11244,
+	"totalNuMessages": 9907,
+	"totalMlViolations": 11257,
 	"totalNuFailures": 0
 }


### PR DESCRIPTION
## Summary

[Speculation Rules](https://wicg.github.io/nav-speculation/speculation-rules.html) is a WICG draft API, **not part of HTML Living Standard**. markuplint's reference scope is HTML LS + ARIA + URL LS, so nu-validator enforcing the WICG JSON schema counts as over-detection from markuplint's perspective.

This PR adds 7 `excluded-ids.json` patterns covering the Speculation Rules JSON-content validation messages. 41 SR JSON-content fixtures flip from `nu-only` to `nu-over` (a *deferred-WICG* subclass of `nu-over`).

Future coverage tracked at **#3882** — when implementation lands, all 7 patterns should be removed and the fixtures will flip to `match-error`.

### Patterns

| Pattern | Coverage |
| --- | --- |
| `speculation rule` | Generic SR validation phrasing (~18 messages) |
| `document rule` | SR `where` predicate terminology (~12) |
| `"speculationrules" must have valid JSON` | JSON syntax errors |
| `"speculationrules" must contain a JSON` | JSON shape errors |
| `"prefetch" array` | Top-level prefetch array shape |
| `"prefetch" property within` | Prefetch property type |
| `in the "urls" array` | urls array item validation |

### Carefully scoped out

The 4 remaining SR fixtures (`crossorigin` / `fetchpriority` attribute restrictions on `type=speculationrules`) **stay in `nu-only`** because the script-element attribute restrictions are spelled out in HTML LS itself, not the WICG draft. Future Bucket B markuplint rules should cover them.

## SKILL update bundled

`.claude/skills/bench-triage/SKILL.md` Step 5 table now distinguishes:

- **Forbidden (HTML LS / ARIA / URL LS)** → Add rule / Issue, stays nu-only until fix
- **Forbidden, but spec is outside markuplint's reference scope** → Issue + excluded-ids pattern with `deferred-<spec>` reason (this PR's case)
- **Permitted by HTML LS** → excluded-ids → nu-over (regular)
- **Ambiguous** → summary.md follow-up

And the patterns section now notes pattern vs per-ID stability trade-off.

## Bench delta

| Metric | Before | After | Δ |
| --- | ---: | ---: | ---: |
| match-error | 3368 | 3368 | 0 |
| match-clean | 919 | 919 | 0 |
| ml-only | 981 | 981 | 0 |
| **nu-only** | **145** | **104** | **-41** |
| **nu-over** | **29** | **70** | **+41** |

No false-positive regression. Match rate ~79.4%.

## Test plan

- [x] Each pattern verified to NOT over-match outside `script/speculationrules*` paths (in-SR vs out-SR scan)
- [x] `yarn bench:update:ml` shows match-error / ml-only unchanged after exclusion
- [x] 4 attribute-restriction SR fixtures correctly stay in `nu-only` (HTML LS scope)
- [x] SKILL update reviewed for backward compatibility (existing entries still match the table)