### PR TITLE
feat(html-spec): add shadowrootslotassignment + customelementregistry on template

### DIFF
--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -55290,7 +55290,8 @@
 					"type": "Boolean"
 				},
 				"shadowrootcustomelementregistry": {
-					"description": "Sets the customElementRegistry property of a ShadowRoot created using this element to null, rather than the document's custom element registry. This allows a scoped CustomElementRegistry to be attached later using CustomElementRegistry.initialize()."
+					"description": "Sets the customElementRegistry property of a ShadowRoot created using this element to null, rather than the document's custom element registry. This allows a scoped CustomElementRegistry to be attached later using CustomElementRegistry.initialize().",
+					"type": "Boolean"
 				},
 				"shadowrootdelegatesfocus": {
 					"description": "Sets the value of the delegatesFocus property of a ShadowRoot created using this element to true. If this is set and a non-focusable element in the shadow tree is selected, then focus is delegated to the first focusable element in the tree. The value defaults to false.",
@@ -55313,6 +55314,14 @@
 				"shadowrootserializable": {
 					"description": "Sets the value of the serializable property of a ShadowRoot created using this element to true. If set, the shadow root may be serialized by calling the Element.getHTML() or ShadowRoot.getHTML() methods with the options.serializableShadowRoots parameter set true. The value defaults to false.",
 					"type": "Boolean"
+				},
+				"shadowrootslotassignment": {
+					"description": "Sets the slotAssignment property of a ShadowRoot created using this element. This is the declarative equivalent of the slotAssignment option of the Element.attachShadow() method. named Elements are automatically assigned to <slot> elements within this shadow root. This is the default value. Elements with the slot attribute are assigned to the first <slot> in the template that has the corresponding name attribute. If multiple elements specify the same slot name, they are all added to the first slot in the template that has that name, and rendered in the order they are declared. All unnamed elements — elements that don't specify a slot attribute — are assigned to the default slot in the order they are declared. This is the first unnamed <slot> in the template. manual Elements are manually assigned to particular slot elements using HTMLSlotElement.assign(). No automatic assignment takes place.",
+					"type": {
+						"enum": ["named", "manual"],
+						"missingValueDefault": "named",
+						"invalidValueDefault": "named"
+					}
 				}
 			}
 		},

--- a/packages/@markuplint/html-spec/src/spec.template.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.template.jsonc
@@ -23,12 +23,24 @@
 		"shadowrootdelegatesfocus": {
 			"type": "Boolean"
 		},
+		// https://html.spec.whatwg.org/multipage/scripting.html#attr-template-shadowrootslotassignment
+		"shadowrootslotassignment": {
+			"type": {
+				"enum": ["named", "manual"],
+				"missingValueDefault": "named",
+				"invalidValueDefault": "named"
+			}
+		},
 		// https://html.spec.whatwg.org/multipage/scripting.html#attr-template-shadowrootclonable
 		"shadowrootclonable": {
 			"type": "Boolean"
 		},
 		// https://html.spec.whatwg.org/multipage/scripting.html#attr-template-shadowrootserializable
 		"shadowrootserializable": {
+			"type": "Boolean"
+		},
+		// https://html.spec.whatwg.org/multipage/scripting.html#attr-template-shadowrootcustomelementregistry
+		"shadowrootcustomelementregistry": {
 			"type": "Boolean"
 		},
 		// https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/template#shadowrootreferencetarget

--- a/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
+++ b/packages/@markuplint/rules/src/invalid-attr/index.spec.ts
@@ -3477,4 +3477,29 @@ describe('link[disabled] is only valid on rel="stylesheet" (HTML LS §4.6.7.18)'
 			true,
 		);
 	});
+
+	test('[invalid-attr-valid-051] template[shadowrootslotassignment="named"] is accepted', async () => {
+		const { violations } = await mlRuleTest(rule, '<template shadowrootslotassignment="named"></template>');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('[invalid-attr-valid-052] template[shadowrootslotassignment="manual"] is accepted', async () => {
+		const { violations } = await mlRuleTest(rule, '<template shadowrootslotassignment="manual"></template>');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('[invalid-attr-invalid-080] template[shadowrootslotassignment="auto"] is rejected (not in enum)', async () => {
+		const { violations } = await mlRuleTest(rule, '<template shadowrootslotassignment="auto"></template>');
+		expect(violations).toHaveLength(1);
+		expect(violations[0]).toMatchObject({
+			severity: 'error',
+			message: 'The "shadowrootslotassignment" attribute expects either "named", "manual"',
+			raw: 'auto',
+		});
+	});
+
+	test('[invalid-attr-valid-053] template[shadowrootcustomelementregistry] Boolean attribute is accepted', async () => {
+		const { violations } = await mlRuleTest(rule, '<template shadowrootcustomelementregistry></template>');
+		expect(violations).toStrictEqual([]);
+	});
 });


### PR DESCRIPTION
## Summary

- Add `shadowrootslotassignment` (enumerated: `named` / `manual`, missing/invalid value default: `named`) to the `<template>` element in `spec.template.jsonc` and `index.json`.
- Complete `shadowrootcustomelementregistry` on `<template>` with `type: "Boolean"` — the description was already present in `index.json` via past MDN auto-fetch, but the type information was missing.
- Add 4 regression tests in `invalid-attr/index.spec.ts` ([invalid-attr-valid-051..053] / [invalid-attr-invalid-080]) so a future revert of these spec entries surfaces visibly.

Both attributes are defined in the HTML Living Standard but were absent from the template element spec data tracked by markuplint:

- https://html.spec.whatwg.org/multipage/scripting.html#attr-template-shadowrootslotassignment
- https://html.spec.whatwg.org/multipage/scripting.html#attr-template-shadowrootcustomelementregistry

Pure additive change — no breaking change, no migration required.

## Test plan

- [x] `yarn build` — 39/39 packages succeed
- [x] `yarn lint-check` — 0 warnings / 0 errors (oxlint + oxfmt)
- [x] `yarn test` — 256/256 files, 4154 passed / 1 skipped
- [x] Targeted: `npx vitest run packages/@markuplint/rules/src/invalid-attr/index.spec.ts -t "shadowroot"` — 4 new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)