### PR TITLE
docs(rules): quote script-content README.ja.md frontmatter description

### DIFF
--- a/packages/@markuplint/rules/src/script-content/README.ja.md
+++ b/packages/@markuplint/rules/src/script-content/README.ja.md
@@ -1,6 +1,6 @@
 ---
 id: script-content
-description: `<script>` 要素の本文を、`type` 属性で示されたコンテンツ仕様に基づき検証します。
+description: '`<script>` 要素の本文を、`type` 属性で示されたコンテンツ仕様に基づき検証します。'
 ---
 
 # `script-content`


### PR DESCRIPTION
## Summary

The `description` value in `packages/@markuplint/rules/src/script-content/README.ja.md` frontmatter starts with a backtick, which is invalid YAML. The website prebuild (`gray-matter`) throws a `YAMLException`, so `yarn site:build` fails on `dev`:

```
YAMLException: end of the stream or a document separator is expected at line 3, column 14:
    description: `<script>` 要素の本文を、`type` 属性で示された ...
```

Wrap the value in single quotes (the established pattern for rule README frontmatter that starts with a backtick).

The English `README.md` is unaffected (its description does not start with a backtick). Swept all other rule READMEs (`grep '^description: \``) — this was the only instance.

## Verification

- `yarn site:build` completes successfully with this fix (previously failed at the prebuild step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)