### PR TITLE
fix(ml-core): stop accumulating duplicate mapping errors across setCode

### DIFF
--- a/packages/@markuplint/ml-core/src/ml-core.ts
+++ b/packages/@markuplint/ml-core/src/ml-core.ts
@@ -113,7 +113,17 @@ export class MLCore {
 	#schemas: MLSchema;
 	#ruleCommonSettings: RuleCommonSettings;
 	#sourceCode: string;
+	/**
+	 * Config-time errors (named-rule expansion, the `configErrors` fabric input).
+	 * Set once per construction/`update()` and never mutated by re-parsing.
+	 */
 	#configErrors: Error[];
+	/**
+	 * Rule-mapping errors for the CURRENT document. Reset (not accumulated) on
+	 * every `#createDocument()` so repeated `setCode()` calls don't duplicate
+	 * them. See https://github.com/markuplint/markuplint/issues/3900.
+	 */
+	#mappingErrors: Error[] = [];
 	/**
 	 * Pre-expansion nodeRules preserved for hot-reload.
 	 * When `update()` is called without a new ruleset, these are used as the
@@ -336,7 +346,7 @@ export class MLCore {
 			}
 		}
 
-		for (const error of this.#configErrors) {
+		for (const error of [...this.#configErrors, ...this.#mappingErrors]) {
 			configViolations.push({
 				ruleId: 'config-error',
 				severity: 'warning',
@@ -377,7 +387,7 @@ export class MLCore {
 				const originalSourceCode = this.#sourceCode;
 				const originalAst = this.#ast;
 				const originalDocument = this.#document;
-				const originalConfigErrorCount = this.#configErrors.length;
+				const originalMappingErrors = this.#mappingErrors;
 
 				try {
 					const fixResult = await this.#multiPassFix(violations);
@@ -392,14 +402,13 @@ export class MLCore {
 						};
 					}
 				} finally {
-					// Restore original state - verify() must be non-mutating
+					// Restore original state - verify() must be non-mutating.
+					// The fix loop re-parses, and each #createDocument resets
+					// #mappingErrors; restore it to the pre-fix document's.
 					this.#sourceCode = originalSourceCode;
 					this.#ast = originalAst;
 					this.#document = originalDocument;
-					// Re-parses during the fix loop re-run rule mapping, which
-					// appends duplicate mapping errors via #createDocument;
-					// truncate back to the pre-fix state.
-					this.#configErrors.length = originalConfigErrorCount;
+					this.#mappingErrors = originalMappingErrors;
 				}
 			} else {
 				fixedCode = this.#sourceCode;
@@ -418,6 +427,10 @@ export class MLCore {
 	}
 
 	#createDocument() {
+		// Reset up front: mapping errors belong to the document being (re)built,
+		// so a failed parse or build must not leave a previous document's errors
+		// behind. Repopulated below only on a successful build. See #3900.
+		this.#mappingErrors = [];
 		if (!this.#ast) {
 			return;
 		}
@@ -429,8 +442,11 @@ export class MLCore {
 				tagNameCaseSensitive: this.#parser.tagNameCaseSensitive,
 				pretenders: this.#pretenders,
 			});
-			// Collect errors from rule mapping (e.g., invalid wildcard usage)
-			this.#configErrors.push(...this.#ruleset.mappingErrors);
+			// Collect errors from rule mapping (e.g., invalid wildcard usage).
+			// Reset rather than append: the Document constructor regenerates
+			// `mappingErrors` on every call, so accumulating them would duplicate
+			// the same errors on each re-parse (e.g. via setCode). See #3900.
+			this.#mappingErrors = [...this.#ruleset.mappingErrors];
 			this.#ruleset.mappingErrors.length = 0;
 		} catch (error) {
 			if (error instanceof ParserError) {

--- a/packages/markuplint/src/api/ml-engine.spec.ts
+++ b/packages/markuplint/src/api/ml-engine.spec.ts
@@ -261,6 +261,65 @@ describe('#1862 configFile skips default config search', () => {
 	});
 });
 
+describe('#3900 config-error does not accumulate across setCode', () => {
+	it('reports the same config-error count on every re-evaluation of one engine', async () => {
+		const file = await MLEngine.toMLFile({ sourceCode: '<div id="a"></div>', name: 'a.html' });
+		// `a11y/*: true` is an invalid namespace-wildcard usage → one mapping error.
+		const engine = new MLEngine(file!, {
+			noSearchConfig: true,
+			config: {
+				extends: ['markuplint:a11y'],
+				nodeRules: [{ selector: 'div', rules: { 'a11y/*': true } }],
+			},
+		});
+
+		const countWildcardErrors = (violations?: ReadonlyArray<Violation>) =>
+			(violations ?? []).filter(v => v.ruleId === 'config-error' && v.message.includes('a11y/*')).length;
+
+		// Each code has exactly one matching <div>, so the wildcard config-error
+		// is reported once per evaluation. Before #3900 it was appended to the
+		// instance-lifetime error list on every setCode, growing 1 → 2 → 3.
+		const first = await engine.exec();
+		expect(countWildcardErrors(first?.violations)).toBe(1);
+
+		await engine.setCode('<div id="b"></div>');
+		const second = await engine.exec();
+		expect(countWildcardErrors(second?.violations)).toBe(1);
+
+		await engine.setCode('<div id="c"></div>');
+		const third = await engine.exec();
+		expect(countWildcardErrors(third?.violations)).toBe(1);
+	});
+
+	it('keeps the count stable across fixing runs of one engine', async () => {
+		// Fix mode runs the multi-pass loop, which re-creates the document
+		// several times per evaluation. This guards that that path does not
+		// reintroduce the accumulation: the config-error count must stay at 1
+		// across repeated fix-enabled evaluations of the same engine.
+		const file = await MLEngine.toMLFile({ sourceCode: "<div id='a'></div>", name: 'a.html' });
+		const engine = new MLEngine(file!, {
+			fix: true,
+			noSearchConfig: true,
+			config: {
+				extends: ['markuplint:a11y'],
+				// attr-value-quotes gives the fixer something to apply each run.
+				rules: { 'attr-value-quotes': true },
+				nodeRules: [{ selector: 'div', rules: { 'a11y/*': true } }],
+			},
+		});
+
+		const countWildcardErrors = (violations?: ReadonlyArray<Violation>) =>
+			(violations ?? []).filter(v => v.ruleId === 'config-error' && v.message.includes('a11y/*')).length;
+
+		const first = await engine.exec();
+		expect(countWildcardErrors(first?.violations)).toBe(1);
+
+		await engine.setCode("<div id='b'></div>");
+		const second = await engine.exec();
+		expect(countWildcardErrors(second?.violations)).toBe(1);
+	});
+});
+
 describe('Parse Error Severity', () => {
 	it('from config', async () => {
 		const file = await MLEngine.toMLFile({


### PR DESCRIPTION
## Summary

Closes #3900

`MLCore.#createDocument()` drained `ruleset.mappingErrors` into the instance-lifetime `#configErrors` array. The `Document` constructor regenerates those mapping errors on every call, so each `setCode()` (re-parse) appended another copy — a reused `MLCore`/`MLEngine` (the VS Code extension calls `engine.setCode()` on every edit) reported the same config-error once more per edit.

Found during the code review for the #3890/#3891 PR; that PR only patched the within-`verify()` amplification, leaving the `setCode()` path.

## Fix

- Split config-time errors from per-document mapping errors: `#configErrors` holds construction/`update()` errors only, and a new `#mappingErrors` holds the current document's mapping errors.
- `#createDocument()` resets `#mappingErrors` up front and repopulates it only on a successful build, so a failed parse can't leave a previous document's errors behind. `verify()` reports both arrays.
- Removed the #3890 verify() fix-loop workaround that truncated `#configErrors` back to its pre-fix length (re-parsing no longer mutates that array); the fix loop now saves/restores `#mappingErrors` for non-mutation.

## Tests

- Reuse one `MLEngine` across `setCode` calls with an invalid `a11y/*` wildcard nodeRule; the wildcard config-error count stays at 1 per evaluation (pre-fix: 1 → 2 → 3). Each code keeps exactly one matching `<div>` so per-node mapping-error multiplicity doesn't confound the check.
- A second case runs with `fix: true` to guard that the multi-pass loop's repeated document re-creation doesn't reintroduce the accumulation.
- Full suite: 4203 passed, typecheck clean; oxlint/oxfmt clean.

No public API, config, or documentation change — the user-facing config-error semantics in `docs/architectures/ERROR-HANDLING.md` are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)