### PR TITLE
feat(rules): validate `<script type="speculationrules">` content

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -188,6 +188,7 @@
 		"rcdata",
 		"tref",
 		"vkern",
+		"wicg",
 
 		// Typo
 		"verifing"

--- a/packages/@markuplint/config-presets/README.md
+++ b/packages/@markuplint/config-presets/README.md
@@ -63,7 +63,7 @@ Allow only **permitted contents**| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|
 Need **placeholder label option**| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
 Require the `datetime` attribute if the content of the `time` element is invalid| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
 Specify required attr| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
-[Validate `<script>` body against the spec selected by the `type` attribute (currently: `importmap`).](https://html.spec.whatwg.org/multipage/webappapis.html#parse-an-import-map-string)| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
+[Validate `<script>` body against the spec selected by the `type` attribute (currently: `importmap`, `speculationrules`).](https://html.spec.whatwg.org/multipage/webappapis.html#parse-an-import-map-string)| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
 [Enforce WHATWG constraints between `srcset`, `sizes`, and `loading` attributes](https://html.spec.whatwg.org/multipage/images.html#srcset-attributes)| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
 [Validate link type keywords](https://html.spec.whatwg.org/multipage/links.html#linkTypes)|Validates that `rel` attribute keywords are allowed on the given element and context (e.g., body-ok for `<link>` inside `<body>`).|✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
 [Form-associated `form` attribute must reference a form element](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fae-form)| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|

--- a/packages/@markuplint/config-presets/src/preset.html-standard.jsonc
+++ b/packages/@markuplint/config-presets/src/preset.html-standard.jsonc
@@ -206,9 +206,10 @@
 
 		/**
 		 * Validate `<script>` body against the spec selected by the `type` attribute
-		 * (currently: `importmap`).
+		 * (currently: `importmap`, `speculationrules`).
 		 *
 		 * @see https://html.spec.whatwg.org/multipage/webappapis.html#parse-an-import-map-string
+		 * @see https://html.spec.whatwg.org/multipage/speculative-loading.html
 		 */
 		"html-standard/script-content": {
 			"specConformance": "normative",

--- a/packages/@markuplint/rules/src/script-content/README.ja.md
+++ b/packages/@markuplint/rules/src/script-content/README.ja.md
@@ -9,9 +9,10 @@ description: '`<script>` 要素の本文を、`type` 属性で示されたコン
 
 現在対応しているコンテンツ形式:
 
-| `type` の値 | 仕様                                                                                                                                   |
-| ----------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `importmap` | [HTML Living Standard § Parse an import map string](https://html.spec.whatwg.org/multipage/webappapis.html#parse-an-import-map-string) |
+| `type` の値        | 仕様                                                                                                                                   |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `importmap`        | [HTML Living Standard § Parse an import map string](https://html.spec.whatwg.org/multipage/webappapis.html#parse-an-import-map-string) |
+| `speculationrules` | [HTML Living Standard § 7.6 Speculation rules](https://html.spec.whatwg.org/multipage/speculative-loading.html)                        |
 
 `type` 属性は ASCII 大文字小文字を区別せずに照合します（ユーザーエージェントの MIME タイプ判定に整合）。
 
@@ -64,6 +65,59 @@ description: '`<script>` 要素の本文を、`type` 属性で示されたコン
         "x": "./y.js"
       }
     }
+  }
+</script>
+```
+
+## `type="speculationrules"`
+
+[Speculation Rules](https://html.spec.whatwg.org/multipage/speculative-loading.html) は HTML Living Standard § 7.6 で定義されています（元は WICG `nav-speculation` ドラフトで、現在は HTML Standard へリダイレクトされます）。インラインの投機ルールに対して以下を違反として報告します。
+
+- 要素本文が空・空白のみ、または JSON としてパースできない
+- トップレベル値が JSON オブジェクトではない、または `prefetch` / `prerender` プロパティが存在しない
+- トップレベルに `tag` / `prefetch` / `prerender` 以外のキーが存在する
+- `prefetch` / `prerender` の値が JSON 配列ではない、またはその中のルールが JSON オブジェクトではない
+- ルールに `source` / `urls` / `where` / `relative_to` / `eagerness` / `referrer_policy` / `tag` / `requires` / `expects_no_vary_search` / `target_hint` 以外のキーが存在する
+- `source` が文字列ではない、または `list` / `document` 以外の値である
+- リストルール（明示または `urls` から推論）に `urls` がない、または `where` が存在する
+- ドキュメントルール（明示または `where` から推論）に `where` がない、または `urls` が存在する
+- ルールに `source` がなく source を推論できない（`urls` も `where` もない、または両方ある）
+- `urls` が JSON 配列ではない・空・非文字列または空文字列の要素を含む
+- `eagerness` が文字列ではない、または `immediate` / `eager` / `moderate` / `conservative` 以外の値である
+- `where` が JSON オブジェクトではない、または述語（`and` / `or` / `not` / `href_matches` / `selector_matches`）をちょうど 1 つ含まない
+- `and` / `or` 述語が JSON 配列ではない、または空である
+- `href_matches` / `selector_matches` のパターンが文字列でも文字列配列でもない・空・空文字列の要素を含む
+
+❌ このルールに適合しない**誤った**コードの例
+
+```html
+<script type="speculationrules">
+  {
+    "prefetch": [{ "source": "list" }]
+  }
+</script>
+<script type="speculationrules">
+  {
+    "prefetch": [{ "source": "document", "where": {} }]
+  }
+</script>
+```
+
+✅ このルールに適合する**正しい**コードの例
+
+```html
+<script type="speculationrules">
+  {
+    "prefetch": [
+      {
+        "source": "document",
+        "where": {
+          "and": [{ "href_matches": "/*" }, { "not": { "selector_matches": ".no-prefetch" } }]
+        },
+        "eagerness": "moderate"
+      }
+    ],
+    "prerender": [{ "source": "list", "urls": ["/next"] }]
   }
 </script>
 ```

--- a/packages/@markuplint/rules/src/script-content/README.md
+++ b/packages/@markuplint/rules/src/script-content/README.md
@@ -9,9 +9,10 @@ Validate the body of `<script>` elements against the spec that governs the value
 
 Currently supported content formats:
 
-| `type` value | Spec                                                                                                                                   |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `importmap`  | [HTML Living Standard § Parse an import map string](https://html.spec.whatwg.org/multipage/webappapis.html#parse-an-import-map-string) |
+| `type` value       | Spec                                                                                                                                   |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `importmap`        | [HTML Living Standard § Parse an import map string](https://html.spec.whatwg.org/multipage/webappapis.html#parse-an-import-map-string) |
+| `speculationrules` | [HTML Living Standard § 7.6 Speculation rules](https://html.spec.whatwg.org/multipage/speculative-loading.html)                        |
 
 `type` attribute matching is ASCII case-insensitive, matching how user agents look up the script's effective MIME type.
 
@@ -64,6 +65,59 @@ The rule reports the following issues for inline import maps:
         "x": "./y.js"
       }
     }
+  }
+</script>
+```
+
+## `type="speculationrules"`
+
+[Speculation Rules](https://html.spec.whatwg.org/multipage/speculative-loading.html) are defined in the HTML Living Standard § 7.6 (the feature originated as the WICG `nav-speculation` draft, which now redirects to the HTML Standard). The rule reports the following issues for inline speculation rules:
+
+- The element body is empty, whitespace-only, or cannot be parsed as JSON
+- The top-level value is not a JSON object, or has no `prefetch` or `prerender` property
+- A top-level key other than `tag`, `prefetch`, or `prerender` is present
+- A `prefetch` / `prerender` value is not a JSON array, or a rule in it is not a JSON object
+- A rule has a key other than `source`, `urls`, `where`, `relative_to`, `eagerness`, `referrer_policy`, `tag`, `requires`, `expects_no_vary_search`, or `target_hint`
+- `source` is not a string, or is a value other than `list` or `document`
+- A list rule (explicit or inferred from `urls`) is missing `urls`, or has a `where`
+- A document rule (explicit or inferred from `where`) is missing `where`, or has `urls`
+- A rule has no `source` and its source cannot be inferred (it has neither `urls` nor `where`, or has both)
+- `urls` is not a JSON array, is empty, or contains a non-string or empty-string item
+- `eagerness` is not a string, or is a value other than `immediate`, `eager`, `moderate`, or `conservative`
+- `where` is not a JSON object, or does not contain exactly one predicate (`and`, `or`, `not`, `href_matches`, or `selector_matches`)
+- An `and` / `or` predicate is not a JSON array, or is empty
+- An `href_matches` / `selector_matches` pattern is not a string or an array of strings, is empty, or contains an empty-string item
+
+❌ Examples of **incorrect** code for this rule
+
+```html
+<script type="speculationrules">
+  {
+    "prefetch": [{ "source": "list" }]
+  }
+</script>
+<script type="speculationrules">
+  {
+    "prefetch": [{ "source": "document", "where": {} }]
+  }
+</script>
+```
+
+✅ Examples of **correct** code for this rule
+
+```html
+<script type="speculationrules">
+  {
+    "prefetch": [
+      {
+        "source": "document",
+        "where": {
+          "and": [{ "href_matches": "/*" }, { "not": { "selector_matches": ".no-prefetch" } }]
+        },
+        "eagerness": "moderate"
+      }
+    ],
+    "prerender": [{ "source": "list", "urls": ["/next"] }]
   }
 </script>
 ```

--- a/packages/@markuplint/rules/src/script-content/index.spec.ts
+++ b/packages/@markuplint/rules/src/script-content/index.spec.ts
@@ -236,3 +236,513 @@ test('[script-content-invalid-015] multiple violations are all reported', async 
 	);
 	expect(violations.length).toBe(3);
 });
+
+// `type="speculationrules"` — WICG Speculation Rules
+// @see https://wicg.github.io/nav-speculation/speculation-rules.html
+
+test('[script-content-valid-008] minimal valid list rule', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap(
+			'<script type="speculationrules">{"prefetch":[{"source":"list","urls":["https://example.com"]}]}</script>',
+		),
+	);
+	expect(violations.length).toBe(0);
+});
+
+test('[script-content-valid-009] minimal valid document rule', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap(
+			'<script type="speculationrules">{"prefetch":[{"source":"document","where":{"href_matches":"/*"}}]}</script>',
+		),
+	);
+	expect(violations.length).toBe(0);
+});
+
+test('[script-content-valid-010] both prefetch and prerender rule sets', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap(
+			'<script type="speculationrules">{"prefetch":[{"source":"list","urls":["/a"]}],"prerender":[{"source":"document","where":{"href_matches":"/*"}}]}</script>',
+		),
+	);
+	expect(violations.length).toBe(0);
+});
+
+test('[script-content-valid-011] source inferred as list from urls', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap('<script type="speculationrules">{"prefetch":[{"urls":["/page1.html"]}]}</script>'),
+	);
+	expect(violations.length).toBe(0);
+});
+
+test('[script-content-valid-012] source inferred as document from where', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap(
+			'<script type="speculationrules">{"prefetch":[{"eagerness":"moderate","where":{"href_matches":"/*"}}]}</script>',
+		),
+	);
+	expect(violations.length).toBe(0);
+});
+
+test('[script-content-valid-013] href_matches accepts an array of strings', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap(
+			'<script type="speculationrules">{"prefetch":[{"source":"document","where":{"href_matches":["/blog/*","/news/*"]}}]}</script>',
+		),
+	);
+	expect(violations.length).toBe(0);
+});
+
+test('[script-content-valid-014] nested and / or / not predicates', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap(
+			'<script type="speculationrules">{"prefetch":[{"source":"document","where":{"and":[{"or":[{"href_matches":"/articles/*"},{"href_matches":"/blog/*"}]},{"not":{"selector_matches":[".no-prefetch","a[rel~=nofollow]"]}}]},"eagerness":"conservative"}]}</script>',
+		),
+	);
+	expect(violations.length).toBe(0);
+});
+
+test('[script-content-valid-015] type matching is case-insensitive', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap('<script type="SpeculationRules">{"prefetch":[{"source":"list","urls":["/a"]}]}</script>'),
+	);
+	expect(violations.length).toBe(0);
+});
+
+test('[script-content-valid-016] empty rule set array is allowed', async () => {
+	const { violations } = await mlRuleTest(rule, wrap('<script type="speculationrules">{"prefetch":[]}</script>'));
+	expect(violations.length).toBe(0);
+});
+
+test('[script-content-valid-017] eagerness "immediate" is allowed (HTML LS §7.6)', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap(
+			'<script type="speculationrules">{"prefetch":[{"source":"list","urls":["/a"],"eagerness":"immediate"}]}</script>',
+		),
+	);
+	expect(violations.length).toBe(0);
+});
+
+test('[script-content-valid-018] additional spec rule keys are allowed (HTML LS §7.6.1.2)', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap(
+			'<script type="speculationrules">{"prefetch":[{"source":"list","urls":["/a"],"relative_to":"document","referrer_policy":"no-referrer","requires":["anonymous-client-ip-when-cross-origin"],"expects_no_vary_search":"params=(\\"a\\")","target_hint":"_blank","tag":"my-tag"}]}</script>',
+		),
+	);
+	expect(violations.length).toBe(0);
+});
+
+test('[script-content-valid-019] top-level "tag" is allowed alongside a rule set', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap('<script type="speculationrules">{"tag":"my-tag","prefetch":[{"source":"list","urls":["/a"]}]}</script>'),
+	);
+	expect(violations.length).toBe(0);
+});
+
+test('[script-content-invalid-023] empty content', async () => {
+	const { violations } = await mlRuleTest(rule, wrap('<script type="speculationrules"></script>'));
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe('Speculation rules must contain a JSON object');
+});
+
+test('[script-content-invalid-024] content is not JSON', async () => {
+	const { violations } = await mlRuleTest(rule, wrap('<script type="speculationrules">{ invalid json</script>'));
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe('Speculation rules must be valid JSON');
+});
+
+test('[script-content-invalid-025] top-level value is an array', async () => {
+	const { violations } = await mlRuleTest(rule, wrap('<script type="speculationrules">["a","b"]</script>'));
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe('Speculation rules must be a JSON object');
+});
+
+test('[script-content-invalid-026] missing both prefetch and prerender', async () => {
+	const { violations } = await mlRuleTest(rule, wrap('<script type="speculationrules">{}</script>'));
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe(
+		'Speculation rules must be an object with a "prefetch" or "prerender" property',
+	);
+});
+
+test('[script-content-invalid-027] forbidden top-level key', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap('<script type="speculationrules">{"prefetch":[],"unknownProp":true}</script>'),
+	);
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe(
+		'The speculation rules top-level key "unknownProp" is not allowed (use "tag", "prefetch", or "prerender")',
+	);
+});
+
+test('[script-content-invalid-028] rule set is not an array', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap('<script type="speculationrules">{"prefetch":"not-array"}</script>'),
+	);
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe('The "prefetch" property of speculation rules must be a JSON array');
+});
+
+test('[script-content-invalid-029] rule is not an object', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap('<script type="speculationrules">{"prefetch":["not-an-object"]}</script>'),
+	);
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe('The speculation rule prefetch[0] must be a JSON object');
+});
+
+test('[script-content-invalid-030] forbidden rule key', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap(
+			'<script type="speculationrules">{"prefetch":[{"source":"list","urls":["/a"],"unknownProp":true}]}</script>',
+		),
+	);
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe(
+		'The speculation rule key "unknownProp" is not allowed (use "source", "urls", "where", "relative_to", "eagerness", "referrer_policy", "tag", "requires", "expects_no_vary_search", or "target_hint")',
+	);
+});
+
+test('[script-content-invalid-031] source is not a string', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap('<script type="speculationrules">{"prefetch":[{"source":123}]}</script>'),
+	);
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe('The "source" of prefetch[0] must be a string');
+});
+
+test('[script-content-invalid-032] source has an invalid value', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap('<script type="speculationrules">{"prefetch":[{"source":"invalid"}]}</script>'),
+	);
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe('The "source" value "invalid" is not allowed (use "list" or "document")');
+});
+
+test('[script-content-invalid-033] list rule is missing urls', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap('<script type="speculationrules">{"prefetch":[{"source":"list"}]}</script>'),
+	);
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe('The list rule prefetch[0] must have a "urls" property');
+});
+
+test('[script-content-invalid-034] list rule has a where', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap(
+			'<script type="speculationrules">{"prefetch":[{"source":"list","urls":["/a"],"where":{"href_matches":"*"}}]}</script>',
+		),
+	);
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe('The list rule prefetch[0] must not have a "where" property');
+});
+
+test('[script-content-invalid-035] document rule is missing where', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap('<script type="speculationrules">{"prefetch":[{"source":"document"}]}</script>'),
+	);
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe('The document rule prefetch[0] must have a "where" property');
+});
+
+test('[script-content-invalid-036] document rule has urls', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap(
+			'<script type="speculationrules">{"prefetch":[{"source":"document","where":{"href_matches":"*"},"urls":["/a"]}]}</script>',
+		),
+	);
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe('The document rule prefetch[0] must not have a "urls" property');
+});
+
+test('[script-content-invalid-037] rule has neither source, urls, nor where', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap('<script type="speculationrules">{"prefetch":[{"eagerness":"moderate"}]}</script>'),
+	);
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe(
+		'The speculation rule prefetch[0] must have a "source", or exactly one of "urls" or "where"',
+	);
+});
+
+test('[script-content-invalid-055] rule has both urls and where without source', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap('<script type="speculationrules">{"prefetch":[{"urls":["/a"],"where":{"href_matches":"/*"}}]}</script>'),
+	);
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe(
+		'The speculation rule prefetch[0] must have a "source", or exactly one of "urls" or "where"',
+	);
+});
+
+test('[script-content-invalid-038] urls is not an array', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap('<script type="speculationrules">{"prefetch":[{"source":"list","urls":"not-array"}]}</script>'),
+	);
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe('The "urls" of prefetch[0] must be a JSON array');
+});
+
+test('[script-content-invalid-039] urls is empty', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap('<script type="speculationrules">{"prefetch":[{"source":"list","urls":[]}]}</script>'),
+	);
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe('The "urls" of prefetch[0] must not be empty');
+});
+
+test('[script-content-invalid-040] a url item is not a string', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap('<script type="speculationrules">{"prefetch":[{"source":"list","urls":[123]}]}</script>'),
+	);
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe('The URL at index 0 in "urls" must be a string');
+});
+
+test('[script-content-invalid-041] a url item is an empty string', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap('<script type="speculationrules">{"prefetch":[{"source":"list","urls":[""]}]}</script>'),
+	);
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe('The URL at index 0 in "urls" must not be empty');
+});
+
+test('[script-content-invalid-042] eagerness is not a string', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap('<script type="speculationrules">{"prefetch":[{"source":"list","urls":["/a"],"eagerness":123}]}</script>'),
+	);
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe('The "eagerness" of prefetch[0] must be a string');
+});
+
+test('[script-content-invalid-043] eagerness has an invalid value', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap(
+			'<script type="speculationrules">{"prefetch":[{"source":"list","urls":["/a"],"eagerness":"invalid"}]}</script>',
+		),
+	);
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe(
+		'The "eagerness" value "invalid" is not allowed (use "immediate", "eager", "moderate", or "conservative")',
+	);
+});
+
+test('[script-content-invalid-044] where is not an object', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap('<script type="speculationrules">{"prefetch":[{"source":"document","where":"not-object"}]}</script>'),
+	);
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe('The "where" condition of prefetch[0] must be a JSON object');
+});
+
+test('[script-content-invalid-045] where has no predicate', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap('<script type="speculationrules">{"prefetch":[{"source":"document","where":{}}]}</script>'),
+	);
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe(
+		'The "where" condition of prefetch[0] must have exactly one predicate ("and", "or", "not", "href_matches", or "selector_matches")',
+	);
+});
+
+test('[script-content-invalid-046] where has multiple predicates', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap(
+			'<script type="speculationrules">{"prefetch":[{"source":"document","where":{"href_matches":"*","selector_matches":"a"}}]}</script>',
+		),
+	);
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe(
+		'The "where" condition of prefetch[0] must have exactly one predicate, but has multiple',
+	);
+});
+
+test('[script-content-invalid-047] and predicate is empty', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap('<script type="speculationrules">{"prefetch":[{"source":"document","where":{"and":[]}}]}</script>'),
+	);
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe('The "and" predicate must not be empty');
+});
+
+test('[script-content-invalid-048] and predicate is not an array', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap(
+			'<script type="speculationrules">{"prefetch":[{"source":"document","where":{"and":"not-array"}}]}</script>',
+		),
+	);
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe('The "and" predicate must be a JSON array');
+});
+
+test('[script-content-invalid-049] href_matches is an empty string', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap(
+			'<script type="speculationrules">{"prefetch":[{"source":"document","where":{"href_matches":""}}]}</script>',
+		),
+	);
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe('The "href_matches" pattern must not be empty');
+});
+
+test('[script-content-invalid-050] href_matches is an empty array', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap(
+			'<script type="speculationrules">{"prefetch":[{"source":"document","where":{"href_matches":[]}}]}</script>',
+		),
+	);
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe('The "href_matches" pattern must not be empty');
+});
+
+test('[script-content-invalid-051] href_matches is not a string', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap(
+			'<script type="speculationrules">{"prefetch":[{"source":"document","where":{"href_matches":123}}]}</script>',
+		),
+	);
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe('The "href_matches" pattern must be a string or an array of strings');
+});
+
+test('[script-content-invalid-052] selector_matches is an empty string', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap(
+			'<script type="speculationrules">{"prefetch":[{"source":"document","where":{"selector_matches":""}}]}</script>',
+		),
+	);
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe('The "selector_matches" pattern must not be empty');
+});
+
+test('[script-content-invalid-053] selector_matches is not a string', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap(
+			'<script type="speculationrules">{"prefetch":[{"source":"document","where":{"selector_matches":123}}]}</script>',
+		),
+	);
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe('The "selector_matches" pattern must be a string or an array of strings');
+});
+
+test('[script-content-invalid-054] unknown predicate key', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap('<script type="speculationrules">{"prefetch":[{"source":"document","where":{"unknown":"x"}}]}</script>'),
+	);
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe(
+		'The predicate key "unknown" is not allowed (use "and", "or", "not", "href_matches", or "selector_matches")',
+	);
+});
+
+test('[script-content-invalid-056] a pattern array item is not a string', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap(
+			'<script type="speculationrules">{"prefetch":[{"source":"document","where":{"href_matches":["/ok/*",123]}}]}</script>',
+		),
+	);
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe('Item [1] of the "href_matches" pattern must be a string');
+});
+
+test('[script-content-invalid-057] a pattern array item is an empty string', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap(
+			'<script type="speculationrules">{"prefetch":[{"source":"document","where":{"selector_matches":["a",""]}}]}</script>',
+		),
+	);
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe('Item [1] of the "selector_matches" pattern must not be empty');
+});
+
+test('[script-content-invalid-058] a not predicate value is not an object', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap('<script type="speculationrules">{"prefetch":[{"source":"document","where":{"not":"x"}}]}</script>'),
+	);
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe('The "not" predicate must be a JSON object');
+});
+
+test('[script-content-invalid-059] prerender rule set is validated like prefetch', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap('<script type="speculationrules">{"prerender":[{"source":"list"}]}</script>'),
+	);
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe('The list rule prerender[0] must have a "urls" property');
+});
+
+test('[script-content-invalid-060] or predicate is not an array', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap(
+			'<script type="speculationrules">{"prefetch":[{"source":"document","where":{"or":"not-array"}}]}</script>',
+		),
+	);
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe('The "or" predicate must be a JSON array');
+});
+
+test('[script-content-invalid-061] or predicate is empty', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap('<script type="speculationrules">{"prefetch":[{"source":"document","where":{"or":[]}}]}</script>'),
+	);
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe('The "or" predicate must not be empty');
+});
+
+test('[script-content-invalid-062] a nested predicate inside and is invalid', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		wrap(
+			'<script type="speculationrules">{"prefetch":[{"source":"document","where":{"and":[{"href_matches":"/ok/*"},{"unknown":"x"}]}}]}</script>',
+		),
+	);
+	expect(violations.length).toBe(1);
+	expect(violations[0]?.message).toBe(
+		'The predicate key "unknown" is not allowed (use "and", "or", "not", "href_matches", or "selector_matches")',
+	);
+});

--- a/packages/@markuplint/rules/src/script-content/index.ts
+++ b/packages/@markuplint/rules/src/script-content/index.ts
@@ -54,16 +54,17 @@ export default createRule<boolean, null>({
 		await document.walkOn('Element', el => {
 			if (el.localName !== 'script') return;
 			// Dispatch by `type` value. Add a sibling branch for each new content
-			// format (e.g. application/json, speculationrules) and a matching
-			// `verifyXxx()` helper. Keep the README "Currently supported content
-			// formats" table in sync.
-			const typeAttr = el.getAttribute('type');
-			if (typeAttr?.toLowerCase() !== 'importmap') return;
+			// format and a matching `verifyXxx()` helper. Keep the README
+			// "Currently supported content formats" table in sync.
+			const typeAttr = el.getAttribute('type')?.toLowerCase();
+			if (typeAttr !== 'importmap' && typeAttr !== 'speculationrules') return;
 			if (el.pretenderContext?.type === 'pretender' && !el.hasAttribute('as')) return;
 			if (!el.closeTag) return;
 
 			const rawContent = sourceCode.slice(el.endOffset, el.closeTag.startOffset);
 			const trimmed = rawContent.trim();
+
+			const label = typeAttr === 'importmap' ? 'Import map' : 'Speculation rules';
 
 			const reportAt = (message: string) => {
 				report({
@@ -76,7 +77,7 @@ export default createRule<boolean, null>({
 			};
 
 			if (trimmed === '') {
-				reportAt(t('{0} must contain a JSON object', 'Import map'));
+				reportAt(t('{0} must contain a JSON object', label));
 				return;
 			}
 
@@ -87,78 +88,380 @@ export default createRule<boolean, null>({
 				if (!(error instanceof SyntaxError)) {
 					throw error;
 				}
-				reportAt(t('{0} must be valid JSON', 'Import map'));
+				reportAt(t('{0} must be valid JSON', label));
 				return;
 			}
 
 			if (!isPlainObject(parsed)) {
-				reportAt(t('{0} must be a JSON object', 'Import map'));
+				reportAt(t('{0} must be a JSON object', label));
 				return;
 			}
 
-			for (const key of Object.keys(parsed)) {
-				if (!ALLOWED_TOP_LEVEL_KEYS.has(key)) {
-					reportAt(
-						t(
-							'{0} is {1:c}',
-							t('the import map top-level key "{0*}"', key),
-							'not allowed (use "imports", "scopes", or "integrity")',
-						),
-					);
-				}
-			}
-
-			const imports = parsed.imports;
-			if (imports !== undefined) {
-				if (isPlainObject(imports)) {
-					validateSpecifierMap(imports, 'imports', reportAt, t);
-				} else {
-					reportAt(
-						t(
-							'{0} must be {1}',
-							t('the "{0*}" top-level key of an import map', 'imports'),
-							'a JSON object',
-						),
-					);
-				}
-			}
-
-			const scopes = parsed.scopes;
-			if (scopes !== undefined) {
-				if (isPlainObject(scopes)) {
-					for (const [scopeKey, scopeValue] of Object.entries(scopes)) {
-						if (isPlainObject(scopeValue)) {
-							validateSpecifierMap(scopeValue, `scopes["${scopeKey}"]`, reportAt, t);
-						} else {
-							reportAt(
-								t('{0} must be {1}', t('the value of the scope "{0*}"', scopeKey), 'a JSON object'),
-							);
-						}
-					}
-				} else {
-					reportAt(
-						t('{0} must be {1}', t('the "{0*}" top-level key of an import map', 'scopes'), 'a JSON object'),
-					);
-				}
-			}
-
-			const integrity = parsed.integrity;
-			if (integrity !== undefined) {
-				if (isPlainObject(integrity)) {
-					validateIntegrityMap(integrity, reportAt, t);
-				} else {
-					reportAt(
-						t(
-							'{0} must be {1}',
-							t('the "{0*}" top-level key of an import map', 'integrity'),
-							'a JSON object',
-						),
-					);
-				}
+			if (typeAttr === 'importmap') {
+				verifyImportMap(parsed, reportAt, t);
+			} else {
+				verifySpeculationRules(parsed, reportAt, t);
 			}
 		});
 	},
 });
+
+function verifyImportMap(
+	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+	parsed: Record<string, unknown>,
+	reportAt: (message: string) => void,
+	t: (...args: readonly any[]) => string,
+): void {
+	for (const key of Object.keys(parsed)) {
+		if (!ALLOWED_TOP_LEVEL_KEYS.has(key)) {
+			reportAt(
+				t(
+					'{0} is {1:c}',
+					t('the import map top-level key "{0*}"', key),
+					'not allowed (use "imports", "scopes", or "integrity")',
+				),
+			);
+		}
+	}
+
+	const imports = parsed.imports;
+	if (imports !== undefined) {
+		if (isPlainObject(imports)) {
+			validateSpecifierMap(imports, 'imports', reportAt, t);
+		} else {
+			reportAt(t('{0} must be {1}', t('the "{0*}" top-level key of an import map', 'imports'), 'a JSON object'));
+		}
+	}
+
+	const scopes = parsed.scopes;
+	if (scopes !== undefined) {
+		if (isPlainObject(scopes)) {
+			for (const [scopeKey, scopeValue] of Object.entries(scopes)) {
+				if (isPlainObject(scopeValue)) {
+					validateSpecifierMap(scopeValue, `scopes["${scopeKey}"]`, reportAt, t);
+				} else {
+					reportAt(t('{0} must be {1}', t('the value of the scope "{0*}"', scopeKey), 'a JSON object'));
+				}
+			}
+		} else {
+			reportAt(t('{0} must be {1}', t('the "{0*}" top-level key of an import map', 'scopes'), 'a JSON object'));
+		}
+	}
+
+	const integrity = parsed.integrity;
+	if (integrity !== undefined) {
+		if (isPlainObject(integrity)) {
+			validateIntegrityMap(integrity, reportAt, t);
+		} else {
+			reportAt(
+				t('{0} must be {1}', t('the "{0*}" top-level key of an import map', 'integrity'), 'a JSON object'),
+			);
+		}
+	}
+}
+
+/**
+ * Validate the body of a `<script type="speculationrules">` element.
+ *
+ * Spec status: Speculation Rules is now part of the HTML Living Standard
+ * (§7.6 Speculation rules; the "parse a speculation rule" algorithm is §7.6.1.2).
+ * It originated as the WICG `nav-speculation` draft, which is now a stub that
+ * redirects to the HTML Standard — check the HTML Standard for the latest schema.
+ *
+ * markuplint also mirrors nu-validator's strictness (e.g. unknown keys, empty
+ * `urls`, exactly-one `where` predicate) so the two agree on the conformance
+ * corpus. When the spec changes, update this set/the SR_* sets below, the error
+ * message strings, and the README tables.
+ *
+ * @see https://html.spec.whatwg.org/multipage/speculative-loading.html
+ */
+// Valid keys per HTML LS § 7.6.1.2 "parse a speculation rule" / the rule-set
+// object grammar. Unknown keys are rejected by the spec (the rule returns null),
+// so reporting them is conformant. We accept the full key set to avoid flagging
+// valid rules that use fields beyond the common `source`/`urls`/`where` —
+// value-level validation of the extra fields is intentionally not implemented.
+const SR_TOP_LEVEL_KEYS = new Set(['tag', 'prefetch', 'prerender']);
+const SR_RULE_KEYS = new Set([
+	'source',
+	'urls',
+	'where',
+	'relative_to',
+	'eagerness',
+	'referrer_policy',
+	'tag',
+	'requires',
+	'expects_no_vary_search',
+	'target_hint',
+]);
+const SR_SOURCES = new Set(['list', 'document']);
+const SR_EAGERNESS = new Set(['immediate', 'eager', 'moderate', 'conservative']);
+const SR_PREDICATE_KEYS = new Set(['and', 'or', 'not', 'href_matches', 'selector_matches']);
+
+function verifySpeculationRules(
+	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+	parsed: Record<string, unknown>,
+	reportAt: (message: string) => void,
+	t: (...args: readonly any[]) => string,
+): void {
+	let hasRuleSet = false;
+	for (const key of Object.keys(parsed)) {
+		if (!SR_TOP_LEVEL_KEYS.has(key)) {
+			reportAt(
+				t(
+					'{0} is {1:c}',
+					t('the speculation rules top-level key "{0*}"', key),
+					'not allowed (use "tag", "prefetch", or "prerender")',
+				),
+			);
+			continue;
+		}
+		// `tag` is a ruleset label, not a list of rules; it does not satisfy the
+		// "needs prefetch or prerender" requirement and is not an array of rules.
+		if (key === 'tag') continue;
+		hasRuleSet = true;
+		const ruleSet = parsed[key];
+		if (!Array.isArray(ruleSet)) {
+			reportAt(t('{0} must be {1}', t('the "{0*}" property of speculation rules', key), 'a JSON array'));
+			continue;
+		}
+		for (let i = 0; i < ruleSet.length; i++) {
+			validateSpeculationRule(ruleSet[i], `${key}[${i}]`, reportAt, t);
+		}
+	}
+	if (!hasRuleSet) {
+		reportAt(t('{0} must be {1}', 'Speculation rules', 'an object with a "prefetch" or "prerender" property'));
+	}
+}
+
+function validateSpeculationRule(
+	rule: unknown,
+	label: string,
+	reportAt: (message: string) => void,
+	t: (...args: readonly any[]) => string,
+): void {
+	if (!isPlainObject(rule)) {
+		reportAt(t('{0} must be {1}', t('the speculation rule {0*}', label), 'a JSON object'));
+		return;
+	}
+
+	for (const key of Object.keys(rule)) {
+		if (!SR_RULE_KEYS.has(key)) {
+			reportAt(
+				t(
+					'{0} is {1:c}',
+					t('the speculation rule key "{0*}"', key),
+					'not allowed (use "source", "urls", "where", "relative_to", "eagerness", "referrer_policy", "tag", "requires", "expects_no_vary_search", or "target_hint")',
+				),
+			);
+		}
+	}
+
+	const sourceProvided = rule.source !== undefined;
+	let validSource: 'list' | 'document' | undefined;
+	if (sourceProvided) {
+		if (typeof rule.source !== 'string') {
+			reportAt(t('{0} must be {1}', t('the "source" of {0*}', label), 'a string'));
+		} else if (SR_SOURCES.has(rule.source)) {
+			validSource = rule.source as 'list' | 'document';
+		} else {
+			reportAt(
+				t(
+					'{0} is {1:c}',
+					t('the "source" value "{0*}"', rule.source),
+					'not allowed (use "list" or "document")',
+				),
+			);
+		}
+	}
+
+	if (rule.eagerness !== undefined) {
+		if (typeof rule.eagerness !== 'string') {
+			reportAt(t('{0} must be {1}', t('the "eagerness" of {0*}', label), 'a string'));
+		} else if (!SR_EAGERNESS.has(rule.eagerness)) {
+			reportAt(
+				t(
+					'{0} is {1:c}',
+					t('the "eagerness" value "{0*}"', rule.eagerness),
+					'not allowed (use "immediate", "eager", "moderate", or "conservative")',
+				),
+			);
+		}
+	}
+
+	const hasUrls = rule.urls !== undefined;
+	if (hasUrls) {
+		validateUrls(rule.urls, label, reportAt, t);
+	}
+
+	const hasWhere = rule.where !== undefined;
+	if (hasWhere) {
+		validatePredicate(rule.where, t('the "where" condition of {0*}', label), reportAt, t);
+	}
+
+	// Resolve the effective source: an explicit valid `source`, otherwise
+	// inferred from exactly one of `urls` (→ list) or `where` (→ document) being
+	// present. Per spec the inference is mutually exclusive: when neither or both
+	// are present (and no explicit source), the source cannot be inferred and the
+	// rule is invalid.
+	let effectiveSource = validSource;
+	if (effectiveSource === undefined && !sourceProvided) {
+		if (hasUrls && !hasWhere) {
+			effectiveSource = 'list';
+		} else if (hasWhere && !hasUrls) {
+			effectiveSource = 'document';
+		}
+	}
+
+	if (effectiveSource === 'list') {
+		if (!hasUrls) {
+			reportAt(t('{0} must have {1}', t('the list rule {0*}', label), 'a "urls" property'));
+		}
+		if (hasWhere) {
+			reportAt(t('{0} must not have {1}', t('the list rule {0*}', label), 'a "where" property'));
+		}
+	} else if (effectiveSource === 'document') {
+		if (!hasWhere) {
+			reportAt(t('{0} must have {1}', t('the document rule {0*}', label), 'a "where" property'));
+		}
+		if (hasUrls) {
+			reportAt(t('{0} must not have {1}', t('the document rule {0*}', label), 'a "urls" property'));
+		}
+	} else if (!sourceProvided) {
+		// No explicit source and inference failed (neither `urls`/`where`, or both).
+		reportAt(
+			t(
+				'{0} must have {1}',
+				t('the speculation rule {0*}', label),
+				'a "source", or exactly one of "urls" or "where"',
+			),
+		);
+	}
+}
+
+function validateUrls(
+	urls: unknown,
+	label: string,
+	reportAt: (message: string) => void,
+	t: (...args: readonly any[]) => string,
+): void {
+	if (!Array.isArray(urls)) {
+		reportAt(t('{0} must be {1}', t('the "urls" of {0*}', label), 'a JSON array'));
+		return;
+	}
+	if (urls.length === 0) {
+		reportAt(t('{0} must not be {1}', t('the "urls" of {0*}', label), 'empty'));
+		return;
+	}
+	for (let i = 0; i < urls.length; i++) {
+		const url = urls[i];
+		if (typeof url !== 'string') {
+			reportAt(t('{0} must be {1}', t('the URL at index {0*} in "urls"', i), 'a string'));
+		} else if (url === '') {
+			reportAt(t('{0} must not be {1}', t('the URL at index {0*} in "urls"', i), 'empty'));
+		}
+	}
+}
+
+/**
+ * Validate a document-rule `where` predicate. A predicate object must contain
+ * exactly one of `and` / `or` / `not` / `href_matches` / `selector_matches`.
+ *
+ * @see https://wicg.github.io/nav-speculation/speculation-rules.html#document-rule-predicates
+ */
+function validatePredicate(
+	predicate: unknown,
+	label: string,
+	reportAt: (message: string) => void,
+	t: (...args: readonly any[]) => string,
+): void {
+	if (!isPlainObject(predicate)) {
+		reportAt(t('{0} must be {1}', label, 'a JSON object'));
+		return;
+	}
+
+	const keys = Object.keys(predicate);
+	const predicateKeys: string[] = [];
+	for (const key of keys) {
+		if (SR_PREDICATE_KEYS.has(key)) {
+			predicateKeys.push(key);
+		} else {
+			reportAt(
+				t(
+					'{0} is {1:c}',
+					t('the predicate key "{0*}"', key),
+					'not allowed (use "and", "or", "not", "href_matches", or "selector_matches")',
+				),
+			);
+		}
+	}
+
+	if (predicateKeys.length === 0) {
+		if (keys.length === 0) {
+			reportAt(
+				t(
+					'{0} must have {1}',
+					label,
+					'exactly one predicate ("and", "or", "not", "href_matches", or "selector_matches")',
+				),
+			);
+		}
+		return;
+	}
+	if (predicateKeys.length > 1) {
+		reportAt(t('{0} must have {1}', label, 'exactly one predicate, but has multiple'));
+	}
+
+	for (const key of predicateKeys) {
+		const value = predicate[key];
+		if (key === 'and' || key === 'or') {
+			if (!Array.isArray(value)) {
+				reportAt(t('{0} must be {1}', t('the "{0*}" predicate', key), 'a JSON array'));
+				continue;
+			}
+			if (value.length === 0) {
+				reportAt(t('{0} must not be {1}', t('the "{0*}" predicate', key), 'empty'));
+				continue;
+			}
+			for (let i = 0; i < value.length; i++) {
+				validatePredicate(value[i], t('the "{0*}" predicate item [{1*}]', key, i), reportAt, t);
+			}
+		} else if (key === 'not') {
+			validatePredicate(value, t('the "not" predicate'), reportAt, t);
+		} else {
+			validatePatternValue(value, key, reportAt, t);
+		}
+	}
+}
+
+function validatePatternValue(
+	value: unknown,
+	key: string,
+	reportAt: (message: string) => void,
+	t: (...args: readonly any[]) => string,
+): void {
+	if (typeof value === 'string') {
+		if (value === '') {
+			reportAt(t('{0} must not be {1}', t('the "{0*}" pattern', key), 'empty'));
+		}
+		return;
+	}
+	if (Array.isArray(value)) {
+		if (value.length === 0) {
+			reportAt(t('{0} must not be {1}', t('the "{0*}" pattern', key), 'empty'));
+			return;
+		}
+		for (let i = 0; i < value.length; i++) {
+			const item = value[i];
+			if (typeof item !== 'string') {
+				reportAt(t('{0} must be {1}', t('item [{0*}] of the "{1*}" pattern', i, key), 'a string'));
+			} else if (item === '') {
+				reportAt(t('{0} must not be {1}', t('item [{0*}] of the "{1*}" pattern', i, key), 'empty'));
+			}
+		}
+		return;
+	}
+	reportAt(t('{0} must be {1}', t('the "{0*}" pattern', key), 'a string or an array of strings'));
+}
 
 /**
  * Per HTML LS § normalizing a module integrity map, each entry's key is

--- a/packages/@markuplint/rules/src/script-content/schema.json
+++ b/packages/@markuplint/rules/src/script-content/schema.json
@@ -3,8 +3,8 @@
 	"definitions": {
 		"value": {
 			"type": "boolean",
-			"description": "Validate the body of `<script>` elements when the `type` attribute selects a content format that has a spec (currently: `importmap`).",
-			"description:ja": "`<script>` 要素の本文を、`type` 属性で示されたコンテンツ仕様 (現状は `importmap`) に基づき検証します。"
+			"description": "Validate the body of `<script>` elements when the `type` attribute selects a content format that has a spec (currently: `importmap`, `speculationrules`).",
+			"description:ja": "`<script>` 要素の本文を、`type` 属性で示されたコンテンツ仕様 (現状は `importmap`, `speculationrules`) に基づき検証します。"
 		}
 	},
 	"oneOf": [

--- a/packages/markuplint/src/named-noderules.spec.ts
+++ b/packages/markuplint/src/named-noderules.spec.ts
@@ -57,6 +57,21 @@ describe('Named nodeRules integration', () => {
 			expect(scriptContentViolation!.ruleId).toBe('script-content');
 			expect(scriptContentViolation!.specConformance).toBe('normative');
 		});
+
+		it('reports html-standard/script-content for invalid speculationrules', async () => {
+			const { violations } = await mlTest(
+				'<!doctype html><html><head><meta charset="UTF-8"><title>t</title>' +
+					'<script type="speculationrules">{"prefetch":[{"source":"list"}]}</script></head><body></body></html>',
+				{
+					extends: ['markuplint:html-standard'],
+				},
+			);
+			const scriptContentViolation = violations.find(v => v.name === 'html-standard/script-content');
+			expect(scriptContentViolation).toBeDefined();
+			expect(scriptContentViolation!.ruleId).toBe('script-content');
+			expect(scriptContentViolation!.severity).toBe('error');
+			expect(scriptContentViolation!.specConformance).toBe('normative');
+		});
 	});
 
 	describe('a11y preset', () => {

--- a/tests/external/snapshots/excluded-ids.json
+++ b/tests/external/snapshots/excluded-ids.json
@@ -54,55 +54,6 @@
 			"specUrl": "https://url.spec.whatwg.org/#url-writing",
 			"addedAt": "2026-04-23",
 			"addedBy": "hirao"
-		},
-		{
-			"messageContains": "speculation rule",
-			"reason": "Speculation Rules is a WICG draft (https://wicg.github.io/nav-speculation/speculation-rules.html), not part of HTML Living Standard. markuplint's reference scope is HTML LS + ARIA + URL LS, so nu-validator enforcing the WICG schema counts as over-detection from markuplint's perspective. This adds a deferred-WICG subclass of `nu-over` (distinct from the existing `nu-over` cases where nu over-interprets HTML LS itself). Coverage tracked at https://github.com/markuplint/markuplint/issues/3882 — when implementation lands, **remove all 7 SR-related patterns** (`speculation rule`, `document rule`, `“speculationrules” must have valid JSON`, `“speculationrules” must contain a JSON`, `“prefetch” array`, `“prefetch” property within`, `in the “urls” array`) and the 41 fixtures will flip to `match-error`. Stale-detection note: patterns match message text, so if nu changes wording the patterns silently fall out of effect — confirm `nu-over` SR count stays ~41 in pre-release bench refreshes.",
-			"specUrl": "https://wicg.github.io/nav-speculation/speculation-rules.html",
-			"addedAt": "2026-05-17",
-			"addedBy": "hirao"
-		},
-		{
-			"messageContains": "document rule",
-			"reason": "Speculation Rules `where` predicate terminology — see the Speculation Rules pattern above for the full rationale and tracking issue.",
-			"specUrl": "https://wicg.github.io/nav-speculation/speculation-rules.html",
-			"addedAt": "2026-05-17",
-			"addedBy": "hirao"
-		},
-		{
-			"messageContains": "“speculationrules” must have valid JSON",
-			"reason": "Catches `<script type=speculationrules>` JSON syntax errors (`must have valid JSON content`). Distinct from `must not have a ... attribute` which is HTML LS scope. See the Speculation Rules pattern above for rationale and tracking issue.",
-			"specUrl": "https://wicg.github.io/nav-speculation/speculation-rules.html",
-			"addedAt": "2026-05-17",
-			"addedBy": "hirao"
-		},
-		{
-			"messageContains": "“speculationrules” must contain a JSON",
-			"reason": "Catches `<script type=speculationrules>` JSON shape errors (`must contain a JSON object with...`). See the Speculation Rules pattern above for rationale and tracking issue.",
-			"specUrl": "https://wicg.github.io/nav-speculation/speculation-rules.html",
-			"addedAt": "2026-05-17",
-			"addedBy": "hirao"
-		},
-		{
-			"messageContains": "“prefetch” array",
-			"reason": "Speculation Rules top-level `prefetch` array shape validation — see the Speculation Rules pattern above for rationale and tracking issue.",
-			"specUrl": "https://wicg.github.io/nav-speculation/speculation-rules.html",
-			"addedAt": "2026-05-17",
-			"addedBy": "hirao"
-		},
-		{
-			"messageContains": "“prefetch” property within",
-			"reason": "Speculation Rules `prefetch` property type validation (must be a JSON array) — see the Speculation Rules pattern above for rationale and tracking issue.",
-			"specUrl": "https://wicg.github.io/nav-speculation/speculation-rules.html",
-			"addedAt": "2026-05-17",
-			"addedBy": "hirao"
-		},
-		{
-			"messageContains": "in the “urls” array",
-			"reason": "Speculation Rules `urls` array item-type validation (non-empty string) — see the Speculation Rules pattern above for rationale and tracking issue.",
-			"specUrl": "https://wicg.github.io/nav-speculation/speculation-rules.html",
-			"addedAt": "2026-05-17",
-			"addedBy": "hirao"
 		}
 	]
 }


### PR DESCRIPTION
## Summary

Extends the `script-content` rule to validate the JSON body of `<script type="speculationrules">`, in addition to the existing `importmap` support. Closes #3882.

Speculation Rules is now part of the **HTML Living Standard § 7.6** (it moved there from the WICG `nav-speculation` draft, which now redirects to the HTML Standard). The `importmap` dispatch was refactored into a `verifyImportMap` helper alongside the new `verifySpeculationRules`.

## What is validated

- Top-level object: keys limited to `tag` / `prefetch` / `prerender`; at least one rule set (`prefetch`/`prerender`) required; rule sets must be JSON arrays.
- Per-rule object: key allowlist (`source`, `urls`, `where`, `relative_to`, `eagerness`, `referrer_policy`, `tag`, `requires`, `expects_no_vary_search`, `target_hint`).
- `source`: `list` / `document`, inferred from `urls` (→list) / `where` (→document) when absent; the ambiguous both-present-no-source case is rejected per spec.
- list rule ⇒ has `urls`, no `where`; document rule ⇒ has `where`, no `urls`.
- `urls`: non-empty array of non-empty strings.
- `eagerness`: `immediate` / `eager` / `moderate` / `conservative`.
- `where`: exactly one predicate of `and` / `or` / `not` / `href_matches` / `selector_matches`; `and`/`or` non-empty arrays of predicates; `*_matches` a non-empty string or non-empty array of non-empty strings.

Value-level validation of the less-common fields (`referrer_policy`, `requires`, etc.) is intentionally not implemented yet; those keys are accepted to avoid false positives on valid rules.

## Spec reference

- Latest spec: https://html.spec.whatwg.org/multipage/speculative-loading.html (§ 7.6; parse algorithm § 7.6.1.2)

## Testing

- `script-content`: 81 unit tests (valid 19 / invalid 62), type-checked.
- `markuplint`: added an `html-standard` preset integration test asserting the violation surfaces at `error` severity.
- Full suite: `yarn test` → 4254 passed, no type errors. `yarn build` ✅.

## Note on the coverage bench

This PR removes the 7 deferred-WICG `nu-over` exclusion patterns from `tests/external/snapshots/excluded-ids.json`, so the matching nu-validator fixtures should flip from `nu-over` to `match-error`. The full bench refresh (`yarn bench:update` → `yarn bench:compare`) requires Docker and has not been run in this environment yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)