### PR TITLE
test: exclude row-width-exceeds-col-markup as nu over-detection

### DIFF
--- a/.claude/skills/bench-triage/SKILL.md
+++ b/.claude/skills/bench-triage/SKILL.md
@@ -113,10 +113,12 @@ Follow the existing entry shapes in `excluded-ids.json` (per-`id`
 The verdict flips to `nu-over` only when *every* active nu message
 on the fixture is covered. Partial coverage stays `nu-only`.
 
-When the same diagnostic hits many fixtures, use `patterns[]`
-instead of dozens of per-`id` entries. `specUrl` is required on
-patterns — they are the most load-bearing exclusion. If you cannot
-cite a paragraph, use a per-`id` entry.
+`specUrl` is required on both `entries[]` and `patterns[]`. Every
+exclusion must cite a spec paragraph (HTML LS / WAI-ARIA / URL LS /
+similar). If no spec paragraph can be cited, do not exclude — file an
+Issue to track the future markuplint coverage instead. When the same
+diagnostic hits many fixtures, use `patterns[]` instead of dozens of
+per-`id` entries.
 
 Patterns trade compactness for stability: per-`id` entries pin the
 nu message-ID hash, so a wording shift in nu surfaces as a stale
@@ -201,6 +203,7 @@ directly. Do not add a row without a verbatim spec quote and source URL.
 | `<img srcset="http: 1x">` and similar URL-LS-invalid candidate URLs | **nu correct** — markuplint coverage extended in `@markuplint/types` Srcset | URL LS rejects bare special-scheme fragments missing `//` (`special-scheme-missing-following-solidus`). The Srcset checker now parses each candidate's URL via WHATWG URL with a dummy `https://example.com/` base. |
 | `sizes="-1px"` / `sizes="(min-width: 600px) -100px"` and similar negative `<source-size-value>` | **nu correct** — markuplint coverage extended in `@markuplint/types` SourceSizeList | HTML LS § sizes: `<source-size-value>` must be a non-negative `<length>`. css-tree's `<length>` grammar accepts negatives, so a post-syntax regex catches them at boundaries (start-of-list, after `,`, after the `)` closing a `<media-condition>`). |
 | `A "source" element that has a following sibling "source" element or "img" element with a "srcset" attribute must have a "media" attribute and/or "type" attribute` / `Value of "media" attribute here must not be "all"` | **nu correct** — markuplint coverage extended in `srcset-sizes-constraint` Check 6 | [HTML LS § the source element](https://html.spec.whatwg.org/multipage/embedded-content.html#the-source-element): "When a source element has a following sibling source element or img element with a srcset attribute specified, it must have at least one of the following: A media attribute specified with a value that, after stripping leading and trailing ASCII whitespace, is not the empty string and is not an ASCII case-insensitive match for the string 'all'. A type attribute specified." An always-matching first source shadows the following candidates. Applies even to a srcset-less source. Flipped 7 `picture/always-matching-*-novalid` fixtures nu-only → match-error. |
+| `exceeded the column count established using column markup` (`<col>` + wider row) | **nu over-detection** — excluded per-ID in `entries[]` | [HTML LS §4.9.12.1 *Algorithm for processing rows* Step 7](https://html.spec.whatwg.org/multipage/tables.html#forming-a-table): "If xcurrent is equal to xwidth, then increase xwidth by 1." xwidth grows automatically when a row has more cells than the current column count established by column markup — extra columns are silently created and every column in this row still has an anchor cell, so neither Step 14 (overlap) nor Step 20 (no-anchor) is violated. The real `<col>`-related table model errors (rows narrower than column markup, dangling colspan, empty rows, etc.) are tracked at #3915. |
 
 The remaining `nu-only` bulk (URL parsing) is **not** for exclusion;
 it represents real markuplint gaps for future coverage work. Any

--- a/tests/external/bench/schema/excluded-ids.schema.json
+++ b/tests/external/bench/schema/excluded-ids.schema.json
@@ -11,12 +11,13 @@
 			"items": {
 				"type": "object",
 				"additionalProperties": false,
-				"required": ["id", "path", "nuMessage", "reason", "addedAt", "addedBy"],
+				"required": ["id", "path", "nuMessage", "reason", "specUrl", "addedAt", "addedBy"],
 				"properties": {
 					"id": { "type": "string", "pattern": "^nv-[0-9a-f]{12}(-[0-9]+)?$" },
 					"path": { "type": "string" },
 					"nuMessage": { "type": "string" },
 					"reason": { "type": "string" },
+					"specUrl": { "type": "string", "format": "uri" },
 					"addedAt": { "type": "string", "format": "date" },
 					"addedBy": { "type": "string" }
 				}

--- a/tests/external/bench/types.ts
+++ b/tests/external/bench/types.ts
@@ -90,12 +90,22 @@ export type MarkuplintSnapshot = {
  * does not flag, so the verdict collapses from `nu-over` to `match-clean`.
  * Every field is required so `reason`, `addedAt`, and `addedBy` leave an
  * audit trail.
+ *
+ * Only `id` participates in exclusion matching (see `compare.ts`); the
+ * `path`, `nuMessage`, `specUrl`, `reason`, `addedAt`, and `addedBy` fields
+ * are stored for the audit trail and to make stale entries readable
+ * without consulting the snapshot tree. `id` is a SHA-256 over
+ * `path + type + message + firstLine + firstColumn` (see `message-id.ts`),
+ * so any wording or position drift invalidates the prior `id` and the
+ * stale entry stops matching — its fixture reappears in `nu-only` on the
+ * next bench run, which is the intended re-review signal.
  */
 export type ExcludedIdEntry = {
 	readonly id: string;
 	readonly path: string;
 	readonly nuMessage: string;
 	readonly reason: string;
+	readonly specUrl: string;
 	readonly addedAt: string;
 	readonly addedBy: string;
 };

--- a/tests/external/snapshots/excluded-ids.json
+++ b/tests/external/snapshots/excluded-ids.json
@@ -45,6 +45,15 @@
 			"specUrl": "https://html.spec.whatwg.org/multipage/webappapis.html#sorting-and-normalizing-scopes",
 			"addedAt": "2026-05-18",
 			"addedBy": "hirao"
+		},
+		{
+			"id": "nv-d7b3d14cfb44",
+			"path": "html/elements/table/row-width-exceeds-col-markup-novalid.html",
+			"nuMessage": "A table row was 3 columns wide and exceeded the column count established using column markup (2).",
+			"reason": "HTML LS §4.9.12.1 *Algorithm for processing rows* Step 7: 'If xcurrent is equal to xwidth, then increase xwidth by 1.' xwidth grows automatically when a row has more cells than the current column count established by column markup. There is no spec rule that row width must not exceed column markup width — extra columns are silently created. After xwidth growth every column in this row has an anchor cell, so Step 20 (no-anchor) is also not violated. nu-validator's 'exceeded the column count established using column markup' is heuristic over-detection.",
+			"specUrl": "https://html.spec.whatwg.org/multipage/tables.html#forming-a-table",
+			"addedAt": "2026-07-01",
+			"addedBy": "hirao"
 		}
 	],
 	"patterns": [
@@ -53,13 +62,6 @@
 			"reason": "WHATWG URL Living Standard supersedes RFC 2397. Per URL LS §4.3, 'A valid URL string must be either a relative-URL-with-fragment string or an absolute-URL-with-fragment string.' An absolute-URL-with-fragment string is 'an absolute-URL string, optionally followed by U+0023 (#) and a URL-fragment string.' Since 'data' is a non-special scheme, 'data:<body>#<fragment>' matches this grammar and is a valid URL string. HTML conformance (which requires a valid URL string) is therefore satisfied.",
 			"specUrl": "https://url.spec.whatwg.org/#url-writing",
 			"addedAt": "2026-04-23",
-			"addedBy": "hirao"
-		},
-		{
-			"messageContains": "exceeded the column count established using column markup",
-			"reason": "HTML LS §4.9.12.1 *Algorithm for processing rows* Step 7: 'If xcurrent is equal to xwidth, then increase xwidth by 1.' xwidth grows automatically when a row has more cells than the current column count established by column markup. There is no spec rule that row width must not exceed column markup width — extra columns are silently created. After xwidth growth every column in the row has an anchor cell, so Step 20 (no-anchor) is also not violated. nu-validator's 'exceeded column count established using column markup' is heuristic over-detection.",
-			"specUrl": "https://html.spec.whatwg.org/multipage/tables.html#forming-a-table",
-			"addedAt": "2026-07-01",
 			"addedBy": "hirao"
 		}
 	]

--- a/tests/external/snapshots/excluded-ids.json
+++ b/tests/external/snapshots/excluded-ids.json
@@ -54,6 +54,13 @@
 			"specUrl": "https://url.spec.whatwg.org/#url-writing",
 			"addedAt": "2026-04-23",
 			"addedBy": "hirao"
+		},
+		{
+			"messageContains": "exceeded the column count established using column markup",
+			"reason": "HTML LS §4.9.12.1 *Algorithm for processing rows* Step 7: 'If xcurrent is equal to xwidth, then increase xwidth by 1.' xwidth grows automatically when a row has more cells than the current column count established by column markup. There is no spec rule that row width must not exceed column markup width — extra columns are silently created. After xwidth growth every column in the row has an anchor cell, so Step 20 (no-anchor) is also not violated. nu-validator's 'exceeded column count established using column markup' is heuristic over-detection.",
+			"specUrl": "https://html.spec.whatwg.org/multipage/tables.html#forming-a-table",
+			"addedAt": "2026-07-01",
+			"addedBy": "hirao"
 		}
 	]
 }


### PR DESCRIPTION
## Summary

Record `tests/external/validator/tests/html/elements/table/row-width-exceeds-col-markup-novalid.html` as nu over-detection in `excluded-ids.json` (per-id entry keyed on `nv-d7b3d14cfb44`).

HTML LS [§4.9.12.1 *Algorithm for processing rows* Step 7](https://html.spec.whatwg.org/multipage/tables.html#forming-a-table) grows xwidth when a row has more cells than the current column count:

> If xcurrent is equal to xwidth, then increase xwidth by 1.

There is no spec rule that row width must not exceed column markup width. After xwidth growth every column in this row has an anchor cell, so Step 20 (no-anchor) is also not violated. nu-validator's "exceeded the column count established using column markup" is heuristic over-detection.

The companion bench refresh (and the eventual `match-error` flip of column-markup fixtures that ARE spec violations) lands via #3915.

## Test plan

- [x] `yarn bench:compare` flips `row-width-exceeds-col-markup-novalid.html` from `nu-only` to `nu-over`.

Refs #3915.