### PR TITLE
test: register bench-xref primary mapping for #3921

### DIFF
--- a/tests/external/bench/issue-xref.config.ts
+++ b/tests/external/bench/issue-xref.config.ts
@@ -71,6 +71,13 @@ export const xrefMappings: readonly XrefMapping[] = [
 		note:
 			"HTML LS §4.10.4 label content model: \"Phrasing content, but with no descendant labelable elements unless it is the element's labeled control\". A `<label for=\"x\">` whose target is outside the label may not also contain a labelable descendant. `label-no-multiple-controls` fires only from the second labelable descendant onward, so this single-descendant case slips through.",
 	},
+	{
+		kind: 'primary',
+		issue: 3921,
+		filter: /^html\/elements\/base\/preceded-by-(link|script)-novalid/,
+		note:
+			'HTML LS §4.2.3 The base element: "A `base` element, if it has an `href` attribute, must come before any other elements in the tree that have attributes defined as taking URLs." `<link>`/`<script>` are metadata content, so `<base>` remains in `<head>` alongside them and `permitted-contents` does not fire. `head-element-order` treats `<base>` as an unlisted (highest-priority) entry in its default source-order list, so `<link>` (group 5) preceding `<base>` (group 8) also matches. A dedicated rule (`base-element-position`) is proposed.',
+	},
 
 	// === 2 次群: bench では裏取れない Issue（ステルブロック） ===
 	{


### PR DESCRIPTION
## Summary

Registers a `primary` bench-xref mapping for #3921 (`base-element-position` rule proposal). The rendered `<!-- bench-xref -->` block now appears at the end of Issue #3921's body.

## Test plan

- [x] `yarn bench:xref --issue 3921` — renders 2 fixtures (`preceded-by-link-novalid`, `preceded-by-script-novalid`) as `nu-only`, matches the note in the mapping
- [x] Applied to Issue body via `--write`; block visible on #3921