### PR TITLE
fix(html-spec): div in dl allows exactly one dt+dd group per HTML LS

### DIFF
--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -50347,23 +50347,19 @@
 						"condition": "dl > div",
 						"contents": [
 							{
-								"oneOrMore": [
-									{
-										"zeroOrMore": ":model(script-supporting)"
-									},
-									{
-										"oneOrMore": "dt"
-									},
-									{
-										"zeroOrMore": ":model(script-supporting)"
-									},
-									{
-										"oneOrMore": "dd"
-									},
-									{
-										"zeroOrMore": ":model(script-supporting)"
-									}
-								]
+								"zeroOrMore": ":model(script-supporting)"
+							},
+							{
+								"oneOrMore": "dt"
+							},
+							{
+								"zeroOrMore": ":model(script-supporting)"
+							},
+							{
+								"oneOrMore": "dd"
+							},
+							{
+								"zeroOrMore": ":model(script-supporting)"
 							}
 						]
 					}

--- a/packages/@markuplint/html-spec/src/spec.div.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.div.jsonc
@@ -10,26 +10,27 @@
 		],
 		"conditional": [
 			{
+				// HTML LS §4.4.9 The dl element: "If the parent is a dl element:
+				// One or more dt elements followed by one or more dd elements,
+				// optionally intermixed with script-supporting elements." One group
+				// per `<div>`, not repeatable — the group repetition lives at the
+				// `<dl>` level, not inside each `<div>`.
 				"condition": "dl > div",
 				"contents": [
 					{
-						"oneOrMore": [
-							{
-								"zeroOrMore": ":model(script-supporting)"
-							},
-							{
-								"oneOrMore": "dt"
-							},
-							{
-								"zeroOrMore": ":model(script-supporting)"
-							},
-							{
-								"oneOrMore": "dd"
-							},
-							{
-								"zeroOrMore": ":model(script-supporting)"
-							}
-						]
+						"zeroOrMore": ":model(script-supporting)"
+					},
+					{
+						"oneOrMore": "dt"
+					},
+					{
+						"zeroOrMore": ":model(script-supporting)"
+					},
+					{
+						"oneOrMore": "dd"
+					},
+					{
+						"zeroOrMore": ":model(script-supporting)"
 					}
 				]
 			}

--- a/packages/@markuplint/ml-spec/src/utils/get-spec-by-tag-name.spec.ts
+++ b/packages/@markuplint/ml-spec/src/utils/get-spec-by-tag-name.spec.ts
@@ -9,23 +9,19 @@ const divSpec = {
 			condition: 'dl > div',
 			contents: [
 				{
-					oneOrMore: [
-						{
-							zeroOrMore: ':model(script-supporting)',
-						},
-						{
-							oneOrMore: 'dt',
-						},
-						{
-							zeroOrMore: ':model(script-supporting)',
-						},
-						{
-							oneOrMore: 'dd',
-						},
-						{
-							zeroOrMore: ':model(script-supporting)',
-						},
-					],
+					zeroOrMore: ':model(script-supporting)',
+				},
+				{
+					oneOrMore: 'dt',
+				},
+				{
+					zeroOrMore: ':model(script-supporting)',
+				},
+				{
+					oneOrMore: 'dd',
+				},
+				{
+					zeroOrMore: ':model(script-supporting)',
 				},
 			],
 		},

--- a/packages/@markuplint/rules/src/permitted-contents/index.spec.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/index.spec.ts
@@ -2393,6 +2393,27 @@ describe('Issues', () => {
 			[],
 		);
 	});
+
+	// HTML LS §4.4.9: div inside dl allows exactly one group (dt+ dd+),
+	// not repeated groups. Group repetition is expressed at the dl level.
+	test('[permitted-contents-invalid-034] div in dl with multiple dt+dd groups is invalid', async () => {
+		const { violations } = await mlRuleTest(rule, '<dl><div><dt>a</dt><dd>b</dd><dt>c</dt><dd>d</dd></div></dl>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 30,
+				message: 'The "dt" element is not allowed in the "div" element in this context',
+				raw: '<dt>',
+			},
+		]);
+	});
+
+	test('[permitted-contents-valid-003] div in dl with single dt+dd group is valid', async () => {
+		expect(
+			(await mlRuleTest(rule, '<dl><div><dt>a</dt><dt>b</dt><dd>c</dd><dd>d</dd></div></dl>')).violations,
+		).toStrictEqual([]);
+	});
 });
 
 describe('#3739 (pretender + user tag rule)', () => {


### PR DESCRIPTION
## Summary

Fix the `<div>` content model when its parent is `<dl>`. Per [HTML LS §4.4.9 *The dl element*](https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element):

> If the parent is a dl element: One or more dt elements followed by one or more dd elements, optionally intermixed with script-supporting elements.

That is a **single** group (dt+ dd+). The previous \`spec.div.jsonc\` wrapped the group in \`oneOrMore\`, allowing repeated dt/dd sequences inside one \`<div>\`. The group repetition lives at the \`<dl>\` level (each \`<div>\` is one group; the \`<dl>\` may hold many \`<div>\` children).

## Coverage impact (bench)

- \`tests/external/validator/tests/html/elements/dl/div-multiple-groups-novalid.html\` flips \`nu-only\` → \`match-error\` (nu-only −1).

## Test plan

- [x] \`yarn build\` → 39/39 projects pass
- [x] \`yarn test\` → 4304 passed (was 4303 before the added coverage; +1 new invalid, existing div-in-dl regression tests still green)
- [x] \`yarn lint\` → 0 warnings, 0 errors

## Changes

- \`packages/@markuplint/html-spec/src/spec.div.jsonc\` — remove the outer \`oneOrMore\` wrapper; add spec-citation JSDoc explaining the single-group rule
- \`packages/@markuplint/html-spec/index.json\` — regenerated (only the \`dl > div\` block; unrelated MDN drift from \`yarn up:gen\` reverted)
- \`packages/@markuplint/rules/src/permitted-contents/index.spec.ts\` — add \`invalid-034\` (multi-group div fails) and \`valid-003\` (single-group div with multiple dt/dd inside the one group still passes)
- \`packages/@markuplint/ml-spec/src/utils/get-spec-by-tag-name.spec.ts\` — mirror the new spec structure in the hardcoded \`divSpec\` shape assertion