### PR TITLE
feat!: forbid aria-expanded on button[commandfor] (Invoker Commands API)

### DIFF
--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -49680,6 +49680,22 @@
 								}
 							]
 						}
+					},
+					"[commandfor]": {
+						"properties": {
+							"global": true,
+							"role": true,
+							"without": [
+								{
+									"type": "must-not",
+									"name": "aria-expanded",
+									"alt": {
+										"method": "set-attr",
+										"target": "commandfor"
+									}
+								}
+							]
+						}
 					}
 				},
 				"1.1": {

--- a/packages/@markuplint/html-spec/src/spec.button.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.button.jsonc
@@ -109,6 +109,27 @@
 						}
 					]
 				}
+			},
+			// HTML LS Invoker Commands API: a button that invokes a popover or
+			// dialog via commandfor manages the expanded state automatically
+			// (same reasoning as popovertarget), so a manual aria-expanded would
+			// drift from the actual UI state.
+			// @see https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-commandfor
+			"[commandfor]": {
+				"properties": {
+					"global": true,
+					"role": true,
+					"without": [
+						{
+							"type": "must-not",
+							"name": "aria-expanded",
+							"alt": {
+								"method": "set-attr",
+								"target": "commandfor"
+							}
+						}
+					]
+				}
 			}
 		},
 		"1.1": {

--- a/packages/@markuplint/rules/src/wai-aria-disallowed-props/README.ja.md
+++ b/packages/@markuplint/rules/src/wai-aria-disallowed-props/README.ja.md
@@ -8,7 +8,7 @@ description: 要素のロールで許可されていないARIAプロパティ/�
 
 1. **計算されたロールで許可されていない** — 例: `role="heading"` 上の `aria-pressed`
 2. **命名禁止（naming prohibition）** — `<cite>`、`<abbr>`、`<figcaption>` のような暗黙ロールを持たない要素や autonomous custom element (`<my-widget>` 等) では、命名をサポートするロールを明示的に設定しない限り、`aria-label`、`aria-labelledby`、`aria-braillelabel` を使用できません。Customised-built-in (`<button is="x-y">`) はホスト要素の spec data を継承するため通常経路で評価されます。
-3. **要素固有の禁止** — 特定の要素状態ではすべての `aria-*` 属性が禁止されます（例: `<input type="hidden">`）。また、ある属性が指定されているときに別の `aria-*` が禁止される場合もあります（例: `<button popovertarget>` では popover API が状態を自動管理するため `aria-expanded` 禁止）。
+3. **要素固有の禁止** — 特定の要素状態ではすべての `aria-*` 属性が禁止されます（例: `<input type="hidden">`）。また、ある属性が指定されているときに別の `aria-*` が禁止される場合もあります（例: `<button popovertarget>` や `<button commandfor>` では popover API / Invoker Commands API が状態を自動管理するため `aria-expanded` 禁止）。
 4. **要素固有のホワイトリスト** — 一部の要素はごく限られた `aria-*` 属性のみ受け付けます（例: `<br>`/`<wbr>` は `aria-hidden` のみ）。ホワイトリスト外の属性は拒否されます。
 
 このルールは[`wai-aria`](../wai-aria/)ルールファミリーの一部で、きめ細かなseverity制御のために分割されたものです。
@@ -24,6 +24,7 @@ description: 要素のロールで許可されていないARIAプロパティ/�
 <br aria-atomic="true" />
 <input type="hidden" aria-hidden="true" />
 <button popovertarget="p" aria-expanded="false">Toggle</button>
+<button command="toggle-popover" commandfor="p" aria-expanded="false">Toggle</button>
 ```
 
 ✅ 正しいコード例
@@ -35,6 +36,7 @@ description: 要素のロールで許可されていないARIAプロパティ/�
 <br aria-hidden="true" />
 <input type="hidden" />
 <button popovertarget="p">Toggle</button>
+<button command="toggle-popover" commandfor="p">Toggle</button>
 ```
 
 <!-- textlint-enable ja-technical-writing/ja-no-mixed-period -->

--- a/packages/@markuplint/rules/src/wai-aria-disallowed-props/README.md
+++ b/packages/@markuplint/rules/src/wai-aria-disallowed-props/README.md
@@ -9,7 +9,7 @@ Warns when an ARIA property or state is disallowed in any of the following ways 
 
 1. **Not allowed on the computed role** — e.g. `aria-pressed` on `role="heading"`.
 2. **Naming prohibition** — elements without an implicit role (`<cite>`, `<abbr>`, `<figcaption>`, etc.) and autonomous custom elements (`<my-widget>`, etc.) must not use `aria-label`, `aria-labelledby`, or `aria-braillelabel` unless an explicit naming-supported role is set. Customised-built-in elements (`<button is="x-y">`) inherit the host element's spec data and follow the regular path.
-3. **Element-specific prohibitions** — every `aria-*` attribute is forbidden on certain element states (e.g. `<input type="hidden">`), and individual attributes may be forbidden when another attribute is present (e.g. `aria-expanded` on `<button popovertarget>` because the popover API manages the state automatically).
+3. **Element-specific prohibitions** — every `aria-*` attribute is forbidden on certain element states (e.g. `<input type="hidden">`), and individual attributes may be forbidden when another attribute is present (e.g. `aria-expanded` on `<button popovertarget>` or `<button commandfor>` because the popover / Invoker Commands API manages the state automatically).
 4. **Element-specific whitelist** — some elements accept only a small set of `aria-*` attributes (e.g. `<br>` and `<wbr>` accept only `aria-hidden`); any attribute outside the whitelist is rejected.
 
 This rule is part of the [`wai-aria`](../wai-aria/) rule family, split for granular severity control.
@@ -23,6 +23,7 @@ This rule is part of the [`wai-aria`](../wai-aria/) rule family, split for granu
 <br aria-atomic="true" />
 <input type="hidden" aria-hidden="true" />
 <button popovertarget="p" aria-expanded="false">Toggle</button>
+<button command="toggle-popover" commandfor="p" aria-expanded="false">Toggle</button>
 ```
 
 ✅ Examples of **correct** code for this rule
@@ -34,4 +35,5 @@ This rule is part of the [`wai-aria`](../wai-aria/) rule family, split for granu
 <br aria-hidden="true" />
 <input type="hidden" />
 <button popovertarget="p">Toggle</button>
+<button command="toggle-popover" commandfor="p">Toggle</button>
 ```

--- a/packages/@markuplint/rules/src/wai-aria-disallowed-props/index.spec.ts
+++ b/packages/@markuplint/rules/src/wai-aria-disallowed-props/index.spec.ts
@@ -263,6 +263,33 @@ test('[wai-aria-disallowed-props-issue-3735-002] button without popovertarget al
 	expect((await mlRuleTest(rule, '<button aria-expanded="false">x</button>')).violations).toStrictEqual([]);
 });
 
+// #3830: button[commandfor] must not have aria-expanded. The Invoker Commands
+// API manages the expanded state automatically (same reasoning as popovertarget),
+// so a manual aria-expanded is redundant and may drift from the actual state.
+test('[wai-aria-disallowed-props-issue-3830-001] button[commandfor] aria-expanded is must-not', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		'<button command="toggle-popover" commandfor="p" aria-expanded="false">x</button>',
+	);
+	expect(violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 49,
+			message:
+				'The "aria-expanded" ARIA state must not use on the "button" element. As its state is already provided by the "commandfor" attribute',
+			raw: 'aria-expanded="false"',
+		},
+	]);
+});
+
+test('[wai-aria-disallowed-props-issue-3830-002] button without commandfor allows aria-expanded', async () => {
+	// Sanity check: without commandfor the conditional must not fire.
+	expect(
+		(await mlRuleTest(rule, '<button command="toggle-popover" aria-expanded="false">x</button>')).violations,
+	).toStrictEqual([]);
+});
+
 // #3735 P2: input[type=hidden] sets `properties: false` in spec data, meaning
 // any aria-* attribute is disallowed. The check must fire even though the
 // element has no implicit role and no explicit role (same root cause as #3630

--- a/tests/external/snapshots/diff/coverage.json
+++ b/tests/external/snapshots/diff/coverage.json
@@ -1052,8 +1052,8 @@
 			"path": "html-aria/misc/aria-expanded-with-command-novalid.html",
 			"category": "aria",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -14092,8 +14092,8 @@
 			"path": "html/attributes/command-with-aria-expanded-novalid.html",
 			"category": "global-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -21602,8 +21602,8 @@
 			"path": "html/elements/dl/div-multiple-groups-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{

--- a/tests/external/snapshots/diff/nu-only.json
+++ b/tests/external/snapshots/diff/nu-only.json
@@ -1,13 +1,6 @@
 {
 	"entries": [
 		{
-			"path": "html-aria/misc/aria-expanded-with-command-novalid.html",
-			"category": "aria",
-			"nuMessageIds": [
-				"nv-5c22b7821665"
-			]
-		},
-		{
 			"path": "html-aria/misc/role-tab-with-no-role-tabpanel-novalid.html",
 			"category": "aria",
 			"nuMessageIds": [
@@ -36,13 +29,6 @@
 			"nuMessageIds": [
 				"nv-0c86320f6630",
 				"nv-8aff5b8981a2"
-			]
-		},
-		{
-			"path": "html/attributes/command-with-aria-expanded-novalid.html",
-			"category": "global-attr",
-			"nuMessageIds": [
-				"nv-65bdcb988594"
 			]
 		},
 		{
@@ -100,16 +86,6 @@
 			"category": "invalid-attr",
 			"nuMessageIds": [
 				"nv-397f312420d3"
-			]
-		},
-		{
-			"path": "html/elements/dl/div-multiple-groups-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-323a5f6407e4",
-				"nv-8488d87fd201",
-				"nv-c85c578225cf",
-				"nv-4f10aadba99f"
 			]
 		},
 		{

--- a/tests/external/snapshots/diff/summary.md
+++ b/tests/external/snapshots/diff/summary.md
@@ -1,6 +1,6 @@
 # nu-validator Benchmark Summary
 
-- generated: 2026-07-01T03:45:19.591Z
+- generated: 2026-07-02T01:31:55.919Z
 - submodule: `142931395412c00434ffb40a14d65992efd17aa8`
 - nu-validator: `ghcr.io/validator/validator@sha256:9365682da0f66efc5504ce2a3aba91290aaf08c00799a41d096236fab740bb44`
 - markuplint: `5.0.0-rc.4`
@@ -9,25 +9,25 @@
 ## Totals
 
 - files: **5442**
-- match-error: **3460** (both tools flagged)
+- match-error: **3463** (both tools flagged)
 - match-clean: **883** (neither flagged)
-- nu-only: **51** (only nu-validator flagged; markuplint coverage candidates — open a markuplint issue after a spec read)
+- nu-only: **48** (only nu-validator flagged; markuplint coverage candidates — open a markuplint issue after a spec read)
 - nu-over: **31** (nu-validator errors fully covered by spec-backed excluded-ids — confirmed over-detection)
-- overall match rate: **79.8%**
+- overall match rate: **79.9%**
 - excluded-ids: 6 entries, 1 pattern(s)
 
 ## Per-Category
 
 | Category | Files | Match rate | match-error | match-clean | ml-only | nu-only | nu-over |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| aria | 780 | 76.7% | 178 | 420 | 178 | 4 | 0 |
+| aria | 780 | 76.8% | 179 | 420 | 178 | 3 | 0 |
 | assertions | 40 | 100.0% | 39 | 1 | 0 | 0 | 0 |
 | content-model | 98 | 96.9% | 50 | 45 | 3 | 0 | 0 |
 | data-types | 56 | 94.6% | 48 | 5 | 1 | 2 | 0 |
 | deprecated | 12 | 91.7% | 11 | 0 | 1 | 0 | 0 |
-| global-attr | 57 | 80.7% | 26 | 20 | 8 | 3 | 0 |
+| global-attr | 57 | 82.5% | 27 | 20 | 8 | 2 | 0 |
 | id-duplication | 1 | 100.0% | 1 | 0 | 0 | 0 | 0 |
-| invalid-attr | 3086 | 95.9% | 2729 | 229 | 61 | 38 | 29 |
+| invalid-attr | 3086 | 95.9% | 2730 | 229 | 61 | 37 | 29 |
 | required-attr | 5 | 100.0% | 5 | 0 | 0 | 0 | 0 |
 | uncategorized | 1307 | 41.0% | 373 | 163 | 765 | 4 | 2 |
 

--- a/tests/external/snapshots/meta.json
+++ b/tests/external/snapshots/meta.json
@@ -1,12 +1,12 @@
 {
-	"generatedAt": "2026-07-01T03:45:19.591Z",
+	"generatedAt": "2026-07-02T01:31:55.919Z",
 	"submoduleSha": "142931395412c00434ffb40a14d65992efd17aa8",
 	"nuValidatorImage": "ghcr.io/validator/validator@sha256:9365682da0f66efc5504ce2a3aba91290aaf08c00799a41d096236fab740bb44",
 	"markuplintVersion": "5.0.0-rc.4",
 	"nodeVersion": "24.14.1",
 	"totalFilesNu": 1,
-	"totalFilesMl": 1,
+	"totalFilesMl": 5442,
 	"totalNuMessages": 1,
-	"totalMlViolations": 2,
+	"totalMlViolations": 11355,
 	"totalNuFailures": 0
 }


### PR DESCRIPTION
## Summary

- Add an `aria.conditions[\"[commandfor]\"]` block to `spec.button.jsonc` mirroring the existing `[popovertarget]` constraint (#3735 P1).
- HTML LS Invoker Commands API manages the expanded/collapsed state on the invoker button automatically, so a manual `aria-expanded` would drift from the actual UI state.
- `wai-aria-disallowed-props` reports this through the existing `properties.without` branch — no rule code changes needed.

## Bench impact

Flips 3 fixtures `nu-only` → `match-error` (2 from #3830, 1 snapshot-lag from #3923):

- `html-aria/misc/aria-expanded-with-command-novalid.html`
- `html/attributes/command-with-aria-expanded-novalid.html`
- `html/elements/dl/div-multiple-groups-novalid.html` (already fixed in #3923; snapshots were not refreshed)

Totals: `nu-only` 51 → 48, `match-error` 3460 → 3463, overall match rate 79.8% → 79.9%.

## Note on breaking change marker

The `!` is here because the new spec constraint promotes an existing warning-free markup pattern (`<button command=... commandfor=... aria-expanded=...>`) to an error under `wai-aria-disallowed-props`. Consistent with #3735 which added the popovertarget constraint under the same rule during the RC cycle.

Closes #3830

## Test plan

- [x] `yarn test` — all 4306 tests pass (2 new regression tests: `wai-aria-disallowed-props-issue-3830-001/002`)
- [x] `yarn lint-check` — 0 errors, 0 warnings
- [x] `yarn bench:compare` — 3 fixtures flip nu-only → match-error, no regressions elsewhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)