### PR TITLE
fix(html-spec): forbid aria-expanded / aria-pressed on summary in details

### DIFF
--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -55008,6 +55008,24 @@
 				"properties": {
 					"global": true,
 					"role": "button"
+				},
+				"conditions": {
+					"details > summary:not(summary ~ summary)": {
+						"properties": {
+							"global": true,
+							"role": "button",
+							"without": [
+								{
+									"type": "must-not",
+									"name": "aria-expanded"
+								},
+								{
+									"type": "must-not",
+									"name": "aria-pressed"
+								}
+							]
+						}
+					}
 				}
 			},
 			"omission": false,

--- a/packages/@markuplint/html-spec/src/spec.summary.jsonc
+++ b/packages/@markuplint/html-spec/src/spec.summary.jsonc
@@ -35,6 +35,33 @@
 		"properties": {
 			"global": true,
 			"role": "button"
+		},
+		"conditions": {
+			// ARIA in HTML restricts a summary that is a summary for its parent details element
+			// to "Global aria-* attributes, aria-disabled, and aria-haspopup attributes".
+			// Per HTML LS §4.11.2 the "summary for its parent details" is the first summary
+			// child of details in tree order. `details > summary:not(summary ~ summary)`
+			// matches that (markuplint's selector engine does not support :first-of-type
+			// / :nth-of-type — see @markuplint/selector). Since summary's implicit ARIA
+			// state maps to details.open, aria-expanded and aria-pressed conflict with the
+			// native semantics and must not be used in that context.
+			// https://w3c.github.io/html-aria/#el-summary
+			"details > summary:not(summary ~ summary)": {
+				"properties": {
+					"global": true,
+					"role": "button",
+					"without": [
+						{
+							"type": "must-not",
+							"name": "aria-expanded"
+						},
+						{
+							"type": "must-not",
+							"name": "aria-pressed"
+						}
+					]
+				}
+			}
 		}
 	}
 }

--- a/packages/@markuplint/rules/src/wai-aria-disallowed-props/README.ja.md
+++ b/packages/@markuplint/rules/src/wai-aria-disallowed-props/README.ja.md
@@ -8,7 +8,7 @@ description: 要素のロールで許可されていないARIAプロパティ/�
 
 1. **計算されたロールで許可されていない** — 例: `role="heading"` 上の `aria-pressed`
 2. **命名禁止（naming prohibition）** — `<cite>`、`<abbr>`、`<figcaption>` のような暗黙ロールを持たない要素や autonomous custom element (`<my-widget>` 等) では、命名をサポートするロールを明示的に設定しない限り、`aria-label`、`aria-labelledby`、`aria-braillelabel` を使用できません。Customised-built-in (`<button is="x-y">`) はホスト要素の spec data を継承するため通常経路で評価されます。
-3. **要素固有の禁止** — 特定の要素状態ではすべての `aria-*` 属性が禁止されます（例: `<input type="hidden">`）。また、ある属性が指定されているときに別の `aria-*` が禁止される場合もあります（例: `<button popovertarget>` や `<button commandfor>` では popover API / Invoker Commands API が状態を自動管理するため `aria-expanded` 禁止）。
+3. **要素固有の禁止** — 特定の要素状態ではすべての `aria-*` 属性が禁止されます（例: `<input type="hidden">`）。また、ある属性が指定されているとき、あるいは特定の親要素の中にあるときに別の `aria-*` が禁止される場合もあります（例: `<button popovertarget>` や `<button commandfor>` では popover API / Invoker Commands API が状態を自動管理するため `aria-expanded` 禁止。`<details>` 直下の最初の `<summary>` では expanded 状態が `open` 属性にマップされるため `aria-expanded` と `aria-pressed` が禁止）。
 4. **要素固有のホワイトリスト** — 一部の要素はごく限られた `aria-*` 属性のみ受け付けます（例: `<br>`/`<wbr>` は `aria-hidden` のみ）。ホワイトリスト外の属性は拒否されます。
 
 このルールは[`wai-aria`](../wai-aria/)ルールファミリーの一部で、きめ細かなseverity制御のために分割されたものです。
@@ -25,6 +25,9 @@ description: 要素のロールで許可されていないARIAプロパティ/�
 <input type="hidden" aria-hidden="true" />
 <button popovertarget="p" aria-expanded="false">Toggle</button>
 <button command="toggle-popover" commandfor="p" aria-expanded="false">Toggle</button>
+<details>
+  <summary aria-expanded="false">Summary</summary>
+</details>
 ```
 
 ✅ 正しいコード例
@@ -37,6 +40,9 @@ description: 要素のロールで許可されていないARIAプロパティ/�
 <input type="hidden" />
 <button popovertarget="p">Toggle</button>
 <button command="toggle-popover" commandfor="p">Toggle</button>
+<details>
+  <summary>Summary</summary>
+</details>
 ```
 
 <!-- textlint-enable ja-technical-writing/ja-no-mixed-period -->

--- a/packages/@markuplint/rules/src/wai-aria-disallowed-props/README.md
+++ b/packages/@markuplint/rules/src/wai-aria-disallowed-props/README.md
@@ -9,7 +9,7 @@ Warns when an ARIA property or state is disallowed in any of the following ways 
 
 1. **Not allowed on the computed role** — e.g. `aria-pressed` on `role="heading"`.
 2. **Naming prohibition** — elements without an implicit role (`<cite>`, `<abbr>`, `<figcaption>`, etc.) and autonomous custom elements (`<my-widget>`, etc.) must not use `aria-label`, `aria-labelledby`, or `aria-braillelabel` unless an explicit naming-supported role is set. Customised-built-in elements (`<button is="x-y">`) inherit the host element's spec data and follow the regular path.
-3. **Element-specific prohibitions** — every `aria-*` attribute is forbidden on certain element states (e.g. `<input type="hidden">`), and individual attributes may be forbidden when another attribute is present (e.g. `aria-expanded` on `<button popovertarget>` or `<button commandfor>` because the popover / Invoker Commands API manages the state automatically).
+3. **Element-specific prohibitions** — every `aria-*` attribute is forbidden on certain element states (e.g. `<input type="hidden">`), and individual attributes may be forbidden when another attribute is present or when the element sits in a specific parent context (e.g. `aria-expanded` on `<button popovertarget>` or `<button commandfor>` because the popover / Invoker Commands API manages the state automatically; `aria-expanded` and `aria-pressed` on the first `<summary>` inside `<details>` because the expanded state maps to the `open` attribute).
 4. **Element-specific whitelist** — some elements accept only a small set of `aria-*` attributes (e.g. `<br>` and `<wbr>` accept only `aria-hidden`); any attribute outside the whitelist is rejected.
 
 This rule is part of the [`wai-aria`](../wai-aria/) rule family, split for granular severity control.
@@ -24,6 +24,9 @@ This rule is part of the [`wai-aria`](../wai-aria/) rule family, split for granu
 <input type="hidden" aria-hidden="true" />
 <button popovertarget="p" aria-expanded="false">Toggle</button>
 <button command="toggle-popover" commandfor="p" aria-expanded="false">Toggle</button>
+<details>
+  <summary aria-expanded="false">Summary</summary>
+</details>
 ```
 
 ✅ Examples of **correct** code for this rule
@@ -36,4 +39,7 @@ This rule is part of the [`wai-aria`](../wai-aria/) rule family, split for granu
 <input type="hidden" />
 <button popovertarget="p">Toggle</button>
 <button command="toggle-popover" commandfor="p">Toggle</button>
+<details>
+  <summary>Summary</summary>
+</details>
 ```

--- a/packages/@markuplint/rules/src/wai-aria-disallowed-props/index.spec.ts
+++ b/packages/@markuplint/rules/src/wai-aria-disallowed-props/index.spec.ts
@@ -326,3 +326,76 @@ test('[wai-aria-disallowed-props-issue-3735-005] input[type=text] aria-hidden is
 	// implicitRole=textbox and supports global aria-* attrs including aria-hidden.
 	expect((await mlRuleTest(rule, '<input type="text" aria-hidden="true">')).violations).toStrictEqual([]);
 });
+
+// ARIA in HTML restricts a summary that is a summary for its parent details
+// element to "Global aria-* attributes, aria-disabled, and aria-haspopup
+// attributes". aria-expanded and aria-pressed conflict with the details.open
+// state exposed by the native semantics and must not be used, even though
+// markuplint presets summary's implicit role as button.
+// https://w3c.github.io/html-aria/#el-summary
+test('[wai-aria-disallowed-props-invalid-002] aria-expanded on summary in details is must-not', async () => {
+	const { violations } = await mlRuleTest(rule, '<details><summary aria-expanded="false">s</summary></details>');
+	expect(violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 19,
+			message: 'The "aria-expanded" ARIA state must not use on the "summary" element',
+			raw: 'aria-expanded="false"',
+		},
+	]);
+});
+
+test('[wai-aria-disallowed-props-invalid-003] aria-pressed on summary in details is must-not', async () => {
+	const { violations } = await mlRuleTest(rule, '<details><summary aria-pressed="true">s</summary></details>');
+	expect(violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 19,
+			message: 'The "aria-pressed" ARIA state must not use on the "summary" element',
+			raw: 'aria-pressed="true"',
+		},
+	]);
+});
+
+test('[wai-aria-disallowed-props-valid-002] aria-disabled on summary in details is allowed', async () => {
+	expect(
+		(await mlRuleTest(rule, '<details><summary aria-disabled="true">s</summary></details>')).violations,
+	).toStrictEqual([]);
+});
+
+test('[wai-aria-disallowed-props-valid-003] aria-haspopup on summary in details is allowed', async () => {
+	expect(
+		(await mlRuleTest(rule, '<details><summary aria-haspopup="true">s</summary></details>')).violations,
+	).toStrictEqual([]);
+});
+
+// ARIA in HTML: "otherwise, if the summary element is not a summary for its
+// parent details element, authors MAY specify any role, and any global aria-*
+// attributes and any aria-* attributes applicable to the allowed roles."
+// The must-not is scoped via spec.summary.jsonc conditions to the first
+// summary child of details, so a summary outside details keeps button role's
+// supported aria-* including aria-expanded and aria-pressed.
+test('[wai-aria-disallowed-props-valid-004] aria-expanded on summary outside details is allowed', async () => {
+	expect((await mlRuleTest(rule, '<summary aria-expanded="false">s</summary>')).violations).toStrictEqual([]);
+});
+
+test('[wai-aria-disallowed-props-valid-005] aria-pressed on summary outside details is allowed', async () => {
+	expect((await mlRuleTest(rule, '<summary aria-pressed="true">s</summary>')).violations).toStrictEqual([]);
+});
+
+// A non-first summary in details is not "the summary" per HTML LS §4.11.2; the
+// content-model rule already reports the extra summary, so wai-aria-* here
+// treats it as the "otherwise" ARIA-in-HTML case (button role's supported
+// aria-* remain allowed).
+test('[wai-aria-disallowed-props-valid-006] aria-expanded on non-first summary in details is allowed', async () => {
+	expect(
+		(
+			await mlRuleTest(
+				rule,
+				'<details><summary>first</summary><summary aria-expanded="false">s</summary></details>',
+			)
+		).violations,
+	).toStrictEqual([]);
+});

--- a/tests/external/snapshots/diff/coverage.json
+++ b/tests/external/snapshots/diff/coverage.json
@@ -2172,8 +2172,8 @@
 			"path": "html-aria/misc/summary-for-its-details-with-aria-expanded-novalid.html",
 			"category": "aria",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -2188,8 +2188,8 @@
 			"path": "html-aria/misc/summary-for-its-details-with-aria-pressed-novalid.html",
 			"category": "aria",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{

--- a/tests/external/snapshots/diff/nu-only.json
+++ b/tests/external/snapshots/diff/nu-only.json
@@ -8,22 +8,6 @@
 			]
 		},
 		{
-			"path": "html-aria/misc/summary-for-its-details-with-aria-expanded-novalid.html",
-			"category": "aria",
-			"nuMessageIds": [
-				"nv-e2dbcbc96ae0",
-				"nv-71d55bb7d1b2"
-			]
-		},
-		{
-			"path": "html-aria/misc/summary-for-its-details-with-aria-pressed-novalid.html",
-			"category": "aria",
-			"nuMessageIds": [
-				"nv-a354a70fa4fe",
-				"nv-7e99c1fe9674"
-			]
-		},
-		{
 			"path": "html-math/math-in-head-novalid.html",
 			"category": "uncategorized",
 			"nuMessageIds": [

--- a/tests/external/snapshots/diff/summary.md
+++ b/tests/external/snapshots/diff/summary.md
@@ -1,6 +1,6 @@
 # nu-validator Benchmark Summary
 
-- generated: 2026-07-02T11:09:13.430Z
+- generated: 2026-07-02T13:28:37.050Z
 - submodule: `142931395412c00434ffb40a14d65992efd17aa8`
 - nu-validator: `ghcr.io/validator/validator@sha256:9365682da0f66efc5504ce2a3aba91290aaf08c00799a41d096236fab740bb44`
 - markuplint: `5.0.0-rc.4`
@@ -9,18 +9,18 @@
 ## Totals
 
 - files: **5442**
-- match-error: **3467** (both tools flagged)
+- match-error: **3469** (both tools flagged)
 - match-clean: **883** (neither flagged)
-- nu-only: **44** (only nu-validator flagged; markuplint coverage candidates — open a markuplint issue after a spec read)
+- nu-only: **42** (only nu-validator flagged; markuplint coverage candidates — open a markuplint issue after a spec read)
 - nu-over: **31** (nu-validator errors fully covered by spec-backed excluded-ids — confirmed over-detection)
-- overall match rate: **79.9%**
+- overall match rate: **80.0%**
 - excluded-ids: 6 entries, 1 pattern(s)
 
 ## Per-Category
 
 | Category | Files | Match rate | match-error | match-clean | ml-only | nu-only | nu-over |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| aria | 780 | 76.8% | 179 | 420 | 178 | 3 | 0 |
+| aria | 780 | 77.1% | 181 | 420 | 178 | 1 | 0 |
 | assertions | 40 | 100.0% | 39 | 1 | 0 | 0 | 0 |
 | content-model | 98 | 96.9% | 50 | 45 | 3 | 0 | 0 |
 | data-types | 56 | 94.6% | 48 | 5 | 1 | 2 | 0 |

--- a/tests/external/snapshots/meta.json
+++ b/tests/external/snapshots/meta.json
@@ -1,5 +1,5 @@
 {
-	"generatedAt": "2026-07-02T11:09:13.430Z",
+	"generatedAt": "2026-07-02T13:28:37.050Z",
 	"submoduleSha": "142931395412c00434ffb40a14d65992efd17aa8",
 	"nuValidatorImage": "ghcr.io/validator/validator@sha256:9365682da0f66efc5504ce2a3aba91290aaf08c00799a41d096236fab740bb44",
 	"markuplintVersion": "5.0.0-rc.4",
@@ -7,6 +7,6 @@
 	"totalFilesNu": 1,
 	"totalFilesMl": 5442,
 	"totalNuMessages": 1,
-	"totalMlViolations": 11359,
+	"totalMlViolations": 11361,
 	"totalNuFailures": 0
 }


### PR DESCRIPTION
## Summary

- Add a `properties.without` `must-not` for `aria-expanded` and `aria-pressed` on the first `<summary>` child of `<details>` via `spec.summary.jsonc` `conditions`.
- Scoped selector: `details > summary:not(summary ~ summary)` — markuplint's selector engine does not support `:first-of-type` / `:nth-of-type`, so the equivalent negation is used.
- Orphan or non-first summary elements fall back to the existing button-role supported aria-*, matching ARIA in HTML's "otherwise" clause.
- Extend `wai-aria-disallowed-props` README (EN/JA) with the new case in the element-specific prohibition section and examples.

## Spec basis

[ARIA in HTML — el-summary](https://w3c.github.io/html-aria/#el-summary): a summary that is a summary for its parent details element is limited to "Global aria-* attributes, aria-disabled, and aria-haspopup attributes." Because that summary's expanded state maps to `details.open`, `aria-expanded` and `aria-pressed` conflict with the native semantics and must not be used.

## Bench impact

- nu-only: 44 → 42 (—2)
- `html-aria/misc/summary-for-its-details-with-aria-expanded-novalid.html`: nu-only → match-error
- `html-aria/misc/summary-for-its-details-with-aria-pressed-novalid.html`: nu-only → match-error
- aria-disabled / aria-haspopup isvalid fixtures remain match-clean

## Test plan

- [x] `yarn test` — 4336 passed | 1 skipped, no type errors
- [x] `yarn build` — 39 projects built
- [x] Bench refreshed (`yarn bench:update --target markuplint`) — verdicts confirmed
- [x] New rule tests cover: aria-expanded / aria-pressed in `<details><summary>` (must-not), aria-disabled / aria-haspopup in `<details><summary>` (allowed), aria-expanded / aria-pressed on orphan summary (allowed), aria-expanded on non-first summary in details (allowed)