### PR TITLE
fix(rules): flag placeholder-label-option on empty required select

### DIFF
--- a/packages/@markuplint/rules/src/placeholder-label-option/README.ja.md
+++ b/packages/@markuplint/rules/src/placeholder-label-option/README.ja.md
@@ -40,6 +40,9 @@ description: select要素にプレースホルダーラベルオプションが�
   <option value="option1">オプション1</option>
   <option value="option2">オプション2</option>
 </select>
+
+<!-- 不正: option要素がない -->
+<select required></select>
 ```
 
 ✅ 正しいコード例

--- a/packages/@markuplint/rules/src/placeholder-label-option/README.md
+++ b/packages/@markuplint/rules/src/placeholder-label-option/README.md
@@ -39,6 +39,9 @@ Cite: [HTML Living Standard 4.10.7 The select element](https://html.spec.whatwg.
   <option value="option1">Option 1</option>
   <option value="option2">Option 2</option>
 </select>
+
+<!-- Invalid: no option element -->
+<select required></select>
 ```
 
 ✅ Examples of **correct** code for this rule

--- a/packages/@markuplint/rules/src/placeholder-label-option/index.spec.ts
+++ b/packages/@markuplint/rules/src/placeholder-label-option/index.spec.ts
@@ -113,7 +113,19 @@ test("[placeholder-label-option-invalid-003] Invalid: Invalid: first option elem
 	]);
 });
 
-test('[placeholder-label-option-invalid-004] The `as` attribute', async () => {
+test('[placeholder-label-option-invalid-004] Invalid: empty select without any option', async () => {
+	expect((await mlRuleTest(rule, '<select required></select>')).violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 1,
+			raw: '<select required>',
+			message: 'Need the placeholder label option',
+		},
+	]);
+});
+
+test('[placeholder-label-option-invalid-005] The `as` attribute', async () => {
 	expect(
 		(
 			await mlRuleTest(

--- a/packages/@markuplint/rules/src/placeholder-label-option/index.spec.ts
+++ b/packages/@markuplint/rules/src/placeholder-label-option/index.spec.ts
@@ -113,19 +113,7 @@ test("[placeholder-label-option-invalid-003] Invalid: Invalid: first option elem
 	]);
 });
 
-test('[placeholder-label-option-invalid-004] Invalid: empty select without any option', async () => {
-	expect((await mlRuleTest(rule, '<select required></select>')).violations).toStrictEqual([
-		{
-			severity: 'error',
-			line: 1,
-			col: 1,
-			raw: '<select required>',
-			message: 'Need the placeholder label option',
-		},
-	]);
-});
-
-test('[placeholder-label-option-invalid-005] The `as` attribute', async () => {
+test('[placeholder-label-option-invalid-004] The `as` attribute', async () => {
 	expect(
 		(
 			await mlRuleTest(
@@ -145,6 +133,30 @@ test('[placeholder-label-option-invalid-005] The `as` attribute', async () => {
 			line: 1,
 			col: 1,
 			raw: '<x-select as="select" required>',
+			message: 'Need the placeholder label option',
+		},
+	]);
+});
+
+test('[placeholder-label-option-invalid-005] Invalid: empty select without any option', async () => {
+	expect((await mlRuleTest(rule, '<select required></select>')).violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 1,
+			raw: '<select required>',
+			message: 'Need the placeholder label option',
+		},
+	]);
+});
+
+test('[placeholder-label-option-invalid-006] Invalid: required select with only non-option children', async () => {
+	expect((await mlRuleTest(rule, '<select required><script></script></select>')).violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 1,
+			raw: '<select required>',
 			message: 'Need the placeholder label option',
 		},
 	]);

--- a/packages/@markuplint/rules/src/placeholder-label-option/index.ts
+++ b/packages/@markuplint/rules/src/placeholder-label-option/index.ts
@@ -5,9 +5,17 @@ import { createRule } from '@markuplint/ml-core';
 import meta from './meta.js';
 
 /**
- * Per the HTML spec, a `<select>` with `required`, without `multiple`, and with a
- * display size of 1 must have a placeholder label option (first `<option>` with
- * an empty value directly under `<select>`).
+ * HTML LS §4.10.7 The select element:
+ *
+ * > If a select element has a required attribute specified, does not have a
+ * > multiple attribute specified, and has a display size of 1, then the
+ * > select element must have a placeholder label option.
+ *
+ * `hasPlaceholderLabelOption` decides whether an existing option already
+ * satisfies the requirement; `needPlaceholderLabelOption` gates whether the
+ * requirement applies to this `<select>`.
+ *
+ * @see https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element
  */
 export default createRule<boolean>({
 	meta: meta,

--- a/packages/@markuplint/rules/src/placeholder-label-option/index.ts
+++ b/packages/@markuplint/rules/src/placeholder-label-option/index.ts
@@ -30,13 +30,13 @@ export default createRule<boolean>({
 });
 
 /**
- * Determines whether a `<select>` element requires a placeholder label option.
+ * HTML LS §4.10.7 The select element:
  *
- * Per the HTML spec, a select element needs a placeholder label option when it
- * has `required`, does not have `multiple`, and has a display size of 1.
+ * > If a select element has a required attribute specified, does not have a
+ * > multiple attribute specified, and has a display size of 1, then the
+ * > select element must have a placeholder label option.
  *
- * @param select - The `<select>` element to evaluate.
- * @returns `true` if the select element requires a placeholder label option.
+ * @see https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element
  */
 function needPlaceholderLabelOption(
 	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
@@ -61,13 +61,20 @@ function needPlaceholderLabelOption(
 }
 
 /**
- * Checks whether a `<select>` element already has a valid placeholder label option.
+ * HTML LS §4.10.7 The select element — placeholder label option definition:
  *
- * A placeholder label option is the first `<option>` whose value is the empty string
- * and whose parent is the `<select>` element itself (not an `<optgroup>`).
+ * > If a select element has a required attribute specified, and has a
+ * > display size of 1; and if the value of the first option element in the
+ * > select element's list of options (if any) is the empty string, and that
+ * > option element's parent node is the select element (and not an optgroup
+ * > element), then that option is the select element's placeholder label
+ * > option.
  *
- * @param select - The `<select>` element to check.
- * @returns `true` if the element has a valid placeholder label option.
+ * The "(if any)" clause requires a first option to exist for the placeholder
+ * label option to exist at all; an empty `<select>` therefore has no
+ * placeholder label option and must be reported by `verify`.
+ *
+ * @see https://html.spec.whatwg.org/multipage/form-elements.html#placeholder-label-option
  */
 function hasPlaceholderLabelOption(
 	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types

--- a/packages/@markuplint/rules/src/placeholder-label-option/index.ts
+++ b/packages/@markuplint/rules/src/placeholder-label-option/index.ts
@@ -89,11 +89,11 @@ function hasPlaceholderLabelOption(
 		return false;
 	}
 
-	// > in the select element's list of options (if any) is the empty string
+	// > the value of the first option element in the select element's list of options … is the empty string
+	// No first option → no placeholder label option exists.
 	const firstOption = select.querySelector('option');
 	if (!firstOption) {
-		// if any
-		return true;
+		return false;
 	}
 
 	// > that option element's parent node is the select element (and not an optgroup element)

--- a/tests/external/snapshots/diff/coverage.json
+++ b/tests/external/snapshots/diff/coverage.json
@@ -37008,8 +37008,8 @@
 			"path": "html/elements/select/required-no-option-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{

--- a/tests/external/snapshots/diff/nu-only.json
+++ b/tests/external/snapshots/diff/nu-only.json
@@ -124,13 +124,6 @@
 			]
 		},
 		{
-			"path": "html/elements/select/required-no-option-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-bfbf166bef9d"
-			]
-		},
-		{
 			"path": "html/elements/style/css-property-error-novalid.html",
 			"category": "invalid-attr",
 			"nuMessageIds": [

--- a/tests/external/snapshots/diff/summary.md
+++ b/tests/external/snapshots/diff/summary.md
@@ -1,6 +1,6 @@
 # nu-validator Benchmark Summary
 
-- generated: 2026-07-04T03:13:14.566Z
+- generated: 2026-07-04T09:43:32.498Z
 - submodule: `142931395412c00434ffb40a14d65992efd17aa8`
 - nu-validator: `ghcr.io/validator/validator@sha256:9365682da0f66efc5504ce2a3aba91290aaf08c00799a41d096236fab740bb44`
 - markuplint: `5.0.0-rc.4`
@@ -9,9 +9,9 @@
 ## Totals
 
 - files: **5442**
-- match-error: **3481** (both tools flagged)
+- match-error: **3482** (both tools flagged)
 - match-clean: **883** (neither flagged)
-- nu-only: **29** (only nu-validator flagged; markuplint coverage candidates — open a markuplint issue after a spec read)
+- nu-only: **28** (only nu-validator flagged; markuplint coverage candidates — open a markuplint issue after a spec read)
 - nu-over: **32** (nu-validator errors fully covered by spec-backed excluded-ids — confirmed over-detection)
 - overall match rate: **80.2%**
 - excluded-ids: 7 entries, 1 pattern(s)
@@ -27,7 +27,7 @@
 | deprecated | 12 | 91.7% | 11 | 0 | 1 | 0 | 0 |
 | global-attr | 57 | 82.5% | 27 | 20 | 8 | 2 | 0 |
 | id-duplication | 1 | 100.0% | 1 | 0 | 0 | 0 | 0 |
-| invalid-attr | 3086 | 96.4% | 2746 | 229 | 61 | 21 | 29 |
+| invalid-attr | 3086 | 96.4% | 2747 | 229 | 61 | 20 | 29 |
 | required-attr | 5 | 100.0% | 5 | 0 | 0 | 0 | 0 |
 | uncategorized | 1307 | 41.0% | 373 | 163 | 765 | 4 | 2 |
 

--- a/tests/external/snapshots/meta.json
+++ b/tests/external/snapshots/meta.json
@@ -1,5 +1,5 @@
 {
-	"generatedAt": "2026-07-04T03:13:14.566Z",
+	"generatedAt": "2026-07-04T09:43:32.498Z",
 	"submoduleSha": "142931395412c00434ffb40a14d65992efd17aa8",
 	"nuValidatorImage": "ghcr.io/validator/validator@sha256:9365682da0f66efc5504ce2a3aba91290aaf08c00799a41d096236fab740bb44",
 	"markuplintVersion": "5.0.0-rc.4",
@@ -7,6 +7,6 @@
 	"totalFilesNu": 1,
 	"totalFilesMl": 5442,
 	"totalNuMessages": 1,
-	"totalMlViolations": 11374,
+	"totalMlViolations": 11375,
 	"totalNuFailures": 0
 }


### PR DESCRIPTION
## Summary

- `<select required></select>` (no `<option>` element) was silently accepted by `placeholder-label-option` because `hasPlaceholderLabelOption` returned `true` when the first-option lookup found nothing. HTML LS §4.10.7 requires the presence of a placeholder label option; no first option means none exists, so this must be reported.
- Reworks the JSDoc on the module export and both internal helpers to cite the verbatim HTML LS quote plus permalinks, and pins the non-obvious "(if any)" reading that motivated the fix.
- Rule README (EN + JA) gains a `<!-- Invalid: no option element -->` example so the website reflects the new behaviour.

## Spec basis

> If a select element has a required attribute specified, does not have a multiple attribute specified, and has a display size of 1, then the select element must have a placeholder label option.
> A placeholder label option is a select element's list of options's first option element, if that option element's value is the empty string, and that option element's parent element is the select element (and not an optgroup element).

— [HTML Living Standard § 4.10.7 The select element](https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element)

The "if any" clause requires a first option to exist. An empty `<select>` therefore has no placeholder label option and violates the requirement.

## Bench impact

`html/elements/select/required-no-option-novalid.html` flips `nu-only` → `match-error`. `nu-only` 29 → 28, `match-error` 3481 → 3482.

## Compatibility

RC-period bug fix: previously undetected violations become detected. No rule name / API / config schema changes. Per [feedback_rc_breaking_relaxed](../markuplint/markuplint/blob/dev/CLAUDE.md), no `!` prefix required during RC.

## Test plan

- [x] `yarn build` — succeeds across 39 projects
- [x] `yarn test` — 263 files / 4399 tests pass (1 skipped)
- [x] `yarn lint-check:format` — clean
- [x] `oxlint` — 0 warnings, 0 errors
- [x] `npx vitest run packages/@markuplint/rules/src/placeholder-label-option/` — 6/6 pass, incl. new `invalid-005` (empty select) and `invalid-006` (non-option child only)
- [x] `yarn bench:update:ml` — target fixture flips as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)