### PR TITLE
test: register #3838 bench-xref primary mapping for tab-tabpanel

### DIFF
--- a/tests/external/bench/issue-xref.config.ts
+++ b/tests/external/bench/issue-xref.config.ts
@@ -79,6 +79,14 @@ export const xrefMappings: readonly XrefMapping[] = [
 		note:
 			'`permitted-contents` flattens transparent-model children out of the parent\'s content-model check entirely. `<a href>` inside `<button>` (both transparent-carrying interactive descendants) and `<video>` / `<noscript>` inside `<picture>` all slip past because the transparent element itself is dropped from the parent\'s selector evaluation. HTML LS §3.2.5.3 transparency defers only the *children* to the parent\'s model; the transparent element itself must still satisfy the parent\'s constraints. Fix requires reworking `represent-transparent-nodes.ts` to keep the transparent element in the flattened list.',
 	},
+	{
+		kind: 'primary',
+		issue: 3838,
+		filter:
+			/^html-aria\/(author-requirements\/(574|575|576|577)|misc\/(role-tab-with-no-role-tabpanel-novalid|summary-for-its-details-with-aria-(expanded|pressed)-novalid))/,
+		note:
+			'Umbrella of 7 aria fixtures deferred from the aria-slice PR. Six flipped to `match-error` after Group 1 (author-requirements role chain: `wai-aria-required-owned-elements`) and Group 3 (summary heuristics: `spec.summary.jsonc#aria.properties.without`) landed. The one remaining `nu-only` — `role-tab-with-no-role-tabpanel-novalid` — is a Group 2 role-pair authoring requirement: WAI-ARIA 1.3 §tab role: "Authors MUST ensure that if a `tab` is active, a corresponding `tabpanel` that represents the active `tab` is rendered." Cross-element constraint that no existing rule covers; needs the proposed `wai-aria-required-companion-role` (or equivalent).',
+	},
 
 	// === 2 次群: bench では裏取れない Issue（ステルブロック） ===
 	{


### PR DESCRIPTION
## Summary

- Register #3838 (umbrella of 7 aria fixtures deferred from the aria-slice PR) as a `primary` mapping in `tests/external/bench/issue-xref.config.ts`.
- 6 of 7 fixtures already flipped to `match-error` (Group 1 `wai-aria-required-owned-elements` + Group 3 summary heuristics landed upstream).
- The one remaining `nu-only` — `role-tab-with-no-role-tabpanel-novalid` — is Group 2's role-pair authoring requirement (WAI-ARIA 1.3 §tab: "Authors MUST ensure that if a `tab` is active, a corresponding `tabpanel` that represents the active `tab` is rendered"), which no existing rule covers.

## Test plan

- [x] `yarn bench:xref --audit` — all 12 mapped issues still OPEN
- [x] `yarn bench:xref --issue 3838` — 7 fixtures matched, tally match-error=6 / nu-only=1
- [x] `yarn bench:xref --issue 3838 --write` — Issue body updated on GitHub