### PR TITLE
test: register #3915 bench-xref primary mapping for table-row-column-alignment gaps

### DIFF
--- a/tests/external/bench/issue-xref.config.ts
+++ b/tests/external/bench/issue-xref.config.ts
@@ -81,6 +81,14 @@ export const xrefMappings: readonly XrefMapping[] = [
 	},
 	{
 		kind: 'primary',
+		issue: 3915,
+		filter:
+			/^html\/elements\/table\/(cell-overlaps(-earlier-cell)?|cell-spans-past-(end|row-group)|col-no-cells|integrity\/vertical|row-width-less-than-col-markup)-novalid/,
+		note:
+			'HTML LS [§4.9.12.1 *Forming a table*](https://html.spec.whatwg.org/multipage/tables.html#forming-a-table) — Step 14 ("If any of the slots involved already had a cell covering them, then this is a table model error.") is partially covered by `table-row-column-alignment`; Step 20 ("If there exists a row or column in the table containing only slots that do not have a cell anchored to them, then this is a table model error.") and the cross-row-group constraint ("A cell cannot cover slots that are from two or more row groups.") are not. The seven `nu-only` fixtures split as: Step 20 column via `colspan` blocked by a `rowspan` continuation (`cell-overlaps-novalid`, `cell-overlaps-earlier-cell-novalid`), Step 20 column past the last row (`cell-spans-past-end-novalid`), Step 20 column from `<col>` markup (`col-no-cells-novalid`, `row-width-less-than-col-markup-novalid`), Step 14 + cross-row-group + Step 20 mix (`integrity/vertical-novalid`), and cross-row-group only (`cell-spans-past-row-group-novalid`). The rule is not yet enabled in `tests/external/bench/config.ts`; Issue step 6 enables it with `severity: error` after items 1–5 land.',
+	},
+	{
+		kind: 'primary',
 		issue: 3838,
 		filter:
 			/^html-aria\/(author-requirements\/(574|575|576|577)|misc\/(role-tab-with-no-role-tabpanel-novalid|summary-for-its-details-with-aria-(expanded|pressed)-novalid))/,

--- a/tests/external/bench/issue-xref.config.ts
+++ b/tests/external/bench/issue-xref.config.ts
@@ -83,7 +83,7 @@ export const xrefMappings: readonly XrefMapping[] = [
 		kind: 'primary',
 		issue: 3915,
 		filter:
-			/^html\/elements\/table\/(cell-overlaps(-earlier-cell)?|cell-spans-past-(end|row-group)|col-no-cells|integrity\/vertical|row-width-less-than-col-markup)-novalid/,
+			/^html\/elements\/table\/(cell-overlaps|cell-overlaps-earlier-cell|cell-spans-past-end|cell-spans-past-row-group|col-no-cells|integrity\/vertical|row-width-less-than-col-markup)-novalid/,
 		note:
 			'HTML LS [§4.9.12.1 *Forming a table*](https://html.spec.whatwg.org/multipage/tables.html#forming-a-table) — Step 14 ("If any of the slots involved already had a cell covering them, then this is a table model error.") is partially covered by `table-row-column-alignment`; Step 20 ("If there exists a row or column in the table containing only slots that do not have a cell anchored to them, then this is a table model error.") and the cross-row-group constraint ("A cell cannot cover slots that are from two or more row groups.") are not. The seven `nu-only` fixtures split as: Step 20 column via `colspan` blocked by a `rowspan` continuation (`cell-overlaps-novalid`, `cell-overlaps-earlier-cell-novalid`), Step 20 column past the last row (`cell-spans-past-end-novalid`), Step 20 column from `<col>` markup (`col-no-cells-novalid`, `row-width-less-than-col-markup-novalid`), Step 14 + cross-row-group + Step 20 mix (`integrity/vertical-novalid`), and cross-row-group only (`cell-spans-past-row-group-novalid`). The rule is not yet enabled in `tests/external/bench/config.ts`; Issue step 6 enables it with `severity: error` after items 1–5 land.',
 	},


### PR DESCRIPTION
## Summary

Registers a `bench-xref` primary mapping for Issue #3915 (extend `table-row-column-alignment` to cover HTML LS Step 20 and cross-row-group errors). The filter matches the seven remaining `nu-only` fixtures under `html/elements/table/`; the Issue body already enumerates their per-fixture spec bases.

Metadata-only PR; no rule / config behavior changes. The next `Bench xref audit` workflow run (or a manual `yarn bench:xref`) will sync the block onto Issue #3915's body — merging this PR does **not** update the Issue body directly.

## Fixture selection

Included (7):

- `cell-overlaps-earlier-cell-novalid` — Step 20 column
- `cell-overlaps-novalid` — Step 20 column
- `cell-spans-past-end-novalid` — Step 20 column past the last row
- `cell-spans-past-row-group-novalid` — cross-row-group
- `col-no-cells-novalid` — Step 20 column from `<col>` markup
- `integrity/vertical-novalid` — Step 14 + cross-row-group + Step 20 mix
- `row-width-less-than-col-markup-novalid` — Step 20 column from `<col>` markup

Deliberately excluded:

- `row-no-cells-novalid` — already `match-error`
- `row-width-exceeds-col-markup-novalid` — already `nu-over` per #3916

## Test plan

- [x] `npx vitest run tests/external/bench/xref-issue.spec.ts` — 42/42 pass, including the real-config test at `xref-issue.spec.ts:630` that validates every `primary` filter matches ≥1 fixture in the current `coverage.json` snapshot.
- [x] `yarn bench:xref --dry-run --issue 3915` — 7 fixtures matched, all `nu-only`, verdict tally aligns with Issue #3915's fixture list.
- [x] Regex negative controls confirmed (`row-width-exceeds-col-markup`, `row-width-exceeds-cols-haswarn`, `row-no-cells` do **not** match).
- [x] `yarn lint-check` — 0 warnings, 0 errors.

## Follow-ups (out of scope)

- Issue #3915 items 1–5 (grid construction rework, Step 20 scans, `<col>`/`<colgroup>` processing, cross-row-group check) — separate implementation PR.
- Issue #3915 step 6 (enable `table-row-column-alignment` with `severity: error` in `tests/external/bench/config.ts`) — lands with the fixes, once fixtures flip.