### PR TITLE
feat(rules): add wai-aria-tab-requires-tabpanel rule

### DIFF
--- a/packages/@markuplint/config-presets/src/preset.a11y.jsonc
+++ b/packages/@markuplint/config-presets/src/preset.a11y.jsonc
@@ -215,6 +215,10 @@
 			"specConformance": "normative",
 			"rules": { "wai-aria-required-parent-role": true }
 		},
+		"a11y/wai-aria/tab-requires-tabpanel": {
+			"specConformance": "normative",
+			"rules": { "wai-aria-tab-requires-tabpanel": true }
+		},
 		"a11y/wai-aria/presentational-children": {
 			"specConformance": "non-normative",
 			"severity": "warning",

--- a/packages/@markuplint/rules/schema.json
+++ b/packages/@markuplint/rules/schema.json
@@ -231,6 +231,9 @@
 				"wai-aria-required-props": {
 					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/wai-aria-required-props/schema.json"
 				},
+				"wai-aria-tab-requires-tabpanel": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/wai-aria-tab-requires-tabpanel/schema.json"
+				},
 				"wai-aria-value": {
 					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/wai-aria-value/schema.json"
 				}

--- a/packages/@markuplint/rules/src/index.ts
+++ b/packages/@markuplint/rules/src/index.ts
@@ -84,6 +84,7 @@ import WaiAriaPresentationalChildren from './wai-aria-presentational-children/in
 import WaiAriaRequiredOwnedElements from './wai-aria-required-owned-elements/index.js';
 import WaiAriaRequiredParentRole from './wai-aria-required-parent-role/index.js';
 import WaiAriaRequiredProps from './wai-aria-required-props/index.js';
+import WaiAriaTabRequiresTabpanel from './wai-aria-tab-requires-tabpanel/index.js';
 import WaiAriaValue from './wai-aria-value/index.js';
 
 /**
@@ -166,6 +167,7 @@ const rules = {
 	'wai-aria-required-owned-elements': WaiAriaRequiredOwnedElements,
 	'wai-aria-required-parent-role': WaiAriaRequiredParentRole,
 	'wai-aria-required-props': WaiAriaRequiredProps,
+	'wai-aria-tab-requires-tabpanel': WaiAriaTabRequiresTabpanel,
 	'wai-aria-value': WaiAriaValue,
 } as const satisfies Record<string, AnyRuleSeed<any, any>>;
 

--- a/packages/@markuplint/rules/src/wai-aria-tab-requires-tabpanel/README.ja.md
+++ b/packages/@markuplint/rules/src/wai-aria-tab-requires-tabpanel/README.ja.md
@@ -1,0 +1,32 @@
+---
+description: アクティブな"tab"ロールの要素に対応する"tabpanel"ロールの要素がない場合に警告します。
+---
+
+# `wai-aria-tab-requires-tabpanel`
+
+アクティブな`tab`ロールの要素（`aria-selected="true"`）に対応する`tabpanel`ロールの要素がない場合に警告します。
+
+このルールは[`wai-aria`](../wai-aria/)ルールファミリーの一部で、きめ細かなseverity制御のために分割されたものです。
+
+対応関係は、タブ側の`aria-controls`（`tabpanel`を指す）、または`tabpanel`側の`aria-labelledby`（タブの`id`を指す）のいずれかで解決されます。
+
+<!-- textlint-disable ja-technical-writing/ja-no-mixed-period -->
+
+❌ 間違ったコード例
+
+```html
+<div role="tablist">
+  <button role="tab" aria-selected="true">Tab</button>
+</div>
+```
+
+✅ 正しいコード例
+
+```html
+<div role="tablist">
+  <button role="tab" aria-selected="true" aria-controls="panel">Tab</button>
+</div>
+<div id="panel" role="tabpanel">Content</div>
+```
+
+<!-- textlint-enable ja-technical-writing/ja-no-mixed-period -->

--- a/packages/@markuplint/rules/src/wai-aria-tab-requires-tabpanel/README.md
+++ b/packages/@markuplint/rules/src/wai-aria-tab-requires-tabpanel/README.md
@@ -1,0 +1,29 @@
+---
+id: wai-aria-tab-requires-tabpanel
+description: Warns when an active "tab" role element has no corresponding "tabpanel" role element.
+---
+
+# `wai-aria-tab-requires-tabpanel`
+
+Warns when an active `tab` role element (`aria-selected="true"`) has no corresponding `tabpanel` role element.
+
+This rule is part of the [`wai-aria`](../wai-aria/) rule family, split for granular severity control.
+
+The correspondence is resolved via `aria-controls` on the tab (pointing to a `tabpanel`) or `aria-labelledby` on a `tabpanel` (pointing back at the tab's `id`).
+
+❌ Examples of **incorrect** code for this rule
+
+```html
+<div role="tablist">
+  <button role="tab" aria-selected="true">Tab</button>
+</div>
+```
+
+✅ Examples of **correct** code for this rule
+
+```html
+<div role="tablist">
+  <button role="tab" aria-selected="true" aria-controls="panel">Tab</button>
+</div>
+<div id="panel" role="tabpanel">Content</div>
+```

--- a/packages/@markuplint/rules/src/wai-aria-tab-requires-tabpanel/index.spec.ts
+++ b/packages/@markuplint/rules/src/wai-aria-tab-requires-tabpanel/index.spec.ts
@@ -1,0 +1,80 @@
+import { mlRuleTest } from 'markuplint';
+import { test, expect } from 'vitest';
+
+import rule from './index.js';
+
+test('[wai-aria-tab-requires-tabpanel-valid-001] active tab with aria-controls pointing to a tabpanel', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		'<div role="tablist"><button role="tab" aria-selected="true" aria-controls="panel">Tab</button></div><div id="panel" role="tabpanel">Content</div>',
+	);
+	expect(violations).toStrictEqual([]);
+});
+
+test('[wai-aria-tab-requires-tabpanel-valid-002] active tab referenced by a tabpanel via aria-labelledby', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		'<div role="tablist"><button id="tab1" role="tab" aria-selected="true">Tab</button></div><div role="tabpanel" aria-labelledby="tab1">Content</div>',
+	);
+	expect(violations).toStrictEqual([]);
+});
+
+test('[wai-aria-tab-requires-tabpanel-valid-003] inactive tab does not require a tabpanel', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		'<div role="tablist"><button role="tab" aria-selected="false">Tab</button></div>',
+	);
+	expect(violations).toStrictEqual([]);
+});
+
+test('[wai-aria-tab-requires-tabpanel-valid-004] tab without aria-selected does not require a tabpanel', async () => {
+	const { violations } = await mlRuleTest(rule, '<div role="tablist"><button role="tab">Tab</button></div>');
+	expect(violations).toStrictEqual([]);
+});
+
+test('[wai-aria-tab-requires-tabpanel-valid-005] non-tab role is ignored', async () => {
+	const { violations } = await mlRuleTest(rule, '<button aria-selected="true">Not a tab</button>');
+	expect(violations).toStrictEqual([]);
+});
+
+test('[wai-aria-tab-requires-tabpanel-invalid-001] active tab with no tabpanel anywhere in the document', async () => {
+	// Mirrors tests/external/validator/tests/html-aria/misc/role-tab-with-no-role-tabpanel-novalid.html
+	const { violations } = await mlRuleTest(
+		rule,
+		'<div role="tablist">\n  <button role="tab" aria-selected="false">foo</button>\n  <button role="tab" aria-selected="true">bar</button>\n</div>',
+	);
+	expect(violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 3,
+			col: 3,
+			message: 'An active "tab" role requires a corresponding "tabpanel" role',
+			raw: '<button role="tab" aria-selected="true">',
+		},
+	]);
+});
+
+test('[wai-aria-tab-requires-tabpanel-invalid-002] aria-controls points to a non-tabpanel element', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		'<div role="tablist"><button role="tab" aria-selected="true" aria-controls="notpanel">Tab</button></div><div id="notpanel">Not a panel</div>',
+	);
+	expect(violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 21,
+			message: 'An active "tab" role requires a corresponding "tabpanel" role',
+			raw: '<button role="tab" aria-selected="true" aria-controls="notpanel">',
+		},
+	]);
+});
+
+test('[wai-aria-tab-requires-tabpanel-invalid-003] tabpanel aria-labelledby references a different tab', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		'<div role="tablist"><button id="tab1" role="tab" aria-selected="true">Tab</button></div><div role="tabpanel" aria-labelledby="othertab">Content</div>',
+	);
+	expect(violations.length).toBe(1);
+	expect(violations[0]!.message).toBe('An active "tab" role requires a corresponding "tabpanel" role');
+});

--- a/packages/@markuplint/rules/src/wai-aria-tab-requires-tabpanel/index.ts
+++ b/packages/@markuplint/rules/src/wai-aria-tab-requires-tabpanel/index.ts
@@ -1,0 +1,24 @@
+import type { Options } from '../wai-aria/types.js';
+
+import { createRule, getComputedRole, getSpec } from '@markuplint/ml-core';
+import { ARIA_RECOMMENDED_VERSION } from '@markuplint/ml-spec';
+
+import { checkingTabRequiresTabpanel } from '../wai-aria/checkings/tab-requires-tabpanel.js';
+import { defaultOptions } from '../wai-aria/default-options.js';
+import meta from './meta.js';
+
+export default createRule<boolean, Options>({
+	meta,
+	defaultOptions,
+	async verify({ document, report }) {
+		await document.walkOn('Element', el => {
+			const elSpec = getSpec(el, document.specs.specs);
+			if (!elSpec) return;
+			if (!elSpec.globalAttrs['#ARIAAttrs']) return;
+			const ariaVersion =
+				el.rule.options?.version ?? document.ruleCommonSettings?.ariaVersion ?? ARIA_RECOMMENDED_VERSION;
+			const computed = getComputedRole(document.specs, el, ariaVersion);
+			report(checkingTabRequiresTabpanel({ el, role: computed.role }));
+		});
+	},
+});

--- a/packages/@markuplint/rules/src/wai-aria-tab-requires-tabpanel/meta.ts
+++ b/packages/@markuplint/rules/src/wai-aria-tab-requires-tabpanel/meta.ts
@@ -1,0 +1,3 @@
+export default {
+	category: 'a11y',
+} as const;

--- a/packages/@markuplint/rules/src/wai-aria-tab-requires-tabpanel/schema.json
+++ b/packages/@markuplint/rules/src/wai-aria-tab-requires-tabpanel/schema.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"value": {
+			"type": "boolean"
+		}
+	},
+	"oneOf": [
+		{
+			"$ref": "#/definitions/value"
+		},
+		{
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"value": { "$ref": "#/definitions/value" },
+				"severity": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/ml-config/schema.json#/definitions/severity",
+					"default": "error"
+				},
+				"reason": {
+					"type": "string"
+				}
+			}
+		}
+	]
+}

--- a/packages/@markuplint/rules/src/wai-aria/README.ja.md
+++ b/packages/@markuplint/rules/src/wai-aria/README.ja.md
@@ -17,6 +17,7 @@ description: WAI-ARIAおよびARIA in HTMLの仕様のとおりrole属性また�
   - 必須のプロパティ/ステートを指定していない場合
   - ロールが必要とする子ロールを持たない場合（例: `table`は`row`を必要とする）
   - ロールが必要とする親コンテキストの外に配置された場合（例: `tablist`の祖先を持たない`tab`）
+  - アクティブな`tab`ロールに対応する`tabpanel`ロールがない場合
 - 推奨されない使い方
   - 非推奨（廃止予定）のロールを指定した場合
   - 非推奨（廃止予定）のプロパティ/ステートを指定した場合
@@ -86,6 +87,28 @@ description: WAI-ARIAおよびARIA in HTMLの仕様のとおりrole属性また�
 
 > [!NOTE]
 > 明示的なロール（`role`属性で設定されたもの）のみがチェックされます。暗黙のロールは、ネイティブHTMLの親子関係がHTML仕様によって保証されているためスキップされます。
+
+### `checkingTabRequiresTabpanel`
+
+型: `boolean`（デフォルト: `true`）
+
+ARIA仕様の`tab`ロールの要件に従い、アクティブな`tab`ロールの要素（`aria-selected="true"`）が対応する`tabpanel`ロールの要素を持っているかを検証します。
+
+対応関係は、タブ側の`aria-controls`（`tabpanel`を指す）、または`tabpanel`側の`aria-labelledby`（タブの`id`を指す）のいずれかで解決されます。
+
+`false`に設定すると、このチェックは無効になります。
+
+```json class=config
+{
+  "rules": {
+    "wai-aria": {
+      "options": {
+        "checkingTabRequiresTabpanel": false
+      }
+    }
+  }
+}
+```
 
 ## 既知の制限事項
 

--- a/packages/@markuplint/rules/src/wai-aria/README.md
+++ b/packages/@markuplint/rules/src/wai-aria/README.md
@@ -18,6 +18,7 @@ Warn if:
   - Don't set the required property/state.
   - The role doesn't have the required child roles (e.g., `table` requires `row`).
   - The role is placed outside its required parent context (e.g., `tab` without a `tablist` ancestor).
+  - An active `tab` role has no corresponding `tabpanel` role.
 - Unrecommended.
   - Set the deprecated role.
   - Set the deprecated property/state.
@@ -85,6 +86,28 @@ When set to `false`, this check is disabled.
 
 > [!NOTE]
 > Only explicit roles (set via the `role` attribute) are checked. Implicit roles are skipped because native HTML parent-child semantics are already guaranteed by the HTML specification.
+
+### `checkingTabRequiresTabpanel`
+
+Type: `boolean` (default: `true`)
+
+Verifies that an active `tab` role element (`aria-selected="true"`) has a corresponding `tabpanel` role element, per the ARIA specification's `tab` role requirement.
+
+The correspondence is resolved via `aria-controls` on the tab (pointing to a `tabpanel`) or `aria-labelledby` on a `tabpanel` (pointing back at the tab's `id`).
+
+When set to `false`, this check is disabled.
+
+```json class=config
+{
+  "rules": {
+    "wai-aria": {
+      "options": {
+        "checkingTabRequiresTabpanel": false
+      }
+    }
+  }
+}
+```
 
 ## Known Limitations
 

--- a/packages/@markuplint/rules/src/wai-aria/checkings/tab-requires-tabpanel.ts
+++ b/packages/@markuplint/rules/src/wai-aria/checkings/tab-requires-tabpanel.ts
@@ -1,0 +1,80 @@
+import type { Options } from '../types.js';
+import type { ElementChecker } from '@markuplint/ml-core';
+import type { ARIARole } from '@markuplint/ml-spec';
+
+import { ARIA_RECOMMENDED_VERSION, getComputedRole } from '@markuplint/ml-spec';
+
+/**
+ * Checks that an active `tab` role element has a corresponding `tabpanel` role element.
+ *
+ * The correspondence is resolved the same way ARIA in HTML authors are expected to
+ * express it: the tab's `aria-controls` idref list points to a `tabpanel`, or some
+ * `tabpanel` element's `aria-labelledby` idref list points back at the tab's own `id`.
+ *
+ * @see https://www.w3.org/TR/wai-aria-1.3/#tab — "Authors MUST ensure that if a tab
+ * is active, a corresponding tabpanel that represents the active tab is rendered."
+ * @param el - The element node to inspect.
+ * @param role - The computed ARIA role of the element.
+ * @returns A violation if the active tab has no corresponding tabpanel.
+ */
+export const checkingTabRequiresTabpanel: ElementChecker<
+	boolean,
+	Options,
+	{
+		role?: ARIARole | null;
+	}
+> =
+	({ el, role }) =>
+	t => {
+		if (role?.name !== 'tab') {
+			return;
+		}
+
+		const selectedAttr = el.getAttributeNode('aria-selected');
+		if (!selectedAttr || selectedAttr.isDynamicValue || selectedAttr.value !== 'true') {
+			return;
+		}
+
+		const document = el.ownerMLDocument;
+		const ariaVersion =
+			el.rule.options?.version ?? document.ruleCommonSettings?.ariaVersion ?? ARIA_RECOMMENDED_VERSION;
+
+		const isTabpanel = (candidate: typeof el) =>
+			getComputedRole(document.specs, candidate, ariaVersion).role?.name === 'tabpanel';
+
+		const controlsAttr = el.getAttributeNode('aria-controls');
+		if (controlsAttr && !controlsAttr.isDynamicValue) {
+			const hasControlledTabpanel = controlsAttr.value
+				.split(/\s+/)
+				.filter(Boolean)
+				.some(id => {
+					const target = document.getElementById(id);
+					return !!target && isTabpanel(target);
+				});
+			if (hasControlledTabpanel) {
+				return;
+			}
+		}
+
+		const idAttr = el.getAttributeNode('id');
+		if (idAttr && !idAttr.isDynamicValue) {
+			const tabId = idAttr.value;
+			const hasLabellingTabpanel = [...document.querySelectorAll('[aria-labelledby]')].some(candidate => {
+				const labelledbyAttr = candidate.getAttributeNode('aria-labelledby');
+				if (!labelledbyAttr || labelledbyAttr.isDynamicValue) return false;
+				return labelledbyAttr.value.split(/\s+/).includes(tabId) && isTabpanel(candidate);
+			});
+			if (hasLabellingTabpanel) {
+				return;
+			}
+		}
+
+		return {
+			scope: el,
+			message: t(
+				'{0} requires {1}',
+				t('an active "{0*}" {1}', 'tab', 'role'),
+				t('a corresponding "{0*}" {1}', 'tabpanel', 'role'),
+			),
+		};
+	};

--- a/packages/@markuplint/rules/src/wai-aria/default-options.ts
+++ b/packages/@markuplint/rules/src/wai-aria/default-options.ts
@@ -12,6 +12,7 @@ export const defaultOptions: Options = {
 	checkingAllowedAccessibilityChildRoles: true,
 	checkingRequiredOwnedElements: true,
 	checkingRequiredAccessibilityParentRole: true,
+	checkingTabRequiresTabpanel: true,
 	checkingPresentationalChildren: false,
 	checkingInteractionInHidden: false,
 	disallowSetImplicitRole: true,

--- a/packages/@markuplint/rules/src/wai-aria/index.spec.ts
+++ b/packages/@markuplint/rules/src/wai-aria/index.spec.ts
@@ -2709,3 +2709,42 @@ describe('Issue #3682 — separator focusable conditional aria-valuenow', () => 
 		expect(violations).toStrictEqual([]);
 	});
 });
+
+// #3838 (Group 2): active "tab" role requires a corresponding "tabpanel" role
+describe('Issue #3838 — active tab requires a corresponding tabpanel', () => {
+	test('[wai-aria-issue-3838-001] active tab with no tabpanel anywhere is a violation', async () => {
+		// Mirrors tests/external/validator/tests/html-aria/misc/role-tab-with-no-role-tabpanel-novalid.html
+		const { violations } = await mlRuleTest(
+			rule,
+			'<div role="tablist"><button role="tab" aria-selected="false">foo</button><button role="tab" aria-selected="true">bar</button></div>',
+		);
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 74,
+				message: 'An active "tab" role requires a corresponding "tabpanel" role',
+				raw: '<button role="tab" aria-selected="true">',
+			},
+		]);
+	});
+
+	test('[wai-aria-issue-3838-002] active tab with aria-controls pointing to a tabpanel is valid', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<div role="tablist"><button role="tab" aria-selected="true" aria-controls="panel">Tab</button></div><div id="panel" role="tabpanel">Content</div>',
+		);
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('[wai-aria-issue-3838-003] checkingTabRequiresTabpanel:false disables the check', async () => {
+		const { violations } = await mlRuleTest(
+			rule,
+			'<div role="tablist"><button role="tab" aria-selected="true">Tab</button></div>',
+			{
+				rule: { options: { checkingTabRequiresTabpanel: false } },
+			},
+		);
+		expect(violations).toStrictEqual([]);
+	});
+});

--- a/packages/@markuplint/rules/src/wai-aria/index.ts
+++ b/packages/@markuplint/rules/src/wai-aria/index.ts
@@ -21,6 +21,7 @@ import { checkingPresentationalChildren } from './checkings/presentational-child
 import { checkingRequiredAccessibilityParentRole } from './checkings/required-accessibility-parent-role.js';
 import { checkingRequiredOwnedElements } from './checkings/required-owned-elements.js';
 import { checkingRequiredProp } from './checkings/required-prop.js';
+import { checkingTabRequiresTabpanel } from './checkings/tab-requires-tabpanel.js';
 import { checkingValue } from './checkings/value.js';
 import meta from './meta.js';
 
@@ -131,6 +132,10 @@ export default createRule<boolean, Options>({
 
 			if (el.rule.options.checkingInteractionInHidden) {
 				report(checkingInteractionInHidden({ el }));
+			}
+
+			if (el.rule.options.checkingTabRequiresTabpanel) {
+				report(checkingTabRequiresTabpanel({ el, role: computed.role }));
 			}
 		});
 	},

--- a/packages/@markuplint/rules/src/wai-aria/schema.json
+++ b/packages/@markuplint/rules/src/wai-aria/schema.json
@@ -33,6 +33,12 @@
 					"description": "Verify that roles with \"Required Accessibility Parent Role\" (called \"Required Context Role\" in ARIA 1.2) are placed in a valid parent context.",
 					"description:ja": "\"Required Accessibility Parent Role\"（ARIA 1.2では\"Required Context Role\"）を持つロールが正しい親コンテキスト内に配置されているかチェックします。"
 				},
+				"checkingTabRequiresTabpanel": {
+					"type": "boolean",
+					"default": "true",
+					"description": "Verify that an active \"tab\" role element has a corresponding \"tabpanel\" role element (via aria-controls or aria-labelledby).",
+					"description:ja": "アクティブな\"tab\"ロールの要素が、対応する\"tabpanel\"ロールの要素を持っているか（aria-controlsまたはaria-labelledby経由で）チェックします。"
+				},
 				"checkingDeprecatedRole": {
 					"type": "boolean",
 					"default": "true",

--- a/packages/@markuplint/rules/src/wai-aria/types.ts
+++ b/packages/@markuplint/rules/src/wai-aria/types.ts
@@ -24,6 +24,8 @@ export type Options = {
 	checkingRequiredOwnedElements: boolean;
 	/** Whether to verify "Required Accessibility Parent Role" (ARIA 1.3 name) / "Required Context Role" (ARIA 1.2 name). */
 	checkingRequiredAccessibilityParentRole: boolean;
+	/** Whether to verify that an active `tab` role has a corresponding `tabpanel` role. */
+	checkingTabRequiresTabpanel: boolean;
 	/** Whether to warn when ARIA attributes are set on descendants of presentational-children roles. */
 	checkingPresentationalChildren: boolean;
 	/** Whether to warn about focusable interactive elements hidden via `aria-hidden`. */

--- a/packages/markuplint/src/cli/init/get-default-rules.spec.ts
+++ b/packages/markuplint/src/cli/init/get-default-rules.spec.ts
@@ -305,6 +305,10 @@ test('default-rules', () => {
 			category: 'a11y',
 			defaultValue: true,
 		},
+		'wai-aria-tab-requires-tabpanel': {
+			category: 'a11y',
+			defaultValue: true,
+		},
 		'wai-aria-value': {
 			category: 'a11y',
 			defaultValue: true,

--- a/tests/external/bench/config.ts
+++ b/tests/external/bench/config.ts
@@ -115,6 +115,9 @@ export const benchmarkConfig: Config = {
 		'wai-aria-required-owned-elements': { severity: 'error' },
 		'wai-aria-required-parent-role': true,
 		'wai-aria-no-global-prop': true,
+		// WAI-ARIA 1.3 §tab role: "Authors MUST ensure that if a tab is active, a
+		// corresponding tabpanel that represents the active tab is rendered."
+		'wai-aria-tab-requires-tabpanel': true,
 	},
 	nodeRules: [
 		{

--- a/tests/external/bench/issue-xref.config.ts
+++ b/tests/external/bench/issue-xref.config.ts
@@ -54,89 +54,74 @@ export const xrefMappings: readonly XrefMapping[] = [
 		kind: 'primary',
 		issue: 293,
 		filter: /html-svg\/filters-/,
-		note:
-			'`ml-only` fixtures here are all W3C SVG 1.1 test-suite files; their violations are `deprecated-attr` / `invalid-attr` / `permitted-contents` on SVG 1.1 remnants (`version`, `baseProfile`, `xmlns:xlink`, `<font-face>` inside `<defs>`, `font-family` with a custom family), not on filter references. markuplint is spec-correct under SVG 2; nu-validator is lax on these SVG 1.1 features. The proposed `svg-filter-reference-relationship` rule is unrelated and not blocked by this noise.',
+		note: '`ml-only` fixtures here are all W3C SVG 1.1 test-suite files; their violations are `deprecated-attr` / `invalid-attr` / `permitted-contents` on SVG 1.1 remnants (`version`, `baseProfile`, `xmlns:xlink`, `<font-face>` inside `<defs>`, `font-family` with a custom family), not on filter references. markuplint is spec-correct under SVG 2; nu-validator is lax on these SVG 1.1 features. The proposed `svg-filter-reference-relationship` rule is unrelated and not blocked by this noise.',
 	},
 	{
 		kind: 'primary',
 		issue: 3829,
 		filter: /^html\/attributes\/lang\/(extlang-bad|invalid-primary)-novalid/,
-		note:
-			"HTML LS §3.2.6.2 The lang and xml:lang attributes: \"the value must be a valid BCP 47 language tag\". RFC 5646 §2.2.9 item 2: \"Either the tag is in the list of grandfathered tags or all of its primary language, extended language, script, region, variant, and extension subtags appear in the IANA Language Subtag Registry as of the particular registry date\". markuplint's `BCP47` type checker (`@markuplint/types/src/rfc/is-bcp-47.ts`) wraps the `bcp-47` npm package, which only enforces the well-formed grammar and never consults the IANA subtag registry — so an unregistered primary subtag (`zzz`) and an unregistered extlang subtag (`smg` in `bat-smg`) both slip through. `bat-smg` is registered as a `redundant` (not `grandfathered`) tag, so the §2.2.9 grandfathered exception does not apply. Fix requires vendoring the IANA registry snapshot (or a wrapper package that does) into `@markuplint/types`.",
+		note: 'HTML LS §3.2.6.2 The lang and xml:lang attributes: "the value must be a valid BCP 47 language tag". RFC 5646 §2.2.9 item 2: "Either the tag is in the list of grandfathered tags or all of its primary language, extended language, script, region, variant, and extension subtags appear in the IANA Language Subtag Registry as of the particular registry date". markuplint\'s `BCP47` type checker (`@markuplint/types/src/rfc/is-bcp-47.ts`) wraps the `bcp-47` npm package, which only enforces the well-formed grammar and never consults the IANA subtag registry — so an unregistered primary subtag (`zzz`) and an unregistered extlang subtag (`smg` in `bat-smg`) both slip through. `bat-smg` is registered as a `redundant` (not `grandfathered`) tag, so the §2.2.9 grandfathered exception does not apply. Fix requires vendoring the IANA registry snapshot (or a wrapper package that does) into `@markuplint/types`.',
 	},
 	{
 		kind: 'primary',
 		issue: 3921,
 		filter: /^html\/elements\/base\/preceded-by-(link|script)-novalid/,
-		note:
-			'HTML LS §4.2.3 The base element: "A `base` element, if it has an `href` attribute, must come before any other elements in the tree that have attributes defined as taking URLs." `<link>`/`<script>` are metadata content, so `<base>` remains in `<head>` alongside them and `permitted-contents` does not fire. `head-element-order` treats `<base>` as an unlisted (highest-priority) entry in its default source-order list, so `<link>` (group 5) preceding `<base>` (group 8) also matches. A dedicated rule (`base-element-position`) is proposed.',
+		note: 'HTML LS §4.2.3 The base element: "A `base` element, if it has an `href` attribute, must come before any other elements in the tree that have attributes defined as taking URLs." `<link>`/`<script>` are metadata content, so `<base>` remains in `<head>` alongside them and `permitted-contents` does not fire. `head-element-order` treats `<base>` as an unlisted (highest-priority) entry in its default source-order list, so `<link>` (group 5) preceding `<base>` (group 8) also matches. A dedicated rule (`base-element-position`) is proposed.',
 	},
 	{
 		kind: 'primary',
 		issue: 3928,
-		filter:
-			/^html\/elements\/(a\/with-href-button-descendant|audio\/controls-in-button|picture\/(junk-noscript|junk-noscript-after-source-no-img|junk-video-before))-novalid/,
-		note:
-			'`permitted-contents` flattens transparent-model children out of the parent\'s content-model check entirely. `<a href>` inside `<button>` (both transparent-carrying interactive descendants) and `<video>` / `<noscript>` inside `<picture>` all slip past because the transparent element itself is dropped from the parent\'s selector evaluation. HTML LS §3.2.5.3 transparency defers only the *children* to the parent\'s model; the transparent element itself must still satisfy the parent\'s constraints. Fix requires reworking `represent-transparent-nodes.ts` to keep the transparent element in the flattened list.',
+		filter: /^html\/elements\/(a\/with-href-button-descendant|audio\/controls-in-button|picture\/(junk-noscript|junk-noscript-after-source-no-img|junk-video-before))-novalid/,
+		note: "`permitted-contents` flattens transparent-model children out of the parent's content-model check entirely. `<a href>` inside `<button>` (both transparent-carrying interactive descendants) and `<video>` / `<noscript>` inside `<picture>` all slip past because the transparent element itself is dropped from the parent's selector evaluation. HTML LS §3.2.5.3 transparency defers only the *children* to the parent's model; the transparent element itself must still satisfy the parent's constraints. Fix requires reworking `represent-transparent-nodes.ts` to keep the transparent element in the flattened list.",
 	},
 	{
 		kind: 'primary',
 		issue: 3838,
-		filter:
-			/^html-aria\/(author-requirements\/(574|575|576|577)|misc\/(role-tab-with-no-role-tabpanel-novalid|summary-for-its-details-with-aria-(expanded|pressed)-novalid))/,
-		note:
-			'Umbrella of 7 aria fixtures deferred from the aria-slice PR. Six flipped to `match-error` after Group 1 (author-requirements role chain: `wai-aria-required-owned-elements`) and Group 3 (summary heuristics: `spec.summary.jsonc#aria.properties.without`) landed. The one remaining `nu-only` — `role-tab-with-no-role-tabpanel-novalid` — is a Group 2 role-pair authoring requirement: WAI-ARIA 1.3 §tab role: "Authors MUST ensure that if a `tab` is active, a corresponding `tabpanel` that represents the active `tab` is rendered." Cross-element constraint that no existing rule covers; needs the proposed `wai-aria-required-companion-role` (or equivalent).',
+		filter: /^html-aria\/(author-requirements\/(574|575|576|577)|misc\/(role-tab-with-no-role-tabpanel-novalid|summary-for-its-details-with-aria-(expanded|pressed)-novalid))/,
+		note: 'Umbrella of 7 aria fixtures deferred from the aria-slice PR. All 7 are now `match-error`. Six flipped after Group 1 (author-requirements role chain: `wai-aria-required-owned-elements`) and Group 3 (summary heuristics: `spec.summary.jsonc#aria.properties.without`) landed. The last one, `role-tab-with-no-role-tabpanel-novalid` (Group 2, a role-pair authoring requirement — WAI-ARIA 1.3 §tab role: "Authors MUST ensure that if a `tab` is active, a corresponding `tabpanel` that represents the active `tab` is rendered."), flipped after the new `wai-aria-tab-requires-tabpanel` rule landed (resolves via `aria-controls`/`aria-labelledby` correspondence). All acceptance criteria met; safe to close.',
 	},
 	{
 		kind: 'primary',
 		issue: 3832,
 		filter: /^html\/datatypes\/charset-invalid-novalid/,
-		note:
-			'Issue body Case A — `<meta http-equiv="content-type" content="text/html; charset=not-a-charset">`. HTML LS [§4.2.5.3 Pragma directives — Encoding declaration state](https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-content-type): "For meta elements with an http-equiv attribute in the Encoding declaration state, the content attribute must have a value that is an ASCII case-insensitive match for a string that consists of: \\"text/html;\\", optionally followed by any number of ASCII whitespace, followed by \\"charset=utf-8\\"." markuplint\'s `HTTPEquivContentType` checker (`packages/@markuplint/types/src/whatwg/check-http-equiv-content-type.ts`) validates the label shape only (`/^text\\/html;[\\t\\n\\f\\r ]*charset=[\\w.-]+$/i`), so unknown labels like `not-a-charset` slip through. Cases B (`url-empty-novalid`) and C (`sandbox-scripts-same-origin-haswarn`) from the same Issue are already resolved (`match-error` and `nu-over` respectively); this is the sole remaining fixture backing the Issue.',
+		note: 'Issue body Case A — `<meta http-equiv="content-type" content="text/html; charset=not-a-charset">`. HTML LS [§4.2.5.3 Pragma directives — Encoding declaration state](https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-content-type): "For meta elements with an http-equiv attribute in the Encoding declaration state, the content attribute must have a value that is an ASCII case-insensitive match for a string that consists of: \\"text/html;\\", optionally followed by any number of ASCII whitespace, followed by \\"charset=utf-8\\"." markuplint\'s `HTTPEquivContentType` checker (`packages/@markuplint/types/src/whatwg/check-http-equiv-content-type.ts`) validates the label shape only (`/^text\\/html;[\\t\\n\\f\\r ]*charset=[\\w.-]+$/i`), so unknown labels like `not-a-charset` slip through. Cases B (`url-empty-novalid`) and C (`sandbox-scripts-same-origin-haswarn`) from the same Issue are already resolved (`match-error` and `nu-over` respectively); this is the sole remaining fixture backing the Issue.',
 	},
 	{
 		kind: 'primary',
 		issue: 3942,
 		filter: /^html\/elements\/meta\/content-security-policy\//,
-		note:
-			'CSP3 grammar (directive names, source-expression tokens, ASCII-only body) is a separate W3C specification. `packages/@markuplint/html-spec/src/spec.meta.jsonc` documents an explicit fall-through: "Other http-equiv values (default-style, content-security-policy) and `name` / `itemprop` fall through to `Any` at runtime." Three fixtures are recorded as `deferred-CSP` in `excluded-ids.json` and flip `nu-only` → `nu-over`; they will flip to `match-error` if/when a `ContentSecurityPolicy` type lands in `@markuplint/types` and is wired into `spec.meta.jsonc` under a new `[http-equiv=\'content-security-policy\' i]` condition.',
+		note: 'CSP3 grammar (directive names, source-expression tokens, ASCII-only body) is a separate W3C specification. `packages/@markuplint/html-spec/src/spec.meta.jsonc` documents an explicit fall-through: "Other http-equiv values (default-style, content-security-policy) and `name` / `itemprop` fall through to `Any` at runtime." Three fixtures are recorded as `deferred-CSP` in `excluded-ids.json` and flip `nu-only` → `nu-over`; they will flip to `match-error` if/when a `ContentSecurityPolicy` type lands in `@markuplint/types` and is wired into `spec.meta.jsonc` under a new `[http-equiv=\'content-security-policy\' i]` condition.',
 	},
 	{
 		kind: 'primary',
 		issue: 3943,
-		filter:
-			/^(html-math\/math-in-head|html\/elements\/picture\/html-syntax-picture-no-end-tag|html\/parser\/(charset-after-1024|stray-start-tag|text-after-body))-novalid/,
-		note:
-			'Umbrella for 5 fixtures that report legitimate HTML LS parse errors which `parse5` (`packages/@markuplint/html-parser/src/parser.ts` `tokenize()`) silently recovers from: `<math>` inside `<head>` triggering implicit body promotion; open `<picture>` at EOF; `<meta charset>` after the first 1024 bytes ([HTML LS "Specifying the document\'s character encoding"](https://html.spec.whatwg.org/multipage/semantics.html#charset)); a start tag or non-whitespace character after `</body>` ([HTML LS "The \'after body\' insertion mode"](https://html.spec.whatwg.org/multipage/parsing.html#the-after-body-insertion-mode)). A direct probe on the pinned parse5 version confirmed no `onParseError` fires for any of these fixtures. Extending `MLASTParseErrorCode` alone will not close the gap; a post-parse rule pass (per-case) is the pragmatic path.',
+		filter: /^(html-math\/math-in-head|html\/elements\/picture\/html-syntax-picture-no-end-tag|html\/parser\/(charset-after-1024|stray-start-tag|text-after-body))-novalid/,
+		note: 'Umbrella for 5 fixtures that report legitimate HTML LS parse errors which `parse5` (`packages/@markuplint/html-parser/src/parser.ts` `tokenize()`) silently recovers from: `<math>` inside `<head>` triggering implicit body promotion; open `<picture>` at EOF; `<meta charset>` after the first 1024 bytes ([HTML LS "Specifying the document\'s character encoding"](https://html.spec.whatwg.org/multipage/semantics.html#charset)); a start tag or non-whitespace character after `</body>` ([HTML LS "The \'after body\' insertion mode"](https://html.spec.whatwg.org/multipage/parsing.html#the-after-body-insertion-mode)). A direct probe on the pinned parse5 version confirmed no `onParseError` fires for any of these fixtures. Extending `MLASTParseErrorCode` alone will not close the gap; a post-parse rule pass (per-case) is the pragmatic path.',
 	},
 	{
 		kind: 'primary',
 		issue: 3944,
 		filter: /^html\/elements\/img\/missing-alt-in-figure-novalid/,
-		note:
-			'[HTML LS "Requirements for providing text to act as an alternative for images"](https://html.spec.whatwg.org/multipage/images.html#alt) and its "Guidance for conformance checkers" subsection ([`images.html#guidance-for-conformance-checkers`](https://html.spec.whatwg.org/multipage/images.html#guidance-for-conformance-checkers)) enumerate the narrow exceptions under which `alt` may be omitted. The fixture has no `<figcaption>` inside the enclosing `<figure>`, so none of the omission conditions apply. `packages/@markuplint/rules/src/required-attr/index.spec.ts` `[required-attr-invalid-001]` demonstrates that markuplint\'s `required-attr` fires on `img` only via explicit `nodeRule` config; `packages/@markuplint/html-spec/src/spec.img.jsonc` defines `alt` as `{ "type": "Any" }` without a `required` flag or `requiredEither`. The current `requiredEither` grammar cannot express the exception-list shape from the spec — a new rule (working name `img-alt-required`) or a richer condition grammar is required.',
+		note: '[HTML LS "Requirements for providing text to act as an alternative for images"](https://html.spec.whatwg.org/multipage/images.html#alt) and its "Guidance for conformance checkers" subsection ([`images.html#guidance-for-conformance-checkers`](https://html.spec.whatwg.org/multipage/images.html#guidance-for-conformance-checkers)) enumerate the narrow exceptions under which `alt` may be omitted. The fixture has no `<figcaption>` inside the enclosing `<figure>`, so none of the omission conditions apply. `packages/@markuplint/rules/src/required-attr/index.spec.ts` `[required-attr-invalid-001]` demonstrates that markuplint\'s `required-attr` fires on `img` only via explicit `nodeRule` config; `packages/@markuplint/html-spec/src/spec.img.jsonc` defines `alt` as `{ "type": "Any" }` without a `required` flag or `requiredEither`. The current `requiredEither` grammar cannot express the exception-list shape from the spec — a new rule (working name `img-alt-required`) or a richer condition grammar is required.',
 	},
 	{
 		kind: 'primary',
 		issue: 3945,
 		filter: /^html\/elements\/img\/usemap-invalid-reference-novalid/,
-		note:
-			'[HTML LS "Image maps — Authoring"](https://html.spec.whatwg.org/multipage/image-maps.html#authoring): "The `usemap` attribute, if specified, must be a valid hash-name reference to a `map` element." [HTML LS "Valid hash-name reference"](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#valid-hash-name-reference): the reference is a `#`-prefixed string that "exactly matches" a `name` attribute in the same tree (string-equal, case-sensitive). `packages/@markuplint/rules/src/map-id-name-match` covers the internal id/name consistency of `<map>` itself but does not validate `img[usemap]` → `<map name>` lookups. `no-refer-to-non-existent-id` targets `id`-typed attributes only, so `usemap` (declared as `HashName` in `spec.img.jsonc`) is out of its scope. Needs a new rule (working name `usemap-references-map`) shaped like `form-attr-references-form` / `input-list-references-datalist`. Follow-up: reconcile the `[map-id-name-match-invalid-002]` spec comment which claims `<map name>` is matched case-insensitively against `<img usemap>` — this contradicts the "exactly matches" wording verified above.',
+		note: '[HTML LS "Image maps — Authoring"](https://html.spec.whatwg.org/multipage/image-maps.html#authoring): "The `usemap` attribute, if specified, must be a valid hash-name reference to a `map` element." [HTML LS "Valid hash-name reference"](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#valid-hash-name-reference): the reference is a `#`-prefixed string that "exactly matches" a `name` attribute in the same tree (string-equal, case-sensitive). `packages/@markuplint/rules/src/map-id-name-match` covers the internal id/name consistency of `<map>` itself but does not validate `img[usemap]` → `<map name>` lookups. `no-refer-to-non-existent-id` targets `id`-typed attributes only, so `usemap` (declared as `HashName` in `spec.img.jsonc`) is out of its scope. Needs a new rule (working name `usemap-references-map`) shaped like `form-attr-references-form` / `input-list-references-datalist`. Follow-up: reconcile the `[map-id-name-match-invalid-002]` spec comment which claims `<map name>` is matched case-insensitively against `<img usemap>` — this contradicts the "exactly matches" wording verified above.',
 	},
 	{
 		kind: 'primary',
 		issue: 3946,
 		filter: /^html\/elements\/style\/css-property-error-novalid/,
-		note:
-			'CSS syntax and property registry are governed by CSS specifications (CSS Syntax Level 3, CSS Values and Units, individual property specs), not by HTML LS. markuplint\'s tracked spec scope is HTML LS + WAI-ARIA + URL LS per `.claude/skills/bench-triage/SKILL.md`, so CSS is `deferred-CSS`. One fixture is recorded per-id in `excluded-ids.json#entries[]` and flips `nu-only` → `nu-over`; it will flip to `match-error` if/when a CSS grammar-validation rule lands (css-tree, already a dependency of `packages/@markuplint/types`, is a plausible candidate for syntax-only validation). Parallel deferred spec: #3942 (deferred-CSP).',
+		note: "CSS syntax and property registry are governed by CSS specifications (CSS Syntax Level 3, CSS Values and Units, individual property specs), not by HTML LS. markuplint's tracked spec scope is HTML LS + WAI-ARIA + URL LS per `.claude/skills/bench-triage/SKILL.md`, so CSS is `deferred-CSS`. One fixture is recorded per-id in `excluded-ids.json#entries[]` and flips `nu-only` → `nu-over`; it will flip to `match-error` if/when a CSS grammar-validation rule lands (css-tree, already a dependency of `packages/@markuplint/types`, is a plausible candidate for syntax-only validation). Parallel deferred spec: #3942 (deferred-CSP).",
 	},
 
 	// === 2 次群: bench では裏取れない Issue（ステルブロック） ===
 	{
 		kind: 'secondary',
 		issue: 3675,
-		reason:
-			'Internal merge-order blocker; not a benchmark claim. Resolves once dev merges into the branch and the SRIHash type comes along.',
+		reason: 'Internal merge-order blocker; not a benchmark claim. Resolves once dev merges into the branch and the SRIHash type comes along.',
 	},
 	{
 		kind: 'secondary',
@@ -146,14 +131,12 @@ export const xrefMappings: readonly XrefMapping[] = [
 	{
 		kind: 'secondary',
 		issue: 509,
-		reason:
-			'Parser-level concern (ignore preprocessor blocks inside attribute tokens). The nu-validator suite contains no preprocessor fixtures.',
+		reason: 'Parser-level concern (ignore preprocessor blocks inside attribute tokens). The nu-validator suite contains no preprocessor fixtures.',
 	},
 	{
 		kind: 'secondary',
 		issue: 296,
-		reason:
-			'No fixture covers the `<svg><title>` accessibility requirement in the nu-validator suite.',
+		reason: 'No fixture covers the `<svg><title>` accessibility requirement in the nu-validator suite.',
 	},
 	{
 		kind: 'secondary',
@@ -168,7 +151,6 @@ export const xrefMappings: readonly XrefMapping[] = [
 	{
 		kind: 'secondary',
 		issue: 460,
-		reason:
-			'`permitted-content` on elements containing mutable (preprocessor) children is a markuplint-internal concern; the nu-validator suite has no fixtures with mutable placeholders.',
+		reason: '`permitted-content` on elements containing mutable (preprocessor) children is a markuplint-internal concern; the nu-validator suite has no fixtures with mutable placeholders.',
 	},
 ];

--- a/tests/external/snapshots/diff/coverage.json
+++ b/tests/external/snapshots/diff/coverage.json
@@ -2116,8 +2116,8 @@
 			"path": "html-aria/misc/role-tab-with-no-role-tabpanel-novalid.html",
 			"category": "aria",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -14854,9 +14854,7 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": [
-				"nv-cd593c007a34"
-			]
+			"excludedIds": ["nv-cd593c007a34"]
 		},
 		{
 			"path": "html/datatypes/source-size-list-empty-novalid.html",
@@ -15288,9 +15286,7 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": [
-				"nv-3a1dc1374ed4"
-			]
+			"excludedIds": ["nv-3a1dc1374ed4"]
 		},
 		{
 			"path": "html/elements/a/href/scheme-data-single-slash-novalid.html",
@@ -16074,9 +16070,7 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": [
-				"nv-cdb4535e049d"
-			]
+			"excludedIds": ["nv-cdb4535e049d"]
 		},
 		{
 			"path": "html/elements/area/href/scheme-data-single-slash-novalid.html",
@@ -16836,9 +16830,7 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": [
-				"nv-60706ef20301"
-			]
+			"excludedIds": ["nv-60706ef20301"]
 		},
 		{
 			"path": "html/elements/audio/src/scheme-data-single-slash-novalid.html",
@@ -17958,9 +17950,7 @@
 			"nu": "clean",
 			"ml": "error",
 			"verdict": "ml-only",
-			"excludedIds": [
-				"nv-7607d3f108ff"
-			]
+			"excludedIds": ["nv-7607d3f108ff"]
 		},
 		{
 			"path": "html/elements/base/href/scheme-data-no-slash-isvalid.html",
@@ -18896,9 +18886,7 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": [
-				"nv-ed1dbf9dfa0f"
-			]
+			"excludedIds": ["nv-ed1dbf9dfa0f"]
 		},
 		{
 			"path": "html/elements/blockquote/cite/scheme-data-single-slash-novalid.html",
@@ -19610,9 +19598,7 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": [
-				"nv-82f38369e99e"
-			]
+			"excludedIds": ["nv-82f38369e99e"]
 		},
 		{
 			"path": "html/elements/button/formaction/scheme-data-single-slash-novalid.html",
@@ -20412,9 +20398,7 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": [
-				"nv-6d168c2d3178"
-			]
+			"excludedIds": ["nv-6d168c2d3178"]
 		},
 		{
 			"path": "html/elements/del/cite/scheme-data-single-slash-novalid.html",
@@ -22318,9 +22302,7 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": [
-				"nv-27ddcd34ac6d"
-			]
+			"excludedIds": ["nv-27ddcd34ac6d"]
 		},
 		{
 			"path": "html/elements/embed/src/scheme-data-single-slash-novalid.html",
@@ -23072,9 +23054,7 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": [
-				"nv-0a21d5f3b754"
-			]
+			"excludedIds": ["nv-0a21d5f3b754"]
 		},
 		{
 			"path": "html/elements/form/action/scheme-data-single-slash-novalid.html",
@@ -24018,9 +23998,7 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": [
-				"nv-344c8ec6a993"
-			]
+			"excludedIds": ["nv-344c8ec6a993"]
 		},
 		{
 			"path": "html/elements/iframe/src/scheme-data-single-slash-novalid.html",
@@ -24860,9 +24838,7 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": [
-				"nv-8c9d69a03039"
-			]
+			"excludedIds": ["nv-8c9d69a03039"]
 		},
 		{
 			"path": "html/elements/img/src/scheme-data-single-slash-novalid.html",
@@ -25710,9 +25686,7 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": [
-				"nv-54c78eff3c7d"
-			]
+			"excludedIds": ["nv-54c78eff3c7d"]
 		},
 		{
 			"path": "html/elements/input/type-color-isvalid.html",
@@ -26128,9 +26102,7 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": [
-				"nv-ad82b8a8c1e5"
-			]
+			"excludedIds": ["nv-ad82b8a8c1e5"]
 		},
 		{
 			"path": "html/elements/input/type-image-formaction/scheme-data-single-slash-novalid.html",
@@ -26794,9 +26766,7 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": [
-				"nv-e683359e52e5"
-			]
+			"excludedIds": ["nv-e683359e52e5"]
 		},
 		{
 			"path": "html/elements/input/type-image-src/scheme-data-single-slash-novalid.html",
@@ -27460,9 +27430,7 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": [
-				"nv-8c1d1d42e012"
-			]
+			"excludedIds": ["nv-8c1d1d42e012"]
 		},
 		{
 			"path": "html/elements/input/type-submit-formaction/scheme-data-single-slash-novalid.html",
@@ -28190,9 +28158,7 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": [
-				"nv-6872c643a823"
-			]
+			"excludedIds": ["nv-6872c643a823"]
 		},
 		{
 			"path": "html/elements/input/type-url-value/scheme-data-single-slash-novalid.html",
@@ -28856,9 +28822,7 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": [
-				"nv-27b353000357"
-			]
+			"excludedIds": ["nv-27b353000357"]
 		},
 		{
 			"path": "html/elements/ins/cite/scheme-data-single-slash-novalid.html",
@@ -30570,9 +30534,7 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": [
-				"nv-5b612865391d"
-			]
+			"excludedIds": ["nv-5b612865391d"]
 		},
 		{
 			"path": "html/elements/link/href/scheme-data-single-slash-novalid.html",
@@ -31324,9 +31286,7 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": [
-				"nv-6ec2a5c8c04c"
-			]
+			"excludedIds": ["nv-6ec2a5c8c04c"]
 		},
 		{
 			"path": "html/elements/meta/content-security-policy/csp-invalid-source-novalid.html",
@@ -31334,9 +31294,7 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": [
-				"nv-ccff05d53b7c"
-			]
+			"excludedIds": ["nv-ccff05d53b7c"]
 		},
 		{
 			"path": "html/elements/meta/content-security-policy/csp-non-ascii-novalid.html",
@@ -31344,9 +31302,7 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": [
-				"nv-f76bf04a85bb"
-			]
+			"excludedIds": ["nv-f76bf04a85bb"]
 		},
 		{
 			"path": "html/elements/meta/content-security-policy/csp-policy-list-isvalid.html",
@@ -31474,9 +31430,7 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": [
-				"nv-c57d9ac83548"
-			]
+			"excludedIds": ["nv-c57d9ac83548"]
 		},
 		{
 			"path": "html/elements/meta/refresh-isvalid.html",
@@ -31500,9 +31454,7 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": [
-				"nv-f26bf6cca5a8"
-			]
+			"excludedIds": ["nv-f26bf6cca5a8"]
 		},
 		{
 			"path": "html/elements/meta/refresh-quoted-url-novalid.html",
@@ -31510,9 +31462,7 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": [
-				"nv-59fd76f96902"
-			]
+			"excludedIds": ["nv-59fd76f96902"]
 		},
 		{
 			"path": "html/elements/meta/viewport-user-scalable-no-haswarn.html",
@@ -32088,9 +32038,7 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": [
-				"nv-372749d0395d"
-			]
+			"excludedIds": ["nv-372749d0395d"]
 		},
 		{
 			"path": "html/elements/object/data/scheme-data-single-slash-novalid.html",
@@ -32418,9 +32366,7 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": [
-				"nv-785400222871"
-			]
+			"excludedIds": ["nv-785400222871"]
 		},
 		{
 			"path": "html/elements/ol/model-isvalid.html",
@@ -34620,9 +34566,7 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": [
-				"nv-3cd607b1d358"
-			]
+			"excludedIds": ["nv-3cd607b1d358"]
 		},
 		{
 			"path": "html/elements/q/cite/scheme-data-single-slash-novalid.html",
@@ -35150,9 +35094,7 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": [
-				"nv-00d2f9879fd4"
-			]
+			"excludedIds": ["nv-00d2f9879fd4"]
 		},
 		{
 			"path": "html/elements/script/importmap/scopes-value-not-object-novalid.html",
@@ -36504,9 +36446,7 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": [
-				"nv-d2a73eb7f342"
-			]
+			"excludedIds": ["nv-d2a73eb7f342"]
 		},
 		{
 			"path": "html/elements/script/src/scheme-data-single-slash-novalid.html",
@@ -37450,9 +37390,7 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": [
-				"nv-c98e0d290a6d"
-			]
+			"excludedIds": ["nv-c98e0d290a6d"]
 		},
 		{
 			"path": "html/elements/source/src/scheme-data-single-slash-novalid.html",
@@ -37820,9 +37758,7 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": [
-				"nv-c5efac320bbb"
-			]
+			"excludedIds": ["nv-c5efac320bbb"]
 		},
 		{
 			"path": "html/elements/style/html-spec-comms-isvalid.html",
@@ -38142,9 +38078,7 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": [
-				"nv-d7b3d14cfb44"
-			]
+			"excludedIds": ["nv-d7b3d14cfb44"]
 		},
 		{
 			"path": "html/elements/table/row-width-exceeds-cols-haswarn.html",
@@ -38728,9 +38662,7 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": [
-				"nv-22da233e51c1"
-			]
+			"excludedIds": ["nv-22da233e51c1"]
 		},
 		{
 			"path": "html/elements/track/src/scheme-data-single-slash-novalid.html",
@@ -39506,9 +39438,7 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": [
-				"nv-f66fce25c1d0"
-			]
+			"excludedIds": ["nv-f66fce25c1d0"]
 		},
 		{
 			"path": "html/elements/video/poster/scheme-data-single-slash-novalid.html",
@@ -40156,9 +40086,7 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": [
-				"nv-1f2c65f495dc"
-			]
+			"excludedIds": ["nv-1f2c65f495dc"]
 		},
 		{
 			"path": "html/elements/video/src/scheme-data-single-slash-novalid.html",
@@ -40910,9 +40838,7 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": [
-				"nv-72908421456b"
-			]
+			"excludedIds": ["nv-72908421456b"]
 		},
 		{
 			"path": "html/microdata/itemid-without-itemscope-novalid.html",
@@ -41616,9 +41542,7 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": [
-				"nv-5e72124bb955"
-			]
+			"excludedIds": ["nv-5e72124bb955"]
 		},
 		{
 			"path": "html/microdata/itemtype-without-itemscope-novalid.html",

--- a/tests/external/snapshots/diff/markuplint-only.json
+++ b/tests/external/snapshots/diff/markuplint-only.json
@@ -3,52 +3,37 @@
 		{
 			"path": "html-aria/misc/a-href-aria-disabled-true-haswarn.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/misc/aria-controls-broken-idref-novalid.html",
 			"category": "aria",
-			"ruleIds": [
-				"no-refer-to-non-existent-id"
-			]
+			"ruleIds": ["no-refer-to-non-existent-id"]
 		},
 		{
 			"path": "html-aria/misc/aria-describedby-broken-idref-novalid.html",
 			"category": "aria",
-			"ruleIds": [
-				"no-refer-to-non-existent-id"
-			]
+			"ruleIds": ["no-refer-to-non-existent-id"]
 		},
 		{
 			"path": "html-aria/misc/aria-disabled-true-on-disabled-haswarn.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-implicit-props"
-			]
+			"ruleIds": ["wai-aria-implicit-props"]
 		},
 		{
 			"path": "html-aria/misc/aria-flowto-broken-idref-novalid.html",
 			"category": "aria",
-			"ruleIds": [
-				"no-refer-to-non-existent-id"
-			]
+			"ruleIds": ["no-refer-to-non-existent-id"]
 		},
 		{
 			"path": "html-aria/misc/aria-haspopup-on-datalist-input-haswarn.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/misc/aria-labelledby-broken-idref-novalid.html",
 			"category": "aria",
-			"ruleIds": [
-				"no-refer-to-non-existent-id",
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["no-refer-to-non-existent-id", "wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/misc/aria-owns-broken-idref-novalid.html",
@@ -62,7919 +47,5057 @@
 		{
 			"path": "html-aria/misc/aria-valuemin-on-meter-haswarn.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/misc/figure-with-role-doc-example-and-figcaption.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-permitted-roles"
-			]
+			"ruleIds": ["wai-aria-permitted-roles"]
 		},
 		{
 			"path": "html-aria/misc/figure-with-role-figure-and-figcaption-haswarn.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-permitted-roles"
-			]
+			"ruleIds": ["wai-aria-permitted-roles"]
 		},
 		{
 			"path": "html-aria/misc/img-element-with-role-and-accessible-name-isvalid.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-permitted-roles"
-			]
+			"ruleIds": ["wai-aria-permitted-roles"]
 		},
 		{
 			"path": "html-aria/misc/input-image-reset-submit.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-permitted-roles"
-			]
+			"ruleIds": ["wai-aria-permitted-roles"]
 		},
 		{
 			"path": "html-aria/misc/input-number-aria-valuemax-haswarn.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/misc/input-number-aria-valuemin-haswarn.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/misc/label-unassociated-with-labelable-element-with-role-and-aria-expanded-isvalid.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-no-global-prop",
-				"wai-aria-permitted-roles"
-			]
+			"ruleIds": ["wai-aria-no-global-prop", "wai-aria-permitted-roles"]
 		},
 		{
 			"path": "html-aria/misc/li-role-button-with-role-none-ancestor-isvalid.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-permitted-roles"
-			]
+			"ruleIds": ["wai-aria-permitted-roles"]
 		},
 		{
 			"path": "html-aria/misc/role-listitem-with-aria-level-haswarn.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/misc/role-on-math-element-haswarn.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-permitted-roles"
-			]
+			"ruleIds": ["wai-aria-permitted-roles"]
 		},
 		{
 			"path": "html-aria/misc/select-aria-multiselectable-haswarn.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/misc/table-role-presentation-nested-with-td-with-role-isvalid.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/misc/unnecessary-listbox-role-on-select-haswarn.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-permitted-roles"
-			]
+			"ruleIds": ["wai-aria-permitted-roles"]
 		},
 		{
 			"path": "html-aria/misc/unnecessary-role-listbox-haswarn.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-permitted-roles"
-			]
+			"ruleIds": ["wai-aria-permitted-roles"]
 		},
 		{
 			"path": "html-aria/misc/unnecessary-role-on-main-haswarn.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-permitted-roles"
-			]
+			"ruleIds": ["wai-aria-permitted-roles"]
 		},
 		{
 			"path": "html-aria/misc/unnecessary-role-searchbox-haswarn.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-permitted-roles"
-			]
+			"ruleIds": ["wai-aria-permitted-roles"]
 		},
 		{
 			"path": "html-aria/misc/unnecessary-searchbox-role-on-input-haswarn.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-permitted-roles"
-			]
+			"ruleIds": ["wai-aria-permitted-roles"]
 		},
 		{
 			"path": "html-aria/mixed-value/585.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-value"
-			]
+			"ruleIds": ["wai-aria-value"]
 		},
 		{
 			"path": "html-aria/mixed-value/586.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-value"
-			]
+			"ruleIds": ["wai-aria-value"]
 		},
 		{
 			"path": "html-aria/name-computation-img/566-isvalid.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/presentation-role/510.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/presentation-role/511.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/presentation-role/512.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/presentation-role/514.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/presentation-role/515.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/presentation-role/516.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/presentation-role/518.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/presentation-role/520.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/presentation-role/521.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/presentation-role/522.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/presentation-role/524.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/presentation-role/525.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/presentation-role/527.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/roles-plain-concrete/roles-plain-concrete-grid.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/roles-plain-concrete/roles-plain-concrete-list.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/roles-plain-concrete/roles-plain-concrete-menu.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/roles-plain-concrete/roles-plain-concrete-menubar.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/roles-plain-concrete/roles-plain-concrete-tablist.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/roles-plain-concrete/roles-plain-concrete-tree.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/roles-plain-concrete/roles-plain-concrete-treegrid.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/roles-properties-required-inherited/radio-aria-checked-mixed.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-value"
-			]
+			"ruleIds": ["wai-aria-value"]
 		},
 		{
 			"path": "html-aria/roles-properties-required-inherited/radio-aria-checked-undefined.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-value"
-			]
+			"ruleIds": ["wai-aria-value"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/alert-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/alert-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/alert-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/alertdialog-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/alertdialog-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/alertdialog-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/article-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/article-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/article-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/banner-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/banner-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/banner-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/complementary-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/complementary-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/complementary-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/contentinfo-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/contentinfo-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/contentinfo-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/definition-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/definition-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/definition-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/dialog-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/dialog-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/dialog-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/form-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/form-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/form-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/grid-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props",
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-disallowed-props", "wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/grid-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props",
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-disallowed-props", "wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/grid-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props",
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-disallowed-props", "wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/group-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/group-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/group-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/heading-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/heading-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/heading-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/img-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/img-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/img-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/list-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/list-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/list-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/log-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/log-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/log-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/main-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/main-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/main-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/marquee-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/marquee-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/marquee-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/math-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/math-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/math-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/menu-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props",
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-disallowed-props", "wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/menu-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props",
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-disallowed-props", "wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/menu-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props",
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-disallowed-props", "wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/menubar-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props",
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-disallowed-props", "wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/menubar-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props",
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-disallowed-props", "wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/menubar-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props",
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-disallowed-props", "wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/menuitemradio-aria-checked-mixed.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-value"
-			]
+			"ruleIds": ["wai-aria-value"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/menuitemradio-aria-checked-undefined.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-value"
-			]
+			"ruleIds": ["wai-aria-value"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/navigation-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/navigation-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/navigation-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/note-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/note-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/note-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/radio-aria-checked-mixed.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-value"
-			]
+			"ruleIds": ["wai-aria-value"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/radiogroup-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/radiogroup-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/radiogroup-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/region-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/region-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/region-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/rowgroup-aria-activedescendant-obj1.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/search-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/search-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/search-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/status-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/status-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/status-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/tablist-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/tablist-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/tablist-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/tabpanel-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/tabpanel-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/tabpanel-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/timer-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/timer-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/timer-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/toolbar-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/toolbar-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/toolbar-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/tooltip-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/tooltip-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/tooltip-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/tree-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/tree-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/tree-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/treegrid-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/treegrid-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/treegrid-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/treegrid-aria-level-1.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/treeitem-aria-checked-mixed.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-value"
-			]
+			"ruleIds": ["wai-aria-value"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/treeitem-aria-checked-undefined.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-value"
-			]
+			"ruleIds": ["wai-aria-value"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-document-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-document-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-document-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-grid-aria-multiselectable-false.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-grid-aria-multiselectable-true.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-grid-aria-readonly-false.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-grid-aria-readonly-true.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-listbox-aria-multiselectable-false.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-listbox-aria-multiselectable-true.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-listbox-aria-required-false.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-listbox-aria-required-true.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-option-aria-checked-mixed.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-value"
-			]
+			"ruleIds": ["wai-aria-value"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-option-aria-checked-undefined.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-value"
-			]
+			"ruleIds": ["wai-aria-value"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-row-aria-level-1.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-row-aria-selected-false.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-row-aria-selected-true.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-separator-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-separator-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-separator-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-tablist-aria-level-1.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html-aria/setsize-posinset-level/testcase-769.html",
 			"category": "aria",
-			"ruleIds": [
-				"wai-aria-required-parent-role"
-			]
+			"ruleIds": ["wai-aria-required-parent-role"]
 		},
 		{
 			"path": "html-its/allowedcharacters/html/allowedcharacters1html.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-its/domain/html/domain4html.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"required-attr"
-			]
+			"ruleIds": ["invalid-attr", "required-attr"]
 		},
 		{
 			"path": "html-its/elementswithintext/html/withintext2html.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-its/localefilter/html/locale2html.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-its/localefilter/html/locale5html.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-its/localizationnote/html/locnote7html.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-its/locqualityissue/html/locqualityissue4html.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-its/locqualityissue/html/locqualityissue5html.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-its/locqualityissue/html/locqualityissue6html.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-its/locqualityissue/html/locqualityissue7html.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-its/locqualityissue/html/locqualityissue9html.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-its/locqualityrating/html/locqualityrating1html.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-its/locqualityrating/html/locqualityrating2html.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-its/mtconfidence/html/mtconfidence1html.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-its/mtconfidence/html/mtconfidence2html.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-its/mtconfidence/html/mtconfidence3html.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-its/mtconfidence/html/mtconfidence4html.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-its/mtconfidence/html/mtconfidence5html.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-its/provenance/html/provenance3html.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-its/provenance/html/provenance4html.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-its/provenance/html/provenance6html.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-its/provenance/html/provenance7html.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-its/storagesize/html/storagesize1html.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-its/terminology/html/terminology3html.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-its/terminology/html/terminology5html.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-its/textanalysis/html/textanalysis1html.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-its/textanalysis/html/textanalysis2html.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-its/textanalysis/html/textanalysis3html.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-its/textanalysis/html/textanalysis4html.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-its/textanalysis/html/textanalysis5html.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-math/annotation-xml-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"permitted-contents"
-			]
+			"ruleIds": ["permitted-contents"]
 		},
 		{
 			"path": "html-math/maction-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr"
-			]
+			"ruleIds": ["deprecated-attr"]
 		},
 		{
 			"path": "html-math/math-overflow-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0001-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0006-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"link-types"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "link-types"]
 		},
 		{
 			"path": "html-rdfa/0007-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"link-types"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "link-types"]
 		},
 		{
 			"path": "html-rdfa/0008-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"link-types"
-			]
+			"ruleIds": ["invalid-attr", "link-types"]
 		},
 		{
 			"path": "html-rdfa/0009-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0010-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"link-types"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "link-types"]
 		},
 		{
 			"path": "html-rdfa/0014-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0015-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"link-types",
-				"required-attr"
-			]
+			"ruleIds": ["invalid-attr", "link-types", "required-attr"]
 		},
 		{
 			"path": "html-rdfa/0017-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0018-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"link-types"
-			]
+			"ruleIds": ["invalid-attr", "link-types"]
 		},
 		{
 			"path": "html-rdfa/0020-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0021-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0023-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0025-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0026-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0027-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0029-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0030-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"link-types"
-			]
+			"ruleIds": ["invalid-attr", "link-types"]
 		},
 		{
 			"path": "html-rdfa/0031-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0032-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"link-types"
-			]
+			"ruleIds": ["invalid-attr", "link-types"]
 		},
 		{
 			"path": "html-rdfa/0033-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0034-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0036-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0038-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0048-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0049-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0050-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0051-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0052-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0053-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0054-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0055-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"link-types"
-			]
+			"ruleIds": ["invalid-attr", "link-types"]
 		},
 		{
 			"path": "html-rdfa/0056-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0057-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0059-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0060-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0063-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"link-types"
-			]
+			"ruleIds": ["invalid-attr", "link-types"]
 		},
 		{
 			"path": "html-rdfa/0064-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"link-types"
-			]
+			"ruleIds": ["invalid-attr", "link-types"]
 		},
 		{
 			"path": "html-rdfa/0065-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"link-types"
-			]
+			"ruleIds": ["invalid-attr", "link-types"]
 		},
 		{
 			"path": "html-rdfa/0066-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0067-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0068-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0069-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"link-types"
-			]
+			"ruleIds": ["invalid-attr", "link-types"]
 		},
 		{
 			"path": "html-rdfa/0070-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0071-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"link-types"
-			]
+			"ruleIds": ["invalid-attr", "link-types"]
 		},
 		{
 			"path": "html-rdfa/0072-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0073-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0074-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"link-types"
-			]
+			"ruleIds": ["invalid-attr", "link-types"]
 		},
 		{
 			"path": "html-rdfa/0075-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0080-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0083-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0084-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0087-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"link-types"
-			]
+			"ruleIds": ["invalid-attr", "link-types"]
 		},
 		{
 			"path": "html-rdfa/0088-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0089-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0091-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0093-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0099-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0104-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0106-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0107-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0110-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0111-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0112-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0114-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"link-types"
-			]
+			"ruleIds": ["invalid-attr", "link-types"]
 		},
 		{
 			"path": "html-rdfa/0115-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0117-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0118-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0119-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0120-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0122-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0126-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0140-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0174-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0175-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0176-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"link-types"
-			]
+			"ruleIds": ["invalid-attr", "link-types"]
 		},
 		{
 			"path": "html-rdfa/0177-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0178-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0181-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0182-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0186-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0187-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0188-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0189-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0190-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0196-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0197-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0206-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0207-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"link-types"
-			]
+			"ruleIds": ["invalid-attr", "link-types"]
 		},
 		{
 			"path": "html-rdfa/0213-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0214-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0216-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0217-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0218-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0219-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0220-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"link-types"
-			]
+			"ruleIds": ["invalid-attr", "link-types"]
 		},
 		{
 			"path": "html-rdfa/0221-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"link-types"
-			]
+			"ruleIds": ["invalid-attr", "link-types"]
 		},
 		{
 			"path": "html-rdfa/0224-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0225-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0228-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0229-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0231-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0232-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0233-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0234-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"link-types"
-			]
+			"ruleIds": ["invalid-attr", "link-types"]
 		},
 		{
 			"path": "html-rdfa/0235-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0238-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0239-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0240-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0241-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0242-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0243-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0244-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0245-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0246-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0247-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0248-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0249-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0250-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0251-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"required-attr"
-			]
+			"ruleIds": ["invalid-attr", "required-attr"]
 		},
 		{
 			"path": "html-rdfa/0252-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"required-attr"
-			]
+			"ruleIds": ["invalid-attr", "required-attr"]
 		},
 		{
 			"path": "html-rdfa/0253-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0254-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0255-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0257-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0259-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0261-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0262-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0263-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0264-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0265-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0266-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0267-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0268-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0269-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0271-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0272-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0273-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0274-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0275-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0276-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0277-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0278-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0279-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0281-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0282-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0283-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0284-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0287-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0289-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0290-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0291-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0292-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0293-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0296-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0297-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0298-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0299-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"link-types"
-			]
+			"ruleIds": ["invalid-attr", "link-types"]
 		},
 		{
 			"path": "html-rdfa/0300-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0301-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0302-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0303-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"link-types"
-			]
+			"ruleIds": ["invalid-attr", "link-types"]
 		},
 		{
 			"path": "html-rdfa/0311-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0312-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0313-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0315-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0316-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0317-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0318-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents",
-				"required-attr"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents", "required-attr"]
 		},
 		{
 			"path": "html-rdfa/0321-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents",
-				"required-attr"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents", "required-attr"]
 		},
 		{
 			"path": "html-rdfa/0322-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents",
-				"required-attr"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents", "required-attr"]
 		},
 		{
 			"path": "html-rdfa/0323-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents",
-				"required-attr"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents", "required-attr"]
 		},
 		{
 			"path": "html-rdfa/0324-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents",
-				"required-attr"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents", "required-attr"]
 		},
 		{
 			"path": "html-rdfa/0325-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents",
-				"required-attr"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents", "required-attr"]
 		},
 		{
 			"path": "html-rdfa/0326-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents",
-				"required-attr"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents", "required-attr"]
 		},
 		{
 			"path": "html-rdfa/0327-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents",
-				"required-attr"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents", "required-attr"]
 		},
 		{
 			"path": "html-rdfa/0328-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0329-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0330-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfa/0331-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfalite/0015-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"link-types",
-				"required-attr"
-			]
+			"ruleIds": ["invalid-attr", "link-types", "required-attr"]
 		},
 		{
 			"path": "html-rdfalite/0021-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfalite/0023-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfalite/0030-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"link-types"
-			]
+			"ruleIds": ["invalid-attr", "link-types"]
 		},
 		{
 			"path": "html-rdfalite/0050-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfalite/0052-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfalite/0053-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfalite/0066-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfalite/0067-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfalite/0071-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"link-types"
-			]
+			"ruleIds": ["invalid-attr", "link-types"]
 		},
 		{
 			"path": "html-rdfalite/0074-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"link-types"
-			]
+			"ruleIds": ["invalid-attr", "link-types"]
 		},
 		{
 			"path": "html-rdfalite/0075-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfalite/0089-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfalite/0115-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfalite/0117-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfalite/0140-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfalite/0214-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfalite/0235-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfalite/0238-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfalite/0239-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfalite/0240-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfalite/0241-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfalite/0242-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfalite/0255-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfalite/0259-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfalite/0263-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfalite/0264-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfalite/0272-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfalite/0273-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfalite/0274-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfalite/0275-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfalite/0276-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfalite/0277-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfalite/0281-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfalite/0282-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfalite/0283-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfalite/0287-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfalite/0296-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfalite/0301-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfalite/0302-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfalite/0311-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfalite/0312-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfalite/0313-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html-rdfalite/0321-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents",
-				"required-attr"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents", "required-attr"]
 		},
 		{
 			"path": "html-rdfalite/0322-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents",
-				"required-attr"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents", "required-attr"]
 		},
 		{
 			"path": "html-rdfalite/0323-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents",
-				"required-attr"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents", "required-attr"]
 		},
 		{
 			"path": "html-rdfalite/0324-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents",
-				"required-attr"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents", "required-attr"]
 		},
 		{
 			"path": "html-rdfalite/0325-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents",
-				"required-attr"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents", "required-attr"]
 		},
 		{
 			"path": "html-rdfalite/0326-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents",
-				"required-attr"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents", "required-attr"]
 		},
 		{
 			"path": "html-rdfalite/0327-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents",
-				"required-attr"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents", "required-attr"]
 		},
 		{
 			"path": "html-svg/0001isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"permitted-contents"
-			]
+			"ruleIds": ["permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-dom-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/animate-dom-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/animate-elem-02-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-03-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-04-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-05-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-06-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-07-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-08-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-09-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-10-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-11-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-12-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-13-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-14-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-15-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-17-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-19-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-20-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-21-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-22-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-23-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-25-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-26-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-27-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-28-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-29-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-30-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-31-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-32-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-33-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-34-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-35-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-36-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-37-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-38-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-39-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-40-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-41-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-44-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-46-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-52-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-53-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-60-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-61-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-62-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-63-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-64-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-65-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-66-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-67-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-68-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-69-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-70-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-77-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-78-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-80-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-81-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-82-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-83-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-84-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-85-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-86-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-87-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-88-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-89-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-90-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-91-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-elem-92-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-interact-events-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-interact-pevents-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-interact-pevents-02-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-interact-pevents-03-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-interact-pevents-04-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/animate-script-elem-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/animate-struct-dom-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/color-prof-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/color-prop-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/color-prop-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/color-prop-03-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/color-prop-04-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/color-prop-05-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/conform-viewers-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/coords-coord-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/coords-coord-02-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/coords-dom-03-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/coords-dom-04-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/coords-trans-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/coords-trans-02-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/coords-trans-03-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/coords-trans-04-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/coords-trans-05-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/coords-trans-06-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/coords-trans-07-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/coords-trans-08-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/coords-trans-09-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/coords-trans-10-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/coords-trans-11-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/coords-trans-12-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/coords-trans-13-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/coords-trans-14-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/coords-transformattr-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/coords-transformattr-03-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/coords-transformattr-04-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/coords-transformattr-05-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/coords-units-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/coords-units-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/coords-units-03-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/coords-viewattr-03-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/filters-background-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/filters-blend-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/filters-color-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/filters-composite-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/filters-composite-03-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/filters-composite-04-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/filters-composite-05-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/filters-comptran-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/filters-conv-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/filters-conv-03-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/filters-diffuse-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/filters-displace-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/filters-displace-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/filters-example-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/filters-felem-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/filters-felem-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/filters-gauss-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/filters-gauss-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/filters-gauss-03-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/filters-image-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/filters-image-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/filters-image-03-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/filters-image-04-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/filters-image-05-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/filters-light-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/filters-light-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/filters-light-03-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/filters-light-04-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/filters-morph-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/filters-offset-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/filters-offset-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/filters-overview-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/filters-overview-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/filters-overview-03-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/filters-specular-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/filters-tile-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/filters-turb-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/filters-turb-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/fonts-desc-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/fonts-desc-02-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/fonts-desc-03-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/fonts-desc-04-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/fonts-desc-05-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/fonts-elem-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/fonts-elem-02-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/fonts-elem-03-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/fonts-elem-04-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/fonts-elem-05-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/fonts-elem-06-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/fonts-elem-07-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/fonts-glyph-02-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/fonts-glyph-03-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/fonts-kern-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/imp-path-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/interact-cursor-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/interact-dom-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/interact-events-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/interact-events-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/interact-events-202-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/interact-events-203-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/interact-order-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/interact-order-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/interact-order-03-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/interact-pevents-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/interact-pevents-03-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/interact-pevents-04-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/interact-pevents-05-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/interact-pevents-07-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/interact-pevents-08-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/interact-pevents-09-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/interact-pevents-10-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/interact-pointer-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/interact-pointer-03-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/interact-pointer-04-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/interact-zoom-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/interact-zoom-02-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/interact-zoom-03-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/linking-a-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/linking-a-03-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/linking-a-04-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/linking-a-05-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/linking-a-07-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/linking-a-08-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/linking-a-10-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/linking-frag-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/linking-uri-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/linking-uri-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/linking-uri-03-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/masking-mask-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/masking-mask-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/masking-opacity-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/masking-path-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/masking-path-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/masking-path-03-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/masking-path-04-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/masking-path-05-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/masking-path-06-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/masking-path-07-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/masking-path-08-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/masking-path-09-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/masking-path-10-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/masking-path-11-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/masking-path-12-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/masking-path-13-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/masking-path-14-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/painting-control-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/painting-control-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/painting-control-03-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/painting-control-04-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/painting-control-05-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/painting-control-06-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/painting-fill-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/painting-fill-02-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/painting-fill-03-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/painting-fill-04-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/painting-fill-05-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/painting-marker-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/painting-marker-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/painting-marker-03-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/painting-marker-05-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/painting-marker-06-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/painting-marker-07-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/painting-marker-properties-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/painting-render-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/painting-render-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/painting-stroke-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/painting-stroke-02-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/painting-stroke-03-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/painting-stroke-04-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/painting-stroke-05-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/painting-stroke-06-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/painting-stroke-07-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/painting-stroke-08-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/painting-stroke-09-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/painting-stroke-10-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/paths-data-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/paths-data-02-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/paths-data-03-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/paths-data-04-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/paths-data-05-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/paths-data-06-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/paths-data-07-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/paths-data-08-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/paths-data-09-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/paths-data-10-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/paths-data-12-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/paths-data-13-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/paths-data-14-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/paths-data-15-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/paths-data-16-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/paths-data-17-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/paths-data-19-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/paths-dom-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/paths-dom-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/pservers-grad-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/pservers-grad-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/pservers-grad-03-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/pservers-grad-04-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/pservers-grad-05-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/pservers-grad-06-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/pservers-grad-07-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/pservers-grad-08-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/pservers-grad-09-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/pservers-grad-10-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/pservers-grad-11-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/pservers-grad-12-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/pservers-grad-13-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/pservers-grad-14-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/pservers-grad-15-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/pservers-grad-16-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/pservers-grad-17-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/pservers-grad-18-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/pservers-grad-20-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/pservers-grad-21-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/pservers-grad-22-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/pservers-grad-24-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/pservers-grad-stops-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/pservers-pattern-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/pservers-pattern-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/pservers-pattern-03-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/pservers-pattern-04-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/pservers-pattern-05-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/pservers-pattern-06-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/pservers-pattern-07-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/pservers-pattern-08-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/pservers-pattern-09-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/render-elems-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/render-elems-02-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/render-elems-06-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/render-elems-07-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/render-elems-08-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/render-groups-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/render-groups-03-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/script-handle-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/script-handle-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/script-handle-03-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/script-handle-04-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/script-specify-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/shapes-circle-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/shapes-circle-02-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/shapes-ellipse-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/shapes-ellipse-02-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/shapes-ellipse-03-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/shapes-grammar-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/shapes-intro-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/shapes-intro-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/shapes-line-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/shapes-line-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/shapes-polygon-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/shapes-polygon-02-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/shapes-polygon-03-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/shapes-polyline-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/shapes-polyline-02-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/shapes-rect-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/shapes-rect-02-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/shapes-rect-04-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/shapes-rect-05-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/shapes-rect-06-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/shapes-rect-07-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-cond-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-cond-02-t-haswarn.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-cond-03-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-cond-overview-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-cond-overview-03-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-cond-overview-04-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-cond-overview-05-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-defs-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-dom-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/struct-dom-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/struct-dom-03-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/struct-dom-04-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/struct-dom-05-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/struct-dom-06-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/struct-dom-07-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/struct-dom-08-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/struct-dom-11-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/struct-dom-12-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/struct-dom-13-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/struct-dom-14-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/struct-dom-15-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/struct-dom-16-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/struct-dom-17-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/struct-dom-18-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/struct-dom-19-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/struct-dom-20-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/struct-frag-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-frag-02-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-frag-03-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-frag-04-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-frag-06-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-group-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-group-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-group-03-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-image-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-image-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-image-03-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-image-04-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-image-05-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-image-06-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-image-08-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-image-09-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-image-10-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-image-11-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/struct-image-13-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-image-14-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-image-15-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-image-16-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-image-17-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-image-18-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-image-19-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-svg-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/struct-svg-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/struct-svg-03-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-symbol-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-use-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-use-03-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-use-04-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-use-05-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-use-06-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-use-07-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-use-08-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-use-09-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-use-10-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/struct-use-13-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/struct-use-14-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/struct-use-15-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/styling-class-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/styling-css-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/styling-css-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/styling-css-03-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/styling-css-04-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/styling-css-05-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/styling-css-06-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/styling-css-07-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/styling-css-08-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/styling-css-09-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/styling-css-10-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/styling-elem-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/styling-inherit-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/styling-pres-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/styling-pres-03-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/styling-pres-04-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/styling-pres-05-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-align-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-align-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-align-03-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-align-04-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-align-05-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-align-06-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-align-07-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-align-08-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-altglyph-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-altglyph-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-altglyph-03-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-bidi-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-deco-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-dom-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/text-dom-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/text-dom-04-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/text-dom-05-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/text-fonts-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-fonts-02-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-fonts-04-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-fonts-202-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-fonts-203-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-fonts-204-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-intro-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-intro-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-intro-03-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-intro-04-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-intro-05-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-intro-06-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-intro-07-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-intro-09-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-intro-10-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-intro-11-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-intro-12-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-path-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-path-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-spacing-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-text-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-text-03-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-text-04-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-text-05-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-text-06-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-text-07-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-text-08-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-text-09-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-text-10-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-text-11-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-text-12-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-tref-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-tselect-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-tselect-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/text-tselect-03-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/text-tspan-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/text-tspan-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/types-basic-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/types-basic-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["invalid-attr", "permitted-contents"]
 		},
 		{
 			"path": "html-svg/types-dom-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/types-dom-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/types-dom-03-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/types-dom-05-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/types-dom-06-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/types-dom-07-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/types-dom-08-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/types-dom-svgfittoviewbox-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/types-dom-svglengthlist-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/types-dom-svgnumberlist-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/types-dom-svgstringlist-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html-svg/types-dom-svgtransformable-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"@markuplint/ml-core"
-			]
+			"ruleIds": ["@markuplint/ml-core"]
 		},
 		{
 			"path": "html/attributes/autofocus-isvalid.html",
 			"category": "global-attr",
-			"ruleIds": [
-				"no-duplicate-autofocus"
-			]
+			"ruleIds": ["no-duplicate-autofocus"]
 		},
 		{
 			"path": "html/attributes/lang/xmllang-same-isvalid.html",
 			"category": "global-attr",
-			"ruleIds": [
-				"deprecated-attr"
-			]
+			"ruleIds": ["deprecated-attr"]
 		},
 		{
 			"path": "html/attributes/rel/rel-custom-isvalid.html",
 			"category": "global-attr",
-			"ruleIds": [
-				"invalid-attr",
-				"link-types"
-			]
+			"ruleIds": ["invalid-attr", "link-types"]
 		},
 		{
 			"path": "html/attributes/rel/rel-short-isvalid.html",
 			"category": "global-attr",
-			"ruleIds": [
-				"invalid-attr",
-				"link-types"
-			]
+			"ruleIds": ["invalid-attr", "link-types"]
 		},
 		{
 			"path": "html/attributes/rel/rel-typo-alternate-hasinfo.html",
 			"category": "global-attr",
-			"ruleIds": [
-				"invalid-attr",
-				"link-types"
-			]
+			"ruleIds": ["invalid-attr", "link-types"]
 		},
 		{
 			"path": "html/attributes/rel/rel-typo-author-hasinfo.html",
 			"category": "global-attr",
-			"ruleIds": [
-				"invalid-attr",
-				"link-types"
-			]
+			"ruleIds": ["invalid-attr", "link-types"]
 		},
 		{
 			"path": "html/attributes/rel/rel-typo-canonical-hasinfo.html",
 			"category": "global-attr",
-			"ruleIds": [
-				"invalid-attr",
-				"link-types"
-			]
+			"ruleIds": ["invalid-attr", "link-types"]
 		},
 		{
 			"path": "html/attributes/rel/rel-typo-stylesheet-hasinfo.html",
 			"category": "global-attr",
-			"ruleIds": [
-				"invalid-attr",
-				"link-types"
-			]
+			"ruleIds": ["invalid-attr", "link-types"]
 		},
 		{
 			"path": "html/datatypes/datetime-time-valid-isvalid.html",
 			"category": "data-types",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html/elements/a/href-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr",
-				"no-refer-to-non-existent-id"
-			]
+			"ruleIds": ["invalid-attr", "no-refer-to-non-existent-id"]
 		},
 		{
 			"path": "html/elements/a/name-attribute-haswarn.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"deprecated-attr"
-			]
+			"ruleIds": ["deprecated-attr"]
 		},
 		{
 			"path": "html/elements/a/name-empty-haswarn.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"deprecated-attr"
-			]
+			"ruleIds": ["deprecated-attr"]
 		},
 		{
 			"path": "html/elements/area/href-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr",
-				"no-refer-to-non-existent-id"
-			]
+			"ruleIds": ["invalid-attr", "no-refer-to-non-existent-id"]
 		},
 		{
 			"path": "html/elements/audio/src-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html/elements/autofocus/dialog-scoped-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"no-duplicate-autofocus"
-			]
+			"ruleIds": ["no-duplicate-autofocus"]
 		},
 		{
 			"path": "html/elements/autofocus/nested-dialogs-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"no-duplicate-autofocus"
-			]
+			"ruleIds": ["no-duplicate-autofocus"]
 		},
 		{
 			"path": "html/elements/autofocus/popover-scoped-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"no-duplicate-autofocus"
-			]
+			"ruleIds": ["no-duplicate-autofocus"]
 		},
 		{
 			"path": "html/elements/base/href/host-IP-address-broken-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html/elements/base/href/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html/elements/base/href/scheme-data-no-slash-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html/elements/base/href/scheme-javascript-single-slash-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html/elements/blockquote/cite-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html/elements/button/formaction-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html/elements/custom/colon-name-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"permitted-contents",
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["permitted-contents", "wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html/elements/del/cite-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html/elements/div/model-isvalid.html",
 			"category": "content-model",
-			"ruleIds": [
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html/elements/dl/dl-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"permitted-contents"
-			]
+			"ruleIds": ["permitted-contents"]
 		},
 		{
 			"path": "html/elements/embed/src-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html/elements/form/action-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html/elements/iframe/src-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html/elements/img/border-attribute-haswarn.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"deprecated-attr"
-			]
+			"ruleIds": ["deprecated-attr"]
 		},
 		{
 			"path": "html/elements/img/src-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html/elements/img/srcset-width-descriptor-loading-lazy-no-sizes-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"srcset-sizes-constraint"
-			]
+			"ruleIds": ["srcset-sizes-constraint"]
 		},
 		{
 			"path": "html/elements/input/type-image-formaction-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html/elements/input/type-image-src-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html/elements/input/type-submit-formaction-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html/elements/input/type-url-value-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html/elements/ins/cite-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html/elements/link/href-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html/elements/link/imagesrcset-valid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr",
-				"required-attr"
-			]
+			"ruleIds": ["invalid-attr", "required-attr"]
 		},
 		{
 			"path": "html/elements/math/unnecessary-role-math-haswarn.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"wai-aria-permitted-roles"
-			]
+			"ruleIds": ["wai-aria-permitted-roles"]
 		},
 		{
 			"path": "html/elements/meta/names-standard-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"disallowed-element"
-			]
+			"ruleIds": ["disallowed-element"]
 		},
 		{
 			"path": "html/elements/meta/refresh-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html/elements/meter/aria-valuemax-haswarn.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html/elements/object/data-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html/elements/ol/model-isvalid.html",
 			"category": "content-model",
-			"ruleIds": [
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html/elements/optgroup/div-child-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"no-orphaned-end-tag",
-				"permitted-contents"
-			]
+			"ruleIds": ["no-orphaned-end-tag", "permitted-contents"]
 		},
 		{
 			"path": "html/elements/optgroup/legend-child-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"permitted-contents",
-				"required-attr"
-			]
+			"ruleIds": ["permitted-contents", "required-attr"]
 		},
 		{
 			"path": "html/elements/option/aria-selected-haswarn.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html/elements/option/div-child-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"no-orphaned-end-tag"
-			]
+			"ruleIds": ["no-orphaned-end-tag"]
 		},
 		{
 			"path": "html/elements/option/empty-option-with-label-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"permitted-contents"
-			]
+			"ruleIds": ["permitted-contents"]
 		},
 		{
 			"path": "html/elements/option/label-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"permitted-contents"
-			]
+			"ruleIds": ["permitted-contents"]
 		},
 		{
 			"path": "html/elements/option/phrasing-content-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"no-orphaned-end-tag"
-			]
+			"ruleIds": ["no-orphaned-end-tag"]
 		},
 		{
 			"path": "html/elements/picture/picture-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html/elements/progress/aria-valuemax-haswarn.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html/elements/q/cite-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html/elements/rb/rb-interleaved-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"deprecated-element",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-element", "permitted-contents"]
 		},
 		{
 			"path": "html/elements/rb/rb-tabular-hasinfo.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"deprecated-element",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-element", "permitted-contents"]
 		},
 		{
 			"path": "html/elements/rtc/rtc-hasinfo.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"deprecated-element",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-element", "permitted-contents"]
 		},
 		{
 			"path": "html/elements/script/language-attribute-haswarn.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"deprecated-attr"
-			]
+			"ruleIds": ["deprecated-attr"]
 		},
 		{
 			"path": "html/elements/script/language-haswarn.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"deprecated-attr"
-			]
+			"ruleIds": ["deprecated-attr"]
 		},
 		{
 			"path": "html/elements/script/src-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html/elements/select/button-child-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"permitted-contents"
-			]
+			"ruleIds": ["permitted-contents"]
 		},
 		{
 			"path": "html/elements/select/button-in-multiple-size1-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"permitted-contents"
-			]
+			"ruleIds": ["permitted-contents"]
 		},
 		{
 			"path": "html/elements/select/button-selectedcontent-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"permitted-contents"
-			]
+			"ruleIds": ["permitted-contents"]
 		},
 		{
 			"path": "html/elements/select/div-child-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"no-orphaned-end-tag",
-				"permitted-contents"
-			]
+			"ruleIds": ["no-orphaned-end-tag", "permitted-contents"]
 		},
 		{
 			"path": "html/elements/source/src-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html/elements/style/type-text-css-haswarn.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"deprecated-attr"
-			]
+			"ruleIds": ["deprecated-attr"]
 		},
 		{
 			"path": "html/elements/table/role-presentation-with-aria-label-haswarn.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html/elements/table/row-width-exceeds-cols-haswarn.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"table-row-column-alignment"
-			]
+			"ruleIds": ["table-row-column-alignment"]
 		},
 		{
 			"path": "html/elements/table/row-width-less-than-cols-haswarn.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"table-row-column-alignment"
-			]
+			"ruleIds": ["table-row-column-alignment"]
 		},
 		{
 			"path": "html/elements/track/src-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html/elements/ul/model-isvalid.html",
 			"category": "content-model",
-			"ruleIds": [
-				"wai-aria-required-owned-elements"
-			]
+			"ruleIds": ["wai-aria-required-owned-elements"]
 		},
 		{
 			"path": "html/elements/video/poster-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html/elements/video/src-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html/microdata/itemid-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html/microdata/itemtype-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
+			"ruleIds": ["invalid-attr"]
 		},
 		{
 			"path": "html/obsolete/profile-haswarn.html",
 			"category": "deprecated",
-			"ruleIds": [
-				"deprecated-attr"
-			]
+			"ruleIds": ["deprecated-attr"]
 		},
 		{
 			"path": "html/svg/svg-transform-origin-transform-box-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr",
-				"no-refer-to-non-existent-id"
-			]
+			"ruleIds": ["invalid-attr", "no-refer-to-non-existent-id"]
 		},
 		{
 			"path": "html/warnings/aria-multiselectable-on-select-haswarn.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"wai-aria-disallowed-props"
-			]
+			"ruleIds": ["wai-aria-disallowed-props"]
 		},
 		{
 			"path": "html/warnings/unnecessary-role-definition-haswarn.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"wai-aria-permitted-roles"
-			]
+			"ruleIds": ["wai-aria-permitted-roles"]
 		},
 		{
 			"path": "html/warnings/unnecessary-role-group-on-details-haswarn.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"wai-aria-permitted-roles"
-			]
+			"ruleIds": ["wai-aria-permitted-roles"]
 		},
 		{
 			"path": "html/warnings/unnecessary-role-main-haswarn.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"wai-aria-permitted-roles"
-			]
+			"ruleIds": ["wai-aria-permitted-roles"]
 		},
 		{
 			"path": "html/warnings/unnecessary-role-progressbar-haswarn.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"wai-aria-permitted-roles"
-			]
+			"ruleIds": ["wai-aria-permitted-roles"]
 		},
 		{
 			"path": "html/warnings/unnecessary-role-spinbutton-haswarn.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"wai-aria-permitted-roles"
-			]
+			"ruleIds": ["wai-aria-permitted-roles"]
 		},
 		{
 			"path": "html/warnings/unnecessary-role-status-haswarn.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"wai-aria-permitted-roles"
-			]
+			"ruleIds": ["wai-aria-permitted-roles"]
 		},
 		{
 			"path": "html/warnings/unnecessary-role-term-haswarn.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"wai-aria-permitted-roles"
-			]
+			"ruleIds": ["wai-aria-permitted-roles"]
 		},
 		{
 			"path": "langdetect/lang-en-dir-ltr-content-zh-haswarn.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"permitted-contents"
-			]
+			"ruleIds": ["permitted-contents"]
 		},
 		{
 			"path": "langdetect/lang-en-dir-ltr-content-zh-size-less-1024-valid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"permitted-contents"
-			]
+			"ruleIds": ["permitted-contents"]
 		},
 		{
 			"path": "langdetect/lang-en-zh-in-svg-text-en-in-p-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "permitted-contents"]
 		},
 		{
 			"path": "langdetect/lang-he-dir-ltr-content-he-haswarn.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"permitted-contents"
-			]
+			"ruleIds": ["permitted-contents"]
 		},
 		{
 			"path": "langdetect/lang-he-dir-ltr-content-zh-in-p-he-in-pre-haswarn.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"permitted-contents"
-			]
+			"ruleIds": ["permitted-contents"]
 		},
 		{
 			"path": "langdetect/lang-he-zh-in-svg-text-he-in-p-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "permitted-contents"]
 		},
 		{
 			"path": "langdetect/lang-zh-dir-ltr-content-zh-in-pre-he-in-p-haswarn.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"permitted-contents"
-			]
+			"ruleIds": ["permitted-contents"]
 		},
 		{
 			"path": "langdetect/lang-zh-zh-in-p-he-in-svg-text-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"permitted-contents"
-			]
+			"ruleIds": ["deprecated-attr", "permitted-contents"]
 		},
 		{
 			"path": "langdetect/large-style-content-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"deprecated-attr",
-				"invalid-attr"
-			]
+			"ruleIds": ["deprecated-attr", "invalid-attr"]
 		},
 		{
 			"path": "normalization/normalization-haswarn.html",
 			"category": "uncategorized",
-			"ruleIds": [
-				"permitted-contents"
-			]
+			"ruleIds": ["permitted-contents"]
 		}
 	]
 }

--- a/tests/external/snapshots/diff/nu-only.json
+++ b/tests/external/snapshots/diff/nu-only.json
@@ -1,121 +1,79 @@
 {
 	"entries": [
 		{
-			"path": "html-aria/misc/role-tab-with-no-role-tabpanel-novalid.html",
-			"category": "aria",
-			"nuMessageIds": [
-				"nv-1e3c9ebc2ee7"
-			]
-		},
-		{
 			"path": "html-math/math-in-head-novalid.html",
 			"category": "uncategorized",
-			"nuMessageIds": [
-				"nv-0c86320f6630",
-				"nv-8aff5b8981a2"
-			]
+			"nuMessageIds": ["nv-0c86320f6630", "nv-8aff5b8981a2"]
 		},
 		{
 			"path": "html/attributes/lang/extlang-bad-novalid.html",
 			"category": "global-attr",
-			"nuMessageIds": [
-				"nv-b9765660c678"
-			]
+			"nuMessageIds": ["nv-b9765660c678"]
 		},
 		{
 			"path": "html/attributes/lang/invalid-primary-novalid.html",
 			"category": "global-attr",
-			"nuMessageIds": [
-				"nv-ae0b2057a762"
-			]
+			"nuMessageIds": ["nv-ae0b2057a762"]
 		},
 		{
 			"path": "html/datatypes/charset-invalid-novalid.html",
 			"category": "data-types",
-			"nuMessageIds": [
-				"nv-acede5e8fcb0",
-				"nv-b7b2459d8f36"
-			]
+			"nuMessageIds": ["nv-acede5e8fcb0", "nv-b7b2459d8f36"]
 		},
 		{
 			"path": "html/elements/a/with-href-button-descendant-novalid.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-81c2e7bf5413"
-			]
+			"nuMessageIds": ["nv-81c2e7bf5413"]
 		},
 		{
 			"path": "html/elements/audio/controls-in-button-novalid.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-f3f919789208"
-			]
+			"nuMessageIds": ["nv-f3f919789208"]
 		},
 		{
 			"path": "html/elements/img/missing-alt-in-figure-novalid.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-224e80c23676"
-			]
+			"nuMessageIds": ["nv-224e80c23676"]
 		},
 		{
 			"path": "html/elements/img/usemap-invalid-reference-novalid.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-f3a0d6efeee1"
-			]
+			"nuMessageIds": ["nv-f3a0d6efeee1"]
 		},
 		{
 			"path": "html/elements/picture/html-syntax-picture-no-end-tag-novalid.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-3ade6b2bf3d6",
-				"nv-aca994a28b46"
-			]
+			"nuMessageIds": ["nv-3ade6b2bf3d6", "nv-aca994a28b46"]
 		},
 		{
 			"path": "html/elements/picture/junk-noscript-after-source-no-img-novalid.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-fab7ebe451a5",
-				"nv-6cc718a96d01"
-			]
+			"nuMessageIds": ["nv-fab7ebe451a5", "nv-6cc718a96d01"]
 		},
 		{
 			"path": "html/elements/picture/junk-noscript-novalid.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-2f51978ea35d"
-			]
+			"nuMessageIds": ["nv-2f51978ea35d"]
 		},
 		{
 			"path": "html/elements/picture/junk-video-before-novalid.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-6c316a041c38"
-			]
+			"nuMessageIds": ["nv-6c316a041c38"]
 		},
 		{
 			"path": "html/parser/charset-after-1024-novalid.html",
 			"category": "uncategorized",
-			"nuMessageIds": [
-				"nv-b31d83a9ed4b"
-			]
+			"nuMessageIds": ["nv-b31d83a9ed4b"]
 		},
 		{
 			"path": "html/parser/stray-start-tag-novalid.html",
 			"category": "uncategorized",
-			"nuMessageIds": [
-				"nv-3c0b2b71db12"
-			]
+			"nuMessageIds": ["nv-3c0b2b71db12"]
 		},
 		{
 			"path": "html/parser/text-after-body-novalid.html",
 			"category": "uncategorized",
-			"nuMessageIds": [
-				"nv-94d4d4cf4600",
-				"nv-c35f07b7ee36"
-			]
+			"nuMessageIds": ["nv-94d4d4cf4600", "nv-c35f07b7ee36"]
 		}
 	]
 }

--- a/tests/external/snapshots/diff/nu-over.json
+++ b/tests/external/snapshots/diff/nu-over.json
@@ -3,261 +3,187 @@
 		{
 			"path": "html/datatypes/sandbox-scripts-same-origin-haswarn.html",
 			"category": "data-types",
-			"nuMessageIds": [
-				"nv-cd593c007a34"
-			]
+			"nuMessageIds": ["nv-cd593c007a34"]
 		},
 		{
 			"path": "html/elements/a/href/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-3a1dc1374ed4"
-			]
+			"nuMessageIds": ["nv-3a1dc1374ed4"]
 		},
 		{
 			"path": "html/elements/area/href/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-cdb4535e049d"
-			]
+			"nuMessageIds": ["nv-cdb4535e049d"]
 		},
 		{
 			"path": "html/elements/audio/src/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-60706ef20301"
-			]
+			"nuMessageIds": ["nv-60706ef20301"]
 		},
 		{
 			"path": "html/elements/blockquote/cite/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-ed1dbf9dfa0f"
-			]
+			"nuMessageIds": ["nv-ed1dbf9dfa0f"]
 		},
 		{
 			"path": "html/elements/button/formaction/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-82f38369e99e"
-			]
+			"nuMessageIds": ["nv-82f38369e99e"]
 		},
 		{
 			"path": "html/elements/del/cite/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-6d168c2d3178"
-			]
+			"nuMessageIds": ["nv-6d168c2d3178"]
 		},
 		{
 			"path": "html/elements/embed/src/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-27ddcd34ac6d"
-			]
+			"nuMessageIds": ["nv-27ddcd34ac6d"]
 		},
 		{
 			"path": "html/elements/form/action/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-0a21d5f3b754"
-			]
+			"nuMessageIds": ["nv-0a21d5f3b754"]
 		},
 		{
 			"path": "html/elements/iframe/src/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-344c8ec6a993"
-			]
+			"nuMessageIds": ["nv-344c8ec6a993"]
 		},
 		{
 			"path": "html/elements/img/src/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-8c9d69a03039"
-			]
+			"nuMessageIds": ["nv-8c9d69a03039"]
 		},
 		{
 			"path": "html/elements/input/type-button-empty-value-novalid.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-54c78eff3c7d"
-			]
+			"nuMessageIds": ["nv-54c78eff3c7d"]
 		},
 		{
 			"path": "html/elements/input/type-image-formaction/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-ad82b8a8c1e5"
-			]
+			"nuMessageIds": ["nv-ad82b8a8c1e5"]
 		},
 		{
 			"path": "html/elements/input/type-image-src/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-e683359e52e5"
-			]
+			"nuMessageIds": ["nv-e683359e52e5"]
 		},
 		{
 			"path": "html/elements/input/type-submit-formaction/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-8c1d1d42e012"
-			]
+			"nuMessageIds": ["nv-8c1d1d42e012"]
 		},
 		{
 			"path": "html/elements/input/type-url-value/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-6872c643a823"
-			]
+			"nuMessageIds": ["nv-6872c643a823"]
 		},
 		{
 			"path": "html/elements/ins/cite/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-27b353000357"
-			]
+			"nuMessageIds": ["nv-27b353000357"]
 		},
 		{
 			"path": "html/elements/link/href/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-5b612865391d"
-			]
+			"nuMessageIds": ["nv-5b612865391d"]
 		},
 		{
 			"path": "html/elements/meta/content-security-policy/csp-invalid-directive-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-6ec2a5c8c04c"
-			]
+			"nuMessageIds": ["nv-6ec2a5c8c04c"]
 		},
 		{
 			"path": "html/elements/meta/content-security-policy/csp-invalid-source-novalid.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-ccff05d53b7c"
-			]
+			"nuMessageIds": ["nv-ccff05d53b7c"]
 		},
 		{
 			"path": "html/elements/meta/content-security-policy/csp-non-ascii-novalid.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-f76bf04a85bb"
-			]
+			"nuMessageIds": ["nv-f76bf04a85bb"]
 		},
 		{
 			"path": "html/elements/meta/refresh-invalid-keyword-novalid.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-c57d9ac83548"
-			]
+			"nuMessageIds": ["nv-c57d9ac83548"]
 		},
 		{
 			"path": "html/elements/meta/refresh-missing-space-novalid.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-f26bf6cca5a8"
-			]
+			"nuMessageIds": ["nv-f26bf6cca5a8"]
 		},
 		{
 			"path": "html/elements/meta/refresh-quoted-url-novalid.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-59fd76f96902"
-			]
+			"nuMessageIds": ["nv-59fd76f96902"]
 		},
 		{
 			"path": "html/elements/object/data/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-372749d0395d"
-			]
+			"nuMessageIds": ["nv-372749d0395d"]
 		},
 		{
 			"path": "html/elements/object/type-only-novalid.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-785400222871"
-			]
+			"nuMessageIds": ["nv-785400222871"]
 		},
 		{
 			"path": "html/elements/q/cite/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-3cd607b1d358"
-			]
+			"nuMessageIds": ["nv-3cd607b1d358"]
 		},
 		{
 			"path": "html/elements/script/importmap/scopes-key-not-url-novalid.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-00d2f9879fd4"
-			]
+			"nuMessageIds": ["nv-00d2f9879fd4"]
 		},
 		{
 			"path": "html/elements/script/src/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-d2a73eb7f342"
-			]
+			"nuMessageIds": ["nv-d2a73eb7f342"]
 		},
 		{
 			"path": "html/elements/source/src/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-c98e0d290a6d"
-			]
+			"nuMessageIds": ["nv-c98e0d290a6d"]
 		},
 		{
 			"path": "html/elements/style/css-property-error-novalid.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-c5efac320bbb"
-			]
+			"nuMessageIds": ["nv-c5efac320bbb"]
 		},
 		{
 			"path": "html/elements/table/row-width-exceeds-col-markup-novalid.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-d7b3d14cfb44"
-			]
+			"nuMessageIds": ["nv-d7b3d14cfb44"]
 		},
 		{
 			"path": "html/elements/track/src/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-22da233e51c1"
-			]
+			"nuMessageIds": ["nv-22da233e51c1"]
 		},
 		{
 			"path": "html/elements/video/poster/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-f66fce25c1d0"
-			]
+			"nuMessageIds": ["nv-f66fce25c1d0"]
 		},
 		{
 			"path": "html/elements/video/src/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-1f2c65f495dc"
-			]
+			"nuMessageIds": ["nv-1f2c65f495dc"]
 		},
 		{
 			"path": "html/microdata/itemid-scheme-data-contains-fragment-haswarn.html",
 			"category": "uncategorized",
-			"nuMessageIds": [
-				"nv-72908421456b"
-			]
+			"nuMessageIds": ["nv-72908421456b"]
 		},
 		{
 			"path": "html/microdata/itemtype-scheme-data-contains-fragment-haswarn.html",
 			"category": "uncategorized",
-			"nuMessageIds": [
-				"nv-5e72124bb955"
-			]
+			"nuMessageIds": ["nv-5e72124bb955"]
 		}
 	]
 }

--- a/tests/external/snapshots/diff/summary.md
+++ b/tests/external/snapshots/diff/summary.md
@@ -1,6 +1,6 @@
 # nu-validator Benchmark Summary
 
-- generated: 2026-08-10T12:23:42.034Z
+- generated: 2026-08-11T05:27:08.599Z
 - submodule: `142931395412c00434ffb40a14d65992efd17aa8`
 - nu-validator: `ghcr.io/validator/validator@sha256:9365682da0f66efc5504ce2a3aba91290aaf08c00799a41d096236fab740bb44`
 - markuplint: `5.0.0-rc.4`
@@ -9,27 +9,27 @@
 ## Totals
 
 - files: **5442**
-- match-error: **3489** (both tools flagged)
+- match-error: **3490** (both tools flagged)
 - match-clean: **881** (neither flagged)
-- nu-only: **16** (only nu-validator flagged; markuplint coverage candidates — open a markuplint issue after a spec read)
+- nu-only: **15** (only nu-validator flagged; markuplint coverage candidates — open a markuplint issue after a spec read)
 - nu-over: **37** (nu-validator errors fully covered by spec-backed excluded-ids — confirmed over-detection)
 - overall match rate: **80.3%**
 - excluded-ids: 12 entries, 1 pattern(s)
 
 ## Per-Category
 
-| Category | Files | Match rate | match-error | match-clean | ml-only | nu-only | nu-over |
-| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| aria | 780 | 77.1% | 181 | 420 | 178 | 1 | 0 |
-| assertions | 40 | 100.0% | 39 | 1 | 0 | 0 | 0 |
-| content-model | 98 | 96.9% | 50 | 45 | 3 | 0 | 0 |
-| data-types | 56 | 94.6% | 48 | 5 | 1 | 1 | 1 |
-| deprecated | 12 | 91.7% | 11 | 0 | 1 | 0 | 0 |
-| global-attr | 57 | 82.5% | 27 | 20 | 8 | 2 | 0 |
-| id-duplication | 1 | 100.0% | 1 | 0 | 0 | 0 | 0 |
-| invalid-attr | 3086 | 96.6% | 2754 | 227 | 63 | 8 | 34 |
-| required-attr | 5 | 100.0% | 5 | 0 | 0 | 0 | 0 |
-| uncategorized | 1307 | 41.0% | 373 | 163 | 765 | 4 | 2 |
+| Category       | Files | Match rate | match-error | match-clean | ml-only | nu-only | nu-over |
+| -------------- | ----: | ---------: | ----------: | ----------: | ------: | ------: | ------: |
+| aria           |   780 |      77.2% |         182 |         420 |     178 |       0 |       0 |
+| assertions     |    40 |     100.0% |          39 |           1 |       0 |       0 |       0 |
+| content-model  |    98 |      96.9% |          50 |          45 |       3 |       0 |       0 |
+| data-types     |    56 |      94.6% |          48 |           5 |       1 |       1 |       1 |
+| deprecated     |    12 |      91.7% |          11 |           0 |       1 |       0 |       0 |
+| global-attr    |    57 |      82.5% |          27 |          20 |       8 |       2 |       0 |
+| id-duplication |     1 |     100.0% |           1 |           0 |       0 |       0 |       0 |
+| invalid-attr   |  3086 |      96.6% |        2754 |         227 |      63 |       8 |      34 |
+| required-attr  |     5 |     100.0% |           5 |           0 |       0 |       0 |       0 |
+| uncategorized  |  1307 |      41.0% |         373 |         163 |     765 |       4 |       2 |
 
 ## Informational: ml-only
 
@@ -37,18 +37,17 @@
 
 ### Top ml-only rules
 
-| Rule | Count |
-| --- | ---: |
-| invalid-attr | 707 |
-| permitted-contents | 444 |
-| deprecated-attr | 354 |
-| wai-aria-disallowed-props | 121 |
-| @markuplint/ml-core | 75 |
-| wai-aria-required-owned-elements | 47 |
-| link-types | 34 |
-| required-attr | 22 |
-| wai-aria-permitted-roles | 20 |
-| wai-aria-value | 11 |
+| Rule                             | Count |
+| -------------------------------- | ----: |
+| invalid-attr                     |   707 |
+| permitted-contents               |   444 |
+| deprecated-attr                  |   354 |
+| wai-aria-disallowed-props        |   121 |
+| @markuplint/ml-core              |    75 |
+| wai-aria-required-owned-elements |    47 |
+| link-types                       |    34 |
+| required-attr                    |    22 |
+| wai-aria-permitted-roles         |    20 |
+| wai-aria-value                   |    11 |
 
 > `nu-only` entries are candidates for markuplint coverage work **after** verifying the relevant spec paragraph. `nu-over` entries are already confirmed nu-validator over-detection via `excluded-ids.json`. `ml-only` is informational; audit the spec before acting on any individual row.
-

--- a/tests/external/snapshots/meta.json
+++ b/tests/external/snapshots/meta.json
@@ -1,5 +1,5 @@
 {
-	"generatedAt": "2026-08-10T12:23:42.034Z",
+	"generatedAt": "2026-08-11T05:27:08.599Z",
 	"submoduleSha": "142931395412c00434ffb40a14d65992efd17aa8",
 	"nuValidatorImage": "ghcr.io/validator/validator@sha256:9365682da0f66efc5504ce2a3aba91290aaf08c00799a41d096236fab740bb44",
 	"markuplintVersion": "5.0.0-rc.4",
@@ -7,6 +7,6 @@
 	"totalFilesNu": 5442,
 	"totalFilesMl": 5442,
 	"totalNuMessages": 9907,
-	"totalMlViolations": 11438,
+	"totalMlViolations": 11439,
 	"totalNuFailures": 0
 }


### PR DESCRIPTION
## Summary
- New rule `wai-aria-tab-requires-tabpanel`: an active `role=tab` element (`aria-selected="true"`) must have a corresponding `role=tabpanel` (via `aria-controls` or `aria-labelledby`), per WAI-ARIA 1.3 §tab role MUST.
- Wired into the composite `wai-aria` rule as `checkingTabRequiresTabpanel` (default `true`), following the existing `wai-aria-*` split pattern.
- Resolves the last remaining `nu-only` fixture tracked by #3838 (`role-tab-with-no-role-tabpanel-novalid.html`): `nu-only` → `match-error`. All 7 fixtures under that Issue are now `match-error`.

## Test plan
- [x] `npx vitest --typecheck run packages/@markuplint/rules/src/wai-aria-tab-requires-tabpanel packages/@markuplint/rules/src/wai-aria packages/markuplint/src/cli/init/get-default-rules.spec.ts` — all passing
- [x] `npx vitest --typecheck run packages/@markuplint/rules packages/@markuplint/config-presets packages/markuplint` — all passing (no regressions)
- [x] `yarn bench:update:ml && yarn bench:compare` — confirmed the only verdict change across all 5442 bench fixtures is the intended one (`role-tab-with-no-role-tabpanel-novalid.html`: `nu-only` → `match-error`); zero new `ml-only` regressions
- [x] oxlint clean, oxfmt clean on touched files, cspell passed via lint-staged on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)