### PR TITLE
fix(pretenders): resolve same-named components via imports, not scan order

### DIFF
--- a/packages/@markuplint/file-resolver/src/resolve-pretenders.spec.ts
+++ b/packages/@markuplint/file-resolver/src/resolve-pretenders.spec.ts
@@ -1,18 +1,28 @@
+import { readFile, writeFile, mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
 
-import { test, expect } from 'vitest';
+import { test, expect, describe, beforeEach, afterEach } from 'vitest';
 
-import { resolvePretenders } from './resolve-pretenders.js';
+import {
+	disambiguatePretendersForFile,
+	hasResolvableCollision,
+	invalidatePretenderResolutionCaches,
+	resolvePretenders,
+} from './resolve-pretenders.js';
 
-test('files', async () => {
+const readFileForTest = (filePath: string) => readFile(filePath, 'utf8');
+
+test('files — filePath is rebased to be absolute, relative to the pretenders JSON file itself', async () => {
+	const reactDir = path.resolve(import.meta.dirname, '..', '..', '..', '@markuplint-test', 'react');
 	const pretenders = await resolvePretenders({
-		files: [path.resolve(import.meta.dirname, '..', '..', '..', '@markuplint-test', 'react', 'pretenders.json')],
+		files: [path.resolve(reactDir, 'pretenders.json')],
 	});
 	expect(pretenders).toStrictEqual([
 		{
 			selector: 'Sample',
 			as: 'div',
-			filePath: 'sample.jsx:1:16',
+			filePath: `${path.resolve(reactDir, 'sample.jsx')}:1:16`,
 		},
 	]);
 });
@@ -144,4 +154,110 @@ test('imports fallback: reads pretenders field from package.json', async () => {
 			filePath: 'pkg-button.jsx:1:10',
 		},
 	]);
+});
+
+test('scan — filePath is rebased to be absolute, relative to the scan cwd', async () => {
+	const fixtureDir = path.resolve(
+		import.meta.dirname,
+		'..',
+		'..',
+		'..',
+		'@markuplint',
+		'pretenders',
+		'test',
+		'fixtures',
+	);
+	const target = path.resolve(fixtureDir, 'template', 'SimpleButton.vue');
+	const pretenders = await resolvePretenders({
+		scan: [{ files: target }],
+	});
+	expect(pretenders).toHaveLength(1);
+	expect(pretenders[0]!.filePath?.startsWith(`${target}:`)).toBe(true);
+});
+
+const collisionDir = path.resolve(
+	import.meta.dirname,
+	'..',
+	'..',
+	'..',
+	'@markuplint',
+	'pretenders',
+	'test',
+	'fixtures',
+	'collision',
+);
+
+test('disambiguatePretendersForFile leaves an unambiguous list untouched (same reference — fast path)', async () => {
+	const pretenders = [{ selector: 'Solo', as: 'div', filePath: `${path.resolve(collisionDir, 'a.tsx')}:1:1` }];
+	const result = await disambiguatePretendersForFile(
+		path.resolve(collisionDir, 'whatever.tsx'),
+		'export {};',
+		pretenders,
+	);
+	expect(result).toBe(pretenders);
+});
+
+test('hasResolvableCollision does not filter by selector name shape (must stay a superset of the real disambiguation filter)', () => {
+	// `disambiguatePretenders` (the real logic) only resolves plain-identifier
+	// selectors, but this fast-path gate must trigger regardless of shape — see
+	// the JSDoc on `hasResolvableCollision` for why the two must not be kept in sync.
+	const pretenders = [
+		{ selector: '123-not-a-plain-identifier', as: 'div', filePath: '/a.tsx:1:1' },
+		{ selector: '123-not-a-plain-identifier', as: 'span', filePath: '/b.tsx:1:1' },
+	];
+	expect(hasResolvableCollision(pretenders)).toBe(true);
+});
+
+test('disambiguatePretendersForFile resolves a collision via the target file import', async () => {
+	const cFile = path.resolve(collisionDir, 'c.tsx');
+	const sourceCode = await readFileForTest(cFile);
+	const pretenders = [
+		{
+			selector: 'Item',
+			as: { element: 'button', slots: true, inheritAttrs: true },
+			filePath: `${path.resolve(collisionDir, 'a.tsx')}:2:14`,
+		},
+		{
+			selector: 'Item',
+			as: { element: 'li', slots: true, inheritAttrs: true },
+			filePath: `${path.resolve(collisionDir, 'b.tsx')}:2:14`,
+		},
+	];
+	const result = await disambiguatePretendersForFile(cFile, sourceCode, pretenders);
+	expect(result).toHaveLength(1);
+	expect(result[0]!.as).toStrictEqual({ element: 'button', slots: true, inheritAttrs: true });
+});
+
+describe('invalidatePretenderResolutionCaches (long-running processes)', () => {
+	let tmpDir: string;
+
+	beforeEach(async () => {
+		tmpDir = await mkdtemp(path.join(os.tmpdir(), 'file-resolver-pretenders-cache-'));
+	});
+
+	afterEach(async () => {
+		await rm(tmpDir, { recursive: true, force: true });
+	});
+
+	test('picks up a renamed default export across a re-resolve of config.scan', async () => {
+		const targetFile = path.join(tmpDir, 'target.tsx');
+		const importerFile = path.join(tmpDir, 'importer.tsx');
+		await writeFile(targetFile, 'export default function Item() { return <button>x</button>; }');
+		await writeFile(importerFile, "import Item from './target';\nexport const E = () => <Item>x</Item>;");
+
+		const before = await resolvePretenders({ scan: [{ files: [targetFile, importerFile] }] });
+		expect(before.find(p => p.selector === 'E')?.as).toBe('button');
+
+		// Rename the default-exported declaration without invalidating caches: the
+		// stale export table still says the default export's local name is "Item",
+		// which no longer exists after the rename, leaving `E` unresolved.
+		await writeFile(targetFile, 'export default function Widget() { return <span>x</span>; }');
+		const stale = await resolvePretenders({ scan: [{ files: [targetFile, importerFile] }] });
+		expect(stale.find(p => p.selector === 'E')?.as).toBe('Item');
+
+		await invalidatePretenderResolutionCaches();
+
+		const fresh = await resolvePretenders({ scan: [{ files: [targetFile, importerFile] }] });
+		expect(fresh.find(p => p.selector === 'E')?.as).toBe('span');
+	});
 });

--- a/packages/@markuplint/file-resolver/src/resolve-pretenders.ts
+++ b/packages/@markuplint/file-resolver/src/resolve-pretenders.ts
@@ -2,11 +2,24 @@ import type { OptimizedConfig, Pretender, PretenderFileData } from '@markuplint/
 
 import path from 'node:path';
 
+import { rebasePretenderFilePath } from '@markuplint/ml-config';
 import { glob } from 'glob';
 
 import { generalImport } from './general-import.js';
 
 type PretendersConfig = OptimizedConfig['pretenders'];
+
+/**
+ * `Pretender.filePath` is written by scanners relative to their own base
+ * directory, which is meaningless once entries from files/scan results
+ * scattered across different directories are merged into one flat list.
+ * Rebasing to an absolute path immediately after each source is read is
+ * what lets {@link disambiguatePretendersForFile} later compare a
+ * pretender's origin file against the lint target's resolved imports.
+ */
+function rebasePretenderFilePaths(pretenders: readonly Pretender[], baseDir: string): Pretender[] {
+	return pretenders.map(pretender => rebasePretenderFilePath(pretender, relPath => path.resolve(baseDir, relPath)));
+}
 
 /**
  * Resolves pretender definitions from files, imported modules, inline data,
@@ -37,7 +50,9 @@ export async function resolvePretenders(config: PretendersConfig): Promise<Prete
 			if (!pretenderFile?.data) {
 				continue;
 			}
-			data.push(...pretenderFile.data);
+			// `file` is already absolute (resolved by the config provider), so its
+			// own directory is the correct base for the entries it carries.
+			data.push(...rebasePretenderFilePaths(pretenderFile.data, path.dirname(file)));
 		}
 	}
 
@@ -50,6 +65,10 @@ export async function resolvePretenders(config: PretendersConfig): Promise<Prete
 			if (!pretenderFile?.data) {
 				continue;
 			}
+			// The on-disk location of an npm package's pretenders data isn't
+			// recoverable from `generalImport`'s return value, so these entries'
+			// filePath is left as-is — disambiguation simply can't confirm them
+			// (see the module JSDoc for the fallback policy this implies).
 			data.push(...pretenderFile.data);
 		}
 	}
@@ -68,10 +87,81 @@ export async function resolvePretenders(config: PretendersConfig): Promise<Prete
 				const scanned = await scan(resolved, {
 					ignoreComponentNames: entry.ignoreComponentNames ? [...entry.ignoreComponentNames] : undefined,
 				});
-				data.push(...scanned);
+				// `scan()` (with no `cwd` option) reports filePath relative to `process.cwd()`.
+				data.push(...rebasePretenderFilePaths(scanned, process.cwd()));
 			}
 		}
 	}
 
 	return data;
+}
+
+/**
+ * Resolves selector collisions in `pretenders` for the specific file about
+ * to be linted, deferring to `@markuplint/pretenders`' `disambiguatePretenders`
+ * only when there's actually a same-selector, file-backed collision to
+ * resolve — this keeps the common case (no ambiguity) free of both the
+ * dynamic import and any file/AST work.
+ *
+ * @param filePath - Absolute path of the file being linted
+ * @param sourceCode - Full source text of the file being linted
+ * @param pretenders - The flat pretender list {@link resolvePretenders} produced
+ * @returns The disambiguated pretender list, or `pretenders` itself (same
+ *   reference) when there was no collision to resolve
+ */
+export async function disambiguatePretendersForFile(
+	filePath: string,
+	sourceCode: string,
+	pretenders: readonly Pretender[],
+): Promise<readonly Pretender[]> {
+	if (!hasResolvableCollision(pretenders)) {
+		return pretenders;
+	}
+
+	const { disambiguatePretenders } = await import('@markuplint/pretenders');
+	return disambiguatePretenders(pretenders, { filePath, sourceCode });
+}
+
+/**
+ * Deliberately gates on selector+filePath duplication alone — NOT on the
+ * selector name shape `@markuplint/pretenders`' `disambiguatePretenders`
+ * actually resolves (plain identifiers only). Duplicating that name-shape
+ * check here would let the two independently maintained filters drift out
+ * of sync: if the real filter is ever loosened without updating this one,
+ * this fast-path gate would keep skipping the dynamic import for cases the
+ * real logic would now handle, silently disabling disambiguation for them.
+ * Being a strict superset costs at most an unnecessary dynamic import for
+ * selectors the real logic ends up not touching — never a missed one.
+ *
+ * @param pretenders - The flat pretender list to check
+ * @returns `true` if some `selector` is shared by two or more `filePath`-backed entries
+ */
+export function hasResolvableCollision(pretenders: readonly Pretender[]): boolean {
+	const seen = new Set<string>();
+	for (const pretender of pretenders) {
+		if (!pretender.filePath) {
+			continue;
+		}
+		if (seen.has(pretender.selector)) {
+			return true;
+		}
+		seen.add(pretender.selector);
+	}
+	return false;
+}
+
+/**
+ * Clears `@markuplint/pretenders`' module-level import/export resolution
+ * caches. Call this whenever a lint host re-resolves config without cache
+ * (e.g. watch mode after a file change) — otherwise a renamed export or a
+ * newly valid tsconfig `paths` alias keeps resolving as it did before the
+ * change for the rest of the process's lifetime. A no-op (not an error) when
+ * `@markuplint/pretenders` isn't installed, since nothing has populated its
+ * caches in that case either.
+ *
+ * @returns A promise that resolves once the caches have been cleared
+ */
+export async function invalidatePretenderResolutionCaches(): Promise<void> {
+	const pretendersMod = await import('@markuplint/pretenders').catch(() => null);
+	pretendersMod?.clearPretenderCaches();
 }

--- a/packages/@markuplint/ml-config/src/index.ts
+++ b/packages/@markuplint/ml-config/src/index.ts
@@ -14,5 +14,6 @@
  * @module
  */
 export * from './merge-config.js';
+export * from './pretender-file-path.js';
 export * from './utils.js';
 export type * from './types.js';

--- a/packages/@markuplint/ml-config/src/pretender-file-path.spec.ts
+++ b/packages/@markuplint/ml-config/src/pretender-file-path.spec.ts
@@ -1,0 +1,55 @@
+import { describe, test, expect } from 'vitest';
+
+import { parsePretenderFilePath, formatPretenderFilePath, rebasePretenderFilePath } from './pretender-file-path.js';
+
+describe('parsePretenderFilePath', () => {
+	test('parses a well-formed location', () => {
+		expect(parsePretenderFilePath('components/Button.tsx:12:4')).toStrictEqual({
+			path: 'components/Button.tsx',
+			line: '12',
+			col: '4',
+		});
+	});
+
+	test('handles a path that itself contains colons (e.g. a Windows drive letter)', () => {
+		expect(parsePretenderFilePath('C:\\project\\Button.tsx:12:4')).toStrictEqual({
+			path: 'C:\\project\\Button.tsx',
+			line: '12',
+			col: '4',
+		});
+	});
+
+	test('returns null for a string with no trailing line:col', () => {
+		expect(parsePretenderFilePath('components/Button.tsx')).toBeNull();
+	});
+});
+
+describe('formatPretenderFilePath', () => {
+	test('formats a location back into the canonical string', () => {
+		expect(formatPretenderFilePath({ path: 'components/Button.tsx', line: '12', col: '4' })).toBe(
+			'components/Button.tsx:12:4',
+		);
+	});
+});
+
+describe('rebasePretenderFilePath', () => {
+	test('applies the transform to the path portion only, leaving line:col untouched', () => {
+		const pretender = { selector: 'Button', as: 'button', filePath: 'components/Button.tsx:12:4' };
+		const result = rebasePretenderFilePath(pretender, p => `/abs/${p}`);
+		expect(result).toStrictEqual({
+			selector: 'Button',
+			as: 'button',
+			filePath: '/abs/components/Button.tsx:12:4',
+		});
+	});
+
+	test('returns the same pretender unchanged when filePath is absent', () => {
+		const pretender = { selector: 'Button', as: 'button' };
+		expect(rebasePretenderFilePath(pretender, p => `/abs/${p}`)).toStrictEqual(pretender);
+	});
+
+	test('returns the same pretender unchanged when filePath does not match the expected format', () => {
+		const pretender = { selector: 'Button', as: 'button', filePath: 'not-a-location' };
+		expect(rebasePretenderFilePath(pretender, p => `/abs/${p}`)).toStrictEqual(pretender);
+	});
+});

--- a/packages/@markuplint/ml-config/src/pretender-file-path.ts
+++ b/packages/@markuplint/ml-config/src/pretender-file-path.ts
@@ -1,0 +1,69 @@
+/**
+ * @module pretender-file-path
+ *
+ * `Pretender.filePath` encodes a source location as `<path>:<line>:<col>`.
+ * Both `@markuplint/pretenders` and `@markuplint/file-resolver` need to parse
+ * and rebase that string — the former to point at the eventual output JSON's
+ * own location, the latter to make it absolute right after reading each
+ * config source — so the format is owned here rather than re-implemented
+ * (with a slightly different regex each time) in every consumer.
+ */
+
+import type { Pretender } from './types.js';
+
+/** A parsed `Pretender.filePath`. `line`/`col` stay as strings — nothing here needs them as numbers. */
+export interface PretenderFileLocation {
+	readonly path: string;
+	readonly line: string;
+	readonly col: string;
+}
+
+const RE_FILE_PATH_LOCATION = /^(.*):(\d+):(\d+)$/;
+
+/**
+ * @param filePath - A `Pretender.filePath` value
+ * @returns The parsed location, or `null` if `filePath` doesn't end in `:<line>:<col>`
+ */
+export function parsePretenderFilePath(filePath: string): PretenderFileLocation | null {
+	const match = RE_FILE_PATH_LOCATION.exec(filePath);
+	if (!match) {
+		return null;
+	}
+	const [, path, line, col] = match;
+	return { path: path!, line: line!, col: col! };
+}
+
+/**
+ * @param location - A parsed `Pretender.filePath` location
+ * @returns The location formatted back into the canonical `<path>:<line>:<col>` string
+ */
+export function formatPretenderFilePath(location: PretenderFileLocation): string {
+	return `${location.path}:${location.line}:${location.col}`;
+}
+
+/**
+ * Rebases a `Pretender`'s `filePath` by applying `transform` to its path
+ * portion only, leaving `:<line>:<col>` untouched. Entries without a
+ * `filePath`, or whose `filePath` doesn't match the expected format, are
+ * returned unchanged.
+ *
+ * @param pretender - The pretender whose `filePath` should be rebased
+ * @param transform - Maps the path portion of `filePath` to its rebased form
+ * @returns A new `Pretender` with the rebased `filePath`, or `pretender`
+ *   itself (same reference) when there was nothing to rebase
+ */
+export function rebasePretenderFilePath(
+	pretender: Readonly<Pretender>,
+	transform: (path: string) => string,
+): Pretender {
+	if (!pretender.filePath) {
+		return pretender;
+	}
+
+	const location = parsePretenderFilePath(pretender.filePath);
+	if (!location) {
+		return pretender;
+	}
+
+	return { ...pretender, filePath: formatPretenderFilePath({ ...location, path: transform(location.path) }) };
+}

--- a/packages/@markuplint/ml-config/src/types.ts
+++ b/packages/@markuplint/ml-config/src/types.ts
@@ -223,10 +223,11 @@ export type Pretender = {
 	readonly as: string | OriginalNode;
 
 	/**
-	 * If it is a string, it is resolved as an element name.
-	 * An element regards as having the same attributes
-	 * as the pretended custom element because these are inherited.
-	 * If it is an Object, It can specify in detail the element's attributes.
+	 * Where the component was found, as `<path>:<line>:<column>`. Metadata only —
+	 * nothing in linting reads it to influence pretender matching (matching is by
+	 * `selector` alone). `@markuplint/pretenders` scanners emit `<path>` relative
+	 * to the JSON file this entry will be written into, not the scan-time cwd, so
+	 * it stays resolvable regardless of where the file is later loaded from.
 	 *
 	 * @experimental
 	 */

--- a/packages/@markuplint/ml-core/src/ml-core.spec.ts
+++ b/packages/@markuplint/ml-core/src/ml-core.spec.ts
@@ -1,0 +1,58 @@
+import type { MLCoreParams } from './ml-core.js';
+import type { Pretender } from '@markuplint/ml-config';
+import type { MLMLSpec } from '@markuplint/ml-spec';
+
+import { parser } from '@markuplint/html-parser';
+import spec from '@markuplint/html-spec';
+import { describe, test, expect } from 'vitest';
+
+import { convertRuleset } from './convert-ruleset.js';
+import { MLCore } from './ml-core.js';
+
+function createCore(sourceCode: string, pretenders: readonly Pretender[]) {
+	const params: MLCoreParams = {
+		parser,
+		sourceCode,
+		ruleset: convertRuleset({}),
+		rules: [],
+		locale: { locale: 'en' },
+		schemas: [spec as unknown as MLMLSpec, {}],
+		ruleCommonSettings: {},
+		parserOptions: {},
+		severity: {},
+		pretenders,
+		filename: 'test.html',
+	};
+	return new MLCore(params);
+}
+
+function pretendedLocalName(core: MLCore) {
+	const document = core.document;
+	if (document instanceof Error) {
+		throw document;
+	}
+	const el = document.nodeList[0];
+	if (!el?.is(el.ELEMENT_NODE)) {
+		throw new TypeError('Expected the first node to be an element');
+	}
+	return el.pretenderContext?.type === 'pretender' ? el.pretenderContext.as.localName : null;
+}
+
+describe('MLCore#update', () => {
+	test('re-creates the document with the updated pretenders, not the construction-time ones', () => {
+		const core = createCore('<custom-el></custom-el>', [{ selector: 'custom-el', as: 'div' }]);
+		expect(pretendedLocalName(core)).toBe('div');
+
+		core.update({ pretenders: [{ selector: 'custom-el', as: 'span' }] });
+
+		expect(pretendedLocalName(core)).toBe('span');
+	});
+
+	test('keeps the construction-time pretenders when update() is called without any', () => {
+		const core = createCore('<custom-el></custom-el>', [{ selector: 'custom-el', as: 'div' }]);
+
+		core.update({});
+
+		expect(pretendedLocalName(core)).toBe('div');
+	});
+});

--- a/packages/@markuplint/ml-core/src/ml-core.ts
+++ b/packages/@markuplint/ml-core/src/ml-core.ts
@@ -214,10 +214,11 @@ export class MLCore {
 	 *
 	 * @param fabric - Partial fabric with the properties to update
 	 */
-	update({ parser, ruleset, rules, locale, schemas, parserOptions, configErrors }: Partial<MLFabric>) {
+	update({ parser, ruleset, rules, locale, schemas, parserOptions, pretenders, configErrors }: Partial<MLFabric>) {
 		this.#parser = parser ?? this.#parser;
 		this.#locale = locale ?? this.#locale;
 		this.#schemas = schemas ?? this.#schemas;
+		this.#pretenders = pretenders ? [...pretenders] : this.#pretenders;
 		this.#configErrors = [...(configErrors ?? [])];
 
 		const baseRules = rules ? [...rules] : this.#rules.filter(r => !r.baseRuleId);

--- a/packages/@markuplint/pretenders/README.md
+++ b/packages/@markuplint/pretenders/README.md
@@ -121,19 +121,24 @@ Slot detection covers:
 
 ### Import Resolver
 
-The import resolver analyzes `<script>` / frontmatter / ESM blocks in component files and extracts import bindings. This links template component usage to source file locations, enabling cross-file dependency resolution.
-
-Script source extraction is delegated to each parser's component-scanner (Vue, Svelte, Astro), while MDX extraction is built-in. Supported script block types:
+The import resolver analyzes a component file and extracts import bindings, linking component usage to source file locations for cross-file dependency resolution.
 
 - Vue `<script setup>` (via `@markuplint/vue-parser/component-scanner`)
 - Vue Options API `<script>` (fallback when no `<script setup>`; only imports registered in `components: { ... }` are returned)
 - Svelte `<script>` (via `@markuplint/svelte-parser/component-scanner`; prefers instance script over module script)
 - Astro frontmatter (via `@markuplint/astro-parser/component-scanner`)
 - MDX top-level ESM (built-in)
+- JS/TS/JSX/TSX (`.js`, `.jsx`, `.ts`, `.tsx`, `.mjs`, `.cjs`, `.mts`, `.cts`): analyzed directly via the TypeScript AST, so JSX syntax and non-standard TS constructs (which `es-module-lexer` cannot parse) are handled correctly
 
 Dynamic imports with string literal specifiers (`import('./path')`) are included in bindings with `type: 'dynamic'`. Template literal and variable specifiers are excluded.
 
 Barrel file re-exports can be resolved with `resolveBarrelExport`, which maps a named import from a directory with an index file back to its original source module (single-level only).
+
+### Lint-time Disambiguation
+
+When the same component name is declared in more than one scanned file (e.g., two unrelated `Item` components rendering different elements), the generated pretenders keep independent entries for each — but `markuplint`'s lint pipeline still needs to know, for the specific file being linted, which one it actually refers to. `disambiguatePretenders` resolves this from the lint target's own declarations and imports; it's normally invoked automatically by `markuplint`'s config resolution, not called directly.
+
+In long-running hosts (watch mode, editor extensions) that keep re-resolving pretenders across file edits, call `clearPretenderCaches()` after each edit — otherwise a renamed export or a newly valid tsconfig `paths` alias keeps resolving as it did before the change for the rest of the process's lifetime.
 
 ## API
 
@@ -210,9 +215,9 @@ const pretenders = await templateScanner(
 
 ### `analyzeImports(filePath, source)`
 
-Extracts import bindings from a component file's script block. Detects the framework from the file extension and extracts the appropriate source block automatically.
+Extracts import bindings from a component file. Detects the framework from the file extension and extracts the appropriate source automatically — `.vue`, `.svelte`, `.astro`, and `.mdx` extract a script/frontmatter/ESM block first, while `.js`, `.jsx`, `.ts`, `.tsx`, `.mjs`, `.cjs`, `.mts`, and `.cts` are analyzed directly via the TypeScript AST (which, unlike `es-module-lexer`, can parse JSX syntax).
 
-Returns `null` if the file extension is not a supported framework (`.vue`, `.svelte`, `.astro`, `.mdx`).
+Returns `null` if the file extension is not one of the above.
 
 ```ts
 import { analyzeImports } from '@markuplint/pretenders';
@@ -281,3 +286,38 @@ if (binding) {
 #### Returns
 
 `string | null` — The relative source path from the barrel file, or `null` if not a barrel or name not found.
+
+### `disambiguatePretenders(pretenders, options)`
+
+Given a flat pretender list and the file currently being linted, resolves which of several same-selector candidates that file actually refers to. Entries without a `filePath`, or whose `selector` isn't a plain identifier, are never touched. Normally invoked automatically as part of `markuplint`'s config resolution.
+
+```ts
+import { disambiguatePretenders } from '@markuplint/pretenders';
+
+const resolved = await disambiguatePretenders(pretenders, {
+  filePath: '/absolute/path/to/Page.tsx',
+  sourceCode: source,
+});
+```
+
+#### Parameters
+
+| Parameter            | Type                   | Description                                 |
+| -------------------- | ---------------------- | ------------------------------------------- |
+| `pretenders`         | `readonly Pretender[]` | The resolved pretender list to disambiguate |
+| `options.filePath`   | `string`               | Absolute path of the file being linted      |
+| `options.sourceCode` | `string`               | Full source text of the file being linted   |
+
+#### Returns
+
+`Promise<readonly Pretender[]>` — The disambiguated pretender list, or `pretenders` itself when there was nothing to resolve or nothing could be confirmed.
+
+### `clearPretenderCaches()`
+
+Clears the module-level caches that back import/export resolution (module resolution, export tables). Neither cache expires on its own, so a long-running host (watch mode, an editor extension) that keeps resolving pretenders across file edits must call this after each edit — otherwise a renamed export or a newly valid tsconfig `paths` alias keeps resolving as it did before the change for the rest of the process's lifetime.
+
+```ts
+import { clearPretenderCaches } from '@markuplint/pretenders';
+
+clearPretenderCaches();
+```

--- a/packages/@markuplint/pretenders/package.json
+++ b/packages/@markuplint/pretenders/package.json
@@ -35,6 +35,7 @@
 		"@markuplint/ml-ast": "5.0.0-rc.4",
 		"@markuplint/ml-config": "5.0.0-rc.4",
 		"@markuplint/parser-utils": "5.0.0-rc.4",
+		"@markuplint/shared": "5.0.0-rc.4",
 		"es-module-lexer": "2.0.0",
 		"glob": "13.0.6",
 		"meow": "14.1.0",

--- a/packages/@markuplint/pretenders/src/cli.ts
+++ b/packages/@markuplint/pretenders/src/cli.ts
@@ -33,7 +33,7 @@ async function main() {
 
 	const outFilePath = path.resolve(process.cwd(), commands.flags.out);
 
-	await out(outFilePath, pretenders);
+	await out(outFilePath, pretenders, process.cwd());
 }
 
 await main();

--- a/packages/@markuplint/pretenders/src/dependency-mapper.spec.ts
+++ b/packages/@markuplint/pretenders/src/dependency-mapper.spec.ts
@@ -1,8 +1,15 @@
 import type { PretenderDirectorMap } from './pretender-director.js';
 
-import { describe, test, expect } from 'vitest';
+import fs from 'node:fs';
+import { writeFile, mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 
-import { dependencyMapper } from './dependency-mapper.js';
+import { describe, test, expect, afterEach, beforeEach, vi } from 'vitest';
+
+import { clearExportTableCache, dependencyMapper } from './dependency-mapper.js';
+
+const fixtureDir = path.resolve(import.meta.dirname, '..', 'test', 'fixtures', 'dependency-mapper');
 
 describe('dependencyMapper', () => {
 	test('B -> A', () => {
@@ -291,5 +298,167 @@ describe('dependencyMapper', () => {
 				as: 'button',
 			},
 		]);
+	});
+
+	describe('file-context resolution (issue #3951)', () => {
+		test('same-file local declaration takes priority over the name index', () => {
+			const map: PretenderDirectorMap = new Map([
+				['a.tsx#Item', ['Item', 'button', undefined, 'a.tsx']],
+				['b.tsx#Item', ['Item', 'li', undefined, 'b.tsx']],
+				['b.tsx#B', ['B', 'Item', undefined, 'b.tsx']],
+			]);
+			// Name-index-only resolution (no file context) would map 'Item' to whichever
+			// file registered it first — here that's a.tsx, which is the wrong answer for B.
+			const nameIndex = new Map([['Item', 'a.tsx#Item']]);
+
+			const result = dependencyMapper(map, nameIndex);
+			const b = result.find(p => p.selector === 'B');
+			expect(b).toStrictEqual({ selector: 'B', as: 'li', _via: ['Item'] });
+		});
+
+		test('resolves a named import to the actual declaration file, even when a same-named collision exists', () => {
+			const map: PretenderDirectorMap = new Map([
+				['a.tsx#Item', ['Item', 'button', undefined, 'a.tsx']],
+				// Colliding name registered elsewhere; the name index (used without file context)
+				// would point here, which is the wrong file for what c.tsx actually imports.
+				['other.tsx#Item', ['Item', 'li', undefined, 'other.tsx']],
+				['c.tsx#C', ['C', 'Item', undefined, 'c.tsx']],
+			]);
+			const nameIndex = new Map([['Item', 'other.tsx#Item']]);
+			const importsByFile = new Map([
+				['c.tsx', [{ localName: 'Item', importedName: 'Item', source: './a', type: 'named' as const }]],
+			]);
+
+			const result = dependencyMapper(map, nameIndex, { importsByFile, cwd: fixtureDir });
+			const c = result.find(p => p.selector === 'C');
+			expect(c).toStrictEqual({ selector: 'C', as: 'button', _via: ['Item'] });
+		});
+
+		test('resolves a default import via the target file export table, even when a same-named collision exists', () => {
+			const map: PretenderDirectorMap = new Map([
+				['d.tsx#Item', ['Item', 'button', undefined, 'd.tsx']],
+				['other.tsx#Item', ['Item', 'li', undefined, 'other.tsx']],
+				['e.tsx#E', ['E', 'Item', undefined, 'e.tsx']],
+			]);
+			const nameIndex = new Map([['Item', 'other.tsx#Item']]);
+			const importsByFile = new Map([
+				['e.tsx', [{ localName: 'Item', importedName: 'default', source: './d', type: 'default' as const }]],
+			]);
+
+			const result = dependencyMapper(map, nameIndex, { importsByFile, cwd: fixtureDir });
+			const e = result.find(p => p.selector === 'E');
+			expect(e).toStrictEqual({ selector: 'E', as: 'button', _via: ['Item'] });
+		});
+
+		test('carries the resolved file forward across multiple hops, even when a same-named collision exists', () => {
+			const map: PretenderDirectorMap = new Map([
+				['wrapper-a.tsx#Base', ['Base', 'div', undefined, 'wrapper-a.tsx']],
+				['wrapper-a.tsx#Wrapper', ['Wrapper', 'Base', undefined, 'wrapper-a.tsx']],
+				// Colliding name registered elsewhere with a different target.
+				['other.tsx#Base', ['Base', 'span', undefined, 'other.tsx']],
+				['wrapper-b.tsx#Outer', ['Outer', 'Wrapper', undefined, 'wrapper-b.tsx']],
+			]);
+			const nameIndex = new Map([
+				['Base', 'other.tsx#Base'],
+				['Wrapper', 'wrapper-a.tsx#Wrapper'],
+			]);
+			const importsByFile = new Map([
+				[
+					'wrapper-b.tsx',
+					[{ localName: 'Wrapper', importedName: 'Wrapper', source: './wrapper-a', type: 'named' as const }],
+				],
+			]);
+
+			const result = dependencyMapper(map, nameIndex, { importsByFile, cwd: fixtureDir });
+			const outer = result.find(p => p.selector === 'Outer');
+			// Outer -> Wrapper (resolved via import into wrapper-a.tsx) -> Base
+			// (must resolve within wrapper-a.tsx, not fall through to other.tsx's Base)
+			expect(outer).toStrictEqual({ selector: 'Outer', as: 'div', _via: ['Wrapper', 'Base'] });
+		});
+
+		test('falls back to name-index resolution when no context is provided (full backward compat)', () => {
+			const map: PretenderDirectorMap = new Map([
+				['a.tsx#Item', ['Item', 'button', undefined, 'a.tsx']],
+				['c.tsx#C', ['C', 'Item', undefined, 'c.tsx']],
+			]);
+			const nameIndex = new Map([['Item', 'a.tsx#Item']]);
+
+			// No importsByFile/cwd context at all — must behave exactly like the pre-existing algorithm
+			const result = dependencyMapper(map, nameIndex);
+			const c = result.find(p => p.selector === 'C');
+			expect(c).toStrictEqual({ selector: 'C', as: 'button', _via: ['Item'] });
+		});
+	});
+
+	describe('exportTableCache invalidation (long-running processes)', () => {
+		let tmpDir: string;
+
+		beforeEach(async () => {
+			tmpDir = await mkdtemp(path.join(os.tmpdir(), 'dependency-mapper-cache-'));
+		});
+
+		afterEach(async () => {
+			await rm(tmpDir, { recursive: true, force: true });
+		});
+
+		test('clearExportTableCache() picks up a renamed export after re-resolving', async () => {
+			const targetFile = path.join(tmpDir, 'target.tsx');
+			await writeFile(targetFile, 'export default function Item() { return null; }');
+
+			const importsByFile = new Map([
+				[
+					'importer.tsx',
+					[{ localName: 'Item', importedName: 'default', source: './target', type: 'default' as const }],
+				],
+			]);
+
+			const mapBefore: PretenderDirectorMap = new Map([
+				['target.tsx#Item', ['Item', 'button', undefined, 'target.tsx']],
+				['importer.tsx#E', ['E', 'Item', undefined, 'importer.tsx']],
+			]);
+			const resultBefore = dependencyMapper(mapBefore, undefined, { importsByFile, cwd: tmpDir });
+			expect(resultBefore.find(p => p.selector === 'E')?.as).toBe('button');
+
+			// Rename the exported declaration. Without cache invalidation, the resolver
+			// keeps using the pre-rename export table and looks up a map key that no
+			// longer exists, leaving `E` unresolved instead of picking up the new one.
+			await writeFile(targetFile, 'export default function Widget() { return null; }');
+			const mapAfter: PretenderDirectorMap = new Map([
+				['target.tsx#Widget', ['Widget', 'span', undefined, 'target.tsx']],
+				['importer.tsx#E', ['E', 'Item', undefined, 'importer.tsx']],
+			]);
+
+			const resultStale = dependencyMapper(mapAfter, undefined, { importsByFile, cwd: tmpDir });
+			expect(resultStale.find(p => p.selector === 'E')?.as).toBe('Item');
+
+			clearExportTableCache();
+
+			const resultFresh = dependencyMapper(mapAfter, undefined, { importsByFile, cwd: tmpDir });
+			expect(resultFresh.find(p => p.selector === 'E')?.as).toBe('span');
+		});
+	});
+
+	describe('Tier 1 (fatal) errors during export table resolution', () => {
+		test('rethrows instead of swallowing a fatal error into a null export table', () => {
+			clearExportTableCache();
+
+			const map: PretenderDirectorMap = new Map([
+				['a.tsx#Item', ['Item', 'button', undefined, 'a.tsx']],
+				['c.tsx#C', ['C', 'Item', undefined, 'c.tsx']],
+			]);
+			const importsByFile = new Map([
+				['c.tsx', [{ localName: 'Item', importedName: 'Item', source: './a', type: 'named' as const }]],
+			]);
+
+			const spy = vi.spyOn(fs, 'readFileSync').mockImplementation(() => {
+				throw new TypeError('boom: implementation bug, not a missing file');
+			});
+			try {
+				expect(() => dependencyMapper(map, undefined, { importsByFile, cwd: fixtureDir })).toThrow(TypeError);
+			} finally {
+				spy.mockRestore();
+				clearExportTableCache();
+			}
+		});
 	});
 });

--- a/packages/@markuplint/pretenders/src/dependency-mapper.ts
+++ b/packages/@markuplint/pretenders/src/dependency-mapper.ts
@@ -1,30 +1,63 @@
 import type { PretenderDirectorMap } from './pretender-director.js';
 import type { Identifier, Identity } from './types.js';
+import type { ImportBinding } from './import-resolver/types.js';
 import type { Pretender } from '@markuplint/ml-config';
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { isFatalError } from '@markuplint/shared';
+import ts from 'typescript';
+
+import { getExportTable } from './export-table.js';
+import { scriptKindForPath } from './import-resolver/analyze-jsx-imports.js';
+import { resolveComponentImport } from './import-resolver/index.js';
+import { normalizePath, resolveModuleFile } from './import-resolver/resolve-module-file.js';
+
+import type { ExportEntry } from './export-table.js';
+
+export interface DependencyMapperContext {
+	/** Import bindings found in each source file, keyed by the same relative path used as `sourceFile`. */
+	readonly importsByFile?: ReadonlyMap<string, readonly ImportBinding[]>;
+	/** Base directory that relative `sourceFile` paths (and resolved module paths) are relative to. */
+	readonly cwd?: string;
+}
 
 /**
  * Follows chains where one component wraps another (e.g., MyButton -> Button -> button)
  * until a native element is reached or a cycle is detected.
  *
- * Uses import-path-based resolution when a name index is provided, falling back to
- * name-based lookup for backward compatibility.
+ * Resolution order at each hop:
+ * 1. A same-file local declaration (the file the reference itself lives in).
+ * 2. The file's recorded import bindings, resolved to the actual declaration file
+ *    via TypeScript module resolution and the target file's export table.
+ * 3. The legacy name-based index, for backward compatibility when no file context
+ *    is available (or the reference can't be resolved through it).
+ *
+ * (1) and (2) are what let same-named components declared in different files
+ * (e.g., two unrelated `Item` components) resolve independently instead of the
+ * first-registered one silently winning for every reference — see issue #3951.
  */
 export function dependencyMapper(
 	map: Readonly<PretenderDirectorMap>,
 	nameIndex?: Readonly<Map<Identifier, string>>,
+	context?: DependencyMapperContext,
 ): Pretender[] {
 	const resolvedNameIndex = nameIndex ?? buildNameIndex(map);
+	const importsByFile = context?.importsByFile;
+	const cwd = context?.cwd ?? process.cwd();
 	const linkedPretenders: Pretender[] = [];
 
-	for (const [key, [identifier, _identity, _filePath]] of map) {
+	for (const [key, [identifier, _identity, _filePath, _sourceFile]] of map) {
 		let identity = _identity;
 		let filePath = _filePath;
 		let elName = getElName(identity);
+		let currentFile = _sourceFile;
 		const via: string[] = [];
 		const visited = new Set<string>([key]);
 
 		while (true) {
-			const lookupKey = resolvedNameIndex.get(elName) ?? elName;
+			const lookupKey = resolveHop(elName, currentFile, key, map, importsByFile, resolvedNameIndex, cwd);
 			const mappedPretender = map.get(lookupKey);
 			if (!mappedPretender) {
 				break;
@@ -40,6 +73,7 @@ export function dependencyMapper(
 			visited.add(lookupKey);
 			via.push(elName);
 			elName = getElName(identity);
+			currentFile = mappedPretender[3];
 		}
 
 		const pretender: Pretender = {
@@ -55,6 +89,171 @@ export function dependencyMapper(
 	}
 
 	return linkedPretenders.toSorted(propSort('selector'));
+}
+
+/**
+ * Resolves the map key that `elName` (the current hop's rendered element/component
+ * name) should be looked up under, preferring file-context resolution over the
+ * flat name index.
+ */
+function resolveHop(
+	elName: string,
+	currentFile: string | undefined,
+	ownKey: string,
+	map: Readonly<PretenderDirectorMap>,
+	importsByFile: ReadonlyMap<string, readonly ImportBinding[]> | undefined,
+	resolvedNameIndex: Readonly<Map<Identifier, string>>,
+	cwd: string,
+): string {
+	if (currentFile) {
+		const sameFileKey = `${currentFile}#${elName}`;
+		if (sameFileKey !== ownKey && map.has(sameFileKey)) {
+			return sameFileKey;
+		}
+
+		const viaImport = resolveThroughImport(elName, currentFile, importsByFile, cwd);
+		if (viaImport && map.has(viaImport)) {
+			return viaImport;
+		}
+	}
+
+	return resolvedNameIndex.get(elName) ?? elName;
+}
+
+const MAX_RE_EXPORT_DEPTH = 8;
+
+/**
+ * Resolves `elName` through the import bindings recorded for `currentFile`,
+ * returning the map key of the file/name it actually refers to, or `null`
+ * when it can't be confirmed (bare/namespace/dynamic specifiers, unresolved
+ * modules, or export tables that don't confirm the binding).
+ */
+function resolveThroughImport(
+	elName: string,
+	currentFile: string,
+	importsByFile: ReadonlyMap<string, readonly ImportBinding[]> | undefined,
+	cwd: string,
+): string | null {
+	const bindings = importsByFile?.get(currentFile);
+	if (!bindings) {
+		return null;
+	}
+
+	const binding = resolveComponentImport(elName, bindings);
+	if (!binding || binding.type === 'namespace' || binding.type === 'dynamic') {
+		return null;
+	}
+
+	const importerAbs = path.resolve(cwd, currentFile);
+	const resolvedAbs = resolveModuleFile(importerAbs, binding.source);
+	if (!resolvedAbs) {
+		return null;
+	}
+
+	if (isTemplateComponentFile(resolvedAbs)) {
+		// Template components (Vue/Svelte/Astro) are one-file-one-component: the
+		// scanner keys them by file path directly, not by an exported name, so
+		// there is no export table to consult — the resolved file path *is* the key.
+		return normalizePath(path.relative(cwd, resolvedAbs));
+	}
+
+	return resolveExportedName(resolvedAbs, binding.importedName, cwd, new Set());
+}
+
+const TEMPLATE_COMPONENT_EXTENSIONS = new Set(['.vue', '.svelte', '.astro']);
+
+function isTemplateComponentFile(filePath: string): boolean {
+	return TEMPLATE_COMPONENT_EXTENSIONS.has(path.extname(filePath).toLowerCase());
+}
+
+/**
+ * Resolves `exportedName` in the file at `fileAbs` down to a local declaration,
+ * following `export { X } from '...'` re-export chains up to a depth limit.
+ */
+function resolveExportedName(fileAbs: string, exportedName: string, cwd: string, visited: Set<string>): string | null {
+	if (visited.size >= MAX_RE_EXPORT_DEPTH) {
+		return null;
+	}
+	const visitKey = `${fileAbs}#${exportedName}`;
+	if (visited.has(visitKey)) {
+		return null;
+	}
+	visited.add(visitKey);
+
+	const table = getExportTableForFile(fileAbs);
+	const entry = table?.byName.get(exportedName);
+	if (!entry) {
+		return null;
+	}
+
+	const fileRel = normalizePath(path.relative(cwd, fileAbs));
+
+	if (entry.kind === 'local') {
+		return `${fileRel}#${entry.localName}`;
+	}
+
+	return resolveReExport(fileAbs, entry, cwd, visited);
+}
+
+function resolveReExport(
+	fileAbs: string,
+	entry: Extract<ExportEntry, { kind: 're-export' }>,
+	cwd: string,
+	visited: Set<string>,
+): string | null {
+	if (entry.importedName === '*') {
+		// Namespace re-export target — no single member to pin to.
+		return null;
+	}
+
+	const nextAbs = resolveModuleFile(fileAbs, entry.source);
+	if (!nextAbs) {
+		return null;
+	}
+
+	return resolveExportedName(nextAbs, entry.importedName, cwd, visited);
+}
+
+const exportTableCache = new Map<string, ReturnType<typeof getExportTable> | null>();
+
+/**
+ * Clears the module-level export-table cache. `getExportTableForFile()` never
+ * expires an entry on its own, so a long-running host (a watch-mode lint run,
+ * an editor extension) that keeps resolving pretenders across file edits must
+ * call this whenever it re-resolves without cache (e.g. after a file change)
+ * — otherwise a renamed or restructured export keeps resolving to what it
+ * used to be for the rest of the process's lifetime.
+ */
+export function clearExportTableCache() {
+	exportTableCache.clear();
+}
+
+function getExportTableForFile(fileAbs: string) {
+	const cached = exportTableCache.get(fileAbs);
+	if (cached !== undefined) {
+		return cached;
+	}
+
+	let table: ReturnType<typeof getExportTable> | null;
+	try {
+		const content = fs.readFileSync(fileAbs, 'utf8');
+		const sourceFile = ts.createSourceFile(
+			fileAbs,
+			content,
+			ts.ScriptTarget.Latest,
+			true,
+			scriptKindForPath(fileAbs),
+		);
+		table = getExportTable(sourceFile);
+	} catch (error) {
+		if (isFatalError(error)) {
+			throw error;
+		}
+		table = null;
+	}
+
+	exportTableCache.set(fileAbs, table);
+	return table;
 }
 
 /**

--- a/packages/@markuplint/pretenders/src/disambiguate.spec.ts
+++ b/packages/@markuplint/pretenders/src/disambiguate.spec.ts
@@ -1,0 +1,155 @@
+import type { Pretender } from '@markuplint/ml-config';
+
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { describe, test, expect } from 'vitest';
+
+import { disambiguatePretenders } from './disambiguate.js';
+
+const collisionDir = path.resolve(import.meta.dirname, '..', 'test', 'fixtures', 'collision');
+const moduleResolutionDir = path.resolve(import.meta.dirname, '..', 'test', 'fixtures', 'module-resolution');
+const abs = (name: string) => path.resolve(collisionDir, name);
+
+describe('disambiguatePretenders', () => {
+	test('prefers the pretender declared in the lint target file itself', async () => {
+		const filePath = abs('a.tsx');
+		const sourceCode = await readFile(filePath, 'utf8');
+		const pretenders: Pretender[] = [
+			{
+				selector: 'Item',
+				as: { element: 'button', slots: true, inheritAttrs: true },
+				filePath: `${abs('a.tsx')}:2:14`,
+			},
+			{
+				selector: 'Item',
+				as: { element: 'li', slots: true, inheritAttrs: true },
+				filePath: `${abs('b.tsx')}:2:14`,
+			},
+		];
+
+		const result = await disambiguatePretenders(pretenders, { filePath, sourceCode });
+		expect(result).toHaveLength(1);
+		expect(result[0]!.as).toStrictEqual({ element: 'button', slots: true, inheritAttrs: true });
+	});
+
+	test('resolves via a named import to the file it actually imports', async () => {
+		const filePath = abs('c.tsx');
+		const sourceCode = await readFile(filePath, 'utf8');
+		const pretenders: Pretender[] = [
+			{
+				selector: 'Item',
+				as: { element: 'button', slots: true, inheritAttrs: true },
+				filePath: `${abs('a.tsx')}:2:14`,
+			},
+			{
+				selector: 'Item',
+				as: { element: 'li', slots: true, inheritAttrs: true },
+				filePath: `${abs('b.tsx')}:2:14`,
+			},
+		];
+
+		const result = await disambiguatePretenders(pretenders, { filePath, sourceCode });
+		expect(result).toHaveLength(1);
+		expect(result[0]!.as).toStrictEqual({ element: 'button', slots: true, inheritAttrs: true });
+	});
+
+	test('resolves via a default import to the file it actually imports', async () => {
+		const filePath = abs('e.tsx');
+		const sourceCode = await readFile(filePath, 'utf8');
+		const pretenders: Pretender[] = [
+			{
+				selector: 'Item',
+				as: { element: 'span', slots: true, inheritAttrs: true },
+				filePath: `${abs('d.tsx')}:3:6`,
+			},
+			{ selector: 'Item', as: { element: 'div', slots: null }, filePath: `${abs('f.tsx')}:1:14` },
+		];
+
+		const result = await disambiguatePretenders(pretenders, { filePath, sourceCode });
+		expect(result).toHaveLength(1);
+		expect(result[0]!.as).toStrictEqual({ element: 'span', slots: true, inheritAttrs: true });
+	});
+
+	test('resolves via a tsconfig `paths` alias', async () => {
+		const withAliasDir = path.resolve(moduleResolutionDir, 'with-alias');
+		const filePath = path.resolve(withAliasDir, 'src', 'pages', 'Page.tsx');
+		const sourceCode = await readFile(filePath, 'utf8');
+		const correctButton = path.resolve(withAliasDir, 'src', 'components', 'Button.tsx');
+		const decoyButton = path.resolve(withAliasDir, 'src', 'pages', 'DecoyButton.tsx');
+		const pretenders: Pretender[] = [
+			{ selector: 'Button', as: 'button', filePath: `${correctButton}:1:14` },
+			{ selector: 'Button', as: 'div', filePath: `${decoyButton}:1:1` },
+		];
+
+		const result = await disambiguatePretenders(pretenders, { filePath, sourceCode });
+		expect(result).toHaveLength(1);
+		expect(result[0]!.as).toBe('button');
+	});
+
+	test('leaves the array unchanged when the reference cannot be resolved (full fallback)', async () => {
+		const filePath = abs('a.tsx');
+		const sourceCode = await readFile(filePath, 'utf8');
+		const pretenders: Pretender[] = [
+			{ selector: 'Widget', as: 'div', filePath: `${abs('b.tsx')}:1:1` },
+			{ selector: 'Widget', as: 'span', filePath: `${abs('c.tsx')}:1:1` },
+		];
+
+		const result = await disambiguatePretenders(pretenders, { filePath, sourceCode });
+		expect(result).toStrictEqual(pretenders);
+	});
+
+	test('leaves entries without a filePath untouched, even amid a resolved collision', async () => {
+		const filePath = abs('c.tsx');
+		const sourceCode = await readFile(filePath, 'utf8');
+		const handWritten: Pretender = { selector: 'Item', as: 'i' };
+		const pretenders: Pretender[] = [
+			handWritten,
+			{
+				selector: 'Item',
+				as: { element: 'button', slots: true, inheritAttrs: true },
+				filePath: `${abs('a.tsx')}:2:14`,
+			},
+			{
+				selector: 'Item',
+				as: { element: 'li', slots: true, inheritAttrs: true },
+				filePath: `${abs('b.tsx')}:2:14`,
+			},
+		];
+
+		const result = await disambiguatePretenders(pretenders, { filePath, sourceCode });
+		expect(result).toContainEqual(handWritten);
+		expect(result).toHaveLength(2);
+	});
+
+	test('matches filePath entries regardless of path separator style (Windows-style paths)', async () => {
+		const filePath = abs('a.tsx');
+		const sourceCode = await readFile(filePath, 'utf8');
+		const winStylePath = abs('a.tsx').split(path.sep).join('\\');
+		const pretenders: Pretender[] = [
+			{
+				selector: 'Item',
+				as: { element: 'button', slots: true, inheritAttrs: true },
+				filePath: `${winStylePath}:2:14`,
+			},
+			{
+				selector: 'Item',
+				as: { element: 'li', slots: true, inheritAttrs: true },
+				filePath: `${abs('b.tsx')}:2:14`,
+			},
+		];
+
+		const result = await disambiguatePretenders(pretenders, { filePath, sourceCode });
+		expect(result).toHaveLength(1);
+		expect(result[0]!.as).toStrictEqual({ element: 'button', slots: true, inheritAttrs: true });
+	});
+
+	test('does not touch a selector that only has a single candidate', async () => {
+		const filePath = abs('a.tsx');
+		const sourceCode = await readFile(filePath, 'utf8');
+		const pretenders: Pretender[] = [{ selector: 'Solo', as: 'div', filePath: `${abs('a.tsx')}:9:9` }];
+
+		const result = await disambiguatePretenders(pretenders, { filePath, sourceCode });
+		expect(result).toStrictEqual(pretenders);
+	});
+});

--- a/packages/@markuplint/pretenders/src/disambiguate.ts
+++ b/packages/@markuplint/pretenders/src/disambiguate.ts
@@ -1,0 +1,139 @@
+/**
+ * @module disambiguate
+ *
+ * Resolves selector collisions in a flat `Pretender[]` list — the same thing
+ * {@link ./dependency-mapper.js} does while a scanner builds its output, but
+ * applied here at lint time to the file actually being linted. This is what
+ * closes the other half of issue #3951: even once the generated pretenders
+ * JSON carries independent entries for two same-named components declared in
+ * different files, `MLElement.pretending()` still matches by CSS selector
+ * alone — it has no file context, so it can't tell them apart on its own.
+ *
+ * This module inspects the lint target's own declarations and imports to
+ * pick, among several same-named candidates, the one the file actually
+ * refers to — falling back to leaving the list untouched whenever that can't
+ * be confirmed, so lint output never gets worse than the pre-existing
+ * first-match behavior.
+ */
+
+import type { ImportBinding } from './import-resolver/types.js';
+import type { Pretender } from '@markuplint/ml-config';
+
+import { parsePretenderFilePath } from '@markuplint/ml-config';
+
+import { analyzeImports, resolveComponentImport } from './import-resolver/index.js';
+import { normalizePath, resolveModuleFile } from './import-resolver/resolve-module-file.js';
+
+const RE_SIMPLE_COMPONENT_NAME = /^[A-Z][\w$-]*$/i;
+
+/**
+ * Identifies the file to disambiguate pretenders against.
+ */
+export interface DisambiguateOptions {
+	/** Absolute path of the file being linted. */
+	readonly filePath: string;
+	/** Full source text of the file being linted. */
+	readonly sourceCode: string;
+}
+
+/**
+ * @param pretenders - The resolved pretender list a lint run would otherwise
+ *   use as-is. Entries without a `filePath`, or whose `selector` isn't a
+ *   plain identifier, are never touched.
+ * @param options - The file being linted, used to resolve which same-selector
+ *   candidate it actually refers to.
+ * @returns The disambiguated pretender list, or `pretenders` itself (same
+ *   reference) when there was nothing to resolve or nothing could be confirmed.
+ */
+export async function disambiguatePretenders(
+	pretenders: readonly Pretender[],
+	options: DisambiguateOptions,
+): Promise<readonly Pretender[]> {
+	const groups = groupAmbiguousCandidates(pretenders);
+	if (groups.size === 0) {
+		// Fast path: no colliding selector has more than one file-backed candidate,
+		// so there's nothing to resolve — skip import analysis entirely.
+		return pretenders;
+	}
+
+	const importResult = await analyzeImports(options.filePath, options.sourceCode);
+	const bindings = importResult?.bindings ?? [];
+
+	const losers = new Set<Pretender>();
+
+	for (const candidates of groups.values()) {
+		const winner = resolveWinner(candidates, options.filePath, bindings);
+		if (!winner) {
+			continue;
+		}
+		for (const candidate of candidates) {
+			if (candidate !== winner) {
+				losers.add(candidate);
+			}
+		}
+	}
+
+	if (losers.size === 0) {
+		return pretenders;
+	}
+
+	return pretenders.filter(p => !losers.has(p));
+}
+
+function groupAmbiguousCandidates(pretenders: readonly Pretender[]): Map<string, Pretender[]> {
+	const bySelector = new Map<string, Pretender[]>();
+
+	for (const pretender of pretenders) {
+		if (!pretender.filePath || !RE_SIMPLE_COMPONENT_NAME.test(pretender.selector)) {
+			continue;
+		}
+		const list = bySelector.get(pretender.selector);
+		if (list) {
+			list.push(pretender);
+		} else {
+			bySelector.set(pretender.selector, [pretender]);
+		}
+	}
+
+	for (const [selector, list] of bySelector) {
+		if (list.length < 2) {
+			bySelector.delete(selector);
+		}
+	}
+
+	return bySelector;
+}
+
+/**
+ * Picks the one candidate `filePath` actually refers to: first a same-file
+ * local declaration, then an import binding resolved via TypeScript module
+ * resolution. Returns `null` when neither confirms a candidate, so the
+ * caller leaves the whole group untouched.
+ */
+function resolveWinner(
+	candidates: readonly Pretender[],
+	filePath: string,
+	bindings: readonly ImportBinding[],
+): Pretender | null {
+	const local = candidates.find(c => matchesFile(c.filePath!, filePath));
+	if (local) {
+		return local;
+	}
+
+	const binding = resolveComponentImport(candidates[0]!.selector, bindings);
+	if (!binding || binding.type === 'namespace' || binding.type === 'dynamic') {
+		return null;
+	}
+
+	const resolvedAbs = resolveModuleFile(filePath, binding.source);
+	if (!resolvedAbs) {
+		return null;
+	}
+
+	return candidates.find(c => matchesFile(c.filePath!, resolvedAbs)) ?? null;
+}
+
+function matchesFile(pretenderFilePath: string, targetAbsPath: string): boolean {
+	const pathPart = parsePretenderFilePath(pretenderFilePath)?.path ?? pretenderFilePath;
+	return normalizePath(pathPart) === normalizePath(targetAbsPath);
+}

--- a/packages/@markuplint/pretenders/src/export-table.spec.ts
+++ b/packages/@markuplint/pretenders/src/export-table.spec.ts
@@ -1,0 +1,71 @@
+import { describe, test, expect } from 'vitest';
+
+import ts from 'typescript';
+
+import { getExportTable } from './export-table.js';
+
+function sourceFile(code: string) {
+	return ts.createSourceFile('test.tsx', code, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+}
+
+describe('getExportTable', () => {
+	test('default export of a named function declaration', () => {
+		const table = getExportTable(sourceFile('export default function Item() { return null; }'));
+		expect(table.byName.get('default')).toStrictEqual({ kind: 'local', localName: 'Item' });
+	});
+
+	test('default export of a previously declared identifier', () => {
+		const table = getExportTable(sourceFile('const Item = () => null;\nexport default Item;'));
+		expect(table.byName.get('default')).toStrictEqual({ kind: 'local', localName: 'Item' });
+	});
+
+	test('named export via export keyword on a variable declaration', () => {
+		const table = getExportTable(sourceFile('export const Item = styled.button``;'));
+		expect(table.byName.get('Item')).toStrictEqual({ kind: 'local', localName: 'Item' });
+	});
+
+	test('named export via export keyword on a function declaration', () => {
+		const table = getExportTable(sourceFile('export function Item() { return null; }'));
+		expect(table.byName.get('Item')).toStrictEqual({ kind: 'local', localName: 'Item' });
+	});
+
+	test('local re-export with alias: export { Item as ListItem }', () => {
+		const table = getExportTable(sourceFile('const Item = () => null;\nexport { Item as ListItem };'));
+		expect(table.byName.get('ListItem')).toStrictEqual({ kind: 'local', localName: 'Item' });
+		expect(table.byName.has('Item')).toBe(false);
+	});
+
+	test('local re-export without alias: export { Item }', () => {
+		const table = getExportTable(sourceFile('const Item = () => null;\nexport { Item };'));
+		expect(table.byName.get('Item')).toStrictEqual({ kind: 'local', localName: 'Item' });
+	});
+
+	test('re-export from another module: export { Item } from "./a"', () => {
+		const table = getExportTable(sourceFile('export { Item } from "./a";'));
+		expect(table.byName.get('Item')).toStrictEqual({ kind: 're-export', source: './a', importedName: 'Item' });
+	});
+
+	test('re-export of a default export with alias: export { default as Item } from "./a"', () => {
+		const table = getExportTable(sourceFile('export { default as Item } from "./a";'));
+		expect(table.byName.get('Item')).toStrictEqual({ kind: 're-export', source: './a', importedName: 'default' });
+	});
+
+	test('star re-export: export * from "./a"', () => {
+		const table = getExportTable(sourceFile('export * from "./a";'));
+		expect(table.starReExportSources).toStrictEqual(['./a']);
+	});
+
+	test('namespace re-export: export * as ns from "./a" is recorded under its name', () => {
+		const table = getExportTable(sourceFile('export * as ns from "./a";'));
+		expect(table.byName.get('ns')).toStrictEqual({ kind: 're-export', source: './a', importedName: '*' });
+	});
+
+	test('multiple exports coexist in the same table', () => {
+		const table = getExportTable(
+			sourceFile('export const A = () => null;\nexport const B = () => null;\nexport default A;'),
+		);
+		expect(table.byName.get('A')).toStrictEqual({ kind: 'local', localName: 'A' });
+		expect(table.byName.get('B')).toStrictEqual({ kind: 'local', localName: 'B' });
+		expect(table.byName.get('default')).toStrictEqual({ kind: 'local', localName: 'A' });
+	});
+});

--- a/packages/@markuplint/pretenders/src/export-table.ts
+++ b/packages/@markuplint/pretenders/src/export-table.ts
@@ -1,0 +1,153 @@
+/**
+ * @module export-table
+ *
+ * Builds a per-file table of what a module exports, resolving each exported
+ * name back to either a local declaration or a re-export of another module.
+ * This replaces name-guessing when linking an imported identifier to the
+ * pretender entry for the declaration it actually refers to — including
+ * `export default`, aliased named exports, and barrel-style re-exports
+ * (`export { X } from './y'`), which are just a special case of the same
+ * lookup instead of separate logic.
+ *
+ * Only top-level export syntax is inspected; this module does not resolve
+ * across files (that is `resolve-module-file`'s job) or follow
+ * `export * from` chains — a star re-export is recorded as-is, and any
+ * caller doing multi-file resolution must decide how far to follow it.
+ */
+
+import type { SourceFile } from 'typescript';
+
+import ts from 'typescript';
+
+/**
+ * Where a single exported name resolves to: a declaration in the same file,
+ * or a re-export of a name from another module.
+ */
+export type ExportEntry =
+	| { readonly kind: 'local'; readonly localName: string }
+	| { readonly kind: 're-export'; readonly source: string; readonly importedName: string };
+
+/**
+ * A file's export surface, as extracted by {@link getExportTable}.
+ */
+export interface ExportTable {
+	/** Exported name (`'default'` for the default export) → where it comes from. */
+	readonly byName: ReadonlyMap<string, ExportEntry>;
+	/** Module specifiers of `export * from '...'` statements found in the file. */
+	readonly starReExportSources: readonly string[];
+}
+
+/**
+ * Extracts the export table from an already-parsed source file.
+ *
+ * @param source - The parsed TypeScript source file to inspect
+ * @returns The file's export table
+ */
+export function getExportTable(
+	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+	source: SourceFile,
+): ExportTable {
+	const byName = new Map<string, ExportEntry>();
+	const starReExportSources: string[] = [];
+
+	for (const node of source.statements) {
+		if (ts.isExportAssignment(node)) {
+			if (node.isExportEquals) {
+				continue;
+			}
+			const localName = ts.isIdentifier(node.expression) ? node.expression.text : undefined;
+			if (localName) {
+				byName.set('default', { kind: 'local', localName });
+			}
+			continue;
+		}
+
+		if (ts.isExportDeclaration(node)) {
+			collectExportDeclaration(node, byName, starReExportSources);
+			continue;
+		}
+
+		if (ts.isFunctionDeclaration(node) || ts.isClassDeclaration(node)) {
+			collectDeclarationWithModifiers(node, byName);
+			continue;
+		}
+
+		if (ts.isVariableStatement(node) && hasExportModifier(node)) {
+			for (const declaration of node.declarationList.declarations) {
+				if (ts.isIdentifier(declaration.name)) {
+					byName.set(declaration.name.text, { kind: 'local', localName: declaration.name.text });
+				}
+			}
+		}
+	}
+
+	return { byName, starReExportSources };
+}
+
+function collectExportDeclaration(
+	node: ts.ExportDeclaration,
+	byName: Map<string, ExportEntry>,
+	starReExportSources: string[],
+) {
+	const source =
+		node.moduleSpecifier && ts.isStringLiteral(node.moduleSpecifier) ? node.moduleSpecifier.text : undefined;
+
+	if (!node.exportClause) {
+		// `export * from './a'` — bare star re-export, no local module specifier means nothing to record
+		if (source) {
+			starReExportSources.push(source);
+		}
+		return;
+	}
+
+	if (ts.isNamespaceExport(node.exportClause)) {
+		// `export * as ns from './a'`
+		if (source) {
+			byName.set(node.exportClause.name.text, { kind: 're-export', source, importedName: '*' });
+		}
+		return;
+	}
+
+	for (const element of node.exportClause.elements) {
+		const exportedName = element.name.text;
+		const originalName = element.propertyName?.text ?? exportedName;
+
+		if (source) {
+			// `export { Item } from './a'` / `export { default as Item } from './a'`
+			byName.set(exportedName, { kind: 're-export', source, importedName: originalName });
+		} else {
+			// `export { Item }` / `export { Item as ListItem }` — re-exporting a local binding
+			byName.set(exportedName, { kind: 'local', localName: originalName });
+		}
+	}
+}
+
+function collectDeclarationWithModifiers(
+	node: ts.FunctionDeclaration | ts.ClassDeclaration,
+	byName: Map<string, ExportEntry>,
+) {
+	if (!hasExportModifier(node) || !node.name) {
+		return;
+	}
+
+	if (hasDefaultModifier(node)) {
+		byName.set('default', { kind: 'local', localName: node.name.text });
+		return;
+	}
+
+	byName.set(node.name.text, { kind: 'local', localName: node.name.text });
+}
+
+function hasExportModifier(
+	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+	node: ts.FunctionDeclaration | ts.ClassDeclaration | ts.VariableStatement,
+): boolean {
+	return (node.modifiers ?? []).some(modifier => modifier.kind === ts.SyntaxKind.ExportKeyword);
+}
+
+function hasDefaultModifier(
+	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+	node: ts.FunctionDeclaration | ts.ClassDeclaration,
+): boolean {
+	return (node.modifiers ?? []).some(modifier => modifier.kind === ts.SyntaxKind.DefaultKeyword);
+}

--- a/packages/@markuplint/pretenders/src/import-resolver/analyze-jsx-imports.spec.ts
+++ b/packages/@markuplint/pretenders/src/import-resolver/analyze-jsx-imports.spec.ts
@@ -1,0 +1,73 @@
+import { describe, test, expect } from 'vitest';
+
+import ts from 'typescript';
+
+import { collectImportBindings } from './analyze-jsx-imports.js';
+
+function sourceFile(code: string) {
+	return ts.createSourceFile('test.tsx', code, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+}
+
+describe('collectImportBindings', () => {
+	test('default import', () => {
+		const bindings = collectImportBindings(sourceFile("import Item from './a';"));
+		expect(bindings).toStrictEqual([
+			{ localName: 'Item', importedName: 'default', source: './a', type: 'default' },
+		]);
+	});
+
+	test('named import', () => {
+		const bindings = collectImportBindings(sourceFile("import { Item } from './a';"));
+		expect(bindings).toStrictEqual([{ localName: 'Item', importedName: 'Item', source: './a', type: 'named' }]);
+	});
+
+	test('named import with alias', () => {
+		const bindings = collectImportBindings(sourceFile("import { Item as ListItem } from './a';"));
+		expect(bindings).toStrictEqual([{ localName: 'ListItem', importedName: 'Item', source: './a', type: 'named' }]);
+	});
+
+	test('namespace import', () => {
+		const bindings = collectImportBindings(sourceFile("import * as NS from './a';"));
+		expect(bindings).toStrictEqual([{ localName: 'NS', importedName: '*', source: './a', type: 'namespace' }]);
+	});
+
+	test('default + named import', () => {
+		const bindings = collectImportBindings(sourceFile("import Item, { Other } from './a';"));
+		expect(bindings).toStrictEqual([
+			{ localName: 'Item', importedName: 'default', source: './a', type: 'default' },
+			{ localName: 'Other', importedName: 'Other', source: './a', type: 'named' },
+		]);
+	});
+
+	test('type-only import declaration is skipped entirely', () => {
+		const bindings = collectImportBindings(sourceFile("import type { Item } from './a';"));
+		expect(bindings).toStrictEqual([]);
+	});
+
+	test('inline type-only named specifier is skipped, siblings are kept', () => {
+		const bindings = collectImportBindings(sourceFile("import { type Item, Other } from './a';"));
+		expect(bindings).toStrictEqual([{ localName: 'Other', importedName: 'Other', source: './a', type: 'named' }]);
+	});
+
+	test('side-effect import contributes no bindings', () => {
+		const bindings = collectImportBindings(sourceFile("import './a';"));
+		expect(bindings).toStrictEqual([]);
+	});
+
+	test('extracts imports correctly even when the file also contains JSX syntax', () => {
+		// Regression guard: es-module-lexer (used elsewhere in this package) fails to
+		// parse TSX source containing JSX syntax; this AST-based extractor must not.
+		const bindings = collectImportBindings(
+			sourceFile("import { Item } from './a';\nexport const A = () => <Item>x</Item>;"),
+		);
+		expect(bindings).toStrictEqual([{ localName: 'Item', importedName: 'Item', source: './a', type: 'named' }]);
+	});
+
+	test('multiple import declarations are all collected', () => {
+		const bindings = collectImportBindings(sourceFile("import A from './a';\nimport { B } from './b';"));
+		expect(bindings).toStrictEqual([
+			{ localName: 'A', importedName: 'default', source: './a', type: 'default' },
+			{ localName: 'B', importedName: 'B', source: './b', type: 'named' },
+		]);
+	});
+});

--- a/packages/@markuplint/pretenders/src/import-resolver/analyze-jsx-imports.ts
+++ b/packages/@markuplint/pretenders/src/import-resolver/analyze-jsx-imports.ts
@@ -1,0 +1,114 @@
+/**
+ * @module analyze-jsx-imports
+ *
+ * Extracts import bindings from TSX/JSX (and plain TS/JS) source using the
+ * TypeScript AST directly, rather than es-module-lexer. es-module-lexer
+ * cannot parse source containing JSX syntax or non-standard TS constructs —
+ * it throws and {@link ../import-resolver/parse-imports.js} swallows that
+ * into an empty result — which would silently defeat import-based
+ * disambiguation for exactly the file kind this package spends most of its
+ * time scanning.
+ */
+
+import type { ImportBinding } from './types.js';
+import type { SourceFile } from 'typescript';
+
+import path from 'node:path';
+
+import ts from 'typescript';
+
+/**
+ * Collects all static import bindings declared at the top level of `source`.
+ * Type-only imports (`import type { ... }`) and their inline equivalents
+ * (`import { type X }`) are excluded, as are side-effect-only imports.
+ *
+ * @param source - The parsed TypeScript source file to inspect
+ * @returns The import bindings found at the top level of `source`
+ */
+export function collectImportBindings(
+	// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+	source: SourceFile,
+): ImportBinding[] {
+	const bindings: ImportBinding[] = [];
+
+	for (const node of source.statements) {
+		if (!ts.isImportDeclaration(node) || node.importClause?.isTypeOnly) {
+			continue;
+		}
+		if (!ts.isStringLiteral(node.moduleSpecifier)) {
+			continue;
+		}
+		const importClause = node.importClause;
+		if (!importClause) {
+			// Side-effect import: `import './a'`
+			continue;
+		}
+
+		const moduleSource = node.moduleSpecifier.text;
+
+		if (importClause.name) {
+			bindings.push({
+				localName: importClause.name.text,
+				importedName: 'default',
+				source: moduleSource,
+				type: 'default',
+			});
+		}
+
+		const namedBindings = importClause.namedBindings;
+		if (!namedBindings) {
+			continue;
+		}
+
+		if (ts.isNamespaceImport(namedBindings)) {
+			bindings.push({
+				localName: namedBindings.name.text,
+				importedName: '*',
+				source: moduleSource,
+				type: 'namespace',
+			});
+			continue;
+		}
+
+		for (const element of namedBindings.elements) {
+			if (element.isTypeOnly) {
+				continue;
+			}
+			bindings.push({
+				localName: element.name.text,
+				importedName: element.propertyName?.text ?? element.name.text,
+				source: moduleSource,
+				type: 'named',
+			});
+		}
+	}
+
+	return bindings;
+}
+
+/**
+ * Maps a file extension to the `ts.ScriptKind` needed to parse it correctly
+ * (in particular, `.tsx`/`.jsx` must be parsed with JSX syntax enabled).
+ *
+ * @param filePath - The file path whose extension determines the script kind
+ * @returns The `ts.ScriptKind` to parse `filePath` with
+ */
+export function scriptKindForPath(filePath: string): ts.ScriptKind {
+	const ext = path.extname(filePath).toLowerCase();
+	switch (ext) {
+		case '.tsx': {
+			return ts.ScriptKind.TSX;
+		}
+		case '.jsx': {
+			return ts.ScriptKind.JSX;
+		}
+		case '.js':
+		case '.mjs':
+		case '.cjs': {
+			return ts.ScriptKind.JS;
+		}
+		default: {
+			return ts.ScriptKind.TS;
+		}
+	}
+}

--- a/packages/@markuplint/pretenders/src/import-resolver/index.spec.ts
+++ b/packages/@markuplint/pretenders/src/import-resolver/index.spec.ts
@@ -267,14 +267,36 @@ import { Card } from './ui'
 		});
 	});
 
+	describe('JSX/TSX (issue #3951)', () => {
+		test('extracts imports from TSX source, including files that also contain JSX syntax', async () => {
+			const source = "import Item from './a';\nexport const A = () => <Item>x</Item>;";
+			const result = await analyzeImports('A.tsx', source);
+			expect(result).not.toBeNull();
+			expect(result!.bindings).toStrictEqual([
+				{ localName: 'Item', importedName: 'default', source: './a', type: 'default' },
+			]);
+		});
+
+		test('extracts imports from plain JS', async () => {
+			const result = await analyzeImports('a.js', "import { Item } from './b';");
+			expect(result).not.toBeNull();
+			expect(result!.bindings).toStrictEqual([
+				{ localName: 'Item', importedName: 'Item', source: './b', type: 'named' },
+			]);
+		});
+
+		test('extracts imports from plain TS', async () => {
+			const result = await analyzeImports('a.ts', "import { Item } from './b';");
+			expect(result).not.toBeNull();
+			expect(result!.bindings).toStrictEqual([
+				{ localName: 'Item', importedName: 'Item', source: './b', type: 'named' },
+			]);
+		});
+	});
+
 	describe('unsupported frameworks', () => {
 		test('returns null for .html files', async () => {
 			const result = await analyzeImports('page.html', '<div>hello</div>');
-			expect(result).toBeNull();
-		});
-
-		test('returns null for .tsx files', async () => {
-			const result = await analyzeImports('App.tsx', 'export default () => <div />');
 			expect(result).toBeNull();
 		});
 	});

--- a/packages/@markuplint/pretenders/src/import-resolver/index.ts
+++ b/packages/@markuplint/pretenders/src/import-resolver/index.ts
@@ -35,11 +35,15 @@ import type { ImportBinding, ImportAnalysisResult } from './types.js';
 
 import path from 'node:path';
 
+import ts from 'typescript';
+
 import { getScanner } from '../scanner-loader.js';
 
+import { collectImportBindings, scriptKindForPath } from './analyze-jsx-imports.js';
 import { extractVueScript, extractVueOptionsApiComponents, extractMdxEsm } from './extract-script-source.js';
 import { parseImports } from './parse-imports.js';
 export { resolveBarrelExport } from './resolve-barrel.js';
+export { collectImportBindings, scriptKindForPath } from './analyze-jsx-imports.js';
 
 export type { ImportBinding, ImportAnalysisResult } from './types.js';
 
@@ -47,15 +51,25 @@ export type { ImportBinding, ImportAnalysisResult } from './types.js';
  * Supported framework types for import analysis.
  * Superset of template scanner's framework types — includes MDX which
  * is a component usage site (not definition), making it relevant
- * for import analysis but not for template scanning.
+ * for import analysis but not for template scanning. `jsx` covers plain
+ * TS/JS source (including TSX/JSX), analyzed via the TypeScript AST instead
+ * of es-module-lexer, which fails to parse JSX syntax.
  */
-type ImportFrameworkType = 'vue' | 'svelte' | 'astro' | 'mdx';
+type ImportFrameworkType = 'vue' | 'svelte' | 'astro' | 'mdx' | 'jsx';
 
 const EXTENSION_MAP: Record<string, ImportFrameworkType> = {
 	'.vue': 'vue',
 	'.svelte': 'svelte',
 	'.astro': 'astro',
 	'.mdx': 'mdx',
+	'.js': 'jsx',
+	'.jsx': 'jsx',
+	'.ts': 'jsx',
+	'.tsx': 'jsx',
+	'.mjs': 'jsx',
+	'.cjs': 'jsx',
+	'.mts': 'jsx',
+	'.cts': 'jsx',
 };
 
 function getImportFrameworkType(filePath: string): ImportFrameworkType | null {
@@ -95,6 +109,17 @@ export async function analyzeImports(filePath: string, source: string): Promise<
 	const framework = getImportFrameworkType(filePath);
 	if (!framework) {
 		return null;
+	}
+
+	if (framework === 'jsx') {
+		const sourceFile = ts.createSourceFile(
+			filePath,
+			source,
+			ts.ScriptTarget.Latest,
+			true,
+			scriptKindForPath(filePath),
+		);
+		return { bindings: collectImportBindings(sourceFile) };
 	}
 
 	// Vue Options API requires special handling: extract regular <script>,

--- a/packages/@markuplint/pretenders/src/import-resolver/resolve-module-file.spec.ts
+++ b/packages/@markuplint/pretenders/src/import-resolver/resolve-module-file.spec.ts
@@ -1,0 +1,105 @@
+import fs from 'node:fs';
+import { writeFile, mkdir, mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { resolveModuleFile, normalizePath, clearModuleResolutionCaches } from './resolve-module-file.js';
+
+const fixtureDir = path.resolve(import.meta.dirname, '..', '..', 'test', 'fixtures', 'module-resolution');
+
+describe('resolveModuleFile', () => {
+	test('resolves a relative specifier to an absolute file path', () => {
+		const importer = path.resolve(fixtureDir, 'relative', 'importer.tsx');
+		const resolved = resolveModuleFile(importer, './a');
+		expect(resolved).toBe(normalizePath(path.resolve(fixtureDir, 'relative', 'a.tsx')));
+	});
+
+	test('resolves a tsconfig `paths` alias', () => {
+		const importer = path.resolve(fixtureDir, 'with-alias', 'src', 'pages', 'Page.tsx');
+		const resolved = resolveModuleFile(importer, '@/components/Button');
+		expect(resolved).toBe(normalizePath(path.resolve(fixtureDir, 'with-alias', 'src', 'components', 'Button.tsx')));
+	});
+
+	test('resolves a relative specifier pointing at a .vue file', () => {
+		const importer = path.resolve(fixtureDir, 'vue-relative', 'importer.tsx');
+		const resolved = resolveModuleFile(importer, './Button.vue');
+		expect(resolved).toBe(normalizePath(path.resolve(fixtureDir, 'vue-relative', 'Button.vue')));
+	});
+
+	test('returns null for a non-relative specifier that cannot be resolved', () => {
+		const importer = path.resolve(fixtureDir, 'relative', 'importer.tsx');
+		const resolved = resolveModuleFile(importer, 'nonexistent-package-xyz');
+		expect(resolved).toBeNull();
+	});
+
+	test('returns null for a relative specifier that does not resolve to any file', () => {
+		const importer = path.resolve(fixtureDir, 'relative', 'importer.tsx');
+		const resolved = resolveModuleFile(importer, './does-not-exist');
+		expect(resolved).toBeNull();
+	});
+});
+
+describe('module resolution cache invalidation (long-running processes)', () => {
+	let tmpDir: string;
+
+	beforeEach(async () => {
+		tmpDir = await mkdtemp(path.join(os.tmpdir(), 'resolve-module-file-cache-'));
+	});
+
+	afterEach(async () => {
+		await rm(tmpDir, { recursive: true, force: true });
+	});
+
+	test('clearModuleResolutionCaches() picks up a newly added tsconfig `paths` alias', async () => {
+		const tsconfigPath = path.join(tmpDir, 'tsconfig.json');
+		await writeFile(tsconfigPath, JSON.stringify({ compilerOptions: {} }));
+		await mkdir(path.join(tmpDir, 'src', 'components'), { recursive: true });
+		await writeFile(path.join(tmpDir, 'src', 'components', 'Button.tsx'), 'export const Button = () => null;');
+		const importer = path.join(tmpDir, 'src', 'pages', 'Page.tsx');
+		await mkdir(path.dirname(importer), { recursive: true });
+		await writeFile(importer, "import { Button } from '@/components/Button';");
+
+		// No alias defined yet — resolution fails.
+		expect(resolveModuleFile(importer, '@/components/Button')).toBeNull();
+
+		// Add the alias and re-resolve WITHOUT clearing the cache: the parsed
+		// tsconfig from before the edit is still used, so it keeps failing.
+		await writeFile(
+			tsconfigPath,
+			JSON.stringify({ compilerOptions: { baseUrl: '.', paths: { '@/*': ['src/*'] } } }),
+		);
+		expect(resolveModuleFile(importer, '@/components/Button')).toBeNull();
+
+		clearModuleResolutionCaches();
+
+		expect(resolveModuleFile(importer, '@/components/Button')).toBe(
+			normalizePath(path.join(tmpDir, 'src', 'components', 'Button.tsx')),
+		);
+	});
+});
+
+describe('Tier 1 (fatal) errors during the relative fallback file search', () => {
+	test('rethrows instead of swallowing a fatal error as "file not found"', () => {
+		const importer = path.resolve(fixtureDir, 'vue-relative', 'importer.tsx');
+		const spy = vi.spyOn(fs, 'statSync').mockImplementation(() => {
+			throw new TypeError('boom: implementation bug, not a missing file');
+		});
+		try {
+			expect(() => resolveModuleFile(importer, './Button.vue')).toThrow(TypeError);
+		} finally {
+			spy.mockRestore();
+		}
+	});
+});
+
+describe('normalizePath', () => {
+	test('converts backslashes to forward slashes', () => {
+		expect(normalizePath('foo\\bar\\baz.tsx')).toBe('foo/bar/baz.tsx');
+	});
+
+	test('leaves forward-slash paths untouched', () => {
+		expect(normalizePath('foo/bar/baz.tsx')).toBe('foo/bar/baz.tsx');
+	});
+});

--- a/packages/@markuplint/pretenders/src/import-resolver/resolve-module-file.ts
+++ b/packages/@markuplint/pretenders/src/import-resolver/resolve-module-file.ts
@@ -1,0 +1,158 @@
+/**
+ * @module resolve-module-file
+ *
+ * Resolves an import specifier used inside a component file to an absolute
+ * file path, using the TypeScript compiler's own module resolution so that
+ * relative specifiers, extension inference, `baseUrl`/`paths` aliases, and
+ * `node_modules` all behave exactly as they do for the TypeScript compiler
+ * itself. `tsconfig.json` discovery and parsing is cached per config file
+ * path, and module resolution results are cached per compiler options set.
+ *
+ * TypeScript has no knowledge of `.vue`/`.svelte`/`.astro` files, so relative
+ * specifiers that TypeScript fails to resolve fall back to a plain
+ * filesystem-based extension search.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { isFatalError } from '@markuplint/shared';
+import ts from 'typescript';
+
+const TEMPLATE_EXTENSIONS = ['.vue', '.svelte', '.astro'];
+const FALLBACK_EXTENSIONS = ['', '.tsx', '.ts', '.jsx', '.js', '.mjs', '.cjs', ...TEMPLATE_EXTENSIONS];
+const FALLBACK_INDEX_NAMES = ['index.tsx', 'index.ts', 'index.jsx', 'index.js', 'index.mjs', 'index.cjs'];
+
+const DEFAULT_COMPILER_OPTIONS: ts.CompilerOptions = {
+	allowJs: true,
+	jsx: ts.JsxEmit.ReactJSX,
+	moduleResolution: ts.ModuleResolutionKind.Bundler,
+	module: ts.ModuleKind.ESNext,
+};
+
+const parsedConfigCache = new Map<string, ts.ParsedCommandLine | null>();
+const moduleResolutionCacheByConfig = new Map<string, ts.ModuleResolutionCache>();
+
+/**
+ * Clears the module-level tsconfig/module-resolution caches. Neither cache
+ * expires on its own, so a long-running host (a watch-mode lint run, an
+ * editor extension) that keeps calling `resolveModuleFile()` across file
+ * edits must call this whenever it re-resolves without cache (e.g. after a
+ * file change) — otherwise an edited `tsconfig.json` (a new `paths` alias)
+ * or a newly created file that makes a previously-unresolvable specifier
+ * resolvable keeps using the stale parsed config / resolution result for
+ * the rest of the process's lifetime.
+ */
+export function clearModuleResolutionCaches() {
+	parsedConfigCache.clear();
+	moduleResolutionCacheByConfig.clear();
+}
+
+/**
+ * Converts backslashes to `/`, regardless of the current OS.
+ * TypeScript's own `sourceFile.fileName` is always slash-delimited, so all
+ * paths compared against it (or emitted for cross-platform-stable output)
+ * must go through this first. Using `path.sep` here would be a no-op on
+ * POSIX systems even when the input path was produced on Windows.
+ *
+ * @param filePath - The path to normalize
+ * @returns `filePath` with all backslashes replaced by forward slashes
+ */
+export function normalizePath(filePath: string): string {
+	return filePath.split('\\').join('/');
+}
+
+function getParsedConfig(importerDir: string): ts.ParsedCommandLine | null {
+	const configPath = ts.findConfigFile(importerDir, ts.sys.fileExists);
+	if (!configPath) {
+		return null;
+	}
+
+	const cached = parsedConfigCache.get(configPath);
+	if (cached !== undefined) {
+		return cached;
+	}
+
+	const configFile = ts.readConfigFile(configPath, ts.sys.readFile);
+	const parsed = configFile.error
+		? null
+		: ts.parseJsonConfigFileContent(configFile.config as unknown, ts.sys, path.dirname(configPath));
+	parsedConfigCache.set(configPath, parsed);
+	return parsed;
+}
+
+function getModuleResolutionCache(configPath: string, compilerOptions: ts.CompilerOptions): ts.ModuleResolutionCache {
+	let cache = moduleResolutionCacheByConfig.get(configPath);
+	if (!cache) {
+		cache = ts.createModuleResolutionCache(process.cwd(), s => s, compilerOptions);
+		moduleResolutionCacheByConfig.set(configPath, cache);
+	}
+	return cache;
+}
+
+/**
+ * Resolves a static import specifier found in `importerAbsPath` to an
+ * absolute file path.
+ *
+ * @param importerAbsPath - Absolute path of the file containing the import
+ * @param specifier - The module specifier text (e.g. `./Button`, `@/components/Button`)
+ * @returns The normalized (`/`-delimited) absolute path of the resolved file,
+ *          or `null` when resolution fails (e.g. a bare npm specifier with no
+ *          matching package, or a relative specifier with no matching file).
+ */
+export function resolveModuleFile(importerAbsPath: string, specifier: string): string | null {
+	const importerDir = path.dirname(importerAbsPath);
+	const configPath = ts.findConfigFile(importerDir, ts.sys.fileExists);
+	const parsedConfig = configPath ? getParsedConfig(importerDir) : null;
+	const compilerOptions = parsedConfig?.options ?? DEFAULT_COMPILER_OPTIONS;
+	const cache = getModuleResolutionCache(configPath ?? '__default__', compilerOptions);
+
+	const result = ts.resolveModuleName(specifier, importerAbsPath, compilerOptions, ts.sys, cache);
+	if (result.resolvedModule) {
+		return normalizePath(result.resolvedModule.resolvedFileName);
+	}
+
+	if (specifier.startsWith('.')) {
+		return resolveRelativeFallback(importerDir, specifier);
+	}
+
+	return null;
+}
+
+function resolveRelativeFallback(importerDir: string, specifier: string): string | null {
+	const base = path.resolve(importerDir, specifier);
+
+	for (const ext of FALLBACK_EXTENSIONS) {
+		const candidate = base + ext;
+		if (isFile(candidate)) {
+			return normalizePath(candidate);
+		}
+	}
+
+	for (const indexName of FALLBACK_INDEX_NAMES) {
+		const candidate = path.join(base, indexName);
+		if (isFile(candidate)) {
+			return normalizePath(candidate);
+		}
+	}
+
+	for (const ext of TEMPLATE_EXTENSIONS) {
+		const candidate = path.join(base, `index${ext}`);
+		if (isFile(candidate)) {
+			return normalizePath(candidate);
+		}
+	}
+
+	return null;
+}
+
+function isFile(candidate: string): boolean {
+	try {
+		return fs.statSync(candidate).isFile();
+	} catch (error) {
+		if (isFatalError(error)) {
+			throw error;
+		}
+		return false;
+	}
+}

--- a/packages/@markuplint/pretenders/src/index.spec.ts
+++ b/packages/@markuplint/pretenders/src/index.spec.ts
@@ -1,0 +1,42 @@
+import { writeFile, mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+
+import { clearPretenderCaches, jsxScanner } from './index.js';
+
+describe('clearPretenderCaches (long-running processes)', () => {
+	let tmpDir: string;
+
+	beforeEach(async () => {
+		tmpDir = await mkdtemp(path.join(os.tmpdir(), 'pretenders-clear-cache-'));
+	});
+
+	afterEach(async () => {
+		await rm(tmpDir, { recursive: true, force: true });
+	});
+
+	test('picks up a renamed default export across a re-scan', async () => {
+		const targetFile = path.join(tmpDir, 'target.tsx');
+		const importerFile = path.join(tmpDir, 'importer.tsx');
+		await writeFile(targetFile, 'export default function Item() { return <button>x</button>; }');
+		await writeFile(importerFile, "import Item from './target';\nexport const E = () => <Item>x</Item>;");
+
+		const before = await jsxScanner([targetFile, importerFile], { cwd: tmpDir });
+		expect(before.find(p => p.selector === 'E')?.as).toBe('button');
+
+		// Rename the default-exported declaration. Without cache invalidation,
+		// resolution keeps looking up the map key for the old local name
+		// ("Item"), which no longer exists after the rename, leaving `E`
+		// unresolved instead of picking up the new declaration.
+		await writeFile(targetFile, 'export default function Widget() { return <span>x</span>; }');
+		const stale = await jsxScanner([targetFile, importerFile], { cwd: tmpDir });
+		expect(stale.find(p => p.selector === 'E')?.as).toBe('Item');
+
+		clearPretenderCaches();
+
+		const fresh = await jsxScanner([targetFile, importerFile], { cwd: tmpDir });
+		expect(fresh.find(p => p.selector === 'E')?.as).toBe('span');
+	});
+});

--- a/packages/@markuplint/pretenders/src/index.ts
+++ b/packages/@markuplint/pretenders/src/index.ts
@@ -24,8 +24,28 @@
  * Dynamic imports (`import('./path')`) are included in bindings with `type: 'dynamic'`
  * and `localName: '*'` as a sentinel. Check `type === 'dynamic'` to distinguish from
  * namespace imports.
+ *
+ * ## Lint-time disambiguation
+ *
+ * - {@link disambiguatePretenders} — Given a flat pretender list and the file currently
+ *   being linted, resolves which of several same-selector candidates that file actually
+ *   refers to (via its own declarations or imports), so linting doesn't fall back to
+ *   whichever same-named component happened to be scanned first (see issue #3951).
+ *
+ * ## Caching
+ *
+ * - {@link clearPretenderCaches} — Clears the module-level caches that back import/export
+ *   resolution (module resolution, export tables). Neither cache expires on its own, so a
+ *   long-running host (watch mode, an editor extension) that re-resolves pretenders across
+ *   file edits must call this after each edit, or renamed exports and newly valid tsconfig
+ *   `paths` aliases keep resolving as they did before the change for the rest of the process.
  */
 
+import { clearExportTableCache } from './dependency-mapper.js';
+import { clearModuleResolutionCaches } from './import-resolver/resolve-module-file.js';
+
+export type { DisambiguateOptions } from './disambiguate.js';
+export { disambiguatePretenders } from './disambiguate.js';
 export { jsxScanner } from './jsx/index.js';
 export { templateScanner } from './template/index.js';
 export { scan } from './scan.js';
@@ -33,6 +53,15 @@ export type { ScanOptions } from './scan.js';
 export { analyzeImports, resolveComponentImport, resolveBarrelExport } from './import-resolver/index.js';
 export type { ImportBinding, ImportAnalysisResult } from './import-resolver/types.js';
 export type * from './types.js';
+
+/**
+ * Clears the module-level caches that back import/export resolution (see the
+ * module-level "Caching" section above for why a long-running host must call this).
+ */
+export function clearPretenderCaches() {
+	clearExportTableCache();
+	clearModuleResolutionCaches();
+}
 
 // Companion Module pattern types
 export type {

--- a/packages/@markuplint/pretenders/src/jsx/index.spec.ts
+++ b/packages/@markuplint/pretenders/src/jsx/index.spec.ts
@@ -218,4 +218,78 @@ describe('jsxScanner', () => {
 			},
 		]);
 	});
+
+	describe('name collision across files (issue #3951)', () => {
+		const collisionDir = path.resolve(testDir, 'collision');
+
+		test('components with the same name in different files resolve independently', async () => {
+			const result = await jsxScanner(
+				[path.resolve(collisionDir, 'a.tsx'), path.resolve(collisionDir, 'b.tsx')],
+				{ cwd: collisionDir },
+			);
+
+			const a = result.find(p => p.selector === 'A');
+			// B's own render root is <ul>, not <Item> (Item is nested inside it) — B itself
+			// doesn't chain to Item. What matters here is that the two `Item` pretenders
+			// below stay independent instead of one silently overwriting the other.
+			const b = result.find(p => p.selector === 'B');
+			const items = result.filter(p => p.selector === 'Item');
+			const itemFromA = items.find(p => p.filePath?.startsWith('a.tsx:'));
+			const itemFromB = items.find(p => p.filePath?.startsWith('b.tsx:'));
+
+			expect(items).toHaveLength(2);
+			expect(itemFromA).toMatchObject({
+				selector: 'Item',
+				as: { element: 'button', slots: true, inheritAttrs: true },
+			});
+			expect(itemFromB).toMatchObject({
+				selector: 'Item',
+				as: { element: 'li', slots: true, inheritAttrs: true },
+			});
+			expect(a).toMatchObject({
+				selector: 'A',
+				as: { element: 'button', slots: true, inheritAttrs: true },
+				_via: ['Item'],
+			});
+			expect(a?.filePath).toMatch(/^a\.tsx:/);
+			expect(b).toMatchObject({ selector: 'B', as: 'ul' });
+		});
+
+		test('a named import resolves to the actual declaration file, not the first-registered same-named one', async () => {
+			// b.tsx is listed first (and a.tsx is only pulled in transitively via c.tsx's
+			// import) so that, absent import-based resolution, the plain name index would
+			// register b.tsx's `Item` (li) first and resolve c.tsx's reference to it.
+			const result = await jsxScanner(
+				[path.resolve(collisionDir, 'b.tsx'), path.resolve(collisionDir, 'c.tsx')],
+				{
+					cwd: collisionDir,
+				},
+			);
+			const c = result.find(p => p.selector === 'C');
+			expect(c).toMatchObject({
+				selector: 'C',
+				as: { element: 'button', slots: true, inheritAttrs: true },
+				_via: ['Item'],
+			});
+			expect(c?.filePath).toMatch(/^a\.tsx:/);
+		});
+
+		test('a default import resolves via the target file export table, not the first-registered same-named one', async () => {
+			// f.tsx is listed first (and d.tsx is only pulled in transitively via e.tsx's
+			// import) so that, absent import-based resolution, the plain name index would
+			// register f.tsx's `Item` (div) first and resolve e.tsx's reference to it.
+			const result = await jsxScanner(
+				[path.resolve(collisionDir, 'f.tsx'), path.resolve(collisionDir, 'e.tsx')],
+				{
+					cwd: collisionDir,
+				},
+			);
+			const e = result.find(p => p.selector === 'E');
+			expect(e).toMatchObject({
+				selector: 'E',
+				as: { element: 'span', slots: true, inheritAttrs: true },
+				_via: ['Item'],
+			});
+		});
+	});
 });

--- a/packages/@markuplint/pretenders/src/jsx/index.spec.ts
+++ b/packages/@markuplint/pretenders/src/jsx/index.spec.ts
@@ -4,7 +4,9 @@ import { describe, test, expect } from 'vitest';
 
 import { jsxScanner } from './index.js';
 
-const _ = (filePath: string) => filePath.split('/').join(path.sep);
+// Scanners always emit `/`-delimited filePath now (for stable, cross-platform
+// JSON output), so this is a no-op — kept so call sites don't need touching.
+const _ = (filePath: string) => filePath;
 const testDir = path.resolve(import.meta.dirname, '..', '..', 'test', 'fixtures');
 
 describe('jsxScanner', () => {

--- a/packages/@markuplint/pretenders/src/jsx/index.ts
+++ b/packages/@markuplint/pretenders/src/jsx/index.ts
@@ -26,6 +26,8 @@ import { getPosition } from '@markuplint/parser-utils/location';
 import ts from 'typescript';
 
 import { createScanner } from '../create-scanner.js';
+import { collectImportBindings } from '../import-resolver/analyze-jsx-imports.js';
+import { normalizePath } from '../import-resolver/resolve-module-file.js';
 import { PretenderDirector } from '../pretender-director.js';
 
 import { createIdentity } from './create-identify.js';
@@ -101,6 +103,8 @@ export const jsxScanner = createScanner<PretenderScanJSXOptions>(
 
 		for (const sourceFile of program.getSourceFiles()) {
 			if (!sourceFile.isDeclarationFile) {
+				const relFilePath = normalizePath(path.relative(cwd, sourceFile.fileName));
+				director.addImports(relFilePath, collectImportBindings(sourceFile));
 				forEachChild(sourceFile, node => visit(node, sourceFile));
 			}
 		}
@@ -178,7 +182,7 @@ export const jsxScanner = createScanner<PretenderScanJSXOptions>(
 			line: number,
 			col: number,
 		) {
-			const filePath = path.relative(cwd, sourceFile.fileName);
+			const filePath = normalizePath(path.relative(cwd, sourceFile.fileName));
 			const find = finder(sourceFile);
 
 			find(root, isReturnStatement, node => {
@@ -379,7 +383,7 @@ export const jsxScanner = createScanner<PretenderScanJSXOptions>(
 			}
 		}
 
-		return Promise.resolve(director.getPretenders());
+		return Promise.resolve(director.getPretenders(cwd));
 	},
 );
 

--- a/packages/@markuplint/pretenders/src/out.spec.ts
+++ b/packages/@markuplint/pretenders/src/out.spec.ts
@@ -1,0 +1,69 @@
+import type { Pretender } from '@markuplint/ml-config';
+
+import { readFile, mkdir, mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, test, expect } from 'vitest';
+
+import { out } from './out.js';
+
+let tmpDir: string;
+
+beforeEach(async () => {
+	tmpDir = await mkdtemp(path.join(os.tmpdir(), 'pretenders-out-'));
+});
+
+afterEach(async () => {
+	await rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('out', () => {
+	test('rebases filePath to be relative to the output file location, not the scan cwd', async () => {
+		// Scan was run from `cwd`, so filePath is relative to it: `components/Button.tsx:1:6`.
+		// The output JSON is written one directory below `cwd` (`dist/pretenders.json`),
+		// so a consumer resolving filePath relative to the JSON's own location needs
+		// `../components/Button.tsx:1:6`, not the scan-time-relative path.
+		const cwd = path.join(tmpDir, 'project');
+		const outFile = path.join(cwd, 'dist', 'pretenders.json');
+		const data: Pretender[] = [{ selector: 'Button', as: 'button', filePath: 'components/Button.tsx:1:6' }];
+
+		await mkdir(path.dirname(outFile), { recursive: true });
+		await out(outFile, data, cwd);
+
+		const written = JSON.parse(await readFile(outFile, 'utf8'));
+		expect(written.data).toStrictEqual([
+			{ selector: 'Button', as: 'button', filePath: '../components/Button.tsx:1:6' },
+		]);
+	});
+
+	test('defaults to process.cwd() when no cwd is given (backward compat)', async () => {
+		const outFile = path.join(tmpDir, 'pretenders.json');
+		const data: Pretender[] = [{ selector: 'Button', as: 'button' }];
+
+		await out(outFile, data);
+
+		const written = JSON.parse(await readFile(outFile, 'utf8'));
+		expect(written.data).toStrictEqual([{ selector: 'Button', as: 'button' }]);
+	});
+
+	test('leaves entries without a filePath untouched', async () => {
+		const outFile = path.join(tmpDir, 'pretenders.json');
+		const data: Pretender[] = [{ selector: 'Button', as: 'button' }];
+
+		await out(outFile, data, tmpDir);
+
+		const written = JSON.parse(await readFile(outFile, 'utf8'));
+		expect(written.data).toStrictEqual([{ selector: 'Button', as: 'button' }]);
+	});
+
+	test('writes the package version', async () => {
+		const outFile = path.join(tmpDir, 'pretenders.json');
+
+		await out(outFile, []);
+
+		const written = JSON.parse(await readFile(outFile, 'utf8'));
+		expect(typeof written.version).toBe('string');
+		expect(written.version.length).toBeGreaterThan(0);
+	});
+});

--- a/packages/@markuplint/pretenders/src/out.ts
+++ b/packages/@markuplint/pretenders/src/out.ts
@@ -2,16 +2,39 @@ import type { Pretender, PretenderFileData } from '@markuplint/ml-config';
 
 import { writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
+import path from 'node:path';
+
+import { rebasePretenderFilePath } from '@markuplint/ml-config';
+
+import { normalizePath } from './import-resolver/resolve-module-file.js';
 
 const require = createRequire(import.meta.url);
 
-export async function out(filePath: string, data: readonly Pretender[]) {
+/**
+ * @param filePath - Where to write the pretenders JSON
+ * @param data - Discovered pretender mappings, each carrying a `filePath`
+ *   relative to `cwd` (the convention scanners use)
+ * @param cwd - Base directory `data`'s `filePath` values are relative to.
+ *   Defaults to `process.cwd()`, matching the scanners' own default.
+ */
+export async function out(filePath: string, data: readonly Pretender[], cwd: string = process.cwd()) {
+	const outputDir = path.dirname(path.resolve(filePath));
+	// `Pretender.filePath` is written by scanners relative to the scan-time `cwd`,
+	// which is almost never where the output JSON itself ends up living. Rebasing
+	// it here — relative to the JSON file's own location — is what lets a
+	// consumer resolve it later without needing to know the original scan cwd.
+	const rebasedData = data.map(pretender =>
+		rebasePretenderFilePath(pretender, relPath =>
+			normalizePath(path.relative(outputDir, path.resolve(cwd, relPath))),
+		),
+	);
+
 	await writeFile(
 		filePath,
 		JSON.stringify(
 			{
 				version: require('../package.json').version,
-				data,
+				data: rebasedData,
 			} satisfies PretenderFileData,
 			null,
 			2,

--- a/packages/@markuplint/pretenders/src/pretender-director.ts
+++ b/packages/@markuplint/pretenders/src/pretender-director.ts
@@ -1,8 +1,12 @@
+import type { ImportBinding } from './import-resolver/types.js';
 import type { Identifier, Identity, ImportPath } from './types.js';
 
 import { dependencyMapper } from './dependency-mapper.js';
 
-export type PretenderDirectorMap = Map<string, [identifier: Identifier, identity: Identity, filePath?: string]>;
+export type PretenderDirectorMap = Map<
+	string,
+	[identifier: Identifier, identity: Identity, filePath?: string, sourceFile?: string]
+>;
 
 /**
  * The internal map keys on import paths when available, falling back to
@@ -11,6 +15,7 @@ export type PretenderDirectorMap = Map<string, [identifier: Identifier, identity
 export class PretenderDirector {
 	#map: PretenderDirectorMap = new Map();
 	#nameIndex: Map<Identifier, string> = new Map();
+	#importsByFile: Map<string, readonly ImportBinding[]> = new Map();
 
 	/**
 	 * When the key (import path or identifier) is already registered, the call
@@ -30,14 +35,28 @@ export class PretenderDirector {
 			return;
 		}
 
-		this.#map.set(key, [identifier, identity, `${filePath}:${line}:${col}`]);
+		this.#map.set(key, [identifier, identity, `${filePath}:${line}:${col}`, filePath]);
 
 		if (!this.#nameIndex.has(identifier)) {
 			this.#nameIndex.set(identifier, key);
 		}
 	}
 
-	getPretenders() {
-		return dependencyMapper(this.#map, this.#nameIndex);
+	/**
+	 * Registers the import bindings found in `filePath`, so that
+	 * {@link dependencyMapper} can resolve a JSX/template reference to the
+	 * file it was actually imported from instead of guessing by name alone.
+	 */
+	addImports(filePath: string, bindings: readonly ImportBinding[]) {
+		this.#importsByFile.set(filePath, bindings);
+	}
+
+	/**
+	 * @param cwd - Base directory that the recorded `sourceFile` paths (and any
+	 *   module resolution triggered while chasing an import) are relative to.
+	 *   Must match the `cwd` the scanner itself used to build those paths.
+	 */
+	getPretenders(cwd?: string) {
+		return dependencyMapper(this.#map, this.#nameIndex, { importsByFile: this.#importsByFile, cwd });
 	}
 }

--- a/packages/@markuplint/pretenders/src/scan.spec.ts
+++ b/packages/@markuplint/pretenders/src/scan.spec.ts
@@ -6,7 +6,9 @@ import { jsxScanner } from './jsx/index.js';
 import { scan } from './scan.js';
 import { templateScanner } from './template/index.js';
 
-const _ = (filePath: string) => filePath.split('/').join(path.sep);
+// Scanners always emit `/`-delimited filePath now (for stable, cross-platform
+// JSON output), so this is a no-op — kept so call sites don't need touching.
+const _ = (filePath: string) => filePath;
 const fixtureDir = path.resolve(import.meta.dirname, '..', 'test', 'fixtures');
 const jsxFixture = (name: string) => path.resolve(fixtureDir, name);
 const templateFixture = (name: string) => path.resolve(fixtureDir, 'template', name);

--- a/packages/@markuplint/pretenders/src/template/index.spec.ts
+++ b/packages/@markuplint/pretenders/src/template/index.spec.ts
@@ -182,6 +182,25 @@ describe('templateScanner', () => {
 		});
 	});
 
+	describe('Name collision resolved via import (issue #3951)', () => {
+		test('a wrapper component resolves its imported child to the file it actually imports, not a same-named sibling', async () => {
+			// subB/Button.vue is scanned first (and subA/Button.vue only appears after
+			// the wrapper) so that, absent import-based resolution, the plain name index
+			// would register subB's `Button` (div) first and resolve the wrapper's
+			// reference to it instead of the file it actually imports.
+			const result = await templateScanner([
+				resolve('subB/Button.vue'),
+				resolve('collision/wrapper-uses-a.vue'),
+				resolve('subA/Button.vue'),
+			]);
+
+			const wrapper = result.find(p => p.selector === 'WrapperUsesA');
+			expect(wrapper).toMatchObject({
+				as: expect.objectContaining({ element: 'button' }),
+			});
+		});
+	});
+
 	describe('Edge cases', () => {
 		test('rejects relative file paths', () => {
 			expect(() => templateScanner(['relative/path.vue'])).toThrow(ReferenceError);

--- a/packages/@markuplint/pretenders/src/template/index.spec.ts
+++ b/packages/@markuplint/pretenders/src/template/index.spec.ts
@@ -4,7 +4,9 @@ import { describe, test, expect } from 'vitest';
 
 import { templateScanner } from './index.js';
 
-const _ = (filePath: string) => filePath.split('/').join(path.sep);
+// Scanners always emit `/`-delimited filePath now (for stable, cross-platform
+// JSON output), so this is a no-op — kept so call sites don't need touching.
+const _ = (filePath: string) => filePath;
 const fixtureDir = path.resolve(import.meta.dirname, '..', '..', 'test', 'fixtures', 'template');
 const resolve = (name: string) => path.resolve(fixtureDir, name);
 

--- a/packages/@markuplint/pretenders/src/template/index.ts
+++ b/packages/@markuplint/pretenders/src/template/index.ts
@@ -5,6 +5,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import { createScanner } from '../create-scanner.js';
+import { analyzeImports } from '../import-resolver/index.js';
+import { normalizePath } from '../import-resolver/resolve-module-file.js';
 import { PretenderDirector } from '../pretender-director.js';
 import { getScanner } from '../scanner-loader.js';
 
@@ -53,7 +55,7 @@ export const templateScanner = createScanner<PretenderScanTemplateOptions>(async
 			continue;
 		}
 
-		const relFilePath = path.relative(cwd, filePath);
+		const relFilePath = normalizePath(path.relative(cwd, filePath));
 
 		const attrs: readonly PretenderAttr[] = scan.attrs.map(a =>
 			a.value === undefined ? { name: a.name } : { name: a.name, value: a.value },
@@ -69,7 +71,12 @@ export const templateScanner = createScanner<PretenderScanTemplateOptions>(async
 				: scan.rootElement;
 
 		director.add(componentName, identity, relFilePath, scan.line ?? 1, scan.col ?? 1, relFilePath);
+
+		const importAnalysis = await analyzeImports(filePath, sourceCode);
+		if (importAnalysis) {
+			director.addImports(relFilePath, importAnalysis.bindings);
+		}
 	}
 
-	return director.getPretenders();
+	return director.getPretenders(cwd);
 });

--- a/packages/@markuplint/pretenders/test/fixtures/collision/a.tsx
+++ b/packages/@markuplint/pretenders/test/fixtures/collision/a.tsx
@@ -1,0 +1,4 @@
+import { styled } from '@linaria/react';
+
+export const Item = styled.button``;
+export const A = () => <Item>x</Item>;

--- a/packages/@markuplint/pretenders/test/fixtures/collision/b.tsx
+++ b/packages/@markuplint/pretenders/test/fixtures/collision/b.tsx
@@ -1,0 +1,8 @@
+import { styled } from '@linaria/react';
+
+export const Item = styled.li``;
+export const B = () => (
+	<ul>
+		<Item>y</Item>
+	</ul>
+);

--- a/packages/@markuplint/pretenders/test/fixtures/collision/c.tsx
+++ b/packages/@markuplint/pretenders/test/fixtures/collision/c.tsx
@@ -1,0 +1,3 @@
+import { Item } from './a';
+
+export const C = () => <Item>z</Item>;

--- a/packages/@markuplint/pretenders/test/fixtures/collision/d.tsx
+++ b/packages/@markuplint/pretenders/test/fixtures/collision/d.tsx
@@ -1,0 +1,5 @@
+import { styled } from '@linaria/react';
+
+const Item = styled.span``;
+
+export default Item;

--- a/packages/@markuplint/pretenders/test/fixtures/collision/e.tsx
+++ b/packages/@markuplint/pretenders/test/fixtures/collision/e.tsx
@@ -1,0 +1,3 @@
+import Item from './d';
+
+export const E = () => <Item>w</Item>;

--- a/packages/@markuplint/pretenders/test/fixtures/collision/f.tsx
+++ b/packages/@markuplint/pretenders/test/fixtures/collision/f.tsx
@@ -1,0 +1,1 @@
+export const Item = () => <div />;

--- a/packages/@markuplint/pretenders/test/fixtures/dependency-mapper/a.tsx
+++ b/packages/@markuplint/pretenders/test/fixtures/dependency-mapper/a.tsx
@@ -1,0 +1,1 @@
+export const Item = () => null;

--- a/packages/@markuplint/pretenders/test/fixtures/dependency-mapper/c.tsx
+++ b/packages/@markuplint/pretenders/test/fixtures/dependency-mapper/c.tsx
@@ -1,0 +1,3 @@
+import { Item } from './a';
+
+export const C = () => <Item>x</Item>;

--- a/packages/@markuplint/pretenders/test/fixtures/dependency-mapper/d.tsx
+++ b/packages/@markuplint/pretenders/test/fixtures/dependency-mapper/d.tsx
@@ -1,0 +1,3 @@
+export default function Item() {
+	return null;
+}

--- a/packages/@markuplint/pretenders/test/fixtures/dependency-mapper/e.tsx
+++ b/packages/@markuplint/pretenders/test/fixtures/dependency-mapper/e.tsx
@@ -1,0 +1,3 @@
+import Item from './d';
+
+export const E = () => <Item>x</Item>;

--- a/packages/@markuplint/pretenders/test/fixtures/dependency-mapper/wrapper-a.tsx
+++ b/packages/@markuplint/pretenders/test/fixtures/dependency-mapper/wrapper-a.tsx
@@ -1,0 +1,2 @@
+export const Base = () => null;
+export const Wrapper = () => <Base>x</Base>;

--- a/packages/@markuplint/pretenders/test/fixtures/dependency-mapper/wrapper-b.tsx
+++ b/packages/@markuplint/pretenders/test/fixtures/dependency-mapper/wrapper-b.tsx
@@ -1,0 +1,3 @@
+import { Wrapper } from './wrapper-a';
+
+export const Outer = () => <Wrapper>x</Wrapper>;

--- a/packages/@markuplint/pretenders/test/fixtures/module-resolution/relative/a.tsx
+++ b/packages/@markuplint/pretenders/test/fixtures/module-resolution/relative/a.tsx
@@ -1,0 +1,1 @@
+export const Item = () => null;

--- a/packages/@markuplint/pretenders/test/fixtures/module-resolution/relative/importer.tsx
+++ b/packages/@markuplint/pretenders/test/fixtures/module-resolution/relative/importer.tsx
@@ -1,0 +1,3 @@
+import { Item } from './a';
+
+export const Consumer = () => <Item />;

--- a/packages/@markuplint/pretenders/test/fixtures/module-resolution/vue-relative/Button.vue
+++ b/packages/@markuplint/pretenders/test/fixtures/module-resolution/vue-relative/Button.vue
@@ -1,0 +1,3 @@
+<template>
+	<button><slot /></button>
+</template>

--- a/packages/@markuplint/pretenders/test/fixtures/module-resolution/vue-relative/importer.tsx
+++ b/packages/@markuplint/pretenders/test/fixtures/module-resolution/vue-relative/importer.tsx
@@ -1,0 +1,3 @@
+import Button from './Button.vue';
+
+export const Consumer = () => <Button />;

--- a/packages/@markuplint/pretenders/test/fixtures/module-resolution/with-alias/src/components/Button.tsx
+++ b/packages/@markuplint/pretenders/test/fixtures/module-resolution/with-alias/src/components/Button.tsx
@@ -1,0 +1,1 @@
+export const Button = () => null;

--- a/packages/@markuplint/pretenders/test/fixtures/module-resolution/with-alias/src/pages/Page.tsx
+++ b/packages/@markuplint/pretenders/test/fixtures/module-resolution/with-alias/src/pages/Page.tsx
@@ -1,0 +1,3 @@
+import { Button } from '@/components/Button';
+
+export const Page = () => <Button />;

--- a/packages/@markuplint/pretenders/test/fixtures/module-resolution/with-alias/tsconfig.json
+++ b/packages/@markuplint/pretenders/test/fixtures/module-resolution/with-alias/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"compilerOptions": {
+		"baseUrl": ".",
+		"paths": {
+			"@/*": ["src/*"]
+		}
+	}
+}

--- a/packages/@markuplint/pretenders/test/fixtures/template/collision/wrapper-uses-a.vue
+++ b/packages/@markuplint/pretenders/test/fixtures/template/collision/wrapper-uses-a.vue
@@ -1,0 +1,7 @@
+<script setup>
+import Button from '../subA/Button.vue';
+</script>
+
+<template>
+	<Button />
+</template>

--- a/packages/markuplint/src/api/ml-engine.spec.ts
+++ b/packages/markuplint/src/api/ml-engine.spec.ts
@@ -2,6 +2,7 @@ import type { ConfigSet } from '@markuplint/file-resolver';
 import type { Violation } from '@markuplint/ml-config';
 
 import fs from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
 
 import { describe, it, expect } from 'vitest';
@@ -71,6 +72,73 @@ describe('Watcher', () => {
 		expect(result1st?.violations.length).toBe(6);
 		expect(result2nd.length).toBe(5);
 		return;
+	});
+
+	it('re-resolving config also invalidates pretenders resolution caches (issue #3951 follow-up)', async () => {
+		// Without invalidating @markuplint/pretenders' own module-level caches on
+		// every cache-busting re-resolve, a renamed export a wrapper component
+		// depends on would keep resolving as it did before the rename for the
+		// rest of the process's lifetime — this exercises that wiring end to end.
+		const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ml-engine-pretenders-cache-'));
+		try {
+			const targetFile = path.join(tmpDir, 'target.tsx');
+			const importerFile = path.join(tmpDir, 'importer.tsx');
+			const pageFile = path.join(tmpDir, 'page.tsx');
+			const configFile = path.join(tmpDir, '.markuplintrc');
+
+			await fs.writeFile(targetFile, 'export default function Item() { return <button>x</button>; }');
+			await fs.writeFile(
+				importerFile,
+				"import Item from './target';\nexport const Wrapper = () => <Item>x</Item>;",
+			);
+			await fs.writeFile(
+				pageFile,
+				"import { Wrapper } from './importer';\nexport const Page = () => <ul><Wrapper>content</Wrapper></ul>;",
+			);
+			const config = {
+				parser: { '\\.tsx$': '@markuplint/jsx-parser' },
+				pretenders: { scan: [{ files: ['target.tsx', 'importer.tsx'] }] },
+				rules: { 'permitted-contents': true },
+			};
+			await fs.writeFile(configFile, JSON.stringify(config));
+
+			const file = await MLEngine.toMLFile(pageFile);
+			const engine = new MLEngine(file!, { watch: true });
+
+			// `Wrapper` resolves through `Item` to <button>, which isn't allowed
+			// directly inside <ul> — this must report a permitted-contents violation
+			// naming "button" as the disallowed element.
+			const result1st = await engine.exec();
+			expect(
+				result1st?.violations.some(v => v.ruleId === 'permitted-contents' && v.message.includes('button')),
+			).toBe(true);
+
+			// Rename the default export the wrapper depends on (element unchanged).
+			await fs.writeFile(targetFile, 'export default function Widget() { return <button>x</button>; }');
+
+			const lintPromise = new Promise<readonly Violation[]>(resolve => {
+				engine.on('lint', (_, __, violations) => resolve(violations));
+			});
+			// Touch the config file (no semantic change) to trigger the watcher's
+			// cache-busting re-resolve, which must also invalidate the pretenders caches.
+			await fs.writeFile(configFile, JSON.stringify(config));
+			const violations2nd = await lintPromise;
+
+			await engine.close();
+
+			// If the pretenders caches were NOT invalidated, `Wrapper` would still
+			// resolve `Item`'s stale export-table entry, fail to find the renamed
+			// declaration, and stay unresolved — reported as a disallowed "Item"
+			// element instead of "button". Asserting on the element name (not just
+			// the rule ID) is what actually distinguishes the fixed behavior from
+			// the regression.
+			expect(violations2nd.some(v => v.ruleId === 'permitted-contents' && v.message.includes('button'))).toBe(
+				true,
+			);
+			expect(violations2nd.some(v => v.message.includes('Item'))).toBe(false);
+		} finally {
+			await fs.rm(tmpDir, { recursive: true, force: true });
+		}
 	});
 });
 

--- a/packages/markuplint/src/api/ml-engine.ts
+++ b/packages/markuplint/src/api/ml-engine.ts
@@ -6,6 +6,8 @@ import type { Ruleset, Plugin, Document, RuleConfigValue, MLFabric } from '@mark
 
 import {
 	ConfigProvider,
+	disambiguatePretendersForFile,
+	invalidatePretenderResolutionCaches,
 	resolveFiles,
 	resolveParser,
 	resolvePretenders,
@@ -329,7 +331,7 @@ export class MLEngine extends Emitter<MLEngineEventMap> {
 			...this.#options?.severity,
 		};
 
-		const pretenders = await this.#resolvePretenders(configSet);
+		const pretenders = await this.#resolvePretenders(configSet, cache);
 		fileLog('Resolved pretenders: %O', pretenders);
 
 		const ruleset = this.#resolveRuleset(configSet);
@@ -453,10 +455,20 @@ export class MLEngine extends Emitter<MLEngineEventMap> {
 	async #resolvePretenders(
 		// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
 		configSet: ConfigSet,
+		cache: boolean,
 	) {
+		if (!cache) {
+			// A cache-busting re-resolve (e.g. watch mode after a file change) must also
+			// invalidate `@markuplint/pretenders`' own module-level resolution caches —
+			// otherwise a renamed export or a newly valid tsconfig `paths` alias keeps
+			// resolving as it did before the change for the rest of the process's lifetime.
+			await invalidatePretenderResolutionCaches();
+		}
 		const pretenders = await resolvePretenders(configSet.config.pretenders);
-		fileLog('Resolved pretenders: %O', pretenders);
-		return pretenders;
+		const sourceCode = await this.#file.getCode();
+		const disambiguated = await disambiguatePretendersForFile(this.#file.path, sourceCode, pretenders);
+		fileLog('Resolved pretenders: %O', disambiguated);
+		return disambiguated;
 	}
 
 	async #resolveRules(plugins: readonly Plugin[], ruleset: Ruleset) {

--- a/packages/markuplint/src/pretenders-scan.spec.ts
+++ b/packages/markuplint/src/pretenders-scan.spec.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { describe, test, expect } from 'vitest';
 
 import { setGlobal } from './global-settings.js';
-import { mlTest } from './testing-tool/index.js';
+import { mlTest, mlTestFile } from './testing-tool/index.js';
 
 setGlobal({
 	locale: 'en',
@@ -243,6 +243,62 @@ describe('pretenders.scan integration', () => {
 
 			// Recognized: <button> is valid inside <div>, no violations
 			expect(recognizedViolations.filter(v => v.ruleId === 'permitted-contents')).toStrictEqual([]);
+		});
+	});
+
+	describe('lint-time disambiguation of same-named components (issue #3951)', () => {
+		const collisionDir = path.resolve(jsxFixturesDir, 'collision');
+		const jsxParserConfig = { parser: { '\\.tsx$': '@markuplint/jsx-parser' } };
+
+		test('linting b.tsx resolves its own Item to <li>, not the first-scanned a.tsx Item (<button>)', async () => {
+			// b.tsx: `export const Item = styled.li\`\`; export const B = () => <ul><Item>y</Item></ul>;`
+			// <li> is valid inside <ul>. Before the fix, the scan-order-first `Item` (a.tsx's
+			// <button>) would win regardless of which file is being linted, and <button> is
+			// NOT valid directly inside <ul> — so this would report a permitted-contents violation.
+			const { violations } = await mlTestFile(path.join(collisionDir, 'b.tsx'), {
+				...jsxParserConfig,
+				pretenders: {
+					scan: [{ files: [path.join(collisionDir, 'a.tsx'), path.join(collisionDir, 'b.tsx')] }],
+				},
+				rules: {
+					'permitted-contents': true,
+				},
+			});
+			expect(violations.filter(v => v.ruleId === 'permitted-contents')).toStrictEqual([]);
+		});
+
+		test('linting a.tsx still resolves its own Item to <button>', async () => {
+			const { violations } = await mlTestFile(path.join(collisionDir, 'a.tsx'), {
+				...jsxParserConfig,
+				pretenders: {
+					scan: [{ files: [path.join(collisionDir, 'a.tsx'), path.join(collisionDir, 'b.tsx')] }],
+				},
+				rules: {
+					'permitted-contents': true,
+				},
+			});
+			// <button> is valid content on its own (not nested inside another interactive
+			// element here), so no permitted-contents violation is expected either way —
+			// this asserts the other side of the collision didn't regress.
+			expect(violations.filter(v => v.ruleId === 'permitted-contents')).toStrictEqual([]);
+		});
+
+		test('mlTest (inline source, no real file path) falls back to the pre-existing behavior without throwing', async () => {
+			// With no real file path to resolve imports against, disambiguation can't
+			// confirm a winner and must leave the pretender list untouched — this must
+			// not throw or otherwise break linting.
+			const { violations } = await mlTest('<div><Item></Item></div>', {
+				pretenders: {
+					data: [
+						{ selector: 'Item', as: 'button', filePath: path.join(collisionDir, 'a.tsx') + ':2:14' },
+						{ selector: 'Item', as: 'li', filePath: path.join(collisionDir, 'b.tsx') + ':2:14' },
+					],
+				},
+				rules: {
+					'permitted-contents': true,
+				},
+			});
+			expect(violations.filter(v => v.ruleId === 'permitted-contents')).toStrictEqual([]);
 		});
 	});
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2424,6 +2424,7 @@ __metadata:
     "@markuplint/ml-ast": "npm:5.0.0-rc.4"
     "@markuplint/ml-config": "npm:5.0.0-rc.4"
     "@markuplint/parser-utils": "npm:5.0.0-rc.4"
+    "@markuplint/shared": "npm:5.0.0-rc.4"
     "@markuplint/svelte-parser": "npm:5.0.0-rc.4"
     "@markuplint/vue-parser": "npm:5.0.0-rc.4"
     es-module-lexer: "npm:2.0.0"


### PR DESCRIPTION
## Summary

Fixes #3951: components with the same name declared in different files (e.g. two unrelated `Item` components rendering different elements) collided — both at generation time (chain resolution silently resolved to whichever same-named component was scanned first) and at lint time (`MLElement.pretending()` matches by CSS selector alone, with no file context).

- **Generation**: `dependencyMapper()` now resolves each chain hop through, in order: a same-file local declaration, then the file's recorded import bindings (via TypeScript module resolution and the target file's export table), falling back to the legacy name index only when neither confirms a candidate.
- **Lint time**: new `disambiguatePretenders` applies the same file-context resolution to the file actually being linted, wired up automatically through `file-resolver`'s config resolution.
- **Watch mode**: the new import/export resolution caches are invalidated whenever a lint host re-resolves without cache, so renamed exports and newly valid tsconfig `paths` aliases are picked up instead of resolving stale for the rest of the process's lifetime.
- Also fixes an unrelated existing bug found while testing the above: `MLCore.update()` silently dropped `pretenders` from the fabric it applied, so watch-mode re-resolves never updated pretender mappings at all.

All fallback paths are non-regressive: when a reference can't be confirmed, the previous first-match behavior is preserved rather than producing a new failure mode.

## Test plan

- [x] `yarn lint-check`
- [x] `yarn build`
- [x] `yarn test` (4473 tests, TDD red→green throughout, including a temporarily-disabled-then-restored e2e check to confirm the watch-mode test actually catches the regression)
- [x] Manually reproduced the issue's `a.tsx`/`b.tsx` scenario via the CLI before/after the fix