### PR TITLE
fix(rules): keep transparent element itself in parent content-model check

### DIFF
--- a/packages/@markuplint/rules/src/permitted-contents/README.ja.md
+++ b/packages/@markuplint/rules/src/permitted-contents/README.ja.md
@@ -41,6 +41,12 @@ description: HTML要素のコンテンツモデルと構造的な制約を検証
 		<header>許可されていないネストされたheader</header>
 	</div>
 </header>
+
+<!-- button要素はインタラクティブコンテンツの子孫を許可しない。a[href]は、
+     a要素自体がtransparentなコンテンツモデルであってもインタラクティブコンテンツになる -->
+<button>
+	<a href="/path"><span>許可されていないインタラクティブコンテンツ</span></a>
+</button>
 ```
 <!-- prettier-ignore-end -->
 
@@ -62,6 +68,10 @@ description: HTML要素のコンテンツモデルと構造的な制約を検証
 <header>
 	<nav>ナビゲーション</nav>
 </header>
+
+<button>
+	<a>href属性がないため、インタラクティブコンテンツにならない</a>
+</button>
 ```
 <!-- prettier-ignore-end -->
 

--- a/packages/@markuplint/rules/src/permitted-contents/README.md
+++ b/packages/@markuplint/rules/src/permitted-contents/README.md
@@ -38,6 +38,12 @@ It is possible to make the structure robust by setting element relationships on 
 		<header>Not allowed nested header</header>
 	</div>
 </header>
+
+<!-- button disallows interactive content descendants; a[href] is interactive
+     content even though <a> itself has a transparent content model -->
+<button>
+	<a href="/path"><span>Not allowed interactive content</span></a>
+</button>
 ```
 <!-- prettier-ignore-end -->
 
@@ -59,6 +65,10 @@ It is possible to make the structure robust by setting element relationships on 
 <header>
 	<nav>Navigation</nav>
 </header>
+
+<button>
+	<a>Non-interactive because it has no href attribute</a>
+</button>
 ```
 <!-- prettier-ignore-end -->
 

--- a/packages/@markuplint/rules/src/permitted-contents/index.spec.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/index.spec.ts
@@ -2414,6 +2414,113 @@ describe('Issues', () => {
 			(await mlRuleTest(rule, '<dl><div><dt>a</dt><dt>b</dt><dd>c</dd><dd>d</dd></div></dl>')).violations,
 		).toStrictEqual([]);
 	});
+
+	// #3928: a transparent-content-model element (e.g. <a>, <audio>, <ins>) must
+	// still be evaluated against the parent's own content model at its own
+	// position — the transparent flattening that lets its children pass through
+	// must not make the element itself disappear from that check.
+	test('[permitted-contents-issue-3928-001] a[href] (interactive) directly inside button is invalid', async () => {
+		const { violations } = await mlRuleTest(rule, '<button><a href="/x"><span>text</span></a></button>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 9,
+				raw: '<a href="/x">',
+				message: 'The "a" element is not allowed in the "button" element in this context',
+			},
+		]);
+	});
+
+	test('[permitted-contents-issue-3928-002] audio[controls] (interactive) directly inside button is invalid', async () => {
+		const { violations } = await mlRuleTest(rule, '<button><audio controls></audio></button>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 9,
+				raw: '<audio controls>',
+				message: 'The "audio" element is not allowed in the "button" element in this context',
+			},
+		]);
+	});
+
+	test('[permitted-contents-issue-3928-003] video directly inside picture is invalid', async () => {
+		const { violations } = await mlRuleTest(rule, '<picture><video></video><img src="x" alt=""></picture>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 1,
+				raw: '<picture>',
+				message: 'Require an element. (Need "img")',
+			},
+		]);
+	});
+
+	test('[permitted-contents-issue-3928-004] audio directly inside picture is invalid', async () => {
+		const { violations } = await mlRuleTest(rule, '<picture><audio></audio><img src="x" alt=""></picture>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 1,
+				raw: '<picture>',
+				message: 'Require an element. (Need "img")',
+			},
+		]);
+	});
+
+	test('[permitted-contents-issue-3928-005] canvas directly inside picture is invalid', async () => {
+		const { violations } = await mlRuleTest(rule, '<picture><canvas></canvas><img src="x" alt=""></picture>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 1,
+				raw: '<picture>',
+				message: 'Require an element. (Need "img")',
+			},
+		]);
+	});
+
+	test('[permitted-contents-issue-3928-006] a wrapping img directly inside picture is invalid', async () => {
+		const { violations } = await mlRuleTest(rule, '<picture><a><img src="x" alt=""></a></picture>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 1,
+				raw: '<picture>',
+				message: 'Require an element. (Need "img")',
+			},
+		]);
+	});
+
+	test('[permitted-contents-issue-3928-007] ins directly inside picture is invalid', async () => {
+		const { violations } = await mlRuleTest(rule, '<picture><ins></ins><img src="x" alt=""></picture>');
+		expect(violations).toStrictEqual([
+			{
+				severity: 'error',
+				line: 1,
+				col: 1,
+				raw: '<picture>',
+				message: 'Require an element. (Need "img")',
+			},
+		]);
+	});
+
+	test('[permitted-contents-issue-3928-008] non-interactive a inside button stays valid', async () => {
+		// <a> without href is not interactive content, so it remains permitted
+		// phrasing content — the fix must not flag benign transparent usage.
+		const { violations } = await mlRuleTest(rule, '<button><a>text</a></button>');
+		expect(violations).toStrictEqual([]);
+	});
+
+	test('[permitted-contents-issue-3928-009] a[href] wrapping phrasing content inside p stays valid', async () => {
+		const { violations } = await mlRuleTest(rule, '<p><a href="#">text</a></p>');
+		expect(violations).toStrictEqual([]);
+	});
 });
 
 describe('#3739 (pretender + user tag rule)', () => {

--- a/packages/@markuplint/rules/src/permitted-contents/represent-transparent-nodes.spec.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/represent-transparent-nodes.spec.ts
@@ -40,29 +40,31 @@ test('[permitted-contents-invalid-001] <div>', () => {
 });
 
 test('[permitted-contents-invalid-002] <audio>', () => {
-	expect(c('<audio></audio>')).toStrictEqual([[]]);
-	expect(c('<audio><span></span></audio>')).toStrictEqual([['span*']]);
-	expect(c('<audio><source></source><span></span></audio>')).toStrictEqual([['span*']]);
-	expect(c('<audio><source></source><track></track><span></span></audio>')).toStrictEqual([['span*']]);
+	// The transparent element itself is kept in the flattened list (#3928) so
+	// the parent's content model can still evaluate its own placement.
+	expect(c('<audio></audio>')).toStrictEqual([['audio']]);
+	expect(c('<audio><span></span></audio>')).toStrictEqual([['audio', 'span*']]);
+	expect(c('<audio><source></source><span></span></audio>')).toStrictEqual([['audio', 'span*']]);
+	expect(c('<audio><source></source><track></track><span></span></audio>')).toStrictEqual([['audio', 'span*']]);
 });
 
 describe('non-conditional mode', () => {
 	test('[permitted-contents-invalid-003] <a> with multiple children produces single pattern', () => {
 		const result = c('<a><span></span><em></em></a>', false);
-		expect(result).toStrictEqual([['span*', 'em*']]);
+		expect(result).toStrictEqual([['a', 'span*', 'em*']]);
 	});
 
 	test('[permitted-contents-invalid-004] multiple sibling <a> elements produce single pattern', () => {
 		const result = c('<a><span></span></a><a><em></em></a>', false);
-		expect(result).toStrictEqual([['span*', 'em*']]);
+		expect(result).toStrictEqual([['a', 'span*', 'a', 'em*']]);
 	});
 
 	test('[permitted-contents-invalid-005] 12 sibling <a> elements with 2 children each produce single pattern', () => {
 		const tags = Array.from({ length: 12 }, (_, i) => '<a><span></span><em></em></a>').join('');
 		const result = c(tags, false);
 		expect(result).toHaveLength(1);
-		// Each <a> contributes 2 children (span* + em*) = 24 total
-		expect(result[0]).toHaveLength(24);
+		// Each <a> contributes itself plus 2 children (a + span* + em*) = 36 total
+		expect(result[0]).toHaveLength(36);
 	});
 });
 
@@ -72,10 +74,10 @@ describe('MAX_PATTERNS cap', () => {
 		const tags = Array.from({ length: 10 }, () => '<a href>{#if x}<span>s</span>{/if}</a>').join('');
 		const result = svelteC(tags);
 		expect(result).toHaveLength(1024);
-		// First pattern: every branch taken
-		expect(result[0]).toStrictEqual(Array.from({ length: 10 }, () => 'span*'));
-		// Last pattern: no branch taken — branch distinction is preserved
-		expect(result.at(-1)).toStrictEqual([]);
+		// First pattern: every branch taken — each <a> keeps itself (#3928) plus its span
+		expect(result[0]).toStrictEqual(Array.from({ length: 10 }, () => ['a', 'span*']).flat());
+		// Last pattern: no branch taken — branch distinction is preserved, but each <a> itself remains
+		expect(result.at(-1)).toStrictEqual(Array.from({ length: 10 }, () => 'a'));
 	});
 
 	test('[permitted-contents-issue-3895-002] 11th conditional sibling exceeds the cap and merges branches', () => {
@@ -85,9 +87,10 @@ describe('MAX_PATTERNS cap', () => {
 		const tags = Array.from({ length: 11 }, () => '<a href>{#if x}<span>s</span>{/if}</a>').join('');
 		const result = svelteC(tags);
 		expect(result).toHaveLength(1024);
-		expect(result[0]).toStrictEqual(Array.from({ length: 11 }, () => 'span*'));
+		expect(result[0]).toStrictEqual(Array.from({ length: 11 }, () => ['a', 'span*']).flat());
 		// Even the all-branches-empty pattern receives the merged children —
-		// the cap loses the branch distinction for the 11th sibling
-		expect(result.at(-1)).toStrictEqual(['span*']);
+		// the cap loses the branch distinction for the 11th sibling, but every
+		// <a> (including the first 10, resolved before the cap was hit) keeps itself
+		expect(result.at(-1)).toStrictEqual([...Array.from({ length: 11 }, () => 'a'), 'span*']);
 	});
 });

--- a/packages/@markuplint/rules/src/permitted-contents/represent-transparent-nodes.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/represent-transparent-nodes.ts
@@ -205,20 +205,23 @@ export function representTransparentNodes(
 			branchGroups.push(branchChildren);
 		}
 
-		if (branchGroups.every(g => g.length === 0)) {
-			continue;
-		}
-
+		// The transparent element itself is still a child of the current parent
+		// and must be evaluated against the parent's own content model (e.g., a
+		// `<button>` must reject an `<a href>` descendant even though `<a>`'s
+		// children are also transparently checked). It is pushed exactly once
+		// per resulting pattern below — never once per branch group — so
+		// conditional (`v-if`/`v-else`) branches don't multiply it.
+		// See https://github.com/markuplint/markuplint/issues/3928
 		if (branchGroups.length === 1) {
 			const singleGroup = branchGroups[0]!;
 			for (const p of patterns) {
-				p.push(...singleGroup);
+				p.push(childNode, ...singleGroup);
 			}
 		} else if (patterns.length * branchGroups.length <= MAX_PATTERNS) {
 			const newPatterns: (ChildNode | Result)[][] = [];
 			for (const p of patterns) {
 				for (const group of branchGroups) {
-					newPatterns.push([...p, ...group]);
+					newPatterns.push([...p, childNode, ...group]);
 				}
 			}
 			patterns = newPatterns;
@@ -235,7 +238,7 @@ export function representTransparentNodes(
 			);
 			const allChildren = branchGroups.flat();
 			for (const p of patterns) {
-				p.push(...allChildren);
+				p.push(childNode, ...allChildren);
 			}
 		}
 	}

--- a/packages/@markuplint/rules/src/permitted-contents/start.spec.ts
+++ b/packages/@markuplint/rules/src/permitted-contents/start.spec.ts
@@ -65,7 +65,10 @@ test('[permitted-contents-invalid-006] conditional transparent: <audio>', () => 
 });
 
 test('[permitted-contents-invalid-007] transparent: <audio> with <audio>', () => {
-	expect(c('<audio><audio></audio></audio>')[0]?.type).toBe('MATCHED_ZERO');
+	// The inner <audio> itself is now kept in the flattened list (#3928), so the
+	// outer model's own `transparent` pattern slot absorbs it as a plain match;
+	// the disallow is still reported separately via TRANSPARENT_MODEL_DISALLOWS.
+	expect(c('<audio><audio></audio></audio>')[0]?.type).toBe('MATCHED');
 	expect(c('<audio><audio></audio></audio>')[1]?.type).toBe('TRANSPARENT_MODEL_DISALLOWS');
 });
 

--- a/tests/external/bench/issue-xref.config.ts
+++ b/tests/external/bench/issue-xref.config.ts
@@ -72,7 +72,7 @@ export const xrefMappings: readonly XrefMapping[] = [
 		kind: 'primary',
 		issue: 3928,
 		filter: /^html\/elements\/(a\/with-href-button-descendant|audio\/controls-in-button|picture\/(junk-noscript|junk-noscript-after-source-no-img|junk-video-before))-novalid/,
-		note: "`permitted-contents` flattens transparent-model children out of the parent's content-model check entirely. `<a href>` inside `<button>` (both transparent-carrying interactive descendants) and `<video>` / `<noscript>` inside `<picture>` all slip past because the transparent element itself is dropped from the parent's selector evaluation. HTML LS §3.2.5.3 transparency defers only the *children* to the parent's model; the transparent element itself must still satisfy the parent's constraints. Fix requires reworking `represent-transparent-nodes.ts` to keep the transparent element in the flattened list.",
+		note: "Fixed. `representTransparentNodes` now keeps the transparent element itself in the flattened list alongside its pass-through children, so the parent's own content-model check still evaluates the wrapper's placement (HTML LS §3.2.5.3: transparency defers only the *children* to the parent's model; the transparent element itself must still satisfy the parent's constraints). All 5 fixtures now `match-error`; verified against the full 5442-fixture corpus with zero ml-only/nu-over regressions (path sets identical before/after). Safe to close.",
 	},
 	{
 		kind: 'primary',

--- a/tests/external/bench/issue-xref.config.ts
+++ b/tests/external/bench/issue-xref.config.ts
@@ -76,12 +76,6 @@ export const xrefMappings: readonly XrefMapping[] = [
 	},
 	{
 		kind: 'primary',
-		issue: 3838,
-		filter: /^html-aria\/(author-requirements\/(574|575|576|577)|misc\/(role-tab-with-no-role-tabpanel-novalid|summary-for-its-details-with-aria-(expanded|pressed)-novalid))/,
-		note: 'Umbrella of 7 aria fixtures deferred from the aria-slice PR. All 7 are now `match-error`. Six flipped after Group 1 (author-requirements role chain: `wai-aria-required-owned-elements`) and Group 3 (summary heuristics: `spec.summary.jsonc#aria.properties.without`) landed. The last one, `role-tab-with-no-role-tabpanel-novalid` (Group 2, a role-pair authoring requirement — WAI-ARIA 1.3 §tab role: "Authors MUST ensure that if a `tab` is active, a corresponding `tabpanel` that represents the active `tab` is rendered."), flipped after the new `wai-aria-tab-requires-tabpanel` rule landed (resolves via `aria-controls`/`aria-labelledby` correspondence). All acceptance criteria met; safe to close.',
-	},
-	{
-		kind: 'primary',
 		issue: 3832,
 		filter: /^html\/datatypes\/charset-invalid-novalid/,
 		note: 'Issue body Case A — `<meta http-equiv="content-type" content="text/html; charset=not-a-charset">`. HTML LS [§4.2.5.3 Pragma directives — Encoding declaration state](https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-content-type): "For meta elements with an http-equiv attribute in the Encoding declaration state, the content attribute must have a value that is an ASCII case-insensitive match for a string that consists of: \\"text/html;\\", optionally followed by any number of ASCII whitespace, followed by \\"charset=utf-8\\"." markuplint\'s `HTTPEquivContentType` checker (`packages/@markuplint/types/src/whatwg/check-http-equiv-content-type.ts`) validates the label shape only (`/^text\\/html;[\\t\\n\\f\\r ]*charset=[\\w.-]+$/i`), so unknown labels like `not-a-charset` slip through. Cases B (`url-empty-novalid`) and C (`sandbox-scripts-same-origin-haswarn`) from the same Issue are already resolved (`match-error` and `nu-over` respectively); this is the sole remaining fixture backing the Issue.',

--- a/tests/external/snapshots/diff/coverage.json
+++ b/tests/external/snapshots/diff/coverage.json
@@ -14854,7 +14854,9 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": ["nv-cd593c007a34"]
+			"excludedIds": [
+				"nv-cd593c007a34"
+			]
 		},
 		{
 			"path": "html/datatypes/source-size-list-empty-novalid.html",
@@ -15286,7 +15288,9 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": ["nv-3a1dc1374ed4"]
+			"excludedIds": [
+				"nv-3a1dc1374ed4"
+			]
 		},
 		{
 			"path": "html/elements/a/href/scheme-data-single-slash-novalid.html",
@@ -15644,8 +15648,8 @@
 			"path": "html/elements/a/with-href-button-descendant-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -16070,7 +16074,9 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": ["nv-cdb4535e049d"]
+			"excludedIds": [
+				"nv-cdb4535e049d"
+			]
 		},
 		{
 			"path": "html/elements/area/href/scheme-data-single-slash-novalid.html",
@@ -16428,8 +16434,8 @@
 			"path": "html/elements/audio/controls-in-button-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -16830,7 +16836,9 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": ["nv-60706ef20301"]
+			"excludedIds": [
+				"nv-60706ef20301"
+			]
 		},
 		{
 			"path": "html/elements/audio/src/scheme-data-single-slash-novalid.html",
@@ -17950,7 +17958,9 @@
 			"nu": "clean",
 			"ml": "error",
 			"verdict": "ml-only",
-			"excludedIds": ["nv-7607d3f108ff"]
+			"excludedIds": [
+				"nv-7607d3f108ff"
+			]
 		},
 		{
 			"path": "html/elements/base/href/scheme-data-no-slash-isvalid.html",
@@ -18886,7 +18896,9 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": ["nv-ed1dbf9dfa0f"]
+			"excludedIds": [
+				"nv-ed1dbf9dfa0f"
+			]
 		},
 		{
 			"path": "html/elements/blockquote/cite/scheme-data-single-slash-novalid.html",
@@ -19598,7 +19610,9 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": ["nv-82f38369e99e"]
+			"excludedIds": [
+				"nv-82f38369e99e"
+			]
 		},
 		{
 			"path": "html/elements/button/formaction/scheme-data-single-slash-novalid.html",
@@ -20398,7 +20412,9 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": ["nv-6d168c2d3178"]
+			"excludedIds": [
+				"nv-6d168c2d3178"
+			]
 		},
 		{
 			"path": "html/elements/del/cite/scheme-data-single-slash-novalid.html",
@@ -22302,7 +22318,9 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": ["nv-27ddcd34ac6d"]
+			"excludedIds": [
+				"nv-27ddcd34ac6d"
+			]
 		},
 		{
 			"path": "html/elements/embed/src/scheme-data-single-slash-novalid.html",
@@ -23054,7 +23072,9 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": ["nv-0a21d5f3b754"]
+			"excludedIds": [
+				"nv-0a21d5f3b754"
+			]
 		},
 		{
 			"path": "html/elements/form/action/scheme-data-single-slash-novalid.html",
@@ -23998,7 +24018,9 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": ["nv-344c8ec6a993"]
+			"excludedIds": [
+				"nv-344c8ec6a993"
+			]
 		},
 		{
 			"path": "html/elements/iframe/src/scheme-data-single-slash-novalid.html",
@@ -24838,7 +24860,9 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": ["nv-8c9d69a03039"]
+			"excludedIds": [
+				"nv-8c9d69a03039"
+			]
 		},
 		{
 			"path": "html/elements/img/src/scheme-data-single-slash-novalid.html",
@@ -25686,7 +25710,9 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": ["nv-54c78eff3c7d"]
+			"excludedIds": [
+				"nv-54c78eff3c7d"
+			]
 		},
 		{
 			"path": "html/elements/input/type-color-isvalid.html",
@@ -26102,7 +26128,9 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": ["nv-ad82b8a8c1e5"]
+			"excludedIds": [
+				"nv-ad82b8a8c1e5"
+			]
 		},
 		{
 			"path": "html/elements/input/type-image-formaction/scheme-data-single-slash-novalid.html",
@@ -26766,7 +26794,9 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": ["nv-e683359e52e5"]
+			"excludedIds": [
+				"nv-e683359e52e5"
+			]
 		},
 		{
 			"path": "html/elements/input/type-image-src/scheme-data-single-slash-novalid.html",
@@ -27430,7 +27460,9 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": ["nv-8c1d1d42e012"]
+			"excludedIds": [
+				"nv-8c1d1d42e012"
+			]
 		},
 		{
 			"path": "html/elements/input/type-submit-formaction/scheme-data-single-slash-novalid.html",
@@ -28158,7 +28190,9 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": ["nv-6872c643a823"]
+			"excludedIds": [
+				"nv-6872c643a823"
+			]
 		},
 		{
 			"path": "html/elements/input/type-url-value/scheme-data-single-slash-novalid.html",
@@ -28822,7 +28856,9 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": ["nv-27b353000357"]
+			"excludedIds": [
+				"nv-27b353000357"
+			]
 		},
 		{
 			"path": "html/elements/ins/cite/scheme-data-single-slash-novalid.html",
@@ -30534,7 +30570,9 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": ["nv-5b612865391d"]
+			"excludedIds": [
+				"nv-5b612865391d"
+			]
 		},
 		{
 			"path": "html/elements/link/href/scheme-data-single-slash-novalid.html",
@@ -31286,7 +31324,9 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": ["nv-6ec2a5c8c04c"]
+			"excludedIds": [
+				"nv-6ec2a5c8c04c"
+			]
 		},
 		{
 			"path": "html/elements/meta/content-security-policy/csp-invalid-source-novalid.html",
@@ -31294,7 +31334,9 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": ["nv-ccff05d53b7c"]
+			"excludedIds": [
+				"nv-ccff05d53b7c"
+			]
 		},
 		{
 			"path": "html/elements/meta/content-security-policy/csp-non-ascii-novalid.html",
@@ -31302,7 +31344,9 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": ["nv-f76bf04a85bb"]
+			"excludedIds": [
+				"nv-f76bf04a85bb"
+			]
 		},
 		{
 			"path": "html/elements/meta/content-security-policy/csp-policy-list-isvalid.html",
@@ -31430,7 +31474,9 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": ["nv-c57d9ac83548"]
+			"excludedIds": [
+				"nv-c57d9ac83548"
+			]
 		},
 		{
 			"path": "html/elements/meta/refresh-isvalid.html",
@@ -31454,7 +31500,9 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": ["nv-f26bf6cca5a8"]
+			"excludedIds": [
+				"nv-f26bf6cca5a8"
+			]
 		},
 		{
 			"path": "html/elements/meta/refresh-quoted-url-novalid.html",
@@ -31462,7 +31510,9 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": ["nv-59fd76f96902"]
+			"excludedIds": [
+				"nv-59fd76f96902"
+			]
 		},
 		{
 			"path": "html/elements/meta/viewport-user-scalable-no-haswarn.html",
@@ -32038,7 +32088,9 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": ["nv-372749d0395d"]
+			"excludedIds": [
+				"nv-372749d0395d"
+			]
 		},
 		{
 			"path": "html/elements/object/data/scheme-data-single-slash-novalid.html",
@@ -32366,7 +32418,9 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": ["nv-785400222871"]
+			"excludedIds": [
+				"nv-785400222871"
+			]
 		},
 		{
 			"path": "html/elements/ol/model-isvalid.html",
@@ -32812,16 +32866,16 @@
 			"path": "html/elements/picture/junk-noscript-after-source-no-img-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
 			"path": "html/elements/picture/junk-noscript-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -32948,8 +33002,8 @@
 			"path": "html/elements/picture/junk-video-before-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -34566,7 +34620,9 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": ["nv-3cd607b1d358"]
+			"excludedIds": [
+				"nv-3cd607b1d358"
+			]
 		},
 		{
 			"path": "html/elements/q/cite/scheme-data-single-slash-novalid.html",
@@ -35094,7 +35150,9 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": ["nv-00d2f9879fd4"]
+			"excludedIds": [
+				"nv-00d2f9879fd4"
+			]
 		},
 		{
 			"path": "html/elements/script/importmap/scopes-value-not-object-novalid.html",
@@ -36446,7 +36504,9 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": ["nv-d2a73eb7f342"]
+			"excludedIds": [
+				"nv-d2a73eb7f342"
+			]
 		},
 		{
 			"path": "html/elements/script/src/scheme-data-single-slash-novalid.html",
@@ -37390,7 +37450,9 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": ["nv-c98e0d290a6d"]
+			"excludedIds": [
+				"nv-c98e0d290a6d"
+			]
 		},
 		{
 			"path": "html/elements/source/src/scheme-data-single-slash-novalid.html",
@@ -37758,7 +37820,9 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": ["nv-c5efac320bbb"]
+			"excludedIds": [
+				"nv-c5efac320bbb"
+			]
 		},
 		{
 			"path": "html/elements/style/html-spec-comms-isvalid.html",
@@ -38078,7 +38142,9 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": ["nv-d7b3d14cfb44"]
+			"excludedIds": [
+				"nv-d7b3d14cfb44"
+			]
 		},
 		{
 			"path": "html/elements/table/row-width-exceeds-cols-haswarn.html",
@@ -38662,7 +38728,9 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": ["nv-22da233e51c1"]
+			"excludedIds": [
+				"nv-22da233e51c1"
+			]
 		},
 		{
 			"path": "html/elements/track/src/scheme-data-single-slash-novalid.html",
@@ -39438,7 +39506,9 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": ["nv-f66fce25c1d0"]
+			"excludedIds": [
+				"nv-f66fce25c1d0"
+			]
 		},
 		{
 			"path": "html/elements/video/poster/scheme-data-single-slash-novalid.html",
@@ -40086,7 +40156,9 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": ["nv-1f2c65f495dc"]
+			"excludedIds": [
+				"nv-1f2c65f495dc"
+			]
 		},
 		{
 			"path": "html/elements/video/src/scheme-data-single-slash-novalid.html",
@@ -40838,7 +40910,9 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": ["nv-72908421456b"]
+			"excludedIds": [
+				"nv-72908421456b"
+			]
 		},
 		{
 			"path": "html/microdata/itemid-without-itemscope-novalid.html",
@@ -41542,7 +41616,9 @@
 			"nu": "clean",
 			"ml": "clean",
 			"verdict": "nu-over",
-			"excludedIds": ["nv-5e72124bb955"]
+			"excludedIds": [
+				"nv-5e72124bb955"
+			]
 		},
 		{
 			"path": "html/microdata/itemtype-without-itemscope-novalid.html",

--- a/tests/external/snapshots/diff/markuplint-only.json
+++ b/tests/external/snapshots/diff/markuplint-only.json
@@ -3,37 +3,52 @@
 		{
 			"path": "html-aria/misc/a-href-aria-disabled-true-haswarn.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/misc/aria-controls-broken-idref-novalid.html",
 			"category": "aria",
-			"ruleIds": ["no-refer-to-non-existent-id"]
+			"ruleIds": [
+				"no-refer-to-non-existent-id"
+			]
 		},
 		{
 			"path": "html-aria/misc/aria-describedby-broken-idref-novalid.html",
 			"category": "aria",
-			"ruleIds": ["no-refer-to-non-existent-id"]
+			"ruleIds": [
+				"no-refer-to-non-existent-id"
+			]
 		},
 		{
 			"path": "html-aria/misc/aria-disabled-true-on-disabled-haswarn.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-implicit-props"]
+			"ruleIds": [
+				"wai-aria-implicit-props"
+			]
 		},
 		{
 			"path": "html-aria/misc/aria-flowto-broken-idref-novalid.html",
 			"category": "aria",
-			"ruleIds": ["no-refer-to-non-existent-id"]
+			"ruleIds": [
+				"no-refer-to-non-existent-id"
+			]
 		},
 		{
 			"path": "html-aria/misc/aria-haspopup-on-datalist-input-haswarn.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/misc/aria-labelledby-broken-idref-novalid.html",
 			"category": "aria",
-			"ruleIds": ["no-refer-to-non-existent-id", "wai-aria-disallowed-props"]
+			"ruleIds": [
+				"no-refer-to-non-existent-id",
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/misc/aria-owns-broken-idref-novalid.html",
@@ -47,5057 +62,7919 @@
 		{
 			"path": "html-aria/misc/aria-valuemin-on-meter-haswarn.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/misc/figure-with-role-doc-example-and-figcaption.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-permitted-roles"]
+			"ruleIds": [
+				"wai-aria-permitted-roles"
+			]
 		},
 		{
 			"path": "html-aria/misc/figure-with-role-figure-and-figcaption-haswarn.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-permitted-roles"]
+			"ruleIds": [
+				"wai-aria-permitted-roles"
+			]
 		},
 		{
 			"path": "html-aria/misc/img-element-with-role-and-accessible-name-isvalid.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-permitted-roles"]
+			"ruleIds": [
+				"wai-aria-permitted-roles"
+			]
 		},
 		{
 			"path": "html-aria/misc/input-image-reset-submit.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-permitted-roles"]
+			"ruleIds": [
+				"wai-aria-permitted-roles"
+			]
 		},
 		{
 			"path": "html-aria/misc/input-number-aria-valuemax-haswarn.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/misc/input-number-aria-valuemin-haswarn.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/misc/label-unassociated-with-labelable-element-with-role-and-aria-expanded-isvalid.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-no-global-prop", "wai-aria-permitted-roles"]
+			"ruleIds": [
+				"wai-aria-no-global-prop",
+				"wai-aria-permitted-roles"
+			]
 		},
 		{
 			"path": "html-aria/misc/li-role-button-with-role-none-ancestor-isvalid.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-permitted-roles"]
+			"ruleIds": [
+				"wai-aria-permitted-roles"
+			]
 		},
 		{
 			"path": "html-aria/misc/role-listitem-with-aria-level-haswarn.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/misc/role-on-math-element-haswarn.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-permitted-roles"]
+			"ruleIds": [
+				"wai-aria-permitted-roles"
+			]
 		},
 		{
 			"path": "html-aria/misc/select-aria-multiselectable-haswarn.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/misc/table-role-presentation-nested-with-td-with-role-isvalid.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/misc/unnecessary-listbox-role-on-select-haswarn.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-permitted-roles"]
+			"ruleIds": [
+				"wai-aria-permitted-roles"
+			]
 		},
 		{
 			"path": "html-aria/misc/unnecessary-role-listbox-haswarn.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-permitted-roles"]
+			"ruleIds": [
+				"wai-aria-permitted-roles"
+			]
 		},
 		{
 			"path": "html-aria/misc/unnecessary-role-on-main-haswarn.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-permitted-roles"]
+			"ruleIds": [
+				"wai-aria-permitted-roles"
+			]
 		},
 		{
 			"path": "html-aria/misc/unnecessary-role-searchbox-haswarn.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-permitted-roles"]
+			"ruleIds": [
+				"wai-aria-permitted-roles"
+			]
 		},
 		{
 			"path": "html-aria/misc/unnecessary-searchbox-role-on-input-haswarn.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-permitted-roles"]
+			"ruleIds": [
+				"wai-aria-permitted-roles"
+			]
 		},
 		{
 			"path": "html-aria/mixed-value/585.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-value"]
+			"ruleIds": [
+				"wai-aria-value"
+			]
 		},
 		{
 			"path": "html-aria/mixed-value/586.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-value"]
+			"ruleIds": [
+				"wai-aria-value"
+			]
 		},
 		{
 			"path": "html-aria/name-computation-img/566-isvalid.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/presentation-role/510.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/presentation-role/511.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/presentation-role/512.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/presentation-role/514.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/presentation-role/515.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/presentation-role/516.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/presentation-role/518.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/presentation-role/520.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/presentation-role/521.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/presentation-role/522.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/presentation-role/524.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/presentation-role/525.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/presentation-role/527.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/roles-plain-concrete/roles-plain-concrete-grid.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/roles-plain-concrete/roles-plain-concrete-list.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/roles-plain-concrete/roles-plain-concrete-menu.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/roles-plain-concrete/roles-plain-concrete-menubar.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/roles-plain-concrete/roles-plain-concrete-tablist.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/roles-plain-concrete/roles-plain-concrete-tree.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/roles-plain-concrete/roles-plain-concrete-treegrid.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-required-inherited/radio-aria-checked-mixed.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-value"]
+			"ruleIds": [
+				"wai-aria-value"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-required-inherited/radio-aria-checked-undefined.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-value"]
+			"ruleIds": [
+				"wai-aria-value"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/alert-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/alert-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/alert-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/alertdialog-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/alertdialog-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/alertdialog-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/article-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/article-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/article-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/banner-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/banner-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/banner-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/complementary-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/complementary-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/complementary-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/contentinfo-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/contentinfo-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/contentinfo-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/definition-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/definition-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/definition-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/dialog-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/dialog-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/dialog-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/form-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/form-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/form-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/grid-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props", "wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-disallowed-props",
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/grid-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props", "wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-disallowed-props",
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/grid-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props", "wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-disallowed-props",
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/group-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/group-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/group-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/heading-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/heading-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/heading-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/img-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/img-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/img-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/list-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/list-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/list-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/log-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/log-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/log-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/main-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/main-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/main-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/marquee-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/marquee-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/marquee-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/math-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/math-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/math-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/menu-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props", "wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-disallowed-props",
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/menu-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props", "wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-disallowed-props",
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/menu-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props", "wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-disallowed-props",
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/menubar-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props", "wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-disallowed-props",
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/menubar-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props", "wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-disallowed-props",
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/menubar-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props", "wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-disallowed-props",
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/menuitemradio-aria-checked-mixed.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-value"]
+			"ruleIds": [
+				"wai-aria-value"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/menuitemradio-aria-checked-undefined.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-value"]
+			"ruleIds": [
+				"wai-aria-value"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/navigation-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/navigation-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/navigation-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/note-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/note-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/note-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/radio-aria-checked-mixed.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-value"]
+			"ruleIds": [
+				"wai-aria-value"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/radiogroup-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/radiogroup-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/radiogroup-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/region-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/region-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/region-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/rowgroup-aria-activedescendant-obj1.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/search-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/search-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/search-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/status-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/status-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/status-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/tablist-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/tablist-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/tablist-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/tabpanel-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/tabpanel-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/tabpanel-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/timer-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/timer-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/timer-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/toolbar-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/toolbar-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/toolbar-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/tooltip-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/tooltip-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/tooltip-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/tree-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/tree-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/tree-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/treegrid-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/treegrid-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/treegrid-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/treegrid-aria-level-1.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/treeitem-aria-checked-mixed.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-value"]
+			"ruleIds": [
+				"wai-aria-value"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/treeitem-aria-checked-undefined.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-value"]
+			"ruleIds": [
+				"wai-aria-value"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-document-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-document-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-document-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-grid-aria-multiselectable-false.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-grid-aria-multiselectable-true.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-grid-aria-readonly-false.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-grid-aria-readonly-true.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-listbox-aria-multiselectable-false.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-listbox-aria-multiselectable-true.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-listbox-aria-required-false.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-listbox-aria-required-true.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-option-aria-checked-mixed.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-value"]
+			"ruleIds": [
+				"wai-aria-value"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-option-aria-checked-undefined.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-value"]
+			"ruleIds": [
+				"wai-aria-value"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-row-aria-level-1.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-row-aria-selected-false.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-row-aria-selected-true.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-separator-aria-expanded-false.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-separator-aria-expanded-true.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-separator-aria-expanded-undefined.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-tablist-aria-level-1.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html-aria/setsize-posinset-level/testcase-769.html",
 			"category": "aria",
-			"ruleIds": ["wai-aria-required-parent-role"]
+			"ruleIds": [
+				"wai-aria-required-parent-role"
+			]
 		},
 		{
 			"path": "html-its/allowedcharacters/html/allowedcharacters1html.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-its/domain/html/domain4html.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "required-attr"]
+			"ruleIds": [
+				"invalid-attr",
+				"required-attr"
+			]
 		},
 		{
 			"path": "html-its/elementswithintext/html/withintext2html.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-its/localefilter/html/locale2html.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-its/localefilter/html/locale5html.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-its/localizationnote/html/locnote7html.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-its/locqualityissue/html/locqualityissue4html.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-its/locqualityissue/html/locqualityissue5html.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-its/locqualityissue/html/locqualityissue6html.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-its/locqualityissue/html/locqualityissue7html.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-its/locqualityissue/html/locqualityissue9html.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-its/locqualityrating/html/locqualityrating1html.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-its/locqualityrating/html/locqualityrating2html.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-its/mtconfidence/html/mtconfidence1html.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-its/mtconfidence/html/mtconfidence2html.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-its/mtconfidence/html/mtconfidence3html.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-its/mtconfidence/html/mtconfidence4html.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-its/mtconfidence/html/mtconfidence5html.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-its/provenance/html/provenance3html.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-its/provenance/html/provenance4html.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-its/provenance/html/provenance6html.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-its/provenance/html/provenance7html.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-its/storagesize/html/storagesize1html.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-its/terminology/html/terminology3html.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-its/terminology/html/terminology5html.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-its/textanalysis/html/textanalysis1html.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-its/textanalysis/html/textanalysis2html.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-its/textanalysis/html/textanalysis3html.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-its/textanalysis/html/textanalysis4html.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-its/textanalysis/html/textanalysis5html.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-math/annotation-xml-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["permitted-contents"]
+			"ruleIds": [
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-math/maction-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr"]
+			"ruleIds": [
+				"deprecated-attr"
+			]
 		},
 		{
 			"path": "html-math/math-overflow-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0001-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0006-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "link-types"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"link-types"
+			]
 		},
 		{
 			"path": "html-rdfa/0007-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "link-types"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"link-types"
+			]
 		},
 		{
 			"path": "html-rdfa/0008-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "link-types"]
+			"ruleIds": [
+				"invalid-attr",
+				"link-types"
+			]
 		},
 		{
 			"path": "html-rdfa/0009-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0010-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "link-types"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"link-types"
+			]
 		},
 		{
 			"path": "html-rdfa/0014-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0015-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "link-types", "required-attr"]
+			"ruleIds": [
+				"invalid-attr",
+				"link-types",
+				"required-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0017-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0018-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "link-types"]
+			"ruleIds": [
+				"invalid-attr",
+				"link-types"
+			]
 		},
 		{
 			"path": "html-rdfa/0020-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0021-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0023-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0025-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0026-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0027-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0029-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0030-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "link-types"]
+			"ruleIds": [
+				"invalid-attr",
+				"link-types"
+			]
 		},
 		{
 			"path": "html-rdfa/0031-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0032-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "link-types"]
+			"ruleIds": [
+				"invalid-attr",
+				"link-types"
+			]
 		},
 		{
 			"path": "html-rdfa/0033-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0034-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0036-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0038-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0048-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0049-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0050-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0051-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0052-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0053-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0054-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0055-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "link-types"]
+			"ruleIds": [
+				"invalid-attr",
+				"link-types"
+			]
 		},
 		{
 			"path": "html-rdfa/0056-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0057-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0059-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0060-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0063-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "link-types"]
+			"ruleIds": [
+				"invalid-attr",
+				"link-types"
+			]
 		},
 		{
 			"path": "html-rdfa/0064-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "link-types"]
+			"ruleIds": [
+				"invalid-attr",
+				"link-types"
+			]
 		},
 		{
 			"path": "html-rdfa/0065-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "link-types"]
+			"ruleIds": [
+				"invalid-attr",
+				"link-types"
+			]
 		},
 		{
 			"path": "html-rdfa/0066-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0067-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0068-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0069-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "link-types"]
+			"ruleIds": [
+				"invalid-attr",
+				"link-types"
+			]
 		},
 		{
 			"path": "html-rdfa/0070-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0071-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "link-types"]
+			"ruleIds": [
+				"invalid-attr",
+				"link-types"
+			]
 		},
 		{
 			"path": "html-rdfa/0072-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0073-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0074-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "link-types"]
+			"ruleIds": [
+				"invalid-attr",
+				"link-types"
+			]
 		},
 		{
 			"path": "html-rdfa/0075-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0080-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0083-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0084-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0087-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "link-types"]
+			"ruleIds": [
+				"invalid-attr",
+				"link-types"
+			]
 		},
 		{
 			"path": "html-rdfa/0088-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0089-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0091-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0093-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0099-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0104-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0106-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0107-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0110-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0111-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0112-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0114-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "link-types"]
+			"ruleIds": [
+				"invalid-attr",
+				"link-types"
+			]
 		},
 		{
 			"path": "html-rdfa/0115-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0117-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0118-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0119-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0120-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0122-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0126-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0140-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0174-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0175-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0176-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "link-types"]
+			"ruleIds": [
+				"invalid-attr",
+				"link-types"
+			]
 		},
 		{
 			"path": "html-rdfa/0177-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0178-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0181-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0182-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0186-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0187-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0188-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0189-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0190-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0196-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0197-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0206-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0207-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "link-types"]
+			"ruleIds": [
+				"invalid-attr",
+				"link-types"
+			]
 		},
 		{
 			"path": "html-rdfa/0213-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0214-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0216-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0217-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0218-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0219-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0220-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "link-types"]
+			"ruleIds": [
+				"invalid-attr",
+				"link-types"
+			]
 		},
 		{
 			"path": "html-rdfa/0221-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "link-types"]
+			"ruleIds": [
+				"invalid-attr",
+				"link-types"
+			]
 		},
 		{
 			"path": "html-rdfa/0224-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0225-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0228-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0229-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0231-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0232-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0233-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0234-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "link-types"]
+			"ruleIds": [
+				"invalid-attr",
+				"link-types"
+			]
 		},
 		{
 			"path": "html-rdfa/0235-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0238-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0239-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0240-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0241-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0242-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0243-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0244-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0245-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0246-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0247-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0248-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0249-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0250-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0251-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "required-attr"]
+			"ruleIds": [
+				"invalid-attr",
+				"required-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0252-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "required-attr"]
+			"ruleIds": [
+				"invalid-attr",
+				"required-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0253-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0254-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0255-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0257-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0259-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0261-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0262-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0263-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0264-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0265-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0266-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0267-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0268-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0269-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0271-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0272-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0273-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0274-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0275-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0276-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0277-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0278-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0279-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0281-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0282-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0283-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0284-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0287-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0289-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0290-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0291-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0292-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0293-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0296-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0297-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0298-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0299-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "link-types"]
+			"ruleIds": [
+				"invalid-attr",
+				"link-types"
+			]
 		},
 		{
 			"path": "html-rdfa/0300-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0301-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0302-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0303-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "link-types"]
+			"ruleIds": [
+				"invalid-attr",
+				"link-types"
+			]
 		},
 		{
 			"path": "html-rdfa/0311-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0312-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0313-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0315-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0316-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0317-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0318-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents", "required-attr"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents",
+				"required-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0321-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents", "required-attr"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents",
+				"required-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0322-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents", "required-attr"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents",
+				"required-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0323-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents", "required-attr"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents",
+				"required-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0324-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents", "required-attr"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents",
+				"required-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0325-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents", "required-attr"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents",
+				"required-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0326-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents", "required-attr"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents",
+				"required-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0327-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents", "required-attr"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents",
+				"required-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0328-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0329-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0330-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfa/0331-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0015-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "link-types", "required-attr"]
+			"ruleIds": [
+				"invalid-attr",
+				"link-types",
+				"required-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0021-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0023-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0030-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "link-types"]
+			"ruleIds": [
+				"invalid-attr",
+				"link-types"
+			]
 		},
 		{
 			"path": "html-rdfalite/0050-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0052-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0053-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0066-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0067-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0071-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "link-types"]
+			"ruleIds": [
+				"invalid-attr",
+				"link-types"
+			]
 		},
 		{
 			"path": "html-rdfalite/0074-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "link-types"]
+			"ruleIds": [
+				"invalid-attr",
+				"link-types"
+			]
 		},
 		{
 			"path": "html-rdfalite/0075-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0089-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0115-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0117-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0140-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0214-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0235-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0238-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0239-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0240-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0241-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0242-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0255-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0259-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0263-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0264-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0272-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0273-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0274-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0275-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0276-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0277-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0281-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0282-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0283-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0287-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0296-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0301-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0302-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0311-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0312-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0313-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0321-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents", "required-attr"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents",
+				"required-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0322-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents", "required-attr"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents",
+				"required-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0323-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents", "required-attr"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents",
+				"required-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0324-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents", "required-attr"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents",
+				"required-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0325-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents", "required-attr"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents",
+				"required-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0326-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents", "required-attr"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents",
+				"required-attr"
+			]
 		},
 		{
 			"path": "html-rdfalite/0327-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents", "required-attr"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents",
+				"required-attr"
+			]
 		},
 		{
 			"path": "html-svg/0001isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["permitted-contents"]
+			"ruleIds": [
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-dom-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/animate-dom-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-02-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-03-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-04-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-05-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-06-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-07-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-08-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-09-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-10-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-11-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-12-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-13-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-14-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-15-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-17-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-19-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-20-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-21-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-22-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-23-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-25-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-26-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-27-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-28-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-29-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-30-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-31-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-32-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-33-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-34-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-35-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-36-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-37-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-38-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-39-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-40-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-41-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-44-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-46-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-52-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-53-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-60-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-61-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-62-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-63-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-64-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-65-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-66-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-67-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-68-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-69-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-70-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-77-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-78-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-80-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-81-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-82-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-83-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-84-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-85-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-86-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-87-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-88-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-89-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-90-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-91-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-elem-92-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-interact-events-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-interact-pevents-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-interact-pevents-02-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-interact-pevents-03-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-interact-pevents-04-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/animate-script-elem-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/animate-struct-dom-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/color-prof-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/color-prop-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/color-prop-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/color-prop-03-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/color-prop-04-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/color-prop-05-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/conform-viewers-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/coords-coord-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/coords-coord-02-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/coords-dom-03-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/coords-dom-04-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/coords-trans-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/coords-trans-02-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/coords-trans-03-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/coords-trans-04-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/coords-trans-05-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/coords-trans-06-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/coords-trans-07-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/coords-trans-08-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/coords-trans-09-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/coords-trans-10-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/coords-trans-11-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/coords-trans-12-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/coords-trans-13-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/coords-trans-14-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/coords-transformattr-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/coords-transformattr-03-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/coords-transformattr-04-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/coords-transformattr-05-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/coords-units-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/coords-units-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/coords-units-03-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/coords-viewattr-03-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/filters-background-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/filters-blend-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/filters-color-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/filters-composite-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/filters-composite-03-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/filters-composite-04-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/filters-composite-05-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/filters-comptran-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/filters-conv-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/filters-conv-03-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/filters-diffuse-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/filters-displace-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/filters-displace-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/filters-example-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/filters-felem-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/filters-felem-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/filters-gauss-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/filters-gauss-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/filters-gauss-03-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/filters-image-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/filters-image-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/filters-image-03-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/filters-image-04-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/filters-image-05-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/filters-light-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/filters-light-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/filters-light-03-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/filters-light-04-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/filters-morph-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/filters-offset-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/filters-offset-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/filters-overview-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/filters-overview-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/filters-overview-03-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/filters-specular-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/filters-tile-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/filters-turb-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/filters-turb-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/fonts-desc-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/fonts-desc-02-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/fonts-desc-03-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/fonts-desc-04-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/fonts-desc-05-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/fonts-elem-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/fonts-elem-02-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/fonts-elem-03-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/fonts-elem-04-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/fonts-elem-05-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/fonts-elem-06-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/fonts-elem-07-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/fonts-glyph-02-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/fonts-glyph-03-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/fonts-kern-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/imp-path-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/interact-cursor-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/interact-dom-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/interact-events-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/interact-events-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/interact-events-202-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/interact-events-203-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/interact-order-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/interact-order-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/interact-order-03-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/interact-pevents-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/interact-pevents-03-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/interact-pevents-04-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/interact-pevents-05-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/interact-pevents-07-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/interact-pevents-08-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/interact-pevents-09-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/interact-pevents-10-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/interact-pointer-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/interact-pointer-03-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/interact-pointer-04-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/interact-zoom-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/interact-zoom-02-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/interact-zoom-03-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/linking-a-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/linking-a-03-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/linking-a-04-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/linking-a-05-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/linking-a-07-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/linking-a-08-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/linking-a-10-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/linking-frag-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/linking-uri-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/linking-uri-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/linking-uri-03-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/masking-mask-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/masking-mask-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/masking-opacity-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/masking-path-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/masking-path-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/masking-path-03-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/masking-path-04-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/masking-path-05-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/masking-path-06-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/masking-path-07-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/masking-path-08-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/masking-path-09-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/masking-path-10-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/masking-path-11-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/masking-path-12-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/masking-path-13-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/masking-path-14-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/painting-control-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/painting-control-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/painting-control-03-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/painting-control-04-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/painting-control-05-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/painting-control-06-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/painting-fill-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/painting-fill-02-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/painting-fill-03-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/painting-fill-04-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/painting-fill-05-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/painting-marker-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/painting-marker-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/painting-marker-03-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/painting-marker-05-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/painting-marker-06-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/painting-marker-07-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/painting-marker-properties-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/painting-render-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/painting-render-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/painting-stroke-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/painting-stroke-02-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/painting-stroke-03-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/painting-stroke-04-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/painting-stroke-05-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/painting-stroke-06-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/painting-stroke-07-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/painting-stroke-08-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/painting-stroke-09-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/painting-stroke-10-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/paths-data-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/paths-data-02-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/paths-data-03-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/paths-data-04-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/paths-data-05-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/paths-data-06-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/paths-data-07-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/paths-data-08-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/paths-data-09-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/paths-data-10-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/paths-data-12-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/paths-data-13-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/paths-data-14-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/paths-data-15-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/paths-data-16-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/paths-data-17-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/paths-data-19-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/paths-dom-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/paths-dom-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/pservers-grad-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/pservers-grad-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/pservers-grad-03-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/pservers-grad-04-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/pservers-grad-05-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/pservers-grad-06-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/pservers-grad-07-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/pservers-grad-08-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/pservers-grad-09-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/pservers-grad-10-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/pservers-grad-11-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/pservers-grad-12-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/pservers-grad-13-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/pservers-grad-14-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/pservers-grad-15-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/pservers-grad-16-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/pservers-grad-17-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/pservers-grad-18-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/pservers-grad-20-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/pservers-grad-21-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/pservers-grad-22-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/pservers-grad-24-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/pservers-grad-stops-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/pservers-pattern-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/pservers-pattern-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/pservers-pattern-03-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/pservers-pattern-04-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/pservers-pattern-05-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/pservers-pattern-06-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/pservers-pattern-07-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/pservers-pattern-08-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/pservers-pattern-09-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/render-elems-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/render-elems-02-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/render-elems-06-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/render-elems-07-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/render-elems-08-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/render-groups-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/render-groups-03-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/script-handle-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/script-handle-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/script-handle-03-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/script-handle-04-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/script-specify-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/shapes-circle-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/shapes-circle-02-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/shapes-ellipse-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/shapes-ellipse-02-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/shapes-ellipse-03-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/shapes-grammar-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/shapes-intro-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/shapes-intro-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/shapes-line-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/shapes-line-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/shapes-polygon-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/shapes-polygon-02-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/shapes-polygon-03-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/shapes-polyline-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/shapes-polyline-02-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/shapes-rect-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/shapes-rect-02-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/shapes-rect-04-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/shapes-rect-05-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/shapes-rect-06-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/shapes-rect-07-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-cond-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-cond-02-t-haswarn.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-cond-03-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-cond-overview-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-cond-overview-03-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-cond-overview-04-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-cond-overview-05-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-defs-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-dom-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/struct-dom-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/struct-dom-03-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/struct-dom-04-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/struct-dom-05-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/struct-dom-06-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/struct-dom-07-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/struct-dom-08-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/struct-dom-11-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/struct-dom-12-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/struct-dom-13-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/struct-dom-14-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/struct-dom-15-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/struct-dom-16-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/struct-dom-17-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/struct-dom-18-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/struct-dom-19-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/struct-dom-20-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/struct-frag-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-frag-02-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-frag-03-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-frag-04-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-frag-06-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-group-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-group-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-group-03-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-image-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-image-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-image-03-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-image-04-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-image-05-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-image-06-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-image-08-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-image-09-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-image-10-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-image-11-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/struct-image-13-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-image-14-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-image-15-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-image-16-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-image-17-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-image-18-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-image-19-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-svg-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/struct-svg-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/struct-svg-03-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-symbol-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-use-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-use-03-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-use-04-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-use-05-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-use-06-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-use-07-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-use-08-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-use-09-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-use-10-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/struct-use-13-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/struct-use-14-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/struct-use-15-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/styling-class-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/styling-css-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/styling-css-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/styling-css-03-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/styling-css-04-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/styling-css-05-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/styling-css-06-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/styling-css-07-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/styling-css-08-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/styling-css-09-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/styling-css-10-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/styling-elem-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/styling-inherit-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/styling-pres-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/styling-pres-03-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/styling-pres-04-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/styling-pres-05-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-align-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-align-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-align-03-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-align-04-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-align-05-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-align-06-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-align-07-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-align-08-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-altglyph-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-altglyph-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-altglyph-03-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-bidi-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-deco-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-dom-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/text-dom-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/text-dom-04-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/text-dom-05-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/text-fonts-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-fonts-02-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-fonts-04-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-fonts-202-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-fonts-203-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-fonts-204-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-intro-01-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-intro-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-intro-03-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-intro-04-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-intro-05-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-intro-06-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-intro-07-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-intro-09-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-intro-10-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-intro-11-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-intro-12-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-path-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-path-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-spacing-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-text-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-text-03-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-text-04-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-text-05-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-text-06-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-text-07-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-text-08-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-text-09-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-text-10-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-text-11-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-text-12-t-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-tref-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-tselect-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-tselect-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/text-tselect-03-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/text-tspan-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/text-tspan-02-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/types-basic-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/types-basic-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "permitted-contents"]
+			"ruleIds": [
+				"invalid-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html-svg/types-dom-01-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/types-dom-02-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/types-dom-03-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/types-dom-05-b-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/types-dom-06-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/types-dom-07-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/types-dom-08-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/types-dom-svgfittoviewbox-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/types-dom-svglengthlist-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/types-dom-svgnumberlist-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/types-dom-svgstringlist-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html-svg/types-dom-svgtransformable-01-f-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["@markuplint/ml-core"]
+			"ruleIds": [
+				"@markuplint/ml-core"
+			]
 		},
 		{
 			"path": "html/attributes/autofocus-isvalid.html",
 			"category": "global-attr",
-			"ruleIds": ["no-duplicate-autofocus"]
+			"ruleIds": [
+				"no-duplicate-autofocus"
+			]
 		},
 		{
 			"path": "html/attributes/lang/xmllang-same-isvalid.html",
 			"category": "global-attr",
-			"ruleIds": ["deprecated-attr"]
+			"ruleIds": [
+				"deprecated-attr"
+			]
 		},
 		{
 			"path": "html/attributes/rel/rel-custom-isvalid.html",
 			"category": "global-attr",
-			"ruleIds": ["invalid-attr", "link-types"]
+			"ruleIds": [
+				"invalid-attr",
+				"link-types"
+			]
 		},
 		{
 			"path": "html/attributes/rel/rel-short-isvalid.html",
 			"category": "global-attr",
-			"ruleIds": ["invalid-attr", "link-types"]
+			"ruleIds": [
+				"invalid-attr",
+				"link-types"
+			]
 		},
 		{
 			"path": "html/attributes/rel/rel-typo-alternate-hasinfo.html",
 			"category": "global-attr",
-			"ruleIds": ["invalid-attr", "link-types"]
+			"ruleIds": [
+				"invalid-attr",
+				"link-types"
+			]
 		},
 		{
 			"path": "html/attributes/rel/rel-typo-author-hasinfo.html",
 			"category": "global-attr",
-			"ruleIds": ["invalid-attr", "link-types"]
+			"ruleIds": [
+				"invalid-attr",
+				"link-types"
+			]
 		},
 		{
 			"path": "html/attributes/rel/rel-typo-canonical-hasinfo.html",
 			"category": "global-attr",
-			"ruleIds": ["invalid-attr", "link-types"]
+			"ruleIds": [
+				"invalid-attr",
+				"link-types"
+			]
 		},
 		{
 			"path": "html/attributes/rel/rel-typo-stylesheet-hasinfo.html",
 			"category": "global-attr",
-			"ruleIds": ["invalid-attr", "link-types"]
+			"ruleIds": [
+				"invalid-attr",
+				"link-types"
+			]
 		},
 		{
 			"path": "html/datatypes/datetime-time-valid-isvalid.html",
 			"category": "data-types",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html/elements/a/href-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["invalid-attr", "no-refer-to-non-existent-id"]
+			"ruleIds": [
+				"invalid-attr",
+				"no-refer-to-non-existent-id"
+			]
 		},
 		{
 			"path": "html/elements/a/name-attribute-haswarn.html",
 			"category": "invalid-attr",
-			"ruleIds": ["deprecated-attr"]
+			"ruleIds": [
+				"deprecated-attr"
+			]
 		},
 		{
 			"path": "html/elements/a/name-empty-haswarn.html",
 			"category": "invalid-attr",
-			"ruleIds": ["deprecated-attr"]
+			"ruleIds": [
+				"deprecated-attr"
+			]
 		},
 		{
 			"path": "html/elements/area/href-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["invalid-attr", "no-refer-to-non-existent-id"]
+			"ruleIds": [
+				"invalid-attr",
+				"no-refer-to-non-existent-id"
+			]
 		},
 		{
 			"path": "html/elements/audio/src-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html/elements/autofocus/dialog-scoped-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["no-duplicate-autofocus"]
+			"ruleIds": [
+				"no-duplicate-autofocus"
+			]
 		},
 		{
 			"path": "html/elements/autofocus/nested-dialogs-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["no-duplicate-autofocus"]
+			"ruleIds": [
+				"no-duplicate-autofocus"
+			]
 		},
 		{
 			"path": "html/elements/autofocus/popover-scoped-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["no-duplicate-autofocus"]
+			"ruleIds": [
+				"no-duplicate-autofocus"
+			]
 		},
 		{
 			"path": "html/elements/base/href/host-IP-address-broken-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html/elements/base/href/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html/elements/base/href/scheme-data-no-slash-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html/elements/base/href/scheme-javascript-single-slash-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html/elements/blockquote/cite-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html/elements/button/formaction-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html/elements/custom/colon-name-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["permitted-contents", "wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"permitted-contents",
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html/elements/del/cite-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html/elements/div/model-isvalid.html",
 			"category": "content-model",
-			"ruleIds": ["wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html/elements/dl/dl-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["permitted-contents"]
+			"ruleIds": [
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html/elements/embed/src-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html/elements/form/action-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html/elements/iframe/src-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html/elements/img/border-attribute-haswarn.html",
 			"category": "invalid-attr",
-			"ruleIds": ["deprecated-attr"]
+			"ruleIds": [
+				"deprecated-attr"
+			]
 		},
 		{
 			"path": "html/elements/img/src-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html/elements/img/srcset-width-descriptor-loading-lazy-no-sizes-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["srcset-sizes-constraint"]
+			"ruleIds": [
+				"srcset-sizes-constraint"
+			]
 		},
 		{
 			"path": "html/elements/input/type-image-formaction-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html/elements/input/type-image-src-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html/elements/input/type-submit-formaction-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html/elements/input/type-url-value-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html/elements/ins/cite-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html/elements/link/href-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html/elements/link/imagesrcset-valid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["invalid-attr", "required-attr"]
+			"ruleIds": [
+				"invalid-attr",
+				"required-attr"
+			]
 		},
 		{
 			"path": "html/elements/math/unnecessary-role-math-haswarn.html",
 			"category": "invalid-attr",
-			"ruleIds": ["wai-aria-permitted-roles"]
+			"ruleIds": [
+				"wai-aria-permitted-roles"
+			]
 		},
 		{
 			"path": "html/elements/meta/names-standard-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["disallowed-element"]
+			"ruleIds": [
+				"disallowed-element"
+			]
 		},
 		{
 			"path": "html/elements/meta/refresh-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html/elements/meter/aria-valuemax-haswarn.html",
 			"category": "invalid-attr",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html/elements/object/data-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html/elements/ol/model-isvalid.html",
 			"category": "content-model",
-			"ruleIds": ["wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html/elements/optgroup/div-child-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["no-orphaned-end-tag", "permitted-contents"]
+			"ruleIds": [
+				"no-orphaned-end-tag",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html/elements/optgroup/legend-child-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["permitted-contents", "required-attr"]
+			"ruleIds": [
+				"permitted-contents",
+				"required-attr"
+			]
 		},
 		{
 			"path": "html/elements/option/aria-selected-haswarn.html",
 			"category": "invalid-attr",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html/elements/option/div-child-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["no-orphaned-end-tag"]
+			"ruleIds": [
+				"no-orphaned-end-tag"
+			]
 		},
 		{
 			"path": "html/elements/option/empty-option-with-label-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["permitted-contents"]
+			"ruleIds": [
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html/elements/option/label-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["permitted-contents"]
+			"ruleIds": [
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html/elements/option/phrasing-content-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["no-orphaned-end-tag"]
+			"ruleIds": [
+				"no-orphaned-end-tag"
+			]
 		},
 		{
 			"path": "html/elements/picture/picture-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html/elements/progress/aria-valuemax-haswarn.html",
 			"category": "invalid-attr",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html/elements/q/cite-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html/elements/rb/rb-interleaved-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["deprecated-element", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-element",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html/elements/rb/rb-tabular-hasinfo.html",
 			"category": "invalid-attr",
-			"ruleIds": ["deprecated-element", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-element",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html/elements/rtc/rtc-hasinfo.html",
 			"category": "invalid-attr",
-			"ruleIds": ["deprecated-element", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-element",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html/elements/script/language-attribute-haswarn.html",
 			"category": "invalid-attr",
-			"ruleIds": ["deprecated-attr"]
+			"ruleIds": [
+				"deprecated-attr"
+			]
 		},
 		{
 			"path": "html/elements/script/language-haswarn.html",
 			"category": "invalid-attr",
-			"ruleIds": ["deprecated-attr"]
+			"ruleIds": [
+				"deprecated-attr"
+			]
 		},
 		{
 			"path": "html/elements/script/src-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html/elements/select/button-child-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["permitted-contents"]
+			"ruleIds": [
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html/elements/select/button-in-multiple-size1-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["permitted-contents"]
+			"ruleIds": [
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html/elements/select/button-selectedcontent-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["permitted-contents"]
+			"ruleIds": [
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html/elements/select/div-child-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["no-orphaned-end-tag", "permitted-contents"]
+			"ruleIds": [
+				"no-orphaned-end-tag",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "html/elements/source/src-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html/elements/style/type-text-css-haswarn.html",
 			"category": "invalid-attr",
-			"ruleIds": ["deprecated-attr"]
+			"ruleIds": [
+				"deprecated-attr"
+			]
 		},
 		{
 			"path": "html/elements/table/role-presentation-with-aria-label-haswarn.html",
 			"category": "invalid-attr",
-			"ruleIds": ["wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html/elements/table/row-width-exceeds-cols-haswarn.html",
 			"category": "invalid-attr",
-			"ruleIds": ["table-row-column-alignment"]
+			"ruleIds": [
+				"table-row-column-alignment"
+			]
 		},
 		{
 			"path": "html/elements/table/row-width-less-than-cols-haswarn.html",
 			"category": "invalid-attr",
-			"ruleIds": ["table-row-column-alignment"]
+			"ruleIds": [
+				"table-row-column-alignment"
+			]
 		},
 		{
 			"path": "html/elements/track/src-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html/elements/ul/model-isvalid.html",
 			"category": "content-model",
-			"ruleIds": ["wai-aria-required-owned-elements"]
+			"ruleIds": [
+				"wai-aria-required-owned-elements"
+			]
 		},
 		{
 			"path": "html/elements/video/poster-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html/elements/video/src-isvalid.html",
 			"category": "invalid-attr",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html/microdata/itemid-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html/microdata/itemtype-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr"]
+			"ruleIds": [
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "html/obsolete/profile-haswarn.html",
 			"category": "deprecated",
-			"ruleIds": ["deprecated-attr"]
+			"ruleIds": [
+				"deprecated-attr"
+			]
 		},
 		{
 			"path": "html/svg/svg-transform-origin-transform-box-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["invalid-attr", "no-refer-to-non-existent-id"]
+			"ruleIds": [
+				"invalid-attr",
+				"no-refer-to-non-existent-id"
+			]
 		},
 		{
 			"path": "html/warnings/aria-multiselectable-on-select-haswarn.html",
 			"category": "uncategorized",
-			"ruleIds": ["wai-aria-disallowed-props"]
+			"ruleIds": [
+				"wai-aria-disallowed-props"
+			]
 		},
 		{
 			"path": "html/warnings/unnecessary-role-definition-haswarn.html",
 			"category": "uncategorized",
-			"ruleIds": ["wai-aria-permitted-roles"]
+			"ruleIds": [
+				"wai-aria-permitted-roles"
+			]
 		},
 		{
 			"path": "html/warnings/unnecessary-role-group-on-details-haswarn.html",
 			"category": "uncategorized",
-			"ruleIds": ["wai-aria-permitted-roles"]
+			"ruleIds": [
+				"wai-aria-permitted-roles"
+			]
 		},
 		{
 			"path": "html/warnings/unnecessary-role-main-haswarn.html",
 			"category": "uncategorized",
-			"ruleIds": ["wai-aria-permitted-roles"]
+			"ruleIds": [
+				"wai-aria-permitted-roles"
+			]
 		},
 		{
 			"path": "html/warnings/unnecessary-role-progressbar-haswarn.html",
 			"category": "uncategorized",
-			"ruleIds": ["wai-aria-permitted-roles"]
+			"ruleIds": [
+				"wai-aria-permitted-roles"
+			]
 		},
 		{
 			"path": "html/warnings/unnecessary-role-spinbutton-haswarn.html",
 			"category": "uncategorized",
-			"ruleIds": ["wai-aria-permitted-roles"]
+			"ruleIds": [
+				"wai-aria-permitted-roles"
+			]
 		},
 		{
 			"path": "html/warnings/unnecessary-role-status-haswarn.html",
 			"category": "uncategorized",
-			"ruleIds": ["wai-aria-permitted-roles"]
+			"ruleIds": [
+				"wai-aria-permitted-roles"
+			]
 		},
 		{
 			"path": "html/warnings/unnecessary-role-term-haswarn.html",
 			"category": "uncategorized",
-			"ruleIds": ["wai-aria-permitted-roles"]
+			"ruleIds": [
+				"wai-aria-permitted-roles"
+			]
 		},
 		{
 			"path": "langdetect/lang-en-dir-ltr-content-zh-haswarn.html",
 			"category": "uncategorized",
-			"ruleIds": ["permitted-contents"]
+			"ruleIds": [
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "langdetect/lang-en-dir-ltr-content-zh-size-less-1024-valid.html",
 			"category": "uncategorized",
-			"ruleIds": ["permitted-contents"]
+			"ruleIds": [
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "langdetect/lang-en-zh-in-svg-text-en-in-p-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "langdetect/lang-he-dir-ltr-content-he-haswarn.html",
 			"category": "uncategorized",
-			"ruleIds": ["permitted-contents"]
+			"ruleIds": [
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "langdetect/lang-he-dir-ltr-content-zh-in-p-he-in-pre-haswarn.html",
 			"category": "uncategorized",
-			"ruleIds": ["permitted-contents"]
+			"ruleIds": [
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "langdetect/lang-he-zh-in-svg-text-he-in-p-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "langdetect/lang-zh-dir-ltr-content-zh-in-pre-he-in-p-haswarn.html",
 			"category": "uncategorized",
-			"ruleIds": ["permitted-contents"]
+			"ruleIds": [
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "langdetect/lang-zh-zh-in-p-he-in-svg-text-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "permitted-contents"]
+			"ruleIds": [
+				"deprecated-attr",
+				"permitted-contents"
+			]
 		},
 		{
 			"path": "langdetect/large-style-content-isvalid.html",
 			"category": "uncategorized",
-			"ruleIds": ["deprecated-attr", "invalid-attr"]
+			"ruleIds": [
+				"deprecated-attr",
+				"invalid-attr"
+			]
 		},
 		{
 			"path": "normalization/normalization-haswarn.html",
 			"category": "uncategorized",
-			"ruleIds": ["permitted-contents"]
+			"ruleIds": [
+				"permitted-contents"
+			]
 		}
 	]
 }

--- a/tests/external/snapshots/diff/nu-only.json
+++ b/tests/external/snapshots/diff/nu-only.json
@@ -3,77 +3,76 @@
 		{
 			"path": "html-math/math-in-head-novalid.html",
 			"category": "uncategorized",
-			"nuMessageIds": ["nv-0c86320f6630", "nv-8aff5b8981a2"]
+			"nuMessageIds": [
+				"nv-0c86320f6630",
+				"nv-8aff5b8981a2"
+			]
 		},
 		{
 			"path": "html/attributes/lang/extlang-bad-novalid.html",
 			"category": "global-attr",
-			"nuMessageIds": ["nv-b9765660c678"]
+			"nuMessageIds": [
+				"nv-b9765660c678"
+			]
 		},
 		{
 			"path": "html/attributes/lang/invalid-primary-novalid.html",
 			"category": "global-attr",
-			"nuMessageIds": ["nv-ae0b2057a762"]
+			"nuMessageIds": [
+				"nv-ae0b2057a762"
+			]
 		},
 		{
 			"path": "html/datatypes/charset-invalid-novalid.html",
 			"category": "data-types",
-			"nuMessageIds": ["nv-acede5e8fcb0", "nv-b7b2459d8f36"]
-		},
-		{
-			"path": "html/elements/a/with-href-button-descendant-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": ["nv-81c2e7bf5413"]
-		},
-		{
-			"path": "html/elements/audio/controls-in-button-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": ["nv-f3f919789208"]
+			"nuMessageIds": [
+				"nv-acede5e8fcb0",
+				"nv-b7b2459d8f36"
+			]
 		},
 		{
 			"path": "html/elements/img/missing-alt-in-figure-novalid.html",
 			"category": "invalid-attr",
-			"nuMessageIds": ["nv-224e80c23676"]
+			"nuMessageIds": [
+				"nv-224e80c23676"
+			]
 		},
 		{
 			"path": "html/elements/img/usemap-invalid-reference-novalid.html",
 			"category": "invalid-attr",
-			"nuMessageIds": ["nv-f3a0d6efeee1"]
+			"nuMessageIds": [
+				"nv-f3a0d6efeee1"
+			]
 		},
 		{
 			"path": "html/elements/picture/html-syntax-picture-no-end-tag-novalid.html",
 			"category": "invalid-attr",
-			"nuMessageIds": ["nv-3ade6b2bf3d6", "nv-aca994a28b46"]
-		},
-		{
-			"path": "html/elements/picture/junk-noscript-after-source-no-img-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": ["nv-fab7ebe451a5", "nv-6cc718a96d01"]
-		},
-		{
-			"path": "html/elements/picture/junk-noscript-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": ["nv-2f51978ea35d"]
-		},
-		{
-			"path": "html/elements/picture/junk-video-before-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": ["nv-6c316a041c38"]
+			"nuMessageIds": [
+				"nv-3ade6b2bf3d6",
+				"nv-aca994a28b46"
+			]
 		},
 		{
 			"path": "html/parser/charset-after-1024-novalid.html",
 			"category": "uncategorized",
-			"nuMessageIds": ["nv-b31d83a9ed4b"]
+			"nuMessageIds": [
+				"nv-b31d83a9ed4b"
+			]
 		},
 		{
 			"path": "html/parser/stray-start-tag-novalid.html",
 			"category": "uncategorized",
-			"nuMessageIds": ["nv-3c0b2b71db12"]
+			"nuMessageIds": [
+				"nv-3c0b2b71db12"
+			]
 		},
 		{
 			"path": "html/parser/text-after-body-novalid.html",
 			"category": "uncategorized",
-			"nuMessageIds": ["nv-94d4d4cf4600", "nv-c35f07b7ee36"]
+			"nuMessageIds": [
+				"nv-94d4d4cf4600",
+				"nv-c35f07b7ee36"
+			]
 		}
 	]
 }

--- a/tests/external/snapshots/diff/nu-over.json
+++ b/tests/external/snapshots/diff/nu-over.json
@@ -3,187 +3,261 @@
 		{
 			"path": "html/datatypes/sandbox-scripts-same-origin-haswarn.html",
 			"category": "data-types",
-			"nuMessageIds": ["nv-cd593c007a34"]
+			"nuMessageIds": [
+				"nv-cd593c007a34"
+			]
 		},
 		{
 			"path": "html/elements/a/href/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": ["nv-3a1dc1374ed4"]
+			"nuMessageIds": [
+				"nv-3a1dc1374ed4"
+			]
 		},
 		{
 			"path": "html/elements/area/href/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": ["nv-cdb4535e049d"]
+			"nuMessageIds": [
+				"nv-cdb4535e049d"
+			]
 		},
 		{
 			"path": "html/elements/audio/src/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": ["nv-60706ef20301"]
+			"nuMessageIds": [
+				"nv-60706ef20301"
+			]
 		},
 		{
 			"path": "html/elements/blockquote/cite/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": ["nv-ed1dbf9dfa0f"]
+			"nuMessageIds": [
+				"nv-ed1dbf9dfa0f"
+			]
 		},
 		{
 			"path": "html/elements/button/formaction/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": ["nv-82f38369e99e"]
+			"nuMessageIds": [
+				"nv-82f38369e99e"
+			]
 		},
 		{
 			"path": "html/elements/del/cite/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": ["nv-6d168c2d3178"]
+			"nuMessageIds": [
+				"nv-6d168c2d3178"
+			]
 		},
 		{
 			"path": "html/elements/embed/src/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": ["nv-27ddcd34ac6d"]
+			"nuMessageIds": [
+				"nv-27ddcd34ac6d"
+			]
 		},
 		{
 			"path": "html/elements/form/action/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": ["nv-0a21d5f3b754"]
+			"nuMessageIds": [
+				"nv-0a21d5f3b754"
+			]
 		},
 		{
 			"path": "html/elements/iframe/src/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": ["nv-344c8ec6a993"]
+			"nuMessageIds": [
+				"nv-344c8ec6a993"
+			]
 		},
 		{
 			"path": "html/elements/img/src/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": ["nv-8c9d69a03039"]
+			"nuMessageIds": [
+				"nv-8c9d69a03039"
+			]
 		},
 		{
 			"path": "html/elements/input/type-button-empty-value-novalid.html",
 			"category": "invalid-attr",
-			"nuMessageIds": ["nv-54c78eff3c7d"]
+			"nuMessageIds": [
+				"nv-54c78eff3c7d"
+			]
 		},
 		{
 			"path": "html/elements/input/type-image-formaction/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": ["nv-ad82b8a8c1e5"]
+			"nuMessageIds": [
+				"nv-ad82b8a8c1e5"
+			]
 		},
 		{
 			"path": "html/elements/input/type-image-src/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": ["nv-e683359e52e5"]
+			"nuMessageIds": [
+				"nv-e683359e52e5"
+			]
 		},
 		{
 			"path": "html/elements/input/type-submit-formaction/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": ["nv-8c1d1d42e012"]
+			"nuMessageIds": [
+				"nv-8c1d1d42e012"
+			]
 		},
 		{
 			"path": "html/elements/input/type-url-value/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": ["nv-6872c643a823"]
+			"nuMessageIds": [
+				"nv-6872c643a823"
+			]
 		},
 		{
 			"path": "html/elements/ins/cite/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": ["nv-27b353000357"]
+			"nuMessageIds": [
+				"nv-27b353000357"
+			]
 		},
 		{
 			"path": "html/elements/link/href/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": ["nv-5b612865391d"]
+			"nuMessageIds": [
+				"nv-5b612865391d"
+			]
 		},
 		{
 			"path": "html/elements/meta/content-security-policy/csp-invalid-directive-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": ["nv-6ec2a5c8c04c"]
+			"nuMessageIds": [
+				"nv-6ec2a5c8c04c"
+			]
 		},
 		{
 			"path": "html/elements/meta/content-security-policy/csp-invalid-source-novalid.html",
 			"category": "invalid-attr",
-			"nuMessageIds": ["nv-ccff05d53b7c"]
+			"nuMessageIds": [
+				"nv-ccff05d53b7c"
+			]
 		},
 		{
 			"path": "html/elements/meta/content-security-policy/csp-non-ascii-novalid.html",
 			"category": "invalid-attr",
-			"nuMessageIds": ["nv-f76bf04a85bb"]
+			"nuMessageIds": [
+				"nv-f76bf04a85bb"
+			]
 		},
 		{
 			"path": "html/elements/meta/refresh-invalid-keyword-novalid.html",
 			"category": "invalid-attr",
-			"nuMessageIds": ["nv-c57d9ac83548"]
+			"nuMessageIds": [
+				"nv-c57d9ac83548"
+			]
 		},
 		{
 			"path": "html/elements/meta/refresh-missing-space-novalid.html",
 			"category": "invalid-attr",
-			"nuMessageIds": ["nv-f26bf6cca5a8"]
+			"nuMessageIds": [
+				"nv-f26bf6cca5a8"
+			]
 		},
 		{
 			"path": "html/elements/meta/refresh-quoted-url-novalid.html",
 			"category": "invalid-attr",
-			"nuMessageIds": ["nv-59fd76f96902"]
+			"nuMessageIds": [
+				"nv-59fd76f96902"
+			]
 		},
 		{
 			"path": "html/elements/object/data/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": ["nv-372749d0395d"]
+			"nuMessageIds": [
+				"nv-372749d0395d"
+			]
 		},
 		{
 			"path": "html/elements/object/type-only-novalid.html",
 			"category": "invalid-attr",
-			"nuMessageIds": ["nv-785400222871"]
+			"nuMessageIds": [
+				"nv-785400222871"
+			]
 		},
 		{
 			"path": "html/elements/q/cite/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": ["nv-3cd607b1d358"]
+			"nuMessageIds": [
+				"nv-3cd607b1d358"
+			]
 		},
 		{
 			"path": "html/elements/script/importmap/scopes-key-not-url-novalid.html",
 			"category": "invalid-attr",
-			"nuMessageIds": ["nv-00d2f9879fd4"]
+			"nuMessageIds": [
+				"nv-00d2f9879fd4"
+			]
 		},
 		{
 			"path": "html/elements/script/src/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": ["nv-d2a73eb7f342"]
+			"nuMessageIds": [
+				"nv-d2a73eb7f342"
+			]
 		},
 		{
 			"path": "html/elements/source/src/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": ["nv-c98e0d290a6d"]
+			"nuMessageIds": [
+				"nv-c98e0d290a6d"
+			]
 		},
 		{
 			"path": "html/elements/style/css-property-error-novalid.html",
 			"category": "invalid-attr",
-			"nuMessageIds": ["nv-c5efac320bbb"]
+			"nuMessageIds": [
+				"nv-c5efac320bbb"
+			]
 		},
 		{
 			"path": "html/elements/table/row-width-exceeds-col-markup-novalid.html",
 			"category": "invalid-attr",
-			"nuMessageIds": ["nv-d7b3d14cfb44"]
+			"nuMessageIds": [
+				"nv-d7b3d14cfb44"
+			]
 		},
 		{
 			"path": "html/elements/track/src/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": ["nv-22da233e51c1"]
+			"nuMessageIds": [
+				"nv-22da233e51c1"
+			]
 		},
 		{
 			"path": "html/elements/video/poster/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": ["nv-f66fce25c1d0"]
+			"nuMessageIds": [
+				"nv-f66fce25c1d0"
+			]
 		},
 		{
 			"path": "html/elements/video/src/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
-			"nuMessageIds": ["nv-1f2c65f495dc"]
+			"nuMessageIds": [
+				"nv-1f2c65f495dc"
+			]
 		},
 		{
 			"path": "html/microdata/itemid-scheme-data-contains-fragment-haswarn.html",
 			"category": "uncategorized",
-			"nuMessageIds": ["nv-72908421456b"]
+			"nuMessageIds": [
+				"nv-72908421456b"
+			]
 		},
 		{
 			"path": "html/microdata/itemtype-scheme-data-contains-fragment-haswarn.html",
 			"category": "uncategorized",
-			"nuMessageIds": ["nv-5e72124bb955"]
+			"nuMessageIds": [
+				"nv-5e72124bb955"
+			]
 		}
 	]
 }

--- a/tests/external/snapshots/diff/summary.md
+++ b/tests/external/snapshots/diff/summary.md
@@ -1,6 +1,6 @@
 # nu-validator Benchmark Summary
 
-- generated: 2026-08-11T05:27:08.599Z
+- generated: 2026-08-11T13:52:52.367Z
 - submodule: `142931395412c00434ffb40a14d65992efd17aa8`
 - nu-validator: `ghcr.io/validator/validator@sha256:9365682da0f66efc5504ce2a3aba91290aaf08c00799a41d096236fab740bb44`
 - markuplint: `5.0.0-rc.4`
@@ -9,27 +9,27 @@
 ## Totals
 
 - files: **5442**
-- match-error: **3490** (both tools flagged)
+- match-error: **3495** (both tools flagged)
 - match-clean: **881** (neither flagged)
-- nu-only: **15** (only nu-validator flagged; markuplint coverage candidates — open a markuplint issue after a spec read)
+- nu-only: **10** (only nu-validator flagged; markuplint coverage candidates — open a markuplint issue after a spec read)
 - nu-over: **37** (nu-validator errors fully covered by spec-backed excluded-ids — confirmed over-detection)
-- overall match rate: **80.3%**
+- overall match rate: **80.4%**
 - excluded-ids: 12 entries, 1 pattern(s)
 
 ## Per-Category
 
-| Category       | Files | Match rate | match-error | match-clean | ml-only | nu-only | nu-over |
-| -------------- | ----: | ---------: | ----------: | ----------: | ------: | ------: | ------: |
-| aria           |   780 |      77.2% |         182 |         420 |     178 |       0 |       0 |
-| assertions     |    40 |     100.0% |          39 |           1 |       0 |       0 |       0 |
-| content-model  |    98 |      96.9% |          50 |          45 |       3 |       0 |       0 |
-| data-types     |    56 |      94.6% |          48 |           5 |       1 |       1 |       1 |
-| deprecated     |    12 |      91.7% |          11 |           0 |       1 |       0 |       0 |
-| global-attr    |    57 |      82.5% |          27 |          20 |       8 |       2 |       0 |
-| id-duplication |     1 |     100.0% |           1 |           0 |       0 |       0 |       0 |
-| invalid-attr   |  3086 |      96.6% |        2754 |         227 |      63 |       8 |      34 |
-| required-attr  |     5 |     100.0% |           5 |           0 |       0 |       0 |       0 |
-| uncategorized  |  1307 |      41.0% |         373 |         163 |     765 |       4 |       2 |
+| Category | Files | Match rate | match-error | match-clean | ml-only | nu-only | nu-over |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| aria | 780 | 77.2% | 182 | 420 | 178 | 0 | 0 |
+| assertions | 40 | 100.0% | 39 | 1 | 0 | 0 | 0 |
+| content-model | 98 | 96.9% | 50 | 45 | 3 | 0 | 0 |
+| data-types | 56 | 94.6% | 48 | 5 | 1 | 1 | 1 |
+| deprecated | 12 | 91.7% | 11 | 0 | 1 | 0 | 0 |
+| global-attr | 57 | 82.5% | 27 | 20 | 8 | 2 | 0 |
+| id-duplication | 1 | 100.0% | 1 | 0 | 0 | 0 | 0 |
+| invalid-attr | 3086 | 96.8% | 2759 | 227 | 63 | 3 | 34 |
+| required-attr | 5 | 100.0% | 5 | 0 | 0 | 0 | 0 |
+| uncategorized | 1307 | 41.0% | 373 | 163 | 765 | 4 | 2 |
 
 ## Informational: ml-only
 
@@ -37,17 +37,18 @@
 
 ### Top ml-only rules
 
-| Rule                             | Count |
-| -------------------------------- | ----: |
-| invalid-attr                     |   707 |
-| permitted-contents               |   444 |
-| deprecated-attr                  |   354 |
-| wai-aria-disallowed-props        |   121 |
-| @markuplint/ml-core              |    75 |
-| wai-aria-required-owned-elements |    47 |
-| link-types                       |    34 |
-| required-attr                    |    22 |
-| wai-aria-permitted-roles         |    20 |
-| wai-aria-value                   |    11 |
+| Rule | Count |
+| --- | ---: |
+| invalid-attr | 707 |
+| permitted-contents | 444 |
+| deprecated-attr | 354 |
+| wai-aria-disallowed-props | 121 |
+| @markuplint/ml-core | 75 |
+| wai-aria-required-owned-elements | 47 |
+| link-types | 34 |
+| required-attr | 22 |
+| wai-aria-permitted-roles | 20 |
+| wai-aria-value | 11 |
 
 > `nu-only` entries are candidates for markuplint coverage work **after** verifying the relevant spec paragraph. `nu-over` entries are already confirmed nu-validator over-detection via `excluded-ids.json`. `ml-only` is informational; audit the spec before acting on any individual row.
+

--- a/tests/external/snapshots/meta.json
+++ b/tests/external/snapshots/meta.json
@@ -1,5 +1,5 @@
 {
-	"generatedAt": "2026-08-11T05:27:08.599Z",
+	"generatedAt": "2026-08-11T13:52:52.367Z",
 	"submoduleSha": "142931395412c00434ffb40a14d65992efd17aa8",
 	"nuValidatorImage": "ghcr.io/validator/validator@sha256:9365682da0f66efc5504ce2a3aba91290aaf08c00799a41d096236fab740bb44",
 	"markuplintVersion": "5.0.0-rc.4",
@@ -7,6 +7,6 @@
 	"totalFilesNu": 5442,
 	"totalFilesMl": 5442,
 	"totalNuMessages": 9907,
-	"totalMlViolations": 11439,
+	"totalMlViolations": 11444,
 	"totalNuFailures": 0
 }


### PR DESCRIPTION
## Summary

- Fix `permitted-contents`: `representTransparentNodes` was replacing every transparent-model child (`<a>`, `<audio>`, `<ins>`, etc.) with only its own children, dropping the element itself from the parent's content-model evaluation. This let `<a href>` (interactive content) hide inside `<button>`, and `<video>` / `<audio>` / `<canvas>` / `<a>` / `<ins>` hide inside `<picture>`. Per HTML LS §3.2.5.3, transparency defers only the *children* to the parent's model — the transparent element itself must still satisfy the parent's own constraints. The element is now kept in the flattened pattern alongside its pass-through children, pushed once per resulting pattern so conditional branches don't multiply it.
- Add 9 regression tests (`[permitted-contents-issue-3928-*]`) covering all 6 repro shapes from the issue plus 2 "stays valid" sanity checks (non-interactive `<a>` in `<button>`, `<a href>` wrapping phrasing content in `<p>`).
- Update rule README (EN/JA) with an incorrect/correct example pair.
- Refresh the nu-validator bench snapshot: `nu-only` 15 → 10 (the 5 fixtures listed in #3928 flip to `match-error`). Verified against the full 5442-fixture corpus that `ml-only` (1019) and `nu-over` (37) path sets are byte-identical before/after — no new false positives or regressions anywhere else in the corpus.
- Mark the #3928 bench-xref primary mapping resolved via `yarn bench:xref --issue 3928 --write`.

Closes #3928

## Test plan

- [x] `yarn test` — 272 files / 4500 tests passed, 1 skipped (pre-existing), no type errors
- [x] `npx vitest run packages/@markuplint/rules/src/permitted-contents` — 9 files / 164 tests passed
- [x] `yarn bench:verify` — 5442/5442 fixtures passed
- [x] Diffed `coverage.json` before/after: only the 5 fixtures named in #3928 changed verdict (`nu-only` → `match-error`); `ml-only`/`nu-over` path sets identical
- [x] `yarn lint` — oxlint 0 warnings/errors, oxfmt clean, cspell 0 issues
- [x] `yarn build` (with `NX_WORKSPACE_ROOT_PATH`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
