### PR TITLE
fix(types): strict charset=utf-8; feat(rules): usemap-references-map

### DIFF
--- a/packages/@markuplint/config-presets/README.md
+++ b/packages/@markuplint/config-presets/README.md
@@ -73,6 +73,7 @@ Specify required attr| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
 [`<label for>` must reference a labelable element by ID](https://html.spec.whatwg.org/multipage/forms.html#attr-label-for)| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
 [`<label>` descendant-control constraints (at most one form-control descendant; none when `for` targets an external labelable element)](https://html.spec.whatwg.org/multipage/forms.html#the-label-element)| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
 [`<map>` `id` must equal `name` when both are specified](https://html.spec.whatwg.org/multipage/image-maps.html#the-map-element)| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
+[`<img usemap>` must be a valid hash-name reference to a `<map>` element](https://html.spec.whatwg.org/multipage/image-maps.html#attr-hyperlink-usemap)| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
 [`<meter>` attribute inequalities (min ≤ value ≤ max etc.)](https://html.spec.whatwg.org/multipage/form-elements.html#the-meter-element)| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
 [`<progress>` attribute inequalities (value ≤ max; value ≤ 1 when max is absent)](https://html.spec.whatwg.org/multipage/form-elements.html#the-progress-element)| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|
 [Single `<select>` allows at most one selected `<option>`](https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element)| |✅|✅|✅|✅|✅|❌|❌|❌|✅|❌|❌|❌|

--- a/packages/@markuplint/config-presets/src/preset.html-standard.jsonc
+++ b/packages/@markuplint/config-presets/src/preset.html-standard.jsonc
@@ -335,6 +335,18 @@
 		},
 
 		/**
+		 * `<img usemap>` must be a valid hash-name reference to a `<map>` element
+		 *
+		 * @see https://html.spec.whatwg.org/multipage/image-maps.html#attr-hyperlink-usemap
+		 */
+		"html-standard/usemap-references-map": {
+			"specConformance": "normative",
+			"rules": {
+				"usemap-references-map": true
+			}
+		},
+
+		/**
 		 * `<meter>` attribute inequalities (min ≤ value ≤ max etc.)
 		 *
 		 * @see https://html.spec.whatwg.org/multipage/form-elements.html#the-meter-element

--- a/packages/@markuplint/rules/schema.json
+++ b/packages/@markuplint/rules/schema.json
@@ -183,6 +183,9 @@
 				"use-list": {
 					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/use-list/schema.json"
 				},
+				"usemap-references-map": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/usemap-references-map/schema.json"
+				},
 				"wai-aria": {
 					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/rules/src/wai-aria/schema.json"
 				},

--- a/packages/@markuplint/rules/src/index.ts
+++ b/packages/@markuplint/rules/src/index.ts
@@ -68,6 +68,7 @@ import RequiredElement from './required-element/index.js';
 import RequiredH1 from './required-h1/index.js';
 import TableRowColumnAlignment from './table-row-column-alignment/index.js';
 import UseList from './use-list/index.js';
+import UsemapReferencesMap from './usemap-references-map/index.js';
 import WaiAria from './wai-aria/index.js';
 import WaiAriaAbstractRole from './wai-aria-abstract-role/index.js';
 import WaiAriaDefaultValue from './wai-aria-default-value/index.js';
@@ -151,6 +152,7 @@ const rules = {
 	'srcset-sizes-constraint': SrcsetSizesConstraint,
 	'table-row-column-alignment': TableRowColumnAlignment,
 	'use-list': UseList,
+	'usemap-references-map': UsemapReferencesMap,
 	'wai-aria': WaiAria,
 	'wai-aria-abstract-role': WaiAriaAbstractRole,
 	'wai-aria-default-value': WaiAriaDefaultValue,

--- a/packages/@markuplint/rules/src/usemap-references-map/README.ja.md
+++ b/packages/@markuplint/rules/src/usemap-references-map/README.ja.md
@@ -1,0 +1,25 @@
+---
+id: usemap-references-map
+description: '`img` 要素の `usemap` 属性は、実在する `map` 要素への有効なハッシュ名参照でなければならないことを強制します。'
+---
+
+# `usemap-references-map`
+
+[HTML Living Standard](https://html.spec.whatwg.org/multipage/image-maps.html#attr-hyperlink-usemap) によれば、`<img>` 要素の `usemap` 属性は「`map` 要素への有効な[ハッシュ名参照](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#valid-hash-name-reference)でなければならない」とされています。これは `#` に続けて、同じツリー内にある `<map>` 要素の `name` 属性の値と完全に一致する文字列です。
+
+参照は `id` ではなく `name` 属性によって行われるため、`id` 参照のみを追跡する [`no-refer-to-non-existent-id`](../no-refer-to-non-existent-id/) では `usemap` の参照先が存在しない、または誤っているケースを検出できません。本ルールはこのギャップを埋めます。
+
+❌ このルールに適合しない**誤った**コードの例
+
+```html
+<img src="shapes.png" alt="" usemap="#nonexistent" />
+```
+
+✅ このルールに適合する**正しい**コードの例
+
+```html
+<img src="shapes.png" alt="" usemap="#shapes" />
+<map name="shapes">
+  <area shape="rect" coords="25,25,125,125" href="red.html" alt="Red box." />
+</map>
+```

--- a/packages/@markuplint/rules/src/usemap-references-map/README.md
+++ b/packages/@markuplint/rules/src/usemap-references-map/README.md
@@ -1,0 +1,25 @@
+---
+id: usemap-references-map
+description: Require that an img element's `usemap` attribute is a valid hash-name reference to a map element.
+---
+
+# `usemap-references-map`
+
+Per the [HTML Living Standard](https://html.spec.whatwg.org/multipage/image-maps.html#attr-hyperlink-usemap), the `usemap` attribute on an `<img>` element "must be a valid [hash-name reference](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#valid-hash-name-reference) to a `map` element" — a `#` followed by a string that exactly matches the `name` attribute of a `<map>` element in the same tree.
+
+Matching is by `name`, not `id`, so [`no-refer-to-non-existent-id`](../no-refer-to-non-existent-id/) — which only tracks `id` references — never catches a missing or misspelled `usemap` target. This rule fills that gap.
+
+❌ Examples of **incorrect** code for this rule
+
+```html
+<img src="shapes.png" alt="" usemap="#nonexistent" />
+```
+
+✅ Examples of **correct** code for this rule
+
+```html
+<img src="shapes.png" alt="" usemap="#shapes" />
+<map name="shapes">
+  <area shape="rect" coords="25,25,125,125" href="red.html" alt="Red box." />
+</map>
+```

--- a/packages/@markuplint/rules/src/usemap-references-map/index.spec.ts
+++ b/packages/@markuplint/rules/src/usemap-references-map/index.spec.ts
@@ -1,0 +1,58 @@
+import { mlRuleTest } from 'markuplint';
+import { test, expect } from 'vitest';
+
+import rule from './index.js';
+
+test('[usemap-references-map-valid-001] resolves to a map element', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		'<img src="shapes.png" alt="" usemap="#shapes"><map name="shapes"></map>',
+	);
+	expect(violations).toStrictEqual([]);
+});
+
+test('[usemap-references-map-valid-002] no usemap attribute', async () => {
+	const { violations } = await mlRuleTest(rule, '<img src="shapes.png" alt="">');
+	expect(violations).toStrictEqual([]);
+});
+
+test('[usemap-references-map-valid-003] dynamic value is skipped', async () => {
+	const { violations } = await mlRuleTest(rule, '<img src="shapes.png" alt="" usemap="{{mapRef}}">', {
+		parser: {
+			'.*': '@markuplint/mustache-parser',
+		},
+	});
+	expect(violations).toStrictEqual([]);
+});
+
+test('[usemap-references-map-invalid-001] no map element in the document', async () => {
+	const { violations } = await mlRuleTest(rule, '<img src="shapes.png" alt="" usemap="#nonexistent">');
+	expect(violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 38,
+			message:
+				'The "usemap" attribute of the "img" element must be a valid hash-name reference to a "map" element',
+			raw: '#nonexistent',
+		},
+	]);
+});
+
+test('[usemap-references-map-invalid-002] map element exists but with a different name', async () => {
+	const { violations } = await mlRuleTest(
+		rule,
+		'<img src="shapes.png" alt="" usemap="#shapes"><map name="other-shapes"></map>',
+	);
+	expect(violations.length).toBe(1);
+});
+
+test('[usemap-references-map-invalid-003] the reference resolves only via id, not name', async () => {
+	// A hash-name reference is defined in terms of the `name` attribute; a
+	// same-valued `id` on an unrelated element must not satisfy it.
+	const { violations } = await mlRuleTest(
+		rule,
+		'<img src="shapes.png" alt="" usemap="#shapes"><map id="shapes"></map>',
+	);
+	expect(violations.length).toBe(1);
+});

--- a/packages/@markuplint/rules/src/usemap-references-map/index.ts
+++ b/packages/@markuplint/rules/src/usemap-references-map/index.ts
@@ -1,0 +1,54 @@
+import { createRule } from '@markuplint/ml-core';
+
+import meta from './meta.js';
+
+/**
+ * Require the `usemap` attribute on an `<img>` element to be a valid
+ * hash-name reference to a `<map>` element. Per HTML LS's definition of
+ * "valid hash-name reference": a string consisting of "#" followed by a
+ * string that exactly matches the `name` attribute of an element of the
+ * referenced type in the same tree — matching is by `name`, not `id`, so
+ * `no-refer-to-non-existent-id` (which only tracks `id` references) never
+ * covers this attribute.
+ *
+ * @see https://html.spec.whatwg.org/multipage/image-maps.html#attr-hyperlink-usemap
+ * @see https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#valid-hash-name-reference
+ */
+export default createRule<boolean, null>({
+	meta: meta,
+	defaultValue: true,
+	defaultOptions: null,
+	async verify({ document, report, t }) {
+		await document.walkOn('Element', el => {
+			if (el.localName !== 'img') return;
+			if (el.pretenderContext?.type === 'pretender' && !el.hasAttribute('as')) return;
+
+			const usemapAttr = el.getAttributeNode('usemap');
+			if (!usemapAttr) return;
+			if (usemapAttr.isDynamicValue) return;
+
+			const value = usemapAttr.value;
+			if (!value.startsWith('#') || value.length <= 1) return;
+
+			const targetName = value.slice(1);
+			const target = [...document.querySelectorAll('map')].find(
+				candidate => candidate.getAttribute('name') === targetName,
+			);
+
+			if (!target) {
+				report({
+					scope: usemapAttr,
+					line: usemapAttr.valueNode?.startLine,
+					col: usemapAttr.valueNode?.startCol,
+					raw: usemapAttr.valueNode?.raw,
+					message: t(
+						'The "{0}" attribute of the "{1}" element must be a valid hash-name reference to a "{2}" element',
+						'usemap',
+						'img',
+						'map',
+					),
+				});
+			}
+		});
+	},
+});

--- a/packages/@markuplint/rules/src/usemap-references-map/meta.ts
+++ b/packages/@markuplint/rules/src/usemap-references-map/meta.ts
@@ -1,0 +1,3 @@
+export default {
+	category: 'validation',
+} as const;

--- a/packages/@markuplint/rules/src/usemap-references-map/schema.json
+++ b/packages/@markuplint/rules/src/usemap-references-map/schema.json
@@ -1,0 +1,29 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"value": {
+			"type": "boolean",
+			"description": "Require that an img element's `usemap` attribute is a valid hash-name reference to a map element.",
+			"description:ja": "`img` 要素の `usemap` 属性は、実在する `map` 要素への有効なハッシュ名参照でなければならないことを強制します。"
+		}
+	},
+	"oneOf": [
+		{
+			"$ref": "#/definitions/value"
+		},
+		{
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"value": { "$ref": "#/definitions/value" },
+				"severity": {
+					"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/ml-config/schema.json#/definitions/severity",
+					"default": "error"
+				},
+				"reason": {
+					"type": "string"
+				}
+			}
+		}
+	]
+}

--- a/packages/@markuplint/types/src/whatwg/check-http-equiv-content-type.spec.ts
+++ b/packages/@markuplint/types/src/whatwg/check-http-equiv-content-type.spec.ts
@@ -26,13 +26,6 @@ describe('valid per HTML LS §4.2.5.2 "Encoding declaration"', () => {
 	test('tab and other ASCII whitespace separators', () => {
 		expect(check('text/html;\tcharset=utf-8').matched).toBe(true);
 	});
-
-	test('accepts labels that are valid Encoding LS shapes even if not UTF-8', () => {
-		// Shape check only. HTML LS separately requires UTF-8; that
-		// document-level requirement is out of this checker's scope.
-		expect(check('text/html; charset=iso-8859-1').matched).toBe(true);
-		expect(check('text/html; charset=windows-1252').matched).toBe(true);
-	});
 });
 
 describe('invalid per HTML LS §4.2.5.2', () => {
@@ -69,8 +62,14 @@ describe('invalid per HTML LS §4.2.5.2', () => {
 	});
 
 	test('charset label with forbidden characters', () => {
-		// Encoding LS labels are ASCII alphanumerics + "." + "_" + "-".
 		expect(check('text/html; charset=utf 8').matched).toBe(false);
 		expect(check('text/html; charset=utf@8').matched).toBe(false);
+	});
+
+	test('a valid Encoding LS label that is not "utf-8" is rejected', () => {
+		// HTML LS requires the literal string "charset=utf-8", not any
+		// Encoding-LS-shaped label.
+		expect(check('text/html; charset=iso-8859-1').matched).toBe(false);
+		expect(check('text/html; charset=windows-1252').matched).toBe(false);
 	});
 });

--- a/packages/@markuplint/types/src/whatwg/check-http-equiv-content-type.ts
+++ b/packages/@markuplint/types/src/whatwg/check-http-equiv-content-type.ts
@@ -3,13 +3,12 @@ import type { CustomSyntaxChecker } from '../types.js';
 import { log } from '../debug.js';
 import { matched, unmatched } from '../match-result.js';
 
-// Encoding LS §4.1 defines labels as ASCII alphanumerics plus "." "_" "-".
-// The pattern below enforces the label *shape*, not the enumerated label
-// table. HTML LS's "the document must be UTF-8" requirement is a
-// document-level concern checked elsewhere and intentionally not baked in
-// here — otherwise `<meta http-equiv="content-type" content="text/html;
-// charset=iso-8859-1">` would raise two overlapping violations.
-const CONTENT_TYPE_RE = /^text\/html;[\t\n\f\r ]*charset=[\w.-]+$/i;
+// HTML LS's Encoding declaration state requires the literal string
+// "charset=utf-8" — not an arbitrary Encoding LS label. Unlike the
+// `charset` content attribute (a plain `enum: ["utf-8"]` in
+// spec.meta.jsonc), this value is free-form text, so the literal is
+// enforced here via regex instead.
+const CONTENT_TYPE_RE = /^text\/html;[\t\n\f\r ]*charset=utf-8$/i;
 
 /**
  * Validates the `content` attribute value of `<meta http-equiv="content-type">`
@@ -17,11 +16,9 @@ const CONTENT_TYPE_RE = /^text\/html;[\t\n\f\r ]*charset=[\w.-]+$/i;
  *
  *   ASCII case-insensitive "text/html;"
  *   , optionally ASCII whitespace
- *   , "charset="
- *   , character encoding label
+ *   , "charset=utf-8"
  *
  * @see https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-content-type
- * @see https://encoding.spec.whatwg.org/#names-and-labels
  */
 export const checkHTTPEquivContentType: CustomSyntaxChecker = () =>
 	function checkHTTPEquivContentType(value) {

--- a/packages/markuplint/src/cli/init/get-default-rules.spec.ts
+++ b/packages/markuplint/src/cli/init/get-default-rules.spec.ts
@@ -241,6 +241,10 @@ test('default-rules', () => {
 			category: 'a11y',
 			defaultValue: false,
 		},
+		'usemap-references-map': {
+			category: 'validation',
+			defaultValue: true,
+		},
 		'wai-aria': {
 			category: 'a11y',
 			defaultValue: true,

--- a/tests/external/bench/config.ts
+++ b/tests/external/bench/config.ts
@@ -62,6 +62,7 @@ export const benchmarkConfig: Config = {
 		'placeholder-label-option': true,
 		'link-types': { options: { allowMicroformats: true } },
 		'map-id-name-match': true,
+		'usemap-references-map': true,
 		'meter-value-bounds': true,
 		'progress-value-bounds': true,
 		// Catches skipped heading levels (HTML LS §4.3.11).

--- a/tests/external/bench/issue-xref.config.ts
+++ b/tests/external/bench/issue-xref.config.ts
@@ -70,12 +70,6 @@ export const xrefMappings: readonly XrefMapping[] = [
 	},
 	{
 		kind: 'primary',
-		issue: 3928,
-		filter: /^html\/elements\/(a\/with-href-button-descendant|audio\/controls-in-button|picture\/(junk-noscript|junk-noscript-after-source-no-img|junk-video-before))-novalid/,
-		note: "Fixed. `representTransparentNodes` now keeps the transparent element itself in the flattened list alongside its pass-through children, so the parent's own content-model check still evaluates the wrapper's placement (HTML LS §3.2.5.3: transparency defers only the *children* to the parent's model; the transparent element itself must still satisfy the parent's constraints). All 5 fixtures now `match-error`; verified against the full 5442-fixture corpus with zero ml-only/nu-over regressions (path sets identical before/after). Safe to close.",
-	},
-	{
-		kind: 'primary',
 		issue: 3832,
 		filter: /^html\/datatypes\/charset-invalid-novalid/,
 		note: 'Issue body Case A — `<meta http-equiv="content-type" content="text/html; charset=not-a-charset">`. HTML LS [§4.2.5.3 Pragma directives — Encoding declaration state](https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-content-type): "For meta elements with an http-equiv attribute in the Encoding declaration state, the content attribute must have a value that is an ASCII case-insensitive match for a string that consists of: \\"text/html;\\", optionally followed by any number of ASCII whitespace, followed by \\"charset=utf-8\\"." markuplint\'s `HTTPEquivContentType` checker (`packages/@markuplint/types/src/whatwg/check-http-equiv-content-type.ts`) validates the label shape only (`/^text\\/html;[\\t\\n\\f\\r ]*charset=[\\w.-]+$/i`), so unknown labels like `not-a-charset` slip through. Cases B (`url-empty-novalid`) and C (`sandbox-scripts-same-origin-haswarn`) from the same Issue are already resolved (`match-error` and `nu-over` respectively); this is the sole remaining fixture backing the Issue.',
@@ -109,6 +103,12 @@ export const xrefMappings: readonly XrefMapping[] = [
 		issue: 3946,
 		filter: /^html\/elements\/style\/css-property-error-novalid/,
 		note: "CSS syntax and property registry are governed by CSS specifications (CSS Syntax Level 3, CSS Values and Units, individual property specs), not by HTML LS. markuplint's tracked spec scope is HTML LS + WAI-ARIA + URL LS per `.claude/skills/bench-triage/SKILL.md`, so CSS is `deferred-CSS`. One fixture is recorded per-id in `excluded-ids.json#entries[]` and flips `nu-only` → `nu-over`; it will flip to `match-error` if/when a CSS grammar-validation rule lands (css-tree, already a dependency of `packages/@markuplint/types`, is a plausible candidate for syntax-only validation). Parallel deferred spec: #3942 (deferred-CSP).",
+	},
+	{
+		kind: 'primary',
+		issue: 3966,
+		filter: /^html\/elements\/base\/href\/host-(192\.0x00A80001|IP-address-fullwidth|IP-address-percent-encoded)-isvalid/,
+		note: '[URL Standard §3.5 "Host parsing", IPv4 number parser](https://url.spec.whatwg.org/#ipv4-number-parser): a dot-separated host label starting with "0x"/"0X" (hex) or a leading "0" (octal) sets `validationError` to true — `IPv4-non-decimal-part` — even though the number still parses successfully. `checkURL` (`packages/@markuplint/types/src/whatwg/check-url.ts`) delegates structural parsing to `URL.canParse()`/`new URL()`, which silently normalizes hex/octal notation (verified: `new URL(\'http://192.0x00A80001\').host` → `\'192.168.0.1\'`) without surfacing the validation error, matching the pattern already handled for `invalid-credentials`/`special-scheme-missing-following-solidus`/etc. in the same file. Surfaced by a nu-validator Docker image update (unrelated to the original nu-only backlog these fixtures\' `-isvalid` naming predates the URL LS wording landing/nu implementing it). Needs host-component isolation plus percent-decode/NFKC-normalize preprocessing before the hex/octal check, to handle the fullwidth-Unicode and percent-encoded obfuscation variants.',
 	},
 
 	// === 2 次群: bench では裏取れない Issue（ステルブロック） ===

--- a/tests/external/snapshots/diff/coverage.json
+++ b/tests/external/snapshots/diff/coverage.json
@@ -3035,41 +3035,41 @@
 		{
 			"path": "html-aria/presentational-children/testcase-839.html",
 			"category": "aria",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "error",
-			"verdict": "match-error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/presentational-children/testcase-840.html",
 			"category": "aria",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "error",
-			"verdict": "match-error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/presentational-children/testcase-842.html",
 			"category": "aria",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "error",
-			"verdict": "match-error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/presentational-children/testcase-843.html",
 			"category": "aria",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "error",
-			"verdict": "match-error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/presentational-children/testcase-844.html",
 			"category": "aria",
-			"nu": "error",
+			"nu": "clean",
 			"ml": "error",
-			"verdict": "match-error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -14508,8 +14508,8 @@
 			"path": "html/datatypes/charset-invalid-novalid.html",
 			"category": "data-types",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -14949,9 +14949,9 @@
 		{
 			"path": "html/elements/a/href-isvalid.html",
 			"category": "invalid-attr",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "error",
-			"verdict": "ml-only",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -15735,9 +15735,9 @@
 		{
 			"path": "html/elements/area/href-isvalid.html",
 			"category": "invalid-attr",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "error",
-			"verdict": "ml-only",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -16489,9 +16489,9 @@
 		{
 			"path": "html/elements/audio/src-isvalid.html",
 			"category": "invalid-attr",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "error",
-			"verdict": "ml-only",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -17299,33 +17299,33 @@
 		{
 			"path": "html/elements/base/href/host-192.0x00A80001-isvalid.html",
 			"category": "invalid-attr",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "clean",
-			"verdict": "match-clean",
+			"verdict": "nu-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html/elements/base/href/host-IP-address-broken-isvalid.html",
 			"category": "invalid-attr",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "error",
-			"verdict": "ml-only",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
 			"path": "html/elements/base/href/host-IP-address-fullwidth-isvalid.html",
 			"category": "invalid-attr",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "clean",
-			"verdict": "match-clean",
+			"verdict": "nu-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html/elements/base/href/host-IP-address-percent-encoded-isvalid.html",
 			"category": "invalid-attr",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "clean",
-			"verdict": "match-clean",
+			"verdict": "nu-only",
 			"excludedIds": []
 		},
 		{
@@ -18557,9 +18557,9 @@
 		{
 			"path": "html/elements/blockquote/cite-isvalid.html",
 			"category": "invalid-attr",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "error",
-			"verdict": "ml-only",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -19263,9 +19263,9 @@
 		{
 			"path": "html/elements/button/formaction-isvalid.html",
 			"category": "invalid-attr",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "error",
-			"verdict": "ml-only",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -20073,9 +20073,9 @@
 		{
 			"path": "html/elements/del/cite-isvalid.html",
 			"category": "invalid-attr",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "error",
-			"verdict": "ml-only",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -21971,9 +21971,9 @@
 		{
 			"path": "html/elements/embed/src-isvalid.html",
 			"category": "invalid-attr",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "error",
-			"verdict": "ml-only",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -22725,9 +22725,9 @@
 		{
 			"path": "html/elements/form/action-isvalid.html",
 			"category": "invalid-attr",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "error",
-			"verdict": "ml-only",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -23671,9 +23671,9 @@
 		{
 			"path": "html/elements/iframe/src-isvalid.html",
 			"category": "invalid-attr",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "error",
-			"verdict": "ml-only",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -24513,9 +24513,9 @@
 		{
 			"path": "html/elements/img/src-isvalid.html",
 			"category": "invalid-attr",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "error",
-			"verdict": "ml-only",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -25212,8 +25212,8 @@
 			"path": "html/elements/img/usemap-invalid-reference-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -25781,9 +25781,9 @@
 		{
 			"path": "html/elements/input/type-image-formaction-isvalid.html",
 			"category": "invalid-attr",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "error",
-			"verdict": "ml-only",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -26447,9 +26447,9 @@
 		{
 			"path": "html/elements/input/type-image-src-isvalid.html",
 			"category": "invalid-attr",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "error",
-			"verdict": "ml-only",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -27113,9 +27113,9 @@
 		{
 			"path": "html/elements/input/type-submit-formaction-isvalid.html",
 			"category": "invalid-attr",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "error",
-			"verdict": "ml-only",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -27779,9 +27779,9 @@
 		{
 			"path": "html/elements/input/type-url-value-isvalid.html",
 			"category": "invalid-attr",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "error",
-			"verdict": "ml-only",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -28517,9 +28517,9 @@
 		{
 			"path": "html/elements/ins/cite-isvalid.html",
 			"category": "invalid-attr",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "error",
-			"verdict": "ml-only",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -30215,9 +30215,9 @@
 		{
 			"path": "html/elements/link/href-isvalid.html",
 			"category": "invalid-attr",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "error",
-			"verdict": "ml-only",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -31481,9 +31481,9 @@
 		{
 			"path": "html/elements/meta/refresh-isvalid.html",
 			"category": "invalid-attr",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "error",
-			"verdict": "ml-only",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -31733,9 +31733,9 @@
 		{
 			"path": "html/elements/object/data-isvalid.html",
 			"category": "invalid-attr",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "error",
-			"verdict": "ml-only",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -34281,9 +34281,9 @@
 		{
 			"path": "html/elements/q/cite-isvalid.html",
 			"category": "invalid-attr",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "error",
-			"verdict": "ml-only",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -36157,9 +36157,9 @@
 		{
 			"path": "html/elements/script/src-isvalid.html",
 			"category": "invalid-attr",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "error",
-			"verdict": "ml-only",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -37103,9 +37103,9 @@
 		{
 			"path": "html/elements/source/src-isvalid.html",
 			"category": "invalid-attr",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "error",
-			"verdict": "ml-only",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -38381,9 +38381,9 @@
 		{
 			"path": "html/elements/track/src-isvalid.html",
 			"category": "invalid-attr",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "error",
-			"verdict": "ml-only",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -39159,9 +39159,9 @@
 		{
 			"path": "html/elements/video/poster-isvalid.html",
 			"category": "invalid-attr",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "error",
-			"verdict": "ml-only",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -39817,9 +39817,9 @@
 		{
 			"path": "html/elements/video/src-isvalid.html",
 			"category": "invalid-attr",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "error",
-			"verdict": "ml-only",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -40899,9 +40899,9 @@
 		{
 			"path": "html/microdata/itemid-isvalid.html",
 			"category": "uncategorized",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "error",
-			"verdict": "ml-only",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -41605,9 +41605,9 @@
 		{
 			"path": "html/microdata/itemtype-isvalid.html",
 			"category": "uncategorized",
-			"nu": "clean",
+			"nu": "error",
 			"ml": "error",
-			"verdict": "ml-only",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{

--- a/tests/external/snapshots/diff/markuplint-only.json
+++ b/tests/external/snapshots/diff/markuplint-only.json
@@ -299,6 +299,41 @@
 			]
 		},
 		{
+			"path": "html-aria/presentational-children/testcase-839.html",
+			"category": "aria",
+			"ruleIds": [
+				"no-refer-to-non-existent-id"
+			]
+		},
+		{
+			"path": "html-aria/presentational-children/testcase-840.html",
+			"category": "aria",
+			"ruleIds": [
+				"no-refer-to-non-existent-id"
+			]
+		},
+		{
+			"path": "html-aria/presentational-children/testcase-842.html",
+			"category": "aria",
+			"ruleIds": [
+				"no-refer-to-non-existent-id"
+			]
+		},
+		{
+			"path": "html-aria/presentational-children/testcase-843.html",
+			"category": "aria",
+			"ruleIds": [
+				"no-refer-to-non-existent-id"
+			]
+		},
+		{
+			"path": "html-aria/presentational-children/testcase-844.html",
+			"category": "aria",
+			"ruleIds": [
+				"no-refer-to-non-existent-id"
+			]
+		},
+		{
 			"path": "html-aria/roles-plain-concrete/roles-plain-concrete-grid.html",
 			"category": "aria",
 			"ruleIds": [
@@ -7346,14 +7381,6 @@
 			]
 		},
 		{
-			"path": "html/elements/a/href-isvalid.html",
-			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr",
-				"no-refer-to-non-existent-id"
-			]
-		},
-		{
 			"path": "html/elements/a/name-attribute-haswarn.html",
 			"category": "invalid-attr",
 			"ruleIds": [
@@ -7365,21 +7392,6 @@
 			"category": "invalid-attr",
 			"ruleIds": [
 				"deprecated-attr"
-			]
-		},
-		{
-			"path": "html/elements/area/href-isvalid.html",
-			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr",
-				"no-refer-to-non-existent-id"
-			]
-		},
-		{
-			"path": "html/elements/audio/src-isvalid.html",
-			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
 			]
 		},
 		{
@@ -7404,13 +7416,6 @@
 			]
 		},
 		{
-			"path": "html/elements/base/href/host-IP-address-broken-isvalid.html",
-			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
-		},
-		{
 			"path": "html/elements/base/href/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
 			"ruleIds": [
@@ -7432,32 +7437,11 @@
 			]
 		},
 		{
-			"path": "html/elements/blockquote/cite-isvalid.html",
-			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
-		},
-		{
-			"path": "html/elements/button/formaction-isvalid.html",
-			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
-		},
-		{
 			"path": "html/elements/custom/colon-name-isvalid.html",
 			"category": "invalid-attr",
 			"ruleIds": [
 				"permitted-contents",
 				"wai-aria-required-owned-elements"
-			]
-		},
-		{
-			"path": "html/elements/del/cite-isvalid.html",
-			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
 			]
 		},
 		{
@@ -7475,27 +7459,6 @@
 			]
 		},
 		{
-			"path": "html/elements/embed/src-isvalid.html",
-			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
-		},
-		{
-			"path": "html/elements/form/action-isvalid.html",
-			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
-		},
-		{
-			"path": "html/elements/iframe/src-isvalid.html",
-			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
-		},
-		{
 			"path": "html/elements/img/border-attribute-haswarn.html",
 			"category": "invalid-attr",
 			"ruleIds": [
@@ -7503,59 +7466,10 @@
 			]
 		},
 		{
-			"path": "html/elements/img/src-isvalid.html",
-			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
-		},
-		{
 			"path": "html/elements/img/srcset-width-descriptor-loading-lazy-no-sizes-isvalid.html",
 			"category": "invalid-attr",
 			"ruleIds": [
 				"srcset-sizes-constraint"
-			]
-		},
-		{
-			"path": "html/elements/input/type-image-formaction-isvalid.html",
-			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
-		},
-		{
-			"path": "html/elements/input/type-image-src-isvalid.html",
-			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
-		},
-		{
-			"path": "html/elements/input/type-submit-formaction-isvalid.html",
-			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
-		},
-		{
-			"path": "html/elements/input/type-url-value-isvalid.html",
-			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
-		},
-		{
-			"path": "html/elements/ins/cite-isvalid.html",
-			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
-		},
-		{
-			"path": "html/elements/link/href-isvalid.html",
-			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
 			]
 		},
 		{
@@ -7581,24 +7495,10 @@
 			]
 		},
 		{
-			"path": "html/elements/meta/refresh-isvalid.html",
-			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
-		},
-		{
 			"path": "html/elements/meter/aria-valuemax-haswarn.html",
 			"category": "invalid-attr",
 			"ruleIds": [
 				"wai-aria-disallowed-props"
-			]
-		},
-		{
-			"path": "html/elements/object/data-isvalid.html",
-			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
 			]
 		},
 		{
@@ -7674,13 +7574,6 @@
 			]
 		},
 		{
-			"path": "html/elements/q/cite-isvalid.html",
-			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
-		},
-		{
 			"path": "html/elements/rb/rb-interleaved-isvalid.html",
 			"category": "invalid-attr",
 			"ruleIds": [
@@ -7719,13 +7612,6 @@
 			]
 		},
 		{
-			"path": "html/elements/script/src-isvalid.html",
-			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
-		},
-		{
 			"path": "html/elements/select/button-child-isvalid.html",
 			"category": "invalid-attr",
 			"ruleIds": [
@@ -7752,13 +7638,6 @@
 			"ruleIds": [
 				"no-orphaned-end-tag",
 				"permitted-contents"
-			]
-		},
-		{
-			"path": "html/elements/source/src-isvalid.html",
-			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
 			]
 		},
 		{
@@ -7790,45 +7669,10 @@
 			]
 		},
 		{
-			"path": "html/elements/track/src-isvalid.html",
-			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
-		},
-		{
 			"path": "html/elements/ul/model-isvalid.html",
 			"category": "content-model",
 			"ruleIds": [
 				"wai-aria-required-owned-elements"
-			]
-		},
-		{
-			"path": "html/elements/video/poster-isvalid.html",
-			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
-		},
-		{
-			"path": "html/elements/video/src-isvalid.html",
-			"category": "invalid-attr",
-			"ruleIds": [
-				"invalid-attr"
-			]
-		},
-		{
-			"path": "html/microdata/itemid-isvalid.html",
-			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
-			]
-		},
-		{
-			"path": "html/microdata/itemtype-isvalid.html",
-			"category": "uncategorized",
-			"ruleIds": [
-				"invalid-attr"
 			]
 		},
 		{

--- a/tests/external/snapshots/diff/nu-only.json
+++ b/tests/external/snapshots/diff/nu-only.json
@@ -23,11 +23,24 @@
 			]
 		},
 		{
-			"path": "html/datatypes/charset-invalid-novalid.html",
-			"category": "data-types",
+			"path": "html/elements/base/href/host-192.0x00A80001-isvalid.html",
+			"category": "invalid-attr",
 			"nuMessageIds": [
-				"nv-acede5e8fcb0",
-				"nv-b7b2459d8f36"
+				"nv-408800eea8f3"
+			]
+		},
+		{
+			"path": "html/elements/base/href/host-IP-address-fullwidth-isvalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-6f8e202afcff"
+			]
+		},
+		{
+			"path": "html/elements/base/href/host-IP-address-percent-encoded-isvalid.html",
+			"category": "invalid-attr",
+			"nuMessageIds": [
+				"nv-51ed8390068d"
 			]
 		},
 		{
@@ -35,13 +48,6 @@
 			"category": "invalid-attr",
 			"nuMessageIds": [
 				"nv-224e80c23676"
-			]
-		},
-		{
-			"path": "html/elements/img/usemap-invalid-reference-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-f3a0d6efeee1"
 			]
 		},
 		{

--- a/tests/external/snapshots/diff/summary.md
+++ b/tests/external/snapshots/diff/summary.md
@@ -1,45 +1,45 @@
 # nu-validator Benchmark Summary
 
-- generated: 2026-08-11T13:52:52.367Z
+- generated: 2026-08-12T03:50:09.918Z
 - submodule: `142931395412c00434ffb40a14d65992efd17aa8`
-- nu-validator: `ghcr.io/validator/validator@sha256:9365682da0f66efc5504ce2a3aba91290aaf08c00799a41d096236fab740bb44`
+- nu-validator: `ghcr.io/validator/validator@sha256:210bbc353b23ba1b1ae65247c156a006afb4ba84703ba1bbf7c41d2080559445`
 - markuplint: `5.0.0-rc.4`
 - node: `24.14.1`
 
 ## Totals
 
 - files: **5442**
-- match-error: **3495** (both tools flagged)
-- match-clean: **881** (neither flagged)
-- nu-only: **10** (only nu-validator flagged; markuplint coverage candidates — open a markuplint issue after a spec read)
+- match-error: **3519** (both tools flagged)
+- match-clean: **878** (neither flagged)
+- nu-only: **11** (only nu-validator flagged; markuplint coverage candidates — open a markuplint issue after a spec read)
 - nu-over: **37** (nu-validator errors fully covered by spec-backed excluded-ids — confirmed over-detection)
-- overall match rate: **80.4%**
+- overall match rate: **80.8%**
 - excluded-ids: 12 entries, 1 pattern(s)
 
 ## Per-Category
 
 | Category | Files | Match rate | match-error | match-clean | ml-only | nu-only | nu-over |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| aria | 780 | 77.2% | 182 | 420 | 178 | 0 | 0 |
+| aria | 780 | 76.5% | 177 | 420 | 183 | 0 | 0 |
 | assertions | 40 | 100.0% | 39 | 1 | 0 | 0 | 0 |
 | content-model | 98 | 96.9% | 50 | 45 | 3 | 0 | 0 |
-| data-types | 56 | 94.6% | 48 | 5 | 1 | 1 | 1 |
+| data-types | 56 | 96.4% | 49 | 5 | 1 | 0 | 1 |
 | deprecated | 12 | 91.7% | 11 | 0 | 1 | 0 | 0 |
 | global-attr | 57 | 82.5% | 27 | 20 | 8 | 2 | 0 |
 | id-duplication | 1 | 100.0% | 1 | 0 | 0 | 0 | 0 |
-| invalid-attr | 3086 | 96.8% | 2759 | 227 | 63 | 3 | 34 |
+| invalid-attr | 3086 | 97.5% | 2785 | 224 | 38 | 5 | 34 |
 | required-attr | 5 | 100.0% | 5 | 0 | 0 | 0 | 0 |
-| uncategorized | 1307 | 41.0% | 373 | 163 | 765 | 4 | 2 |
+| uncategorized | 1307 | 41.2% | 375 | 163 | 763 | 4 | 2 |
 
 ## Informational: ml-only
 
-**1019** fixtures are flagged only by markuplint. This project does not pursue upstream nu-validator reports, so those fixtures feed a narrower audit: confirm with the spec, and if markuplint is the wrong one, fix the rule. The full list lives in `snapshots/diff/markuplint-only.json`.
+**997** fixtures are flagged only by markuplint. This project does not pursue upstream nu-validator reports, so those fixtures feed a narrower audit: confirm with the spec, and if markuplint is the wrong one, fix the rule. The full list lives in `snapshots/diff/markuplint-only.json`.
 
 ### Top ml-only rules
 
 | Rule | Count |
 | --- | ---: |
-| invalid-attr | 707 |
+| invalid-attr | 680 |
 | permitted-contents | 444 |
 | deprecated-attr | 354 |
 | wai-aria-disallowed-props | 121 |
@@ -48,7 +48,7 @@
 | link-types | 34 |
 | required-attr | 22 |
 | wai-aria-permitted-roles | 20 |
-| wai-aria-value | 11 |
+| no-refer-to-non-existent-id | 11 |
 
 > `nu-only` entries are candidates for markuplint coverage work **after** verifying the relevant spec paragraph. `nu-over` entries are already confirmed nu-validator over-detection via `excluded-ids.json`. `ml-only` is informational; audit the spec before acting on any individual row.
 

--- a/tests/external/snapshots/meta.json
+++ b/tests/external/snapshots/meta.json
@@ -1,12 +1,12 @@
 {
-	"generatedAt": "2026-08-11T13:52:52.367Z",
+	"generatedAt": "2026-08-12T03:50:09.918Z",
 	"submoduleSha": "142931395412c00434ffb40a14d65992efd17aa8",
-	"nuValidatorImage": "ghcr.io/validator/validator@sha256:9365682da0f66efc5504ce2a3aba91290aaf08c00799a41d096236fab740bb44",
+	"nuValidatorImage": "ghcr.io/validator/validator@sha256:210bbc353b23ba1b1ae65247c156a006afb4ba84703ba1bbf7c41d2080559445",
 	"markuplintVersion": "5.0.0-rc.4",
 	"nodeVersion": "24.14.1",
 	"totalFilesNu": 5442,
 	"totalFilesMl": 5442,
-	"totalNuMessages": 9907,
-	"totalMlViolations": 11444,
+	"totalNuMessages": 9963,
+	"totalMlViolations": 11446,
 	"totalNuFailures": 0
 }


### PR DESCRIPTION
## Summary

Two nu-validator bench coverage fixes surfaced during nu-only triage:

- **`fix(types)`**: tighten `<meta http-equiv="content-type">`'s content-attribute check to require the literal string `charset=utf-8` (HTML LS's Encoding declaration state), instead of accepting any Encoding-LS-shaped label (e.g. `charset=iso-8859-1`). Closes the last remaining fixture backing #3832.
- **`feat(rules)`**: add `usemap-references-map`, validating that `<img usemap>` is a valid hash-name reference to an actual `<map name>` element in the same tree (HTML LS "Image maps — Authoring"). Shaped like `form-attr-references-form` / `input-list-references-datalist`. Closes #3945.
- **`test`**: full-corpus bench snapshot refresh reflecting both fixes (nu-only −2), plus a new primary bench-xref mapping for #3966 (a nu-validator image update surfaced 3 unrelated `nu-only` fixtures — URL LS `IPv4-non-decimal-part` validation error on hex/octal `<base href>` hosts, not covered by either fix above), and pruning a stale mapping for the already-closed #3928.

## Test plan

- [x] `yarn build`
- [x] `yarn test` (4542 passed, 1 skipped)
- [x] `yarn lint-check` / `yarn lint` (0 warnings, 0 errors)
- [x] Targeted bench verification: both fixtures (`html/datatypes/charset-invalid-novalid.html`, `html/elements/img/usemap-invalid-reference-novalid.html`) flip `nu-only` → `match-error`
- [x] Full 5442-fixture bench refresh with zero unexpected regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
