### PR TITLE
test: enable require-accessible-name in nu-validator bench, close #3944

### DIFF
--- a/tests/external/bench/config.ts
+++ b/tests/external/bench/config.ts
@@ -77,6 +77,14 @@ export const benchmarkConfig: Config = {
 		'no-extra-selected-options': true,
 		'no-orphaned-end-tag': true,
 		'srcset-sizes-constraint': true,
+		// WAI-ARIA role definitions declare `accessibleNameRequired` per role (e.g. the
+		// `img` role: "In order for elements with a role of img to be perceivable,
+		// authors MUST provide a label using the aria-label or aria-labelledby
+		// attribute."), which HTML LS attribute mappings project onto native HTML (e.g.
+		// `alt` supplies the accessible name for `img`). Missing `alt` on an `<img>` is
+		// therefore a spec MUST violation regardless of ancestor context (e.g. inside
+		// `<figure>`).
+		'require-accessible-name': true,
 		// HTML LS §4.9.12.1 *Forming a table* closes with "Authors must not produce a table with
 		// table model errors", covering cell overlap (Step 14), a row or column that no cell is
 		// anchored to (Step 20), and a cell clipped at a row group boundary (§4.9.12 "A cell

--- a/tests/external/bench/issue-xref.config.ts
+++ b/tests/external/bench/issue-xref.config.ts
@@ -82,12 +82,6 @@ export const xrefMappings: readonly XrefMapping[] = [
 	},
 	{
 		kind: 'primary',
-		issue: 3944,
-		filter: /^html\/elements\/img\/missing-alt-in-figure-novalid/,
-		note: '[HTML LS "Requirements for providing text to act as an alternative for images"](https://html.spec.whatwg.org/multipage/images.html#alt) and its "Guidance for conformance checkers" subsection ([`images.html#guidance-for-conformance-checkers`](https://html.spec.whatwg.org/multipage/images.html#guidance-for-conformance-checkers)) enumerate the narrow exceptions under which `alt` may be omitted. The fixture has no `<figcaption>` inside the enclosing `<figure>`, so none of the omission conditions apply. `packages/@markuplint/rules/src/required-attr/index.spec.ts` `[required-attr-invalid-001]` demonstrates that markuplint\'s `required-attr` fires on `img` only via explicit `nodeRule` config; `packages/@markuplint/html-spec/src/spec.img.jsonc` defines `alt` as `{ "type": "Any" }` without a `required` flag or `requiredEither`. The current `requiredEither` grammar cannot express the exception-list shape from the spec — a new rule (working name `img-alt-required`) or a richer condition grammar is required.',
-	},
-	{
-		kind: 'primary',
 		issue: 3946,
 		filter: /^html\/elements\/style\/css-property-error-novalid/,
 		note: "CSS syntax and property registry are governed by CSS specifications (CSS Syntax Level 3, CSS Values and Units, individual property specs), not by HTML LS. markuplint's tracked spec scope is HTML LS + WAI-ARIA + URL LS per `.claude/skills/bench-triage/SKILL.md`, so CSS is `deferred-CSS`. One fixture is recorded per-id in `excluded-ids.json#entries[]` and flips `nu-only` → `nu-over`; it will flip to `match-error` if/when a CSS grammar-validation rule lands (css-tree, already a dependency of `packages/@markuplint/types`, is a plausible candidate for syntax-only validation). Parallel deferred spec: #3942 (deferred-CSP).",

--- a/tests/external/snapshots/diff/coverage.json
+++ b/tests/external/snapshots/diff/coverage.json
@@ -4,16 +4,16 @@
 			"path": "html-aria/_functional/tree/ariatree.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/_functional/tree/ariatree2.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -492,32 +492,32 @@
 			"path": "html-aria/author-requirements/569.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/author-requirements/571-haswarn.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/author-requirements/572-haswarn.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/author-requirements/573-haswarn.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -620,16 +620,16 @@
 			"path": "html-aria/combobox-autocomplete-list/div-haswarn.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/combobox-autocomplete-list/input.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -1884,8 +1884,8 @@
 			"path": "html-aria/misc/input-checkbox-role-button-aria-pressed-isvalid.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -1900,8 +1900,8 @@
 			"path": "html-aria/misc/input-checkbox-with-aria-expanded-isvalid.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -2364,8 +2364,8 @@
 			"path": "html-aria/misc/unnecessary-role-textbox-haswarn.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -2388,8 +2388,8 @@
 			"path": "html-aria/misc/unnecessary-textbox-role-on-input-haswarn.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -2508,8 +2508,8 @@
 			"path": "html-aria/name-computation-general/837.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -2524,8 +2524,8 @@
 			"path": "html-aria/name-computation-img/565-isvalid.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -3348,8 +3348,8 @@
 			"path": "html-aria/roles-plain-concrete/button-input-button-gridcell-slider-treeitem.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -3372,8 +3372,8 @@
 			"path": "html-aria/roles-plain-concrete/roles-plain-concrete-application.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -3476,16 +3476,16 @@
 			"path": "html-aria/roles-plain-concrete/roles-plain-concrete-image.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-plain-concrete/roles-plain-concrete-img.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -3508,16 +3508,16 @@
 			"path": "html-aria/roles-plain-concrete/roles-plain-concrete-listbox-parent-combobox.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-plain-concrete/roles-plain-concrete-listbox.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -3588,8 +3588,8 @@
 			"path": "html-aria/roles-plain-concrete/roles-plain-concrete-option.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -3604,8 +3604,8 @@
 			"path": "html-aria/roles-plain-concrete/roles-plain-concrete-progressbar.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -3668,16 +3668,16 @@
 			"path": "html-aria/roles-plain-concrete/roles-plain-concrete-tabpanel.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-plain-concrete/roles-plain-concrete-textbox.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -4092,24 +4092,24 @@
 			"path": "html-aria/roles-properties-required/roles-properties-required-combobox-aria-expanded-false.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-required/roles-properties-required-combobox-aria-expanded-true.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-required/roles-properties-required-combobox-aria-expanded-undefined.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -4164,24 +4164,24 @@
 			"path": "html-aria/roles-properties-supported-inherited/application-aria-expanded-false.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/application-aria-expanded-true.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/application-aria-expanded-undefined.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -4316,32 +4316,32 @@
 			"path": "html-aria/roles-properties-supported-inherited/combobox-aria-activedescendant-obj1.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/combobox-aria-expanded-false.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/combobox-aria-expanded-true.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/combobox-aria-expanded-undefined.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -4612,8 +4612,8 @@
 			"path": "html-aria/roles-properties-supported-inherited/listbox-aria-activedescendant-obj1.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -4884,32 +4884,32 @@
 			"path": "html-aria/roles-properties-supported-inherited/progressbar-aria-valuemax-1.1.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/progressbar-aria-valuemin-1.1.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/progressbar-aria-valuenow-1.1.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/progressbar-aria-valuetext-Test-string-value.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -5292,8 +5292,8 @@
 			"path": "html-aria/roles-properties-supported-inherited/tree-aria-activedescendant-obj1.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -5324,8 +5324,8 @@
 			"path": "html-aria/roles-properties-supported-inherited/treegrid-aria-activedescendant-obj1.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -5364,56 +5364,56 @@
 			"path": "html-aria/roles-properties-supported-inherited/treegrid-aria-multiselectable-false.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/treegrid-aria-multiselectable-true.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/treegrid-aria-readonly-false.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/treegrid-aria-readonly-true.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/treegrid-aria-required-false.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/treegrid-aria-required-true.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/treeitem-aria-checked-false.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -5428,8 +5428,8 @@
 			"path": "html-aria/roles-properties-supported-inherited/treeitem-aria-checked-true.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -5444,48 +5444,48 @@
 			"path": "html-aria/roles-properties-supported-inherited/treeitem-aria-level-1.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/treeitem-aria-posinset-1.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/treeitem-aria-selected-false.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/treeitem-aria-selected-true.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/treeitem-aria-selected-undefined.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/treeitem-aria-setsize-1.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -5580,32 +5580,32 @@
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-combobox-aria-autocomplete-both.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-combobox-aria-autocomplete-inline.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-combobox-aria-autocomplete-list.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-combobox-aria-autocomplete-none.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -5804,8 +5804,8 @@
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-option-aria-checked-false.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -5820,8 +5820,8 @@
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-option-aria-checked-true.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -5836,40 +5836,40 @@
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-option-aria-posinset-1.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-option-aria-selected-false.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-option-aria-selected-true.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-option-aria-selected-undefined.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-option-aria-setsize-1.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -6028,152 +6028,152 @@
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-textbox-aria-activedescendant-obj1.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-textbox-aria-autocomplete-both.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-textbox-aria-autocomplete-inline.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-textbox-aria-autocomplete-list.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-textbox-aria-autocomplete-none.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-textbox-aria-multiline-false.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-textbox-aria-multiline-true.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-textbox-aria-readonly-false.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-textbox-aria-readonly-true.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-textbox-aria-required-false.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-textbox-aria-required-true.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-tree-aria-multiselectable-false.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-tree-aria-multiselectable-true.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-tree-aria-required-false.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-tree-aria-required-true.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/selected-state/670.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/selected-state/671.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/selected-state/672.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/setsize-posinset-level/setsize-posinset-level-1.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -6196,32 +6196,32 @@
 			"path": "html-aria/stability-of-dom/669.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/testcases-multiselectable/testcase-listbox-multiselectable-A.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/testcases-multiselectable/testcase-listbox-multiselectable-B.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-aria/testcases-multiselectable/testcase-listbox-multiselectable-C.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -6236,8 +6236,8 @@
 			"path": "html-aria/testcases-multiselectable/testcase-tree-multiselectable-C.html",
 			"category": "aria",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -6692,16 +6692,16 @@
 			"path": "html-its/provenance/html/provenance1html.html",
 			"category": "uncategorized",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html-its/provenance/html/provenance2html.html",
 			"category": "uncategorized",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -6724,8 +6724,8 @@
 			"path": "html-its/provenance/html/provenance5html.html",
 			"category": "uncategorized",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -6756,8 +6756,8 @@
 			"path": "html-its/provenance/html/provenance8html.html",
 			"category": "uncategorized",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -13916,8 +13916,8 @@
 			"path": "html/assertions/meter-valid-isvalid.html",
 			"category": "assertions",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -14084,8 +14084,8 @@
 			"path": "html/attributes/command-and-commandfor-isvalid.html",
 			"category": "global-attr",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -14156,8 +14156,8 @@
 			"path": "html/attributes/enterkeyhint/value-isvalid.html",
 			"category": "global-attr",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -15286,8 +15286,8 @@
 			"path": "html/elements/a/href/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "nu-over",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": [
 				"nv-3a1dc1374ed4"
 			]
@@ -15720,8 +15720,8 @@
 			"path": "html/elements/area/href-empty-isvalid.html",
 			"category": "invalid-attr",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -16072,8 +16072,8 @@
 			"path": "html/elements/area/href/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "nu-over",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": [
 				"nv-cdb4535e049d"
 			]
@@ -19608,8 +19608,8 @@
 			"path": "html/elements/button/formaction/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "nu-over",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": [
 				"nv-82f38369e99e"
 			]
@@ -23400,16 +23400,16 @@
 			"path": "html/elements/h1/empty-haswarn.html",
 			"category": "invalid-attr",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html/elements/h1/empty-heading-haswarn.html",
 			"category": "invalid-attr",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -23592,8 +23592,8 @@
 			"path": "html/elements/html/lang-detection/code-heavy-page-isvalid.html",
 			"category": "invalid-attr",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -24394,8 +24394,8 @@
 			"path": "html/elements/img/missing-alt-in-figure-novalid.html",
 			"category": "invalid-attr",
 			"nu": "error",
-			"ml": "clean",
-			"verdict": "nu-only",
+			"ml": "error",
+			"verdict": "match-error",
 			"excludedIds": []
 		},
 		{
@@ -25292,8 +25292,8 @@
 			"path": "html/elements/input/autocomplete-text-isvalid.html",
 			"category": "invalid-attr",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -25308,8 +25308,8 @@
 			"path": "html/elements/input/autocomplete-types-isvalid.html",
 			"category": "invalid-attr",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -25444,8 +25444,8 @@
 			"path": "html/elements/input/datetime-local-with-min-max-isvalid.html",
 			"category": "invalid-attr",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -25676,8 +25676,8 @@
 			"path": "html/elements/input/text-with-dirname-isvalid.html",
 			"category": "invalid-attr",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -25708,8 +25708,8 @@
 			"path": "html/elements/input/type-button-empty-value-novalid.html",
 			"category": "invalid-attr",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "nu-over",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": [
 				"nv-54c78eff3c7d"
 			]
@@ -27772,8 +27772,8 @@
 			"path": "html/elements/input/type-url-value-empty-isvalid.html",
 			"category": "invalid-attr",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -28188,8 +28188,8 @@
 			"path": "html/elements/input/type-url-value/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "nu-over",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": [
 				"nv-6872c643a823"
 			]
@@ -30048,8 +30048,8 @@
 			"path": "html/elements/label/for-isvalid.html",
 			"category": "invalid-attr",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -32458,8 +32458,8 @@
 			"path": "html/elements/optgroup/label-attr-isvalid.html",
 			"category": "invalid-attr",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -32530,8 +32530,8 @@
 			"path": "html/elements/option/model-isvalid.html",
 			"category": "content-model",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -36880,8 +36880,8 @@
 			"path": "html/elements/select/autocomplete-isvalid.html",
 			"category": "invalid-attr",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -36984,8 +36984,8 @@
 			"path": "html/elements/select/hr-child-isvalid.html",
 			"category": "invalid-attr",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -37828,8 +37828,8 @@
 			"path": "html/elements/style/html-spec-comms-isvalid.html",
 			"category": "invalid-attr",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -38230,8 +38230,8 @@
 			"path": "html/elements/textarea/autocomplete-isvalid.html",
 			"category": "invalid-attr",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -43336,40 +43336,40 @@
 			"path": "html/warnings/h2-empty-haswarn.html",
 			"category": "uncategorized",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html/warnings/h3-empty-haswarn.html",
 			"category": "uncategorized",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html/warnings/h4-empty-haswarn.html",
 			"category": "uncategorized",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html/warnings/h5-empty-haswarn.html",
 			"category": "uncategorized",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
 			"path": "html/warnings/h6-empty-haswarn.html",
 			"category": "uncategorized",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{
@@ -43424,8 +43424,8 @@
 			"path": "html/warnings/unnecessary-role-form-haswarn.html",
 			"category": "uncategorized",
 			"nu": "clean",
-			"ml": "clean",
-			"verdict": "match-clean",
+			"ml": "error",
+			"verdict": "ml-only",
 			"excludedIds": []
 		},
 		{

--- a/tests/external/snapshots/diff/markuplint-only.json
+++ b/tests/external/snapshots/diff/markuplint-only.json
@@ -1,6 +1,62 @@
 {
 	"entries": [
 		{
+			"path": "html-aria/_functional/tree/ariatree.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/_functional/tree/ariatree2.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/author-requirements/569.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/author-requirements/571-haswarn.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/author-requirements/572-haswarn.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/author-requirements/573-haswarn.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/combobox-autocomplete-list/div-haswarn.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/combobox-autocomplete-list/input.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
 			"path": "html-aria/misc/a-href-aria-disabled-true-haswarn.html",
 			"category": "aria",
 			"ruleIds": [
@@ -18,7 +74,8 @@
 			"path": "html-aria/misc/aria-describedby-broken-idref-novalid.html",
 			"category": "aria",
 			"ruleIds": [
-				"no-refer-to-non-existent-id"
+				"no-refer-to-non-existent-id",
+				"require-accessible-name"
 			]
 		},
 		{
@@ -39,6 +96,7 @@
 			"path": "html-aria/misc/aria-haspopup-on-datalist-input-haswarn.html",
 			"category": "aria",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-disallowed-props"
 			]
 		},
@@ -55,6 +113,7 @@
 			"category": "aria",
 			"ruleIds": [
 				"no-refer-to-non-existent-id",
+				"require-accessible-name",
 				"wai-aria-required-owned-elements",
 				"wai-aria-required-parent-role"
 			]
@@ -63,6 +122,7 @@
 			"path": "html-aria/misc/aria-valuemin-on-meter-haswarn.html",
 			"category": "aria",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-disallowed-props"
 			]
 		},
@@ -84,13 +144,29 @@
 			"path": "html-aria/misc/img-element-with-role-and-accessible-name-isvalid.html",
 			"category": "aria",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-permitted-roles"
+			]
+		},
+		{
+			"path": "html-aria/misc/input-checkbox-role-button-aria-pressed-isvalid.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/misc/input-checkbox-with-aria-expanded-isvalid.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
 			]
 		},
 		{
 			"path": "html-aria/misc/input-image-reset-submit.html",
 			"category": "aria",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-permitted-roles"
 			]
 		},
@@ -98,6 +174,7 @@
 			"path": "html-aria/misc/input-number-aria-valuemax-haswarn.html",
 			"category": "aria",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-disallowed-props"
 			]
 		},
@@ -105,6 +182,7 @@
 			"path": "html-aria/misc/input-number-aria-valuemin-haswarn.html",
 			"category": "aria",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-disallowed-props"
 			]
 		},
@@ -141,6 +219,7 @@
 			"path": "html-aria/misc/select-aria-multiselectable-haswarn.html",
 			"category": "aria",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-disallowed-props"
 			]
 		},
@@ -148,6 +227,7 @@
 			"path": "html-aria/misc/table-role-presentation-nested-with-td-with-role-isvalid.html",
 			"category": "aria",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-required-owned-elements"
 			]
 		},
@@ -155,6 +235,7 @@
 			"path": "html-aria/misc/unnecessary-listbox-role-on-select-haswarn.html",
 			"category": "aria",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-permitted-roles"
 			]
 		},
@@ -162,6 +243,7 @@
 			"path": "html-aria/misc/unnecessary-role-listbox-haswarn.html",
 			"category": "aria",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-permitted-roles"
 			]
 		},
@@ -176,14 +258,30 @@
 			"path": "html-aria/misc/unnecessary-role-searchbox-haswarn.html",
 			"category": "aria",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-permitted-roles"
+			]
+		},
+		{
+			"path": "html-aria/misc/unnecessary-role-textbox-haswarn.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
 			]
 		},
 		{
 			"path": "html-aria/misc/unnecessary-searchbox-role-on-input-haswarn.html",
 			"category": "aria",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-permitted-roles"
+			]
+		},
+		{
+			"path": "html-aria/misc/unnecessary-textbox-role-on-input-haswarn.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
 			]
 		},
 		{
@@ -201,9 +299,24 @@
 			]
 		},
 		{
+			"path": "html-aria/name-computation-general/837.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/name-computation-img/565-isvalid.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
 			"path": "html-aria/name-computation-img/566-isvalid.html",
 			"category": "aria",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-disallowed-props"
 			]
 		},
@@ -309,7 +422,8 @@
 			"path": "html-aria/presentational-children/testcase-840.html",
 			"category": "aria",
 			"ruleIds": [
-				"no-refer-to-non-existent-id"
+				"no-refer-to-non-existent-id",
+				"require-accessible-name"
 			]
 		},
 		{
@@ -323,7 +437,8 @@
 			"path": "html-aria/presentational-children/testcase-843.html",
 			"category": "aria",
 			"ruleIds": [
-				"no-refer-to-non-existent-id"
+				"no-refer-to-non-existent-id",
+				"require-accessible-name"
 			]
 		},
 		{
@@ -334,6 +449,20 @@
 			]
 		},
 		{
+			"path": "html-aria/roles-plain-concrete/button-input-button-gridcell-slider-treeitem.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-plain-concrete/roles-plain-concrete-application.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
 			"path": "html-aria/roles-plain-concrete/roles-plain-concrete-grid.html",
 			"category": "aria",
 			"ruleIds": [
@@ -341,10 +470,38 @@
 			]
 		},
 		{
+			"path": "html-aria/roles-plain-concrete/roles-plain-concrete-image.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-plain-concrete/roles-plain-concrete-img.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
 			"path": "html-aria/roles-plain-concrete/roles-plain-concrete-list.html",
 			"category": "aria",
 			"ruleIds": [
 				"wai-aria-required-owned-elements"
+			]
+		},
+		{
+			"path": "html-aria/roles-plain-concrete/roles-plain-concrete-listbox-parent-combobox.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-plain-concrete/roles-plain-concrete-listbox.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
 			]
 		},
 		{
@@ -362,6 +519,20 @@
 			]
 		},
 		{
+			"path": "html-aria/roles-plain-concrete/roles-plain-concrete-option.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-plain-concrete/roles-plain-concrete-progressbar.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
 			"path": "html-aria/roles-plain-concrete/roles-plain-concrete-tablist.html",
 			"category": "aria",
 			"ruleIds": [
@@ -369,9 +540,24 @@
 			]
 		},
 		{
+			"path": "html-aria/roles-plain-concrete/roles-plain-concrete-tabpanel.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-plain-concrete/roles-plain-concrete-textbox.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
 			"path": "html-aria/roles-plain-concrete/roles-plain-concrete-tree.html",
 			"category": "aria",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-required-owned-elements"
 			]
 		},
@@ -379,6 +565,7 @@
 			"path": "html-aria/roles-plain-concrete/roles-plain-concrete-treegrid.html",
 			"category": "aria",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-required-owned-elements"
 			]
 		},
@@ -394,6 +581,27 @@
 			"category": "aria",
 			"ruleIds": [
 				"wai-aria-value"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-required/roles-properties-required-combobox-aria-expanded-false.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-required/roles-properties-required-combobox-aria-expanded-true.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-required/roles-properties-required-combobox-aria-expanded-undefined.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
 			]
 		},
 		{
@@ -439,6 +647,27 @@
 			]
 		},
 		{
+			"path": "html-aria/roles-properties-supported-inherited/application-aria-expanded-false.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported-inherited/application-aria-expanded-true.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported-inherited/application-aria-expanded-undefined.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
 			"path": "html-aria/roles-properties-supported-inherited/article-aria-expanded-false.html",
 			"category": "aria",
 			"ruleIds": [
@@ -478,6 +707,34 @@
 			"category": "aria",
 			"ruleIds": [
 				"wai-aria-disallowed-props"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported-inherited/combobox-aria-activedescendant-obj1.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported-inherited/combobox-aria-expanded-false.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported-inherited/combobox-aria-expanded-true.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported-inherited/combobox-aria-expanded-undefined.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
 			]
 		},
 		{
@@ -655,6 +912,7 @@
 			"path": "html-aria/roles-properties-supported-inherited/img-aria-expanded-false.html",
 			"category": "aria",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-disallowed-props"
 			]
 		},
@@ -662,6 +920,7 @@
 			"path": "html-aria/roles-properties-supported-inherited/img-aria-expanded-true.html",
 			"category": "aria",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-disallowed-props"
 			]
 		},
@@ -669,6 +928,7 @@
 			"path": "html-aria/roles-properties-supported-inherited/img-aria-expanded-undefined.html",
 			"category": "aria",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-disallowed-props"
 			]
 		},
@@ -691,6 +951,13 @@
 			"category": "aria",
 			"ruleIds": [
 				"wai-aria-disallowed-props"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported-inherited/listbox-aria-activedescendant-obj1.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
 			]
 		},
 		{
@@ -882,6 +1149,34 @@
 			]
 		},
 		{
+			"path": "html-aria/roles-properties-supported-inherited/progressbar-aria-valuemax-1.1.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported-inherited/progressbar-aria-valuemin-1.1.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported-inherited/progressbar-aria-valuenow-1.1.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported-inherited/progressbar-aria-valuetext-Test-string-value.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
 			"path": "html-aria/roles-properties-supported-inherited/radio-aria-checked-mixed.html",
 			"category": "aria",
 			"ruleIds": [
@@ -1004,6 +1299,7 @@
 			"path": "html-aria/roles-properties-supported-inherited/tabpanel-aria-expanded-false.html",
 			"category": "aria",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-disallowed-props"
 			]
 		},
@@ -1011,6 +1307,7 @@
 			"path": "html-aria/roles-properties-supported-inherited/tabpanel-aria-expanded-true.html",
 			"category": "aria",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-disallowed-props"
 			]
 		},
@@ -1018,6 +1315,7 @@
 			"path": "html-aria/roles-properties-supported-inherited/tabpanel-aria-expanded-undefined.html",
 			"category": "aria",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-disallowed-props"
 			]
 		},
@@ -1085,9 +1383,17 @@
 			]
 		},
 		{
+			"path": "html-aria/roles-properties-supported-inherited/tree-aria-activedescendant-obj1.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
 			"path": "html-aria/roles-properties-supported-inherited/tree-aria-expanded-false.html",
 			"category": "aria",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-disallowed-props"
 			]
 		},
@@ -1095,6 +1401,7 @@
 			"path": "html-aria/roles-properties-supported-inherited/tree-aria-expanded-true.html",
 			"category": "aria",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-disallowed-props"
 			]
 		},
@@ -1102,13 +1409,22 @@
 			"path": "html-aria/roles-properties-supported-inherited/tree-aria-expanded-undefined.html",
 			"category": "aria",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-disallowed-props"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported-inherited/treegrid-aria-activedescendant-obj1.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
 			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/treegrid-aria-expanded-false.html",
 			"category": "aria",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-disallowed-props"
 			]
 		},
@@ -1116,6 +1432,7 @@
 			"path": "html-aria/roles-properties-supported-inherited/treegrid-aria-expanded-true.html",
 			"category": "aria",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-disallowed-props"
 			]
 		},
@@ -1123,6 +1440,7 @@
 			"path": "html-aria/roles-properties-supported-inherited/treegrid-aria-expanded-undefined.html",
 			"category": "aria",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-disallowed-props"
 			]
 		},
@@ -1130,21 +1448,150 @@
 			"path": "html-aria/roles-properties-supported-inherited/treegrid-aria-level-1.html",
 			"category": "aria",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-disallowed-props"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported-inherited/treegrid-aria-multiselectable-false.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported-inherited/treegrid-aria-multiselectable-true.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported-inherited/treegrid-aria-readonly-false.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported-inherited/treegrid-aria-readonly-true.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported-inherited/treegrid-aria-required-false.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported-inherited/treegrid-aria-required-true.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported-inherited/treeitem-aria-checked-false.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
 			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/treeitem-aria-checked-mixed.html",
 			"category": "aria",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-value"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported-inherited/treeitem-aria-checked-true.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
 			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported-inherited/treeitem-aria-checked-undefined.html",
 			"category": "aria",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-value"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported-inherited/treeitem-aria-level-1.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported-inherited/treeitem-aria-posinset-1.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported-inherited/treeitem-aria-selected-false.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported-inherited/treeitem-aria-selected-true.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported-inherited/treeitem-aria-selected-undefined.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported-inherited/treeitem-aria-setsize-1.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported/roles-properties-supported-combobox-aria-autocomplete-both.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported/roles-properties-supported-combobox-aria-autocomplete-inline.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported/roles-properties-supported-combobox-aria-autocomplete-list.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported/roles-properties-supported-combobox-aria-autocomplete-none.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
 			]
 		},
 		{
@@ -1200,6 +1647,7 @@
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-listbox-aria-multiselectable-false.html",
 			"category": "aria",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-required-owned-elements"
 			]
 		},
@@ -1207,6 +1655,7 @@
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-listbox-aria-multiselectable-true.html",
 			"category": "aria",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-required-owned-elements"
 			]
 		},
@@ -1214,6 +1663,7 @@
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-listbox-aria-required-false.html",
 			"category": "aria",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-required-owned-elements"
 			]
 		},
@@ -1221,21 +1671,73 @@
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-listbox-aria-required-true.html",
 			"category": "aria",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-required-owned-elements"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported/roles-properties-supported-option-aria-checked-false.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
 			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-option-aria-checked-mixed.html",
 			"category": "aria",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-value"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported/roles-properties-supported-option-aria-checked-true.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
 			]
 		},
 		{
 			"path": "html-aria/roles-properties-supported/roles-properties-supported-option-aria-checked-undefined.html",
 			"category": "aria",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-value"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported/roles-properties-supported-option-aria-posinset-1.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported/roles-properties-supported-option-aria-selected-false.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported/roles-properties-supported-option-aria-selected-true.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported/roles-properties-supported-option-aria-selected-undefined.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported/roles-properties-supported-option-aria-setsize-1.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
 			]
 		},
 		{
@@ -1288,10 +1790,178 @@
 			]
 		},
 		{
+			"path": "html-aria/roles-properties-supported/roles-properties-supported-textbox-aria-activedescendant-obj1.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported/roles-properties-supported-textbox-aria-autocomplete-both.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported/roles-properties-supported-textbox-aria-autocomplete-inline.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported/roles-properties-supported-textbox-aria-autocomplete-list.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported/roles-properties-supported-textbox-aria-autocomplete-none.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported/roles-properties-supported-textbox-aria-multiline-false.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported/roles-properties-supported-textbox-aria-multiline-true.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported/roles-properties-supported-textbox-aria-readonly-false.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported/roles-properties-supported-textbox-aria-readonly-true.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported/roles-properties-supported-textbox-aria-required-false.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported/roles-properties-supported-textbox-aria-required-true.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported/roles-properties-supported-tree-aria-multiselectable-false.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported/roles-properties-supported-tree-aria-multiselectable-true.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported/roles-properties-supported-tree-aria-required-false.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/roles-properties-supported/roles-properties-supported-tree-aria-required-true.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/selected-state/670.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/selected-state/671.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/selected-state/672.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/setsize-posinset-level/setsize-posinset-level-1.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
 			"path": "html-aria/setsize-posinset-level/testcase-769.html",
 			"category": "aria",
 			"ruleIds": [
 				"wai-aria-required-parent-role"
+			]
+		},
+		{
+			"path": "html-aria/stability-of-dom/669.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/testcases-multiselectable/testcase-listbox-multiselectable-A.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/testcases-multiselectable/testcase-listbox-multiselectable-B.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/testcases-multiselectable/testcase-listbox-multiselectable-C.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-aria/testcases-multiselectable/testcase-tree-multiselectable-C.html",
+			"category": "aria",
+			"ruleIds": [
+				"require-accessible-name"
 			]
 		},
 		{
@@ -1422,6 +2092,20 @@
 			]
 		},
 		{
+			"path": "html-its/provenance/html/provenance1html.html",
+			"category": "uncategorized",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html-its/provenance/html/provenance2html.html",
+			"category": "uncategorized",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
 			"path": "html-its/provenance/html/provenance3html.html",
 			"category": "uncategorized",
 			"ruleIds": [
@@ -1436,6 +2120,13 @@
 			]
 		},
 		{
+			"path": "html-its/provenance/html/provenance5html.html",
+			"category": "uncategorized",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
 			"path": "html-its/provenance/html/provenance6html.html",
 			"category": "uncategorized",
 			"ruleIds": [
@@ -1447,6 +2138,13 @@
 			"category": "uncategorized",
 			"ruleIds": [
 				"invalid-attr"
+			]
+		},
+		{
+			"path": "html-its/provenance/html/provenance8html.html",
+			"category": "uncategorized",
+			"ruleIds": [
+				"require-accessible-name"
 			]
 		},
 		{
@@ -3206,7 +3904,8 @@
 			"path": "html-svg/0001isvalid.html",
 			"category": "uncategorized",
 			"ruleIds": [
-				"permitted-contents"
+				"permitted-contents",
+				"require-accessible-name"
 			]
 		},
 		{
@@ -7312,10 +8011,31 @@
 			]
 		},
 		{
+			"path": "html/assertions/meter-valid-isvalid.html",
+			"category": "assertions",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
 			"path": "html/attributes/autofocus-isvalid.html",
 			"category": "global-attr",
 			"ruleIds": [
 				"no-duplicate-autofocus"
+			]
+		},
+		{
+			"path": "html/attributes/command-and-commandfor-isvalid.html",
+			"category": "global-attr",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html/attributes/enterkeyhint/value-isvalid.html",
+			"category": "global-attr",
+			"ruleIds": [
+				"require-accessible-name"
 			]
 		},
 		{
@@ -7381,6 +8101,13 @@
 			]
 		},
 		{
+			"path": "html/elements/a/href/scheme-data-contains-fragment-haswarn.html",
+			"category": "invalid-attr",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
 			"path": "html/elements/a/name-attribute-haswarn.html",
 			"category": "invalid-attr",
 			"ruleIds": [
@@ -7391,28 +8118,46 @@
 			"path": "html/elements/a/name-empty-haswarn.html",
 			"category": "invalid-attr",
 			"ruleIds": [
-				"deprecated-attr"
+				"deprecated-attr",
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html/elements/area/href-empty-isvalid.html",
+			"category": "invalid-attr",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html/elements/area/href/scheme-data-contains-fragment-haswarn.html",
+			"category": "invalid-attr",
+			"ruleIds": [
+				"require-accessible-name"
 			]
 		},
 		{
 			"path": "html/elements/autofocus/dialog-scoped-isvalid.html",
 			"category": "invalid-attr",
 			"ruleIds": [
-				"no-duplicate-autofocus"
+				"no-duplicate-autofocus",
+				"require-accessible-name"
 			]
 		},
 		{
 			"path": "html/elements/autofocus/nested-dialogs-isvalid.html",
 			"category": "invalid-attr",
 			"ruleIds": [
-				"no-duplicate-autofocus"
+				"no-duplicate-autofocus",
+				"require-accessible-name"
 			]
 		},
 		{
 			"path": "html/elements/autofocus/popover-scoped-isvalid.html",
 			"category": "invalid-attr",
 			"ruleIds": [
-				"no-duplicate-autofocus"
+				"no-duplicate-autofocus",
+				"require-accessible-name"
 			]
 		},
 		{
@@ -7434,6 +8179,13 @@
 			"category": "invalid-attr",
 			"ruleIds": [
 				"invalid-attr"
+			]
+		},
+		{
+			"path": "html/elements/button/formaction/scheme-data-contains-fragment-haswarn.html",
+			"category": "invalid-attr",
+			"ruleIds": [
+				"require-accessible-name"
 			]
 		},
 		{
@@ -7459,6 +8211,27 @@
 			]
 		},
 		{
+			"path": "html/elements/h1/empty-haswarn.html",
+			"category": "invalid-attr",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html/elements/h1/empty-heading-haswarn.html",
+			"category": "invalid-attr",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html/elements/html/lang-detection/code-heavy-page-isvalid.html",
+			"category": "invalid-attr",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
 			"path": "html/elements/img/border-attribute-haswarn.html",
 			"category": "invalid-attr",
 			"ruleIds": [
@@ -7470,6 +8243,62 @@
 			"category": "invalid-attr",
 			"ruleIds": [
 				"srcset-sizes-constraint"
+			]
+		},
+		{
+			"path": "html/elements/input/autocomplete-text-isvalid.html",
+			"category": "invalid-attr",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html/elements/input/autocomplete-types-isvalid.html",
+			"category": "invalid-attr",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html/elements/input/datetime-local-with-min-max-isvalid.html",
+			"category": "invalid-attr",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html/elements/input/text-with-dirname-isvalid.html",
+			"category": "invalid-attr",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html/elements/input/type-button-empty-value-novalid.html",
+			"category": "invalid-attr",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html/elements/input/type-url-value-empty-isvalid.html",
+			"category": "invalid-attr",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html/elements/input/type-url-value/scheme-data-contains-fragment-haswarn.html",
+			"category": "invalid-attr",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html/elements/label/for-isvalid.html",
+			"category": "invalid-attr",
+			"ruleIds": [
+				"require-accessible-name"
 			]
 		},
 		{
@@ -7498,6 +8327,7 @@
 			"path": "html/elements/meter/aria-valuemax-haswarn.html",
 			"category": "invalid-attr",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-disallowed-props"
 			]
 		},
@@ -7513,7 +8343,15 @@
 			"category": "invalid-attr",
 			"ruleIds": [
 				"no-orphaned-end-tag",
-				"permitted-contents"
+				"permitted-contents",
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html/elements/optgroup/label-attr-isvalid.html",
+			"category": "invalid-attr",
+			"ruleIds": [
+				"require-accessible-name"
 			]
 		},
 		{
@@ -7521,6 +8359,7 @@
 			"category": "invalid-attr",
 			"ruleIds": [
 				"permitted-contents",
+				"require-accessible-name",
 				"required-attr"
 			]
 		},
@@ -7528,6 +8367,7 @@
 			"path": "html/elements/option/aria-selected-haswarn.html",
 			"category": "invalid-attr",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-disallowed-props"
 			]
 		},
@@ -7535,41 +8375,54 @@
 			"path": "html/elements/option/div-child-isvalid.html",
 			"category": "invalid-attr",
 			"ruleIds": [
-				"no-orphaned-end-tag"
+				"no-orphaned-end-tag",
+				"require-accessible-name"
 			]
 		},
 		{
 			"path": "html/elements/option/empty-option-with-label-isvalid.html",
 			"category": "invalid-attr",
 			"ruleIds": [
-				"permitted-contents"
+				"permitted-contents",
+				"require-accessible-name"
 			]
 		},
 		{
 			"path": "html/elements/option/label-isvalid.html",
 			"category": "invalid-attr",
 			"ruleIds": [
-				"permitted-contents"
+				"permitted-contents",
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html/elements/option/model-isvalid.html",
+			"category": "content-model",
+			"ruleIds": [
+				"require-accessible-name"
 			]
 		},
 		{
 			"path": "html/elements/option/phrasing-content-isvalid.html",
 			"category": "invalid-attr",
 			"ruleIds": [
-				"no-orphaned-end-tag"
+				"no-orphaned-end-tag",
+				"require-accessible-name"
 			]
 		},
 		{
 			"path": "html/elements/picture/picture-isvalid.html",
 			"category": "invalid-attr",
 			"ruleIds": [
-				"invalid-attr"
+				"invalid-attr",
+				"require-accessible-name"
 			]
 		},
 		{
 			"path": "html/elements/progress/aria-valuemax-haswarn.html",
 			"category": "invalid-attr",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-disallowed-props"
 			]
 		},
@@ -7612,24 +8465,34 @@
 			]
 		},
 		{
+			"path": "html/elements/select/autocomplete-isvalid.html",
+			"category": "invalid-attr",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
 			"path": "html/elements/select/button-child-isvalid.html",
 			"category": "invalid-attr",
 			"ruleIds": [
-				"permitted-contents"
+				"permitted-contents",
+				"require-accessible-name"
 			]
 		},
 		{
 			"path": "html/elements/select/button-in-multiple-size1-isvalid.html",
 			"category": "invalid-attr",
 			"ruleIds": [
-				"permitted-contents"
+				"permitted-contents",
+				"require-accessible-name"
 			]
 		},
 		{
 			"path": "html/elements/select/button-selectedcontent-isvalid.html",
 			"category": "invalid-attr",
 			"ruleIds": [
-				"permitted-contents"
+				"permitted-contents",
+				"require-accessible-name"
 			]
 		},
 		{
@@ -7637,7 +8500,22 @@
 			"category": "invalid-attr",
 			"ruleIds": [
 				"no-orphaned-end-tag",
-				"permitted-contents"
+				"permitted-contents",
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html/elements/select/hr-child-isvalid.html",
+			"category": "invalid-attr",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html/elements/style/html-spec-comms-isvalid.html",
+			"category": "invalid-attr",
+			"ruleIds": [
+				"require-accessible-name"
 			]
 		},
 		{
@@ -7669,6 +8547,13 @@
 			]
 		},
 		{
+			"path": "html/elements/textarea/autocomplete-isvalid.html",
+			"category": "invalid-attr",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
 			"path": "html/elements/ul/model-isvalid.html",
 			"category": "content-model",
 			"ruleIds": [
@@ -7694,7 +8579,43 @@
 			"path": "html/warnings/aria-multiselectable-on-select-haswarn.html",
 			"category": "uncategorized",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-disallowed-props"
+			]
+		},
+		{
+			"path": "html/warnings/h2-empty-haswarn.html",
+			"category": "uncategorized",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html/warnings/h3-empty-haswarn.html",
+			"category": "uncategorized",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html/warnings/h4-empty-haswarn.html",
+			"category": "uncategorized",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html/warnings/h5-empty-haswarn.html",
+			"category": "uncategorized",
+			"ruleIds": [
+				"require-accessible-name"
+			]
+		},
+		{
+			"path": "html/warnings/h6-empty-haswarn.html",
+			"category": "uncategorized",
+			"ruleIds": [
+				"require-accessible-name"
 			]
 		},
 		{
@@ -7702,6 +8623,13 @@
 			"category": "uncategorized",
 			"ruleIds": [
 				"wai-aria-permitted-roles"
+			]
+		},
+		{
+			"path": "html/warnings/unnecessary-role-form-haswarn.html",
+			"category": "uncategorized",
+			"ruleIds": [
+				"require-accessible-name"
 			]
 		},
 		{
@@ -7722,6 +8650,7 @@
 			"path": "html/warnings/unnecessary-role-progressbar-haswarn.html",
 			"category": "uncategorized",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-permitted-roles"
 			]
 		},
@@ -7729,6 +8658,7 @@
 			"path": "html/warnings/unnecessary-role-spinbutton-haswarn.html",
 			"category": "uncategorized",
 			"ruleIds": [
+				"require-accessible-name",
 				"wai-aria-permitted-roles"
 			]
 		},

--- a/tests/external/snapshots/diff/nu-only.json
+++ b/tests/external/snapshots/diff/nu-only.json
@@ -44,13 +44,6 @@
 			]
 		},
 		{
-			"path": "html/elements/img/missing-alt-in-figure-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-224e80c23676"
-			]
-		},
-		{
 			"path": "html/elements/picture/html-syntax-picture-no-end-tag-novalid.html",
 			"category": "invalid-attr",
 			"nuMessageIds": [

--- a/tests/external/snapshots/diff/nu-over.json
+++ b/tests/external/snapshots/diff/nu-over.json
@@ -8,20 +8,6 @@
 			]
 		},
 		{
-			"path": "html/elements/a/href/scheme-data-contains-fragment-haswarn.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-3a1dc1374ed4"
-			]
-		},
-		{
-			"path": "html/elements/area/href/scheme-data-contains-fragment-haswarn.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-cdb4535e049d"
-			]
-		},
-		{
 			"path": "html/elements/audio/src/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
 			"nuMessageIds": [
@@ -33,13 +19,6 @@
 			"category": "invalid-attr",
 			"nuMessageIds": [
 				"nv-ed1dbf9dfa0f"
-			]
-		},
-		{
-			"path": "html/elements/button/formaction/scheme-data-contains-fragment-haswarn.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-82f38369e99e"
 			]
 		},
 		{
@@ -78,13 +57,6 @@
 			]
 		},
 		{
-			"path": "html/elements/input/type-button-empty-value-novalid.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-54c78eff3c7d"
-			]
-		},
-		{
 			"path": "html/elements/input/type-image-formaction/scheme-data-contains-fragment-haswarn.html",
 			"category": "invalid-attr",
 			"nuMessageIds": [
@@ -103,13 +75,6 @@
 			"category": "invalid-attr",
 			"nuMessageIds": [
 				"nv-8c1d1d42e012"
-			]
-		},
-		{
-			"path": "html/elements/input/type-url-value/scheme-data-contains-fragment-haswarn.html",
-			"category": "invalid-attr",
-			"nuMessageIds": [
-				"nv-6872c643a823"
 			]
 		},
 		{

--- a/tests/external/snapshots/diff/summary.md
+++ b/tests/external/snapshots/diff/summary.md
@@ -1,6 +1,6 @@
 # nu-validator Benchmark Summary
 
-- generated: 2026-08-12T06:31:53.804Z
+- generated: 2026-08-12T06:53:36.214Z
 - submodule: `142931395412c00434ffb40a14d65992efd17aa8`
 - nu-validator: `ghcr.io/validator/validator@sha256:210bbc353b23ba1b1ae65247c156a006afb4ba84703ba1bbf7c41d2080559445`
 - markuplint: `5.0.0-rc.4`
@@ -11,10 +11,10 @@
 - files: **5442**
 - match-error: **3520** (both tools flagged)
 - match-clean: **759** (neither flagged)
-- nu-only: **7** (only nu-validator flagged; markuplint coverage candidates — open a markuplint issue after a spec read)
-- nu-over: **35** (nu-validator errors fully covered by spec-backed excluded-ids — confirmed over-detection)
+- nu-only: **10** (only nu-validator flagged; markuplint coverage candidates — open a markuplint issue after a spec read)
+- nu-over: **32** (nu-validator errors fully covered by spec-backed excluded-ids — confirmed over-detection)
 - overall match rate: **78.6%**
-- excluded-ids: 15 entries, 1 pattern(s)
+- excluded-ids: 12 entries, 1 pattern(s)
 
 ## Per-Category
 
@@ -27,7 +27,7 @@
 | deprecated | 12 | 91.7% | 11 | 0 | 1 | 0 | 0 |
 | global-attr | 57 | 78.9% | 27 | 18 | 10 | 2 | 0 |
 | id-duplication | 1 | 100.0% | 1 | 0 | 0 | 0 | 0 |
-| invalid-attr | 3086 | 97.1% | 2786 | 209 | 58 | 1 | 32 |
+| invalid-attr | 3086 | 97.1% | 2786 | 209 | 58 | 4 | 29 |
 | required-attr | 5 | 100.0% | 5 | 0 | 0 | 0 | 0 |
 | uncategorized | 1307 | 40.4% | 375 | 153 | 773 | 4 | 2 |
 

--- a/tests/external/snapshots/diff/summary.md
+++ b/tests/external/snapshots/diff/summary.md
@@ -1,6 +1,6 @@
 # nu-validator Benchmark Summary
 
-- generated: 2026-08-12T03:50:09.918Z
+- generated: 2026-08-12T06:31:53.804Z
 - submodule: `142931395412c00434ffb40a14d65992efd17aa8`
 - nu-validator: `ghcr.io/validator/validator@sha256:210bbc353b23ba1b1ae65247c156a006afb4ba84703ba1bbf7c41d2080559445`
 - markuplint: `5.0.0-rc.4`
@@ -9,31 +9,31 @@
 ## Totals
 
 - files: **5442**
-- match-error: **3519** (both tools flagged)
-- match-clean: **878** (neither flagged)
-- nu-only: **11** (only nu-validator flagged; markuplint coverage candidates — open a markuplint issue after a spec read)
-- nu-over: **37** (nu-validator errors fully covered by spec-backed excluded-ids — confirmed over-detection)
-- overall match rate: **80.8%**
-- excluded-ids: 12 entries, 1 pattern(s)
+- match-error: **3520** (both tools flagged)
+- match-clean: **759** (neither flagged)
+- nu-only: **7** (only nu-validator flagged; markuplint coverage candidates — open a markuplint issue after a spec read)
+- nu-over: **35** (nu-validator errors fully covered by spec-backed excluded-ids — confirmed over-detection)
+- overall match rate: **78.6%**
+- excluded-ids: 15 entries, 1 pattern(s)
 
 ## Per-Category
 
 | Category | Files | Match rate | match-error | match-clean | ml-only | nu-only | nu-over |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| aria | 780 | 76.5% | 177 | 420 | 183 | 0 | 0 |
-| assertions | 40 | 100.0% | 39 | 1 | 0 | 0 | 0 |
-| content-model | 98 | 96.9% | 50 | 45 | 3 | 0 | 0 |
+| aria | 780 | 65.0% | 177 | 330 | 273 | 0 | 0 |
+| assertions | 40 | 97.5% | 39 | 0 | 1 | 0 | 0 |
+| content-model | 98 | 95.9% | 50 | 44 | 4 | 0 | 0 |
 | data-types | 56 | 96.4% | 49 | 5 | 1 | 0 | 1 |
 | deprecated | 12 | 91.7% | 11 | 0 | 1 | 0 | 0 |
-| global-attr | 57 | 82.5% | 27 | 20 | 8 | 2 | 0 |
+| global-attr | 57 | 78.9% | 27 | 18 | 10 | 2 | 0 |
 | id-duplication | 1 | 100.0% | 1 | 0 | 0 | 0 | 0 |
-| invalid-attr | 3086 | 97.5% | 2785 | 224 | 38 | 5 | 34 |
+| invalid-attr | 3086 | 97.1% | 2786 | 209 | 58 | 1 | 32 |
 | required-attr | 5 | 100.0% | 5 | 0 | 0 | 0 | 0 |
-| uncategorized | 1307 | 41.2% | 375 | 163 | 763 | 4 | 2 |
+| uncategorized | 1307 | 40.4% | 375 | 153 | 773 | 4 | 2 |
 
 ## Informational: ml-only
 
-**997** fixtures are flagged only by markuplint. This project does not pursue upstream nu-validator reports, so those fixtures feed a narrower audit: confirm with the spec, and if markuplint is the wrong one, fix the rule. The full list lives in `snapshots/diff/markuplint-only.json`.
+**1121** fixtures are flagged only by markuplint. This project does not pursue upstream nu-validator reports, so those fixtures feed a narrower audit: confirm with the spec, and if markuplint is the wrong one, fix the rule. The full list lives in `snapshots/diff/markuplint-only.json`.
 
 ### Top ml-only rules
 
@@ -42,13 +42,13 @@
 | invalid-attr | 680 |
 | permitted-contents | 444 |
 | deprecated-attr | 354 |
+| require-accessible-name | 186 |
 | wai-aria-disallowed-props | 121 |
 | @markuplint/ml-core | 75 |
 | wai-aria-required-owned-elements | 47 |
 | link-types | 34 |
 | required-attr | 22 |
 | wai-aria-permitted-roles | 20 |
-| no-refer-to-non-existent-id | 11 |
 
 > `nu-only` entries are candidates for markuplint coverage work **after** verifying the relevant spec paragraph. `nu-over` entries are already confirmed nu-validator over-detection via `excluded-ids.json`. `ml-only` is informational; audit the spec before acting on any individual row.
 

--- a/tests/external/snapshots/meta.json
+++ b/tests/external/snapshots/meta.json
@@ -1,12 +1,12 @@
 {
-	"generatedAt": "2026-08-12T03:50:09.918Z",
+	"generatedAt": "2026-08-12T06:31:53.804Z",
 	"submoduleSha": "142931395412c00434ffb40a14d65992efd17aa8",
 	"nuValidatorImage": "ghcr.io/validator/validator@sha256:210bbc353b23ba1b1ae65247c156a006afb4ba84703ba1bbf7c41d2080559445",
 	"markuplintVersion": "5.0.0-rc.4",
 	"nodeVersion": "24.14.1",
-	"totalFilesNu": 5442,
+	"totalFilesNu": 26,
 	"totalFilesMl": 5442,
-	"totalNuMessages": 9963,
-	"totalMlViolations": 11446,
+	"totalNuMessages": 46,
+	"totalMlViolations": 12559,
 	"totalNuFailures": 0
 }

--- a/tests/external/snapshots/meta.json
+++ b/tests/external/snapshots/meta.json
@@ -1,12 +1,12 @@
 {
-	"generatedAt": "2026-08-12T06:31:53.804Z",
+	"generatedAt": "2026-08-12T06:53:36.214Z",
 	"submoduleSha": "142931395412c00434ffb40a14d65992efd17aa8",
 	"nuValidatorImage": "ghcr.io/validator/validator@sha256:210bbc353b23ba1b1ae65247c156a006afb4ba84703ba1bbf7c41d2080559445",
 	"markuplintVersion": "5.0.0-rc.4",
 	"nodeVersion": "24.14.1",
-	"totalFilesNu": 26,
+	"totalFilesNu": 5442,
 	"totalFilesMl": 5442,
-	"totalNuMessages": 46,
+	"totalNuMessages": 9963,
 	"totalMlViolations": 12559,
 	"totalNuFailures": 0
 }


### PR DESCRIPTION
## Summary

- Enable `require-accessible-name` in the nu-validator benchmark config (`tests/external/bench/config.ts`). The rule already computes `accessibleNameRequired` from the ARIA role spec (e.g. the `img` role: "authors MUST provide a label using the aria-label or aria-labelledby attribute"), so a missing `alt` on `<img>` already reports regardless of ancestor context — the bench simply never had it turned on. This flips `html/elements/img/missing-alt-in-figure-novalid.html` from `nu-only` to `match-error`.
- Closes #3944: the original proposal assumed a new `img-alt-required` rule (or a richer `requiredEither` grammar) was needed. `require-accessible-name` already covers this generically for any role with `accessibleNameRequired: true`, so no rule/spec-data change was needed. Commented on and closed the issue, and pruned its now-stale mapping from `tests/external/bench/issue-xref.config.ts`.
- Refreshed all bench-xref issue bodies (`yarn bench:xref --all --write`) so `#293`, `#3829`, `#3921`, `#3942`, `#3943`, `#3946`, `#3966`, and the secondary-mapping issues reflect the current verdict tallies.
- Regenerated benchmark snapshots (`tests/external/snapshots/diff/*.json`, `meta.json`, `summary.md`): `nu-only` 11 → 10, `match-error` +1, `ml-only` +124 (spot-checked several new findings — empty headings, SVG root elements without a `<title>`, ARIA widgets missing a name — all genuine spec MUST violations that nu-validator doesn't check as broadly; sample verified via direct CLI runs, not just inferred from rule intent).

## Side-effect verification

`require-accessible-name` applies broadly (any ARIA role with `accessibleNameRequired: true`), so before landing it in the bench I spot-checked a diverse sample of the new `ml-only` fixtures across different categories (`aria`, `invalid-attr`, `uncategorized`) to rule out false positives — all confirmed as legitimate coverage, several matching the `-haswarn` filename convention (nu emits a warning, not an error, hence they don't already appear as `match-error`).

I also tried enabling `end-tag` with a `severity: 'error'` override for a second `nu-only` fixture (`picture/html-syntax-picture-no-end-tag`), but reverted it after finding it flags `<html lang>` without `</html>` as a violation even though HTML LS §13.1.2.4 explicitly permits omitting that end tag — the rule is a blanket "always close tags" style preference (confirmed by its own `end-tag-valid-001` test), not spec-omission-aware, so it isn't safe to escalate for the bench's spec-conformance comparison. That fixture stays `nu-only`, tracked by the existing #3943 umbrella issue.

## Test plan

- [x] `yarn lint-check`
- [x] `yarn build` (via `NX_WORKSPACE_ROOT_PATH=<worktree> yarn build`)
- [x] `yarn test` (276 files, 4542 passed, 1 skipped, no type errors)
- [x] `npx vitest run tests/external/bench/` (107 passed) — bench infra's own unit specs
- [x] `yarn bench:update` / `yarn bench:compare` re-run to confirm final verdict counts and fix a stale `meta.json` header left by an intermediate `--concurrency 1` probe
