### PR TITLE
fix(rules): surface disallowed-element reason via reasonOnly (close #3815)

### DIFF
--- a/packages/@markuplint/config-presets/src/preset.html-standard.jsonc
+++ b/packages/@markuplint/config-presets/src/preset.html-standard.jsonc
@@ -454,7 +454,9 @@
 			"selector": ":where(head)",
 			"rules": {
 				"disallowed-element": {
-					"value": ["meta[charset] ~ meta[charset]"]
+					"value": ["meta[charset] ~ meta[charset]"],
+					"reason": "There must not be more than one meta element with a charset attribute per document. https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-charset",
+					"reasonOnly": true
 				}
 			}
 		},
@@ -472,7 +474,9 @@
 			"selector": ":where(head)",
 			"rules": {
 				"disallowed-element": {
-					"value": ["meta[name=\"description\" i] ~ meta[name=\"description\" i]"]
+					"value": ["meta[name=\"description\" i] ~ meta[name=\"description\" i]"],
+					"reason": "There must not be more than one meta element where the name attribute value is an ASCII case-insensitive match for \"description\" per document. https://html.spec.whatwg.org/multipage/semantics.html#standard-metadata-names",
+					"reasonOnly": true
 				}
 			}
 		},
@@ -494,7 +498,9 @@
 					"value": [
 						"meta[charset] ~ meta[http-equiv=\"content-type\" i]",
 						"meta[http-equiv=\"content-type\" i] ~ meta[charset]"
-					]
+					],
+					"reason": "A document must not contain both a meta element with an http-equiv attribute in the Encoding declaration state and a meta element with the charset attribute. https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-charset",
+					"reasonOnly": true
 				}
 			}
 		},
@@ -514,7 +520,9 @@
 			"selector": ":where(head)",
 			"rules": {
 				"disallowed-element": {
-					"value": [":is(link, script) ~ base"]
+					"value": [":is(link, script) ~ base"],
+					"reason": "A base element must come before any other elements in the tree that have attributes defined as taking URLs, except the html element. https://html.spec.whatwg.org/multipage/semantics.html#the-base-element",
+					"reasonOnly": true
 				}
 			}
 		},

--- a/packages/@markuplint/ml-config/src/merge-config.spec.ts
+++ b/packages/@markuplint/ml-config/src/merge-config.spec.ts
@@ -405,6 +405,41 @@ describe('mergeRule', () => {
 		});
 	});
 
+	test('reasonOnly is overridden by b', () => {
+		expect(
+			mergeRule(
+				{ value: true, reason: 'old', reasonOnly: false },
+				{ value: true, reason: 'new', reasonOnly: true },
+			),
+		).toStrictEqual({
+			value: true,
+			reason: 'new',
+			reasonOnly: true,
+		});
+	});
+
+	test('reasonOnly is preserved from a when b has no reasonOnly', () => {
+		expect(mergeRule({ value: true, reason: 'base', reasonOnly: true }, { severity: 'warning' })).toStrictEqual({
+			value: true,
+			severity: 'warning',
+			reason: 'base',
+			reasonOnly: true,
+		});
+	});
+
+	test('reasonOnly: false in b overrides reasonOnly: true in a', () => {
+		expect(
+			mergeRule(
+				{ value: true, reason: 'old', reasonOnly: true },
+				{ value: true, reason: 'new', reasonOnly: false },
+			),
+		).toStrictEqual({
+			value: true,
+			reason: 'new',
+			reasonOnly: false,
+		});
+	});
+
 	test('{value} + shorthand', () => {
 		expect(
 			mergeRule(

--- a/packages/@markuplint/ml-config/src/merge-config.ts
+++ b/packages/@markuplint/ml-config/src/merge-config.ts
@@ -82,7 +82,7 @@ export function mergeConfig(a: Config, b?: Config): OptimizedConfig {
  * If `b` is `false`, the rule is unconditionally disabled.
  * If `b` is a direct value (including arrays), it overrides `a`.
  * If both are full config objects, their properties are merged
- * (severity/value/reason: right-side wins, options: shallow-merged).
+ * (severity/value/reason/reasonOnly: right-side wins, options: shallow-merged).
  *
  * Array values intentionally override rather than concatenate: the more
  * specific config replaces the rule's value entirely, matching ESLint and
@@ -125,11 +125,13 @@ export function mergeRule(a: Nullable<AnyRule>, b: AnyRule): AnyRule {
 	const value = oB.value ?? (isRuleConfigValue(oA) ? oA : oA.value);
 	const options = mergeObject(isRuleConfigValue(oA) ? undefined : oA.options, oB.options);
 	const reason = oB.reason ?? (isRuleConfigValue(oA) ? undefined : oA.reason);
+	const reasonOnly = oB.reasonOnly ?? (isRuleConfigValue(oA) ? undefined : oA.reasonOnly);
 	const res = {
 		severity,
 		value,
 		options,
 		reason,
+		reasonOnly,
 	};
 	deleteUndefProp(res);
 	return res;

--- a/packages/@markuplint/ml-config/src/types.ts
+++ b/packages/@markuplint/ml-config/src/types.ts
@@ -482,6 +482,8 @@ export type RuleConfig<T extends RuleConfigValue, O extends PlainData = undefine
 	readonly options?: Readonly<O>;
 	/** A human-readable reason for this rule configuration, included in violation messages */
 	readonly reason?: string;
+	/** When `true`, replaces the violation message with `reason` entirely instead of appending it. Requires `reason` to be set. */
+	readonly reasonOnly?: boolean;
 };
 
 /**
@@ -732,6 +734,7 @@ export type RuleInfo<T extends RuleConfigValue, O extends PlainData = undefined>
 	readonly value: Readonly<T>;
 	readonly options: Readonly<O>;
 	readonly reason?: string;
+	readonly reasonOnly?: boolean;
 };
 
 /**

--- a/packages/@markuplint/ml-config/src/utils.spec.ts
+++ b/packages/@markuplint/ml-config/src/utils.spec.ts
@@ -94,6 +94,15 @@ describe('cleanOptions', () => {
 			value: true,
 		});
 	});
+
+	test('keeps reasonOnly', () => {
+		expect(cleanOptions({ severity: 'error', value: true, reason: 'because', reasonOnly: true })).toStrictEqual({
+			severity: 'error',
+			value: true,
+			reason: 'because',
+			reasonOnly: true,
+		});
+	});
 });
 
 test('exchangeValueOnRule', () => {

--- a/packages/@markuplint/ml-config/src/utils.ts
+++ b/packages/@markuplint/ml-config/src/utils.ts
@@ -81,7 +81,7 @@ export function exchangeValueOnRule(rule: AnyRule, data: Readonly<Record<string,
 
 /**
  * Normalizes a rule configuration by extracting the standard fields
- * (`severity`, `value`, `options`, `reason`) and removing `undefined` properties.
+ * (`severity`, `value`, `options`, `reason`, `reasonOnly`) and removing `undefined` properties.
  *
  * @param rule - The rule configuration to normalize
  * @returns A clean rule configuration with only defined properties
@@ -92,6 +92,7 @@ export function cleanOptions(rule: RuleConfig<RuleConfigValue, PlainData>): Rule
 		value: rule.value,
 		options: rule.options,
 		reason: rule.reason,
+		reasonOnly: rule.reasonOnly,
 	};
 	deleteUndefProp(res);
 	return res;

--- a/packages/@markuplint/ml-core/src/index.spec.ts
+++ b/packages/@markuplint/ml-core/src/index.spec.ts
@@ -615,6 +615,56 @@ describe('Rule', () => {
 		expect(document.nodeList[2].rule).toStrictEqual(resultE);
 	});
 
+	test('reasonOnly setting', () => {
+		const document = createTestDocument('<div></div>', {
+			config: {
+				rules: {
+					ruleA: {
+						reason: '123',
+						reasonOnly: true,
+					},
+					ruleB: {
+						reason: '456',
+					},
+				},
+			},
+		});
+		const ruleA = createRule({
+			name: 'ruleA',
+			defaultValue: 'foo',
+			defaultOptions: null,
+			verify() {
+				throw new Error();
+			},
+		});
+		document.setRule(ruleA);
+		expect(document.nodeList[0].rule).toStrictEqual({
+			disabled: false,
+			severity: 'error',
+			value: 'foo',
+			options: null,
+			reason: '123',
+			reasonOnly: true,
+		});
+
+		const ruleB = createRule({
+			name: 'ruleB',
+			defaultValue: 'bar',
+			defaultOptions: null,
+			verify() {
+				throw new Error();
+			},
+		});
+		document.setRule(ruleB);
+		expect(document.nodeList[0].rule).toStrictEqual({
+			disabled: false,
+			severity: 'error',
+			value: 'bar',
+			options: null,
+			reason: '456',
+		});
+	});
+
 	test('regexSelector + pug', async () => {
 		const document = createTestDocument(
 			`section.Card

--- a/packages/@markuplint/ml-core/src/ml-rule/ml-rule.ts
+++ b/packages/@markuplint/ml-core/src/ml-rule/ml-rule.ts
@@ -183,6 +183,7 @@ export class MLRule<T extends RuleConfigValue, O extends PlainData = undefined> 
 						: configSettings.value,
 				options: mergeOptions(this.defaultOptions, configSettings.options),
 				reason: configSettings.reason,
+				...(configSettings.reasonOnly === undefined ? {} : { reasonOnly: configSettings.reasonOnly }),
 			};
 		}
 		return {
@@ -242,30 +243,30 @@ export class MLRule<T extends RuleConfigValue, O extends PlainData = undefined> 
 				}
 				return {
 					severity: report.scope.rule.severity,
-					message: report.message,
+					...resolveMessageAndReason(
+						report.message,
+						report.scope.rule.reason ?? document.rule.reason,
+						report.scope.rule.reasonOnly ?? document.rule.reasonOnly,
+					),
 					line,
 					col,
 					raw,
 					ruleId,
 					...(aliasName != null && { name: aliasName }),
 					...(this.specConformance != null && { specConformance: this.specConformance }),
-					...((report.scope.rule.reason ?? document.rule.reason)
-						? { reason: report.scope.rule.reason ?? document.rule.reason }
-						: {}),
 					...(fixData != null && { fix: fixData }),
 				};
 			}
 
 			return {
 				severity: document.rule.severity,
-				message: report.message,
+				...resolveMessageAndReason(report.message, document.rule.reason, document.rule.reasonOnly),
 				line: report.line,
 				col: report.col,
 				raw: report.raw,
 				ruleId,
 				...(aliasName != null && { name: aliasName }),
 				...(this.specConformance != null && { specConformance: this.specConformance }),
-				...(document.rule.reason ? { reason: document.rule.reason } : {}),
 				...(fixData != null && { fix: fixData }),
 			};
 		});
@@ -291,6 +292,23 @@ function isRuleConfig<T extends RuleConfigValue, O extends PlainData = undefined
 	data: T | RuleConfig<T, O>,
 ): data is RuleConfig<T, O> {
 	return isPlainObject(data);
+}
+
+/**
+ * Resolves a violation's `message`/`reason` pair from the rule's configured `reason`/`reasonOnly`.
+ * When `reasonOnly` is set and a `reason` is configured, `reason` replaces `message` entirely and
+ * is omitted from the result (it is now redundant with `message`); otherwise `reason` is appended
+ * as a separate field, preserving the original `message`.
+ */
+function resolveMessageAndReason(
+	message: string,
+	reason: string | undefined,
+	reasonOnly: boolean | undefined,
+): { message: string; reason?: string } {
+	if (reason && reasonOnly) {
+		return { message: reason };
+	}
+	return { message, ...(reason ? { reason } : {}) };
 }
 
 function mergeOptions<O extends PlainData>(a: Readonly<O>, b: Readonly<O> | undefined): O {

--- a/packages/@markuplint/rules/src/disallowed-element/README.ja.md
+++ b/packages/@markuplint/rules/src/disallowed-element/README.ja.md
@@ -62,3 +62,22 @@ HTML標準に準拠しているかどうかは[`permitted-contents`](../permitte
   ]
 }
 ```
+
+報告されるメッセージには、既定でセレクターがそのまま埋め込まれます(例: `The "small" element is disallowed`)。[`reason`](/docs/configuration/properties#rules)を設定すると人間が読みやすい説明文を追記でき、`reasonOnly: true`を加えるとメッセージを追記ではなく`reason`の内容で完全に置き換えられます。
+
+```json class=config
+{
+  "nodeRules": [
+    {
+      "selector": "h1, h2, h3, h4, h5, h6",
+      "rules": {
+        "disallowed-element": {
+          "value": ["small"],
+          "reason": "small要素を見出しの補足として使用してはいけません。",
+          "reasonOnly": true
+        }
+      }
+    }
+  ]
+}
+```

--- a/packages/@markuplint/rules/src/disallowed-element/README.md
+++ b/packages/@markuplint/rules/src/disallowed-element/README.md
@@ -57,3 +57,22 @@ If specified to `nodeRules` or `childNodeRules`, It searches the element from ch
   ]
 }
 ```
+
+The reported message embeds the raw selector by default (e.g. `The "small" element is disallowed`). Set [`reason`](/docs/configuration/properties#rules) to append a human-readable explanation, or add `reasonOnly: true` to replace the message with `reason` entirely instead of appending it:
+
+```json class=config
+{
+  "nodeRules": [
+    {
+      "selector": "h1, h2, h3, h4, h5, h6",
+      "rules": {
+        "disallowed-element": {
+          "value": ["small"],
+          "reason": "The small element must not be used for subheadings.",
+          "reasonOnly": true
+        }
+      }
+    }
+  ]
+}
+```

--- a/packages/@markuplint/rules/src/disallowed-element/index.spec.ts
+++ b/packages/@markuplint/rules/src/disallowed-element/index.spec.ts
@@ -298,3 +298,82 @@ test('[disallowed-element-issue-3634-007] meta description case insensitive matc
 		}),
 	]);
 });
+
+test('[disallowed-element-issue-3815-001] reasonOnly replaces the selector-based message with reason', async () => {
+	const { violations } = await mlRuleTest(rule, '<head><meta charset="UTF-8"><meta charset="UTF-8"></head>', {
+		rule: {
+			value: ['meta[charset] ~ meta[charset]'],
+			reason: 'More than one meta charset is disallowed',
+			reasonOnly: true,
+		},
+	});
+	expect(violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 29,
+			raw: '<meta charset="UTF-8">',
+			message: 'More than one meta charset is disallowed',
+		},
+	]);
+});
+
+test('[disallowed-element-issue-3815-002] reason without reasonOnly still appends to the selector-based message', async () => {
+	const { violations } = await mlRuleTest(rule, '<head><meta charset="UTF-8"><meta charset="UTF-8"></head>', {
+		rule: {
+			value: ['meta[charset] ~ meta[charset]'],
+			reason: 'More than one meta charset is disallowed',
+		},
+	});
+	expect(violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 29,
+			raw: '<meta charset="UTF-8">',
+			message: 'The "meta[charset] ~ meta[charset]" element is disallowed',
+			reason: 'More than one meta charset is disallowed',
+		},
+	]);
+});
+
+test('[disallowed-element-issue-3815-003] node-level severity override on a globally-matched element is respected', async () => {
+	const { violations } = await mlRuleTest(rule, '<div><h1><small>Sub-title</small></h1></div>', {
+		rule: ['small'],
+		nodeRule: [
+			{
+				selector: 'small',
+				rule: {
+					severity: 'warning',
+				},
+			},
+		],
+	});
+	expect(violations).toStrictEqual([
+		{
+			severity: 'warning',
+			line: 1,
+			col: 10,
+			raw: '<small>',
+			message: 'The "small" element is disallowed',
+		},
+	]);
+});
+
+test('[disallowed-element-issue-3815-004] reasonOnly without reason falls back to the selector-based message', async () => {
+	const { violations } = await mlRuleTest(rule, '<head><meta charset="UTF-8"><meta charset="UTF-8"></head>', {
+		rule: {
+			value: ['meta[charset] ~ meta[charset]'],
+			reasonOnly: true,
+		},
+	});
+	expect(violations).toStrictEqual([
+		{
+			severity: 'error',
+			line: 1,
+			col: 29,
+			raw: '<meta charset="UTF-8">',
+			message: 'The "meta[charset] ~ meta[charset]" element is disallowed',
+		},
+	]);
+});

--- a/packages/@markuplint/rules/src/disallowed-element/index.ts
+++ b/packages/@markuplint/rules/src/disallowed-element/index.ts
@@ -23,10 +23,16 @@ export default createRule<string[]>({
 			}
 			for (const query of el.rule.value) {
 				const elements = el.querySelectorAll(query);
-				for (const el of elements) {
+				for (const found of elements) {
 					const message = t('{0} is disallowed', t('the "{0*}" {1}', query, 'element'));
 					report({
+						// `scope` resolves the rule's `reason`/`reasonOnly` (the node-level rule
+						// setting is mapped to `el`, not to `found`), so it must stay `el`.
+						// Location comes from `line`/`col`/`raw`, which take precedence over the scope's.
 						scope: el,
+						line: found.startLine,
+						col: found.startCol,
+						raw: found.raw,
 						message,
 					});
 				}

--- a/packages/markuplint/src/named-noderules.spec.ts
+++ b/packages/markuplint/src/named-noderules.spec.ts
@@ -44,6 +44,20 @@ describe('Named nodeRules integration', () => {
 			expect(smallViolation!.specConformance).toBe('normative');
 		});
 
+		it('reports no-small-in-heading with its configured reason', async () => {
+			const { violations } = await mlTest(
+				'<!doctype html><html><head><meta charset="UTF-8"></head><body><h1><small>sub</small></h1></body></html>',
+				{
+					extends: ['markuplint:html-standard'],
+				},
+			);
+			const smallViolation = violations.find(v => v.name === 'html-standard/no-small-in-heading');
+			expect(smallViolation).toBeDefined();
+			expect(smallViolation!.reason).toBe(
+				'The small element must not be used for subheadings. https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-small-element',
+			);
+		});
+
 		it('reports html-standard/no-base-after-link-or-script when <base> follows <link>', async () => {
 			const { violations } = await mlTest(
 				'<!doctype html><html><head><meta charset="UTF-8"><title>t</title>' +
@@ -82,6 +96,73 @@ describe('Named nodeRules integration', () => {
 			);
 			const baseViolation = violations.find(v => v.name === 'html-standard/no-base-after-link-or-script');
 			expect(baseViolation).toBeUndefined();
+		});
+
+		it('reports html-standard/no-duplicate-charset with a reasonOnly message instead of the raw selector', async () => {
+			const { violations } = await mlTest(
+				'<!doctype html><html><head><meta charset="UTF-8"><meta charset="UTF-8"><title>t</title></head><body></body></html>',
+				{
+					extends: ['markuplint:html-standard'],
+				},
+			);
+			const charsetViolation = violations.find(v => v.name === 'html-standard/no-duplicate-charset');
+			expect(charsetViolation).toBeDefined();
+			expect(charsetViolation!.ruleId).toBe('disallowed-element');
+			expect(charsetViolation!.message).toBe(
+				'There must not be more than one meta element with a charset attribute per document. https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-charset',
+			);
+			expect(charsetViolation).not.toHaveProperty('reason');
+		});
+
+		it('reports html-standard/no-duplicate-description with a reasonOnly message instead of the raw selector', async () => {
+			const { violations } = await mlTest(
+				'<!doctype html><html><head><meta charset="UTF-8"><title>t</title>' +
+					'<meta name="description" content="a"><meta name="description" content="b"></head><body></body></html>',
+				{
+					extends: ['markuplint:html-standard'],
+				},
+			);
+			const descriptionViolation = violations.find(v => v.name === 'html-standard/no-duplicate-description');
+			expect(descriptionViolation).toBeDefined();
+			expect(descriptionViolation!.ruleId).toBe('disallowed-element');
+			expect(descriptionViolation!.message).toBe(
+				'There must not be more than one meta element where the name attribute value is an ASCII case-insensitive match for "description" per document. https://html.spec.whatwg.org/multipage/semantics.html#standard-metadata-names',
+			);
+			expect(descriptionViolation).not.toHaveProperty('reason');
+		});
+
+		it('reports html-standard/no-charset-http-equiv-coexist with a reasonOnly message instead of the raw selector', async () => {
+			const { violations } = await mlTest(
+				'<!doctype html><html><head><meta charset="UTF-8">' +
+					'<meta http-equiv="content-type" content="text/html; charset=UTF-8"><title>t</title></head><body></body></html>',
+				{
+					extends: ['markuplint:html-standard'],
+				},
+			);
+			const coexistViolation = violations.find(v => v.name === 'html-standard/no-charset-http-equiv-coexist');
+			expect(coexistViolation).toBeDefined();
+			expect(coexistViolation!.ruleId).toBe('disallowed-element');
+			expect(coexistViolation!.message).toBe(
+				'A document must not contain both a meta element with an http-equiv attribute in the Encoding declaration state and a meta element with the charset attribute. https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-charset',
+			);
+			expect(coexistViolation).not.toHaveProperty('reason');
+		});
+
+		it('reports html-standard/no-base-after-link-or-script with a reasonOnly message instead of the raw selector', async () => {
+			const { violations } = await mlTest(
+				'<!doctype html><html><head><meta charset="UTF-8"><title>t</title>' +
+					'<link rel="stylesheet" href="a.css"><base href="/"></head><body></body></html>',
+				{
+					extends: ['markuplint:html-standard'],
+				},
+			);
+			const baseViolation = violations.find(v => v.name === 'html-standard/no-base-after-link-or-script');
+			expect(baseViolation).toBeDefined();
+			expect(baseViolation!.ruleId).toBe('disallowed-element');
+			expect(baseViolation!.message).toBe(
+				'A base element must come before any other elements in the tree that have attributes defined as taking URLs, except the html element. https://html.spec.whatwg.org/multipage/semantics.html#the-base-element',
+			);
+			expect(baseViolation).not.toHaveProperty('reason');
 		});
 
 		it('reports html-standard/script-content for malformed importmap', async () => {

--- a/website/docs/configuration/properties.md
+++ b/website/docs/configuration/properties.md
@@ -569,6 +569,7 @@ type Rule<T, O> =
       value?: T;
       option?: O;
       reason?: string;
+      reasonOnly?: boolean;
     };
 
 type NamedRuleGroup = {


### PR DESCRIPTION
## Summary

- Adds a `reasonOnly` rule config option (alongside the existing `reason`) that replaces a violation's message with `reason` entirely instead of appending it, threaded through `RuleConfig`/`RuleInfo` (`ml-config`) and violation building (`ml-core`).
- Fixes `disallowed-element`: `report()` was scoping violations to the matched element found via `querySelectorAll` instead of the node the rule setting is actually mapped to, so a configured `reason`/`reasonOnly` was silently lost whenever the rule ran through a `nodeRules` override (e.g. every `html-standard` virtual rule built on `disallowed-element`). Scope now stays on the rule-mapped node; the violation's `line`/`col`/`raw` are passed explicitly so reported positions are unchanged.
- Sets `reason` + `reasonOnly: true` on the four previously bare `disallowed-element` virtual rules in the `html-standard` preset (`no-duplicate-charset`, `no-duplicate-description`, `no-charset-http-equiv-coexist`, `no-base-after-link-or-script`), so their messages read as spec-style explanations instead of raw CSS selectors.
- Documents `reasonOnly` in `disallowed-element`'s README (EN/JA) and in the configuration reference.

Closes #3815.

## Why this approach

Issue #3815 proposed a `disallowed-element`-specific `message` option. Investigation found `reason` already exists as a rule-config option common to every rule, so this PR generalizes with a `reasonOnly` sibling instead of adding a rule-specific option — keeping the mechanism reusable and avoiding inconsistent per-rule behavior.

## Test plan

- [x] `yarn test` (4638 passed, 1 skipped, no type errors)
- [x] `yarn lint`
- [x] New/updated tests:
  - `ml-config`: `reasonOnly` merge/normalization (`merge-config.spec.ts`, `utils.spec.ts`)
  - `ml-core`: `reasonOnly` propagation into `RuleInfo` (`index.spec.ts`)
  - `rules/disallowed-element`: `reasonOnly` message replacement, `reason`-without-`reasonOnly` append behavior, `reasonOnly` fallback when `reason` is unset, and a regression test proving a node-level `severity` override on a globally-matched element still applies (`index.spec.ts`)
  - `markuplint`: end-to-end coverage for all four `html-standard` virtual rules reporting their configured `reason`, plus a regression test proving `no-small-in-heading`'s pre-existing `reason` is now actually surfaced (`named-noderules.spec.ts`)
