### PR TITLE
docs: move migrate4-5 skill under skills/migrations/v4-v5

### DIFF
--- a/skills/migrate4-5/SKILL.md
+++ b/skills/migrate4-5/SKILL.md
@@ -1,141 +1,18 @@
 ---
-name: migrate4-5
-description: Guides you through migrating markuplint configuration from v4 to v5. Detects current versions, reviews the migration guide, interactively confirms breaking changes and new rules with the user, updates config files and tests. For Claude Code.
+name: migrate4-5-legacy-path
+description: Deprecated install path for the v4-to-v5 migration skill. Prefer npx skills add markuplint/markuplint@migrations/v4-v5 — content lives in skills/migrations/v4-v5/SKILL.md.
 ---
 
-# migrate4-5
+# migrate4-5 (legacy install path)
 
-Guides you through migrating markuplint from **stable v4** (last release `v4.18.3`) to v5. Treat v5 alpha/rc rule names as if they never existed.
+This directory exists so `npx skills add markuplint/markuplint@migrate4-5` keeps resolving after the skill moved to **`skills/migrations/v4-v5/`** (mirroring `docs/migration/v4-v5/`).
 
-## When to Use
+**Canonical install:**
 
-Use this skill when the user requests any of the following:
-
-- "Upgrade markuplint to v5"
-- "Migrate markuplint from v4 to v5"
-- "Update markuplint version"
-- "markuplint migration"
-
-## Steps
-
-### 1. Detect Current Versions
-
-- Detect the current versions of markuplint-related packages (`markuplint`, `@markuplint/*`) from `package.json` and list them
-- Locate configuration files (`.markuplintrc`, `.markuplintrc.json`, `markuplint.config.js`, etc.)
-- Confirm Node.js is **v24.0.0 or later** (v4 documented v18.18.0). Stop and have the user upgrade Node before changing packages.
-
-### 2. Review the Migration Guide
-
-- Fetch the v4→v5 guide. While v5 is a prerelease, use https://next.markuplint.dev/docs/migration/v4-to-v5/ ; after stable, use https://markuplint.dev/docs/migration/v4-to-v5/
-- **Required pages:** index, [Renames and splits](https://next.markuplint.dev/docs/migration/v4-to-v5/rules/rule-names), [ARIA](https://next.markuplint.dev/docs/migration/v4-to-v5/aria), [CLI](https://next.markuplint.dev/docs/migration/v4-to-v5/cli), [Config](https://next.markuplint.dev/docs/migration/v4-to-v5/config)
-- Also fetch Framework, `invalid-attr`, `required-element`, `deprecated-element`, `table-row-column-alignment` if the config uses those
-- If this repository is the markuplint source tree, prefer `docs/migration/v4-v5/` over the live site (it is the GitHub-browsable source)
-- Inspect `node_modules` presets and `rule-aliases` only to confirm what the installed v5 actually expands — do not invent names from memory
-- Do **not** migrate using `wai-aria-*` intermediate names, `no-unsupported-features`, `script-content`, `srcset-sizes-constraint`, or `input-button-non-empty-value`. Those were not stable v4 rule names.
-
-### 3. Confirm with the User (use AskUserQuestion extensively)
-
-**Always use AskUserQuestion at each decision. Never decide for the user.** Batch up to 4 related questions.
-
-#### Phase 1: Silent gaps and CI (must ask)
-
-These do not produce a deprecation warning:
-
-1. Raw (non-preset) **`permitted-contents`** → add `no-disallowed-ancestor`, `require-ancestor`, `no-duplicate-sibling-attr` to keep v4 coverage?
-2. Raw **`no-refer-to-non-existent-id`** → add `no-broken-fragment-link`? (`markuplint:html-standard` alone still lacks this sibling; `a11y` / `recommended` include it.)
-3. Raw **`label-has-control`** → add `label-no-multiple-controls`? (`markuplint:a11y` alone does **not** enable the sibling; `html-standard` / `recommended` do.)
-4. Table-model rules `no-table-cell-overlap`, `no-table-span-overflow`, `no-empty-table-track` escalate **warning → error**. Keep errors, or set `"severity": "warning"` to mimic v4?
-5. v4 CI treated warnings as failures? Add **`--no-allow-warnings`** (v5 allows warnings by default).
-6. ARIA default is **1.3**. Keep 1.3, or set `ruleCommonSettings.ariaVersion` to `"1.2"`?
-7. `wai-aria: true` / `markuplint:a11y` now also run checks that were **off or absent** in v4 `wai-aria` defaults: `no-aria-on-presentational-children`, `no-focusable-in-aria-hidden`, `no-default-aria-value`, `require-parent-role`, `tab-requires-tabpanel`. Keep them, or disable individually?
-
-#### Phase 2: Preset extras on `markuplint:recommended`
-
-v4 `recommended` did not include these; v5 does. Confirm whether to keep or disable:
-
-- `markuplint:compat`: `no-unsupported-browser-features`, `no-nonstandard-features` (needs browserslist for the former; `no-experimental-features` stays opt-in)
-- `markuplint:code-styles`: `case-sensitive-attr-name`, `case-sensitive-tag-name`
-- `markuplint:security`: `no-event-handler-attr`
-- `markuplint:html-standard` now enables `no-unknown-attr` / `no-disallowed-attr` / `no-invalid-attr-value` (v4 `html-standard` did not include `invalid-attr`) and drops `no-duplicate-dt` / `no-ineffective-attr`
-
-#### Phase 3: Other breaking changes that apply
-
-Ask only if the config uses the feature:
-
-- `--config` no longer merges with auto-discovered config
-- `extends`: array rule values **replace**; nested `options` are **shallow**-merged
-- `required-element` → `require-element`; ghost elements no longer satisfy requirements (`ignoreOmittedElements` default `true`)
-- `invalid-attr` `{ type: X }` wrapper removed; route options per the guide
-- htmx: `@markuplint/htmx-parser` → `@markuplint/htmx-spec` (drop `parser` entry)
-- Alpine: keep parser; spec `@markuplint/alpine-parser/spec` → `@markuplint/alpine-spec`
-- `@markuplint/rule-textlint` removed
-- pretenders on standard HTML/SVG tags are ignored
-- `:closest()` → `:is(… *)` (removed in v6)
-
-#### Phase 4: New rules not in any preset
-
-Present opt-in rules (`attr-order`, `class-naming`, … — list from the guide's "no preset" set). For `attr-order`, the user must supply the exact order array; `true` is not enough.
-
-### 4. Update Dependency Versions
-
-- Bump `markuplint` and every `@markuplint/*` to the **same** v5 version
-- Uninstall `@markuplint/htmx-parser` / `@markuplint/rule-textlint` if present
-- Install `@markuplint/htmx-spec` / `@markuplint/alpine-spec` when those frameworks are in use
-
-### 5. Update Configuration Files
-
-- Rewrite deprecated rule names from Markuplint's deprecation warnings after one run (old names work until v6; still rewrite now)
-- Apply the silent-gap siblings the user confirmed
-- Set `ruleCommonSettings.ariaVersion` if they chose 1.2
-- Disable extra ARIA/preset rules they declined
-- Convert `invalid-attr` / `required-element` / framework `parser`/`specs` as agreed
-- Named preset groups (`a11y/html-lang`, `a11y/wai-aria/*`, …) can be toggled in `rules` without renaming the user's own nodeRules unless they want names
-
-### 6. Update Tests
-
-- Run markuplint; include `ruleId` and Named Rule Group `name` in assertions when present
-- `--config` / `-c` in tests loads **only** that file
-- Attribute-order and column numbers may shift if `attr-order` is adopted
-
-### 7. Commit
-
-Split by change type in the **user's** repo (example):
-
-1. `feat!: upgrade markuplint to v5` — package.json + lockfile
-2. `fix: migrate markuplint config for v5` — config
-3. `test: update fixtures for markuplint v5`
-
-## Reference: must-check (no warning)
-
-| Situation | Add or change |
-| --- | --- |
-| Raw `permitted-contents` | `no-disallowed-ancestor`, `require-ancestor`, `no-duplicate-sibling-attr` |
-| Raw `no-refer-to-non-existent-id` | `no-broken-fragment-link` |
-| Raw `label-has-control` | `label-no-multiple-controls` |
-| Table model | three rules now `error` |
-| CI on warnings | `--no-allow-warnings` |
-
-Old **renamed/split** names still work with a deprecation warning until v6. Option-routed splits (stable v4): `doctype`, `landmark-roles`, `required-h1`, `invalid-attr` — do not blindly enable every sibling.
-
-`wai-aria` expands to 21 rules; toggles are **not** mapped. See the ARIA guide for the v4 option table.
-
-## Reference: Named Rule Groups
-
-Preset entries with a `name` (for example `a11y/html-lang`) can be disabled or given a different severity from `rules`:
-
-```js
-rules: {
-  'a11y/html-lang': false,
-  'a11y/*': false,
-}
+```bash
+npx skills add markuplint/markuplint@migrations/v4-v5
 ```
 
-Adding `name` to the user's own `nodeRules` is optional, not required for v4→v5.
+When working in the markuplint repository, read and follow **`skills/migrations/v4-v5/SKILL.md`**. When this legacy skill is the only copy installed, fetch the migration guide from the website (`/docs/migration/v4-to-v5/`) and apply the same checklist as that file (silent splits, Node 24, `--no-allow-warnings`, preset gaps).
 
-## Reference: `-c` / `--config`
-
-v5 loads **only** the file passed to `--config`. It does not merge `.markuplintrc`. Tests that used v4 merge behavior must `extends` the project config or pass a complete file.
-
-## Reference: browserslist rules
-
-`no-unsupported-browser-features` (in `markuplint:compat`, hence `recommended`) is a no-op without browserslist. `no-experimental-features` is **not** in the compat preset (opt-in). `no-nonstandard-features` is in compat.
+Do not maintain divergent migration steps here — update `skills/migrations/v4-v5/SKILL.md` only.

--- a/skills/migrations/v4-v5/SKILL.md
+++ b/skills/migrations/v4-v5/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: migrate4-5
+description: Guides you through migrating markuplint configuration from v4 to v5. Detects current versions, reviews the migration guide, interactively confirms breaking changes and new rules with the user, updates config files and tests. For Claude Code.
+---
+
+# migrate4-5
+
+Guides you through migrating markuplint from **stable v4** (last release `v4.18.3`) to v5. Treat v5 alpha/rc rule names as if they never existed.
+
+Install: `npx skills add markuplint/markuplint@migrations/v4-v5`
+
+## When to Use
+
+Use this skill when the user requests any of the following:
+
+- "Upgrade markuplint to v5"
+- "Migrate markuplint from v4 to v5"
+- "Update markuplint version"
+- "markuplint migration"
+
+## Steps
+
+### 1. Detect Current Versions
+
+- Detect the current versions of markuplint-related packages (`markuplint`, `@markuplint/*`) from `package.json` and list them
+- Locate configuration files (`.markuplintrc`, `.markuplintrc.json`, `markuplint.config.js`, etc.)
+- Confirm Node.js is **v24.0.0 or later** (v4 documented v18.18.0). Stop and have the user upgrade Node before changing packages.
+
+### 2. Review the Migration Guide
+
+**Documentation base URL**: check the target v5 version with `npx markuplint --version`. If it contains `alpha`, `beta`, or `rc`, use `https://next.markuplint.dev`; otherwise use `https://markuplint.dev`.
+
+- **Website guide (users):** `{base}/docs/migration/v4-to-v5/`
+- **GitHub guide (markuplint source tree):** prefer `docs/migration/v4-v5/` over the live site — it is the browsable source with the same facts
+
+**Required pages:** index (`README.md` / index), [Renames and splits](docs/migration/v4-v5/rule-names.md), [ARIA](docs/migration/v4-v5/aria.md), [CLI](docs/migration/v4-v5/cli.md), [Config](docs/migration/v4-v5/config.md)
+
+Also fetch when the config uses the feature:
+
+| Topic | GitHub path | Website path |
+| --- | --- | --- |
+| Framework parsers | `docs/migration/v4-v5/framework.md` | `{base}/docs/migration/v4-to-v5/framework` |
+| `invalid-attr` split | `docs/migration/v4-v5/rules/invalid-attr.md` | `{base}/docs/migration/v4-to-v5/rules/invalid-attr` |
+| `required-element` | `docs/migration/v4-v5/rules/required-element.md` | `{base}/docs/migration/v4-to-v5/rules/required-element` |
+| `deprecated-element` | `docs/migration/v4-v5/rules/deprecated-element.md` | `{base}/docs/migration/v4-to-v5/rules/deprecated-element` |
+| Table model | `docs/migration/v4-v5/rules/table-row-column-alignment.md` | `{base}/docs/migration/v4-to-v5/rules/table-row-column-alignment` |
+| Parse errors (opt-in) | `docs/migration/v4-v5/rules/parse-error.md` | `{base}/docs/migration/v4-to-v5/rules/parse-error` |
+| textlint removal | `docs/migration/v4-v5/rules/textlint.md` | `{base}/docs/migration/v4-to-v5/rules/textlint` |
+
+Inspect `node_modules` presets and `rule-aliases` only to confirm what the installed v5 actually expands — do not invent names from memory.
+
+Do **not** migrate using `wai-aria-*` intermediate names, `no-unsupported-features`, `script-content`, `srcset-sizes-constraint`, or `input-button-non-empty-value`. Those were not stable v4 rule names.
+
+### 3. Confirm with the User (use AskUserQuestion extensively)
+
+**Always use AskUserQuestion at each decision. Never decide for the user.** Batch up to 4 related questions.
+
+#### Phase 1: Silent gaps and CI (must ask)
+
+These do not produce a deprecation warning:
+
+1. Raw (non-preset) **`permitted-contents`** → add `no-disallowed-ancestor`, `require-ancestor`, `no-duplicate-sibling-attr` to keep v4 coverage?
+2. Raw **`no-refer-to-non-existent-id`** → add `no-broken-fragment-link`? (`markuplint:html-standard` alone still lacks this sibling; `a11y` / `recommended` include it.)
+3. Raw **`label-has-control`** → add `label-no-multiple-controls`? (`markuplint:a11y` alone does **not** enable the sibling; `html-standard` / `recommended` do.) v5 `label-has-control` only reports a label with **no** associated control.
+4. Table-model rules `no-table-cell-overlap`, `no-table-span-overflow`, `no-empty-table-track` escalate **warning → error**. Keep errors, or set `"severity": "warning"` to mimic v4?
+5. v4 CI treated warnings as failures? Add **`--no-allow-warnings`** (v5 allows warnings by default).
+6. ARIA default is **1.3**. Keep 1.3, or set `ruleCommonSettings.ariaVersion` to `"1.2"`?
+7. `wai-aria: true` / `markuplint:a11y` now also run checks that were **off or absent** in v4 `wai-aria` defaults: `no-aria-on-presentational-children`, `no-focusable-in-aria-hidden`, `no-default-aria-value`, `require-parent-role`, `tab-requires-tabpanel`. Keep them, or disable individually?
+
+#### Phase 2: Preset extras on `markuplint:recommended`
+
+v4 `recommended` did not include these; v5 does. Confirm whether to keep or disable:
+
+- `markuplint:compat`: `no-unsupported-browser-features`, `no-nonstandard-features` (needs browserslist for the former; `no-experimental-features` stays opt-in)
+- `markuplint:code-styles`: `case-sensitive-attr-name`, `case-sensitive-tag-name`
+- `markuplint:security`: `no-event-handler-attr`
+- `markuplint:html-standard` now enables `no-unknown-attr` / `no-disallowed-attr` / `no-invalid-attr-value` (v4 `html-standard` did not include `invalid-attr`) and drops `no-duplicate-dt` / `no-ineffective-attr`
+
+#### Phase 3: Other breaking changes that apply
+
+Ask only if the config uses the feature:
+
+- `--config` no longer merges with auto-discovered config
+- `extends`: array rule values **replace**; nested `options` are **shallow**-merged
+- `required-element` → `require-element`; ghost elements no longer satisfy requirements (`ignoreOmittedElements` default `true`)
+- `invalid-attr` `{ type: X }` wrapper removed; route options per the guide
+- htmx: `@markuplint/htmx-parser` → `@markuplint/htmx-spec` (drop `parser` entry)
+- Alpine: keep parser; spec `@markuplint/alpine-parser/spec` → `@markuplint/alpine-spec`
+- `@markuplint/rule-textlint` removed
+- pretenders on standard HTML/SVG tags are ignored
+- `:closest()` → `:is(… *)` (removed in v6)
+- Non-fatal HTML parse errors: opt in via `severity.parseError` (see `rules/parse-error.md`). Off by default.
+
+#### Phase 4: New rules not in any preset
+
+Present opt-in rules (`attr-order`, `class-naming`, … — list from rule-names "no preset" set). For `attr-order`, the user must supply the exact order array; `true` is not enough.
+
+### 4. Update Dependency Versions
+
+- Bump `markuplint` and every `@markuplint/*` to the **same** v5 version
+- Uninstall `@markuplint/htmx-parser` / `@markuplint/rule-textlint` if present
+- Install `@markuplint/htmx-spec` / `@markuplint/alpine-spec` when those frameworks are in use
+
+### 5. Update Configuration Files
+
+- Rewrite deprecated rule names from Markuplint's deprecation warnings after one run (old names work until v6; still rewrite now)
+- Apply the silent-gap siblings the user confirmed
+- Set `ruleCommonSettings.ariaVersion` if they chose 1.2
+- Disable extra ARIA/preset rules they declined
+- Convert `invalid-attr` / `required-element` / framework `parser`/`specs` as agreed
+- Named preset groups (`a11y/html-lang`, `a11y/wai-aria/*`, …) can be toggled in `rules` without renaming the user's own nodeRules unless they want names
+
+### 6. Update Tests
+
+- Run markuplint; include `ruleId` and Named Rule Group `name` in assertions when present
+- `--config` / `-c` in tests loads **only** that file
+- Attribute-order and column numbers may shift if `attr-order` is adopted
+
+### 7. Commit
+
+Split by change type in the **user's** repo (example):
+
+1. `feat!: upgrade markuplint to v5` — package.json + lockfile
+2. `fix: migrate markuplint config for v5` — config
+3. `test: update fixtures for markuplint v5`
+
+## Reference: must-check (no warning)
+
+| Situation | Add or change |
+| --- | --- |
+| Raw `permitted-contents` | `no-disallowed-ancestor`, `require-ancestor`, `no-duplicate-sibling-attr` |
+| Raw `no-refer-to-non-existent-id` | `no-broken-fragment-link` |
+| Raw `label-has-control` | `label-no-multiple-controls` |
+| Table model | three rules now `error` |
+| CI on warnings | `--no-allow-warnings` |
+
+Old **renamed/split** names still work with a deprecation warning until v6. Option-routed splits (stable v4): `doctype`, `landmark-roles`, `required-h1`, `invalid-attr` — do not blindly enable every sibling.
+
+`wai-aria` expands to 21 rules; toggles are **not** mapped. See the ARIA guide for the v4 option table.
+
+## Reference: Named Rule Groups
+
+Preset entries with a `name` (for example `a11y/html-lang`) can be disabled or given a different severity from `rules`:
+
+```js
+rules: {
+  'a11y/html-lang': false,
+  'a11y/*': false,
+}
+```
+
+Adding `name` to the user's own `nodeRules` is optional, not required for v4→v5.
+
+## Reference: `-c` / `--config`
+
+v5 loads **only** the file passed to `--config`. It does not merge `.markuplintrc`. Tests that used v4 merge behavior must `extends` the project config or pass a complete file.
+
+## Reference: browserslist rules
+
+`no-unsupported-browser-features` (in `markuplint:compat`, hence `recommended`) is a no-op without browserslist. `no-experimental-features` is **not** in the compat preset (opt-in). `no-nonstandard-features` is in compat.

--- a/website/docs/guides/ai.md
+++ b/website/docs/guides/ai.md
@@ -45,17 +45,17 @@ Markuplint provides installable [skills](https://github.com/markuplint/markuplin
 npx skills add markuplint/markuplint@markuplint
 npx skills add markuplint/markuplint@markuplint-setup
 npx skills add markuplint/markuplint@markuplint-configure
-npx skills add markuplint/markuplint@migrate4-5
+npx skills add markuplint/markuplint@migrations/v4-v5
 ```
 
 ### Available skills
 
-| Skill                  | Type          | Description                                                                                                                                    |
-| ---------------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `markuplint`           | Auto-loaded   | Reference knowledge — violation interpretation, CLI usage, config patterns. Claude automatically references this when working with HTML files. |
-| `markuplint-setup`     | Slash command | Set up Markuplint from scratch — framework detection, preset selection, initial lint, rule-by-rule adoption with Bulk Suppressions.            |
-| `markuplint-configure` | Slash command | Add, remove, or adjust rules — determines the right scope (project / file / element) and proposes configuration changes.                       |
-| `migrate4-5`           | Auto-loaded   | Migrate a project from Markuplint v4 to v5 — reviews breaking changes, updates packages and configuration step by step.                        |
+| Skill                  | Type          | Description                                                                                                                                                                                          |
+| ---------------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `markuplint`           | Auto-loaded   | Reference knowledge — violation interpretation, CLI usage, config patterns. Claude automatically references this when working with HTML files.                                                       |
+| `markuplint-setup`     | Slash command | Set up Markuplint from scratch — framework detection, preset selection, initial lint, rule-by-rule adoption with Bulk Suppressions.                                                                  |
+| `markuplint-configure` | Slash command | Add, remove, or adjust rules — determines the right scope (project / file / element) and proposes configuration changes.                                                                             |
+| `migrate4-5`           | Auto-loaded   | Migrate a project from Markuplint v4 to v5 — reviews breaking changes, updates packages and configuration step by step. Install path: `@migrations/v4-v5` (`@migrate4-5` remains as a legacy alias). |
 
 ### How to use
 

--- a/website/docs/migration/v4-to-v5/index.md
+++ b/website/docs/migration/v4-to-v5/index.md
@@ -38,7 +38,7 @@ Rewrite from those lines. Then check the silent gaps above by hand. 5. If CI tre
 With [Claude Code](https://claude.com/claude-code):
 
 ```bash
-npx skills add markuplint/markuplint@migrate4-5
+npx skills add markuplint/markuplint@migrations/v4-v5
 ```
 
 :::

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/ai.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/ai.md
@@ -45,17 +45,17 @@ Markuplintは[Claude Code](https://claude.ai/claude-code)向けのインスト�
 npx skills add markuplint/markuplint@markuplint
 npx skills add markuplint/markuplint@markuplint-setup
 npx skills add markuplint/markuplint@markuplint-configure
-npx skills add markuplint/markuplint@migrate4-5
+npx skills add markuplint/markuplint@migrations/v4-v5
 ```
 
 ### 利用可能なスキル
 
-| スキル                 | タイプ             | 説明                                                                                                                   |
-| ---------------------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------- |
-| `markuplint`           | 自動読み込み       | リファレンスナレッジ — 違反メッセージの解釈、CLI使用法、設定パターン。HTMLファイルの作業時にClaudeが自動的に参照。     |
-| `markuplint-setup`     | スラッシュコマンド | ゼロからのセットアップ — フレームワーク検出、プリセット選択、初回リント、Bulk Suppressionsを含むルールごとの採用判断。 |
-| `markuplint-configure` | スラッシュコマンド | ルールの追加・削除・調整 — 適切なスコープ（プロジェクト / ファイル / 要素）を判断して設定変更を提案。                  |
-| `migrate4-5`           | 自動ロード         | Markuplint v4からv5への移行 — 破壊的変更を確認し、パッケージと設定を段階的に更新。                                     |
+| スキル                 | タイプ             | 説明                                                                                                                                                      |
+| ---------------------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `markuplint`           | 自動読み込み       | リファレンスナレッジ — 違反メッセージの解釈、CLI使用法、設定パターン。HTMLファイルの作業時にClaudeが自動的に参照。                                        |
+| `markuplint-setup`     | スラッシュコマンド | ゼロからのセットアップ — フレームワーク検出、プリセット選択、初回リント、Bulk Suppressionsを含むルールごとの採用判断。                                    |
+| `markuplint-configure` | スラッシュコマンド | ルールの追加・削除・調整 — 適切なスコープ（プロジェクト / ファイル / 要素）を判断して設定変更を提案。                                                     |
+| `migrate4-5`           | 自動ロード         | Markuplint v4からv5への移行 — 破壊的変更を確認し、パッケージと設定を段階的に更新。インストールパス: `@migrations/v4-v5`（`@migrate4-5` はレガシー別名）。 |
 
 ### 使い方
 

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/migration/v4-to-v5/index.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/migration/v4-to-v5/index.md
@@ -34,7 +34,7 @@ Node.js を **v24.0.0 以降**にしてください。v5 の全パッケージ�
 [Claude Code](https://claude.com/claude-code):
 
 ```bash
-npx skills add markuplint/markuplint@migrate4-5
+npx skills add markuplint/markuplint@migrations/v4-v5
 ```
 
 :::


### PR DESCRIPTION
## Summary

- Move the v4→v5 migration skill to **`skills/migrations/v4-v5/`**, mirroring `docs/migration/v4-v5/`.
- Keep **`skills/migrate4-5/`** as a legacy install stub (`@migrate4-5`) that points at the canonical skill and website guide.
- Align the skill checklist with PR #3991 facts: version-aware doc URLs, explicit GitHub page paths, `parse-error`, and `label-has-control` scope.
- Update EN/JA website install commands and AI guide tables to **`@migrations/v4-v5`**.

## Test plan

- [ ] `npx skills add markuplint/markuplint@migrations/v4-v5` resolves the full skill
- [ ] `npx skills add markuplint/markuplint@migrate4-5` still resolves the legacy stub
- [ ] Website `/docs/guides/ai` and `/docs/migration/v4-to-v5/` show the new install command (EN + JA)
