### PR TITLE
fix(html-spec): restore deprecated attribute flags lost to MDN's Baseline badge rename

### DIFF
--- a/packages/@markuplint/html-spec/CLAUDE.md
+++ b/packages/@markuplint/html-spec/CLAUDE.md
@@ -16,7 +16,11 @@ Constraints and judgment rules for editing spec data. None of this is derivable 
 
 - Manual `src/spec.*.jsonc` data overrides same-named MDN-scraped data. Use this to correct inaccurate MDN data.
 - MDN-only attributes (no manual entry) can only be overridden or suppressed by ADDING a manual entry — merely deleting nothing has no effect.
-- In a regenerated diff: minor MDN description rewording, new MDN-sourced attributes, and flag transitions → commit as-is. Substantive changes (ARIA mappings, content models) → require manual spec edits verified against HTML Living Standard / WAI-ARIA / HTML-ARIA (fetch the live spec; MDN is not the authority).
+- In a regenerated diff: minor MDN description rewording and new MDN-sourced attributes → commit as-is. Substantive changes (ARIA mappings, content models) → require manual spec edits verified against HTML Living Standard / WAI-ARIA / HTML-ARIA (fetch the live spec; MDN is not the authority).
+- **Flag transitions (`deprecated` / `nonStandard` / `experimental` / `obsolete` appearing or disappearing) are data updates only when they're isolated — a handful of attributes on a page that genuinely changed status.** If a regeneration flips dozens of flags at once across unrelated elements, that is a scraper regression, not an MDN update: MDN's page markup (badge class names, section structure) changes far more often than the underlying status does. Before committing a mass flag change, check in this order:
+  1. Does [BCD](https://github.com/mdn/browser-compat-data) still mark the feature with the flag in question for the affected items? (`api.status` in the relevant `browser-compat-data/*.json`, or `npx bcd-utils` if available)
+  2. Does the MDN page's source markdown ([mdn/content](https://github.com/mdn/content)) still carry the corresponding macro (e.g. `{{deprecated_inline}}`, `{{non-standard_inline}}`) for those items?
+  3. If both still say yes, fetch the live rendered page and compare its actual badge markup (class names, `title` text) against what `generator/scraping.ts` selects for. A renamed or restructured badge — not a real status change — is the usual cause. Confirm by checking whether _other_ flags scraped from the same `<dt>` (e.g. `nonStandard`, `experimental`) also went missing; if only one flag type vanished across many elements while sibling flags on the same nodes stayed intact, the selector for that one flag is stale.
 
 ## ARIA version placement
 

--- a/packages/@markuplint/html-spec/generator/scraping.ts
+++ b/packages/@markuplint/html-spec/generator/scraping.ts
@@ -163,7 +163,9 @@ function getAttributes(
 			$myHeading?.attr('id') === 'obsolete_attributes' ||
 			undefined;
 		const deprecated =
-			$dt.find('.icon-thumbs-down-alt, .icon.deprecated, .icon.icon-deprecated').length > 0 ||
+			$dt.find(
+				'.icon-thumbs-down-alt, .icon.deprecated, .icon.icon-deprecated, .icon.discouraged, .icon.removing',
+			).length > 0 ||
 			$myHeading?.attr('id') === 'deprecated_attributes' ||
 			undefined;
 		const nonStandard =

--- a/packages/@markuplint/html-spec/index.json
+++ b/packages/@markuplint/html-spec/index.json
@@ -48859,6 +48859,7 @@
 			"attributes": {
 				"attributionsrc": {
 					"description": "Specifies that you want the browser to send an Attribution-Reporting-Eligible header. On the server-side this is used to trigger sending an Attribution-Reporting-Register-Source header in the response, to register a navigation-based attribution source. The browser stores the source data associated with the navigation-based attribution source (as provided in the Attribution-Reporting-Register-Source response header) when the user clicks the link. See the Attribution Reporting API for more details. There are two versions of this attribute that you can set: Boolean, i.e., just the attributionsrc name. This specifies that you want the Attribution-Reporting-Eligible header sent to the same server as the href attribute points to. This is fine when you are handling the attribution source registration on the same server. Value containing one or more URLs, for example: htmlattributionsrc=\"https://a.example/register-source https://b.example/register-source\" This is useful in cases where the requested resource is not on a server you control, or you just want to handle registering the attribution source on a different server. In this case, you can specify one or more URLs as the value of attributionsrc. When the resource request occurs, the Attribution-Reporting-Eligible header will be sent to the URL(s) specified in attributionsrc in addition to the resource origin. These URLs can then respond with the Attribution-Reporting-Register-Source to complete registration. Note: Specifying multiple URLs means that multiple attribution sources can be registered on the same feature. You might for example have different campaigns that you are trying to measure the success of, which involve generating different reports on different data. <a> elements cannot be used as attribution triggers, only sources.",
+					"deprecated": true,
 					"nonStandard": true
 				},
 				"charset": {
@@ -49844,6 +49845,7 @@
 				},
 				"moz-opaque": {
 					"description": "Lets the canvas know whether translucency will be a factor. If the canvas knows there's no translucency, painting performance can be optimized. This is only supported by Mozilla-based browsers; use the standardized canvas.getContext('2d', { alpha: false }) instead.",
+					"deprecated": true,
 					"nonStandard": true
 				},
 				"width": {
@@ -50344,6 +50346,7 @@
 			"attributes": {
 				"compact": {
 					"description": "This Boolean attribute hints that the list should be rendered in a compact style. The interpretation of this attribute depends on the user agent and it doesn't work in all browsers.",
+					"deprecated": true,
 					"nonStandard": true
 				}
 			}
@@ -50461,7 +50464,8 @@
 			},
 			"attributes": {
 				"compact": {
-					"description": "This Boolean attribute hints that the list should be rendered in a compact style. The interpretation of this attribute is browser-specific. Use CSS instead: to give a similar effect as the compact attribute, the CSS property line-height can be used with a value of 80%."
+					"description": "This Boolean attribute hints that the list should be rendered in a compact style. The interpretation of this attribute is browser-specific. Use CSS instead: to give a similar effect as the compact attribute, the CSS property line-height can be used with a value of 80%.",
+					"deprecated": true
 				}
 			}
 		},
@@ -50776,7 +50780,8 @@
 			},
 			"attributes": {
 				"accept": {
-					"description": "Comma-separated content types the server accepts. Note: This attribute has been deprecated and should not be used. Instead, use the accept attribute on <input type=file> elements."
+					"description": "Comma-separated content types the server accepts. Note: This attribute has been deprecated and should not be used. Instead, use the accept attribute on <input type=file> elements.",
+					"deprecated": true
 				},
 				"accept-charset": {
 					"description": "The character encoding accepted by the server. The specification allows a single case-insensitive value of \"UTF-8\", reflecting the ubiquity of this encoding (historically multiple character encodings could be specified as a comma-separated or space-separated list).",
@@ -50847,30 +50852,37 @@
 			"attributes": {
 				"frameborder": {
 					"description": "This attribute allows you to specify a frame's border.",
+					"deprecated": true,
 					"nonStandard": true
 				},
 				"marginheight": {
 					"description": "This attribute defines the height of the margin between frames.",
+					"deprecated": true,
 					"nonStandard": true
 				},
 				"marginwidth": {
 					"description": "This attribute defines the width of the margin between frames.",
+					"deprecated": true,
 					"nonStandard": true
 				},
 				"name": {
 					"description": "This attribute is used for labeling frames. Without labeling, every link will open in the frame that it's in – the closest parent frame. See the target attribute for more information.",
+					"deprecated": true,
 					"nonStandard": true
 				},
 				"noresize": {
 					"description": "This attribute prevents resizing of frames by users.",
+					"deprecated": true,
 					"nonStandard": true
 				},
 				"scrolling": {
 					"description": "This attribute defines the existence of a scrollbar. If this attribute is not used, the browser adds a scrollbar when necessary. There are two choices: \"yes\" for forcing a scrollbar even when it is not necessary and \"no\" for forcing no scrollbar even when it is necessary.",
+					"deprecated": true,
 					"nonStandard": true
 				},
 				"src": {
 					"description": "This attribute specifies the document that will be displayed by the frame.",
+					"deprecated": true,
 					"nonStandard": true
 				}
 			}
@@ -50893,10 +50905,12 @@
 			"attributes": {
 				"cols": {
 					"description": "This attribute specifies the number and size of horizontal spaces in a frameset.",
+					"deprecated": true,
 					"nonStandard": true
 				},
 				"rows": {
 					"description": "This attribute specifies the number and size of vertical spaces in a frameset.",
+					"deprecated": true,
 					"nonStandard": true
 				}
 			}
@@ -51094,7 +51108,8 @@
 			},
 			"attributes": {
 				"profile": {
-					"description": "The URIs of one or more metadata profiles, separated by white space."
+					"description": "The URIs of one or more metadata profiles, separated by white space.",
+					"deprecated": true
 				}
 			}
 		},
@@ -51208,22 +51223,27 @@
 			"attributes": {
 				"align": {
 					"description": "Sets the alignment of the rule on the page. If no value is specified, the default value is left.",
+					"deprecated": true,
 					"nonStandard": true
 				},
 				"color": {
 					"description": "Sets the color of the rule through color name or hexadecimal value.",
+					"deprecated": true,
 					"nonStandard": true
 				},
 				"noshade": {
 					"description": "Sets the rule to have no shading.",
+					"deprecated": true,
 					"nonStandard": true
 				},
 				"size": {
 					"description": "Sets the height, in pixels, of the rule.",
+					"deprecated": true,
 					"nonStandard": true
 				},
 				"width": {
 					"description": "Sets the length of the rule on the page through a pixel or percentage value.",
+					"deprecated": true,
 					"nonStandard": true
 				}
 			}
@@ -51261,7 +51281,8 @@
 			},
 			"attributes": {
 				"version": {
-					"description": "Specifies the version of the HTML Document Type Definition that governs the current document. This attribute is not needed, because it is redundant with the version information in the document type declaration."
+					"description": "Specifies the version of the HTML Document Type Definition that governs the current document. This attribute is not needed, because it is redundant with the version information in the document type declaration.",
+					"deprecated": true
 				},
 				"xmlns": {
 					"description": "Specifies the XML Namespace of the document. Default value is \"http://www.w3.org/1999/xhtml\". This is required in documents parsed with XML parsers, and optional in text/html documents.",
@@ -51332,10 +51353,12 @@
 				},
 				"allowpaymentrequest": {
 					"description": "Set to true if a cross-origin <iframe> should be allowed to invoke the Payment Request API. Note: This attribute is considered a legacy attribute and redefined as allow=\"payment *\".",
+					"deprecated": true,
 					"nonStandard": true
 				},
 				"browsingtopics": {
 					"description": "A boolean attribute that, if present, specifies that the selected topics for the current user should be sent with the request for the <iframe>'s source.",
+					"deprecated": true,
 					"nonStandard": true
 				},
 				"credentialless": {
@@ -51517,6 +51540,7 @@
 				},
 				"attributionsrc": {
 					"description": "Specifies that you want the browser to send an Attribution-Reporting-Eligible header along with the image request. On the server-side this is used to trigger sending an Attribution-Reporting-Register-Source or Attribution-Reporting-Register-Trigger header in the response, to register an image-based attribution source or attribution trigger, respectively. Which response header should be sent back depends on the value of the Attribution-Reporting-Eligible header that triggered the registration. The corresponding source or trigger event is set off once the browser receives the response containing the image file. Note: See the Attribution Reporting API for more details. There are two versions of this attribute that you can set: Boolean, i.e., just the attributionsrc name. This specifies that you want the Attribution-Reporting-Eligible header sent to the same server as the src attribute points to. This is fine when you are handling the attribution source or trigger registration on the same server. When registering an attribution trigger this property is optional, and a boolean value will be used if it is omitted. Value containing one or more URLs, for example: html<img src=\"image-file.png\" alt=\"My image file description\" attributionsrc=\"https://a.example/register-source https://b.example/register-source\" /> This is useful in cases where the requested resource is not on a server you control, or you just want to handle registering the attribution source on a different server. In this case, you can specify one or more URLs as the value of attributionsrc. When the resource request occurs the Attribution-Reporting-Eligible header will be sent to the URL(s) specified in attributionSrc in addition to the resource origin. These URLs can then respond with an Attribution-Reporting-Register-Source or Attribution-Reporting-Register-Trigger header as appropriate to complete registration. Note: Specifying multiple URLs means that multiple attribution sources can be registered on the same feature. You might for example have different campaigns that you are trying to measure the success of, which involve generating different reports on different data.",
+					"deprecated": true,
 					"nonStandard": true
 				},
 				"border": {
@@ -52908,7 +52932,8 @@
 			},
 			"attributes": {
 				"type": {
-					"description": "This character attribute indicates the numbering type: a: lowercase letters A: uppercase letters i: lowercase Roman numerals I: uppercase Roman numerals 1: numbers This type overrides the one used by its parent <ol> element, if any. Note: This attribute has been deprecated; use the CSS list-style-type property instead."
+					"description": "This character attribute indicates the numbering type: a: lowercase letters A: uppercase letters i: lowercase Roman numerals I: uppercase Roman numerals 1: numbers This type overrides the one used by its parent <ol> element, if any. Note: This attribute has been deprecated; use the CSS list-style-type property instead.",
+					"deprecated": true
 				},
 				"value": {
 					"description": "This integer attribute indicates the current ordinal value of the list item as defined by the <ol> element. The only allowed value for this attribute is a number, even if the list is displayed with Roman numerals or letters. List items that follow this one continue numbering from the value set. This attribute has no meaning for unordered lists (<ul>) or for menus (<menu>).",
@@ -52988,7 +53013,8 @@
 				},
 				"charset": {
 					"description": "This attribute defines the character encoding of the linked resource. The value is a space- and/or comma-delimited list of character sets as defined in RFC 2045. The default value is iso-8859-1. Note: To produce the same effect as this obsolete attribute, use the Content-Type HTTP header on the linked resource.",
-					"obsolete": true
+					"obsolete": true,
+					"deprecated": true
 				},
 				"color": {
 					"type": "<color>",
@@ -53045,7 +53071,8 @@
 				},
 				"rev": {
 					"description": "The value of this attribute shows the relationship of the current document to the linked document, as defined by the href attribute. The attribute thus defines the reverse relationship compared to the value of the rel attribute. Link type values for the attribute are similar to the possible values for rel. Note: Instead of rev, you should use the rel attribute with the opposite link type value. For example, to establish the reverse link for made, specify author. Also, this attribute doesn't stand for \"revision\" and must not be used with a version number, even though many sites misuse it in this way.",
-					"obsolete": true
+					"obsolete": true,
+					"deprecated": true
 				},
 				"sizes": {
 					"description": "This attribute defines the sizes of the icons for visual media contained in the resource. It must be present only if the rel contains a value of icon or a non-standard type such as Apple's apple-touch-icon. It may have the following values: any, meaning that the icon can be scaled to any size as it is in a vector format, like image/svg+xml. a white-space separated list of sizes, each in the format <width in pixels>x<height in pixels> or <width in pixels>X<height in pixels>. Each of these sizes must be contained in the resource. Note: Most icon formats are only able to store one single icon; therefore, most of the time, the sizes attribute contains only one entry. Microsoft's ICO format and Apple's ICNS format can store multiple icon sizes in a single file. ICO has better browser support, so you should use this format if cross-browser support is a concern.",
@@ -53059,7 +53086,8 @@
 					"condition": ["[rel~='icon' i]", "[rel~='apple-touch-icon' i]"]
 				},
 				"target": {
-					"description": "Defines the frame or window name that has the defined linking relationship or that will show the rendering of any linked resource."
+					"description": "Defines the frame or window name that has the defined linking relationship or that will show the rendering of any linked resource.",
+					"deprecated": true
 				},
 				"title": {
 					"description": "The title attribute has special semantics on the <link> element. When used on a <link rel=\"stylesheet\"> it defines a default or an alternate stylesheet.",
@@ -53194,42 +53222,53 @@
 			"globalAttrs": {},
 			"attributes": {
 				"behavior": {
-					"description": "Sets how the text is scrolled within the marquee. Possible values are scroll, slide and alternate. If no value is specified, the default value is scroll."
+					"description": "Sets how the text is scrolled within the marquee. Possible values are scroll, slide and alternate. If no value is specified, the default value is scroll.",
+					"deprecated": true
 				},
 				"bgcolor": {
-					"description": "Sets the background color through color name or hexadecimal value."
+					"description": "Sets the background color through color name or hexadecimal value.",
+					"deprecated": true
 				},
 				"direction": {
-					"description": "Sets the direction of the scrolling within the marquee. Possible values are left, right, up and down. If no value is specified, the default value is left."
+					"description": "Sets the direction of the scrolling within the marquee. Possible values are left, right, up and down. If no value is specified, the default value is left.",
+					"deprecated": true
 				},
 				"height": {
 					"description": "Sets the height in pixels or percentage value.",
+					"deprecated": true,
 					"nonStandard": true
 				},
 				"hspace": {
 					"description": "Sets the horizontal margin",
+					"deprecated": true,
 					"nonStandard": true
 				},
 				"loop": {
-					"description": "Sets the number of times the marquee will scroll. If no value is specified, the default value is −1, which means the marquee will scroll continuously."
+					"description": "Sets the number of times the marquee will scroll. If no value is specified, the default value is −1, which means the marquee will scroll continuously.",
+					"deprecated": true
 				},
 				"scrollamount": {
 					"description": "Sets the amount of scrolling at each interval in pixels. The default value is 6.",
+					"deprecated": true,
 					"nonStandard": true
 				},
 				"scrolldelay": {
 					"description": "Sets the interval between each scroll movement in milliseconds. The default value is 85. Note that any value smaller than 60 is ignored and the value 60 is used instead unless truespeed is specified.",
+					"deprecated": true,
 					"nonStandard": true
 				},
 				"truespeed": {
-					"description": "By default, scrolldelay values lower than 60 are ignored. If truespeed is present, those values are not ignored."
+					"description": "By default, scrolldelay values lower than 60 are ignored. If truespeed is present, those values are not ignored.",
+					"deprecated": true
 				},
 				"vspace": {
 					"description": "Sets the vertical margin in pixels or percentage value.",
+					"deprecated": true,
 					"nonStandard": true
 				},
 				"width": {
 					"description": "Sets the width in pixels or percentage value.",
+					"deprecated": true,
 					"nonStandard": true
 				}
 			}
@@ -53288,7 +53327,8 @@
 			},
 			"attributes": {
 				"compact": {
-					"description": "This Boolean attribute hints that the list should be rendered in a compact style. The interpretation of this attribute is browser-specific. Use CSS instead: to give a similar effect as the compact attribute, the CSS property line-height can be used with a value of 80%."
+					"description": "This Boolean attribute hints that the list should be rendered in a compact style. The interpretation of this attribute is browser-specific. Use CSS instead: to give a similar effect as the compact attribute, the CSS property line-height can be used with a value of 80%.",
+					"deprecated": true
 				}
 			}
 		},
@@ -53638,19 +53678,24 @@
 			},
 			"attributes": {
 				"archive": {
-					"description": "A space-separated list of URIs for archives of resources for the object."
+					"description": "A space-separated list of URIs for archives of resources for the object.",
+					"deprecated": true
 				},
 				"border": {
-					"description": "The width of a border around the control, in pixels."
+					"description": "The width of a border around the control, in pixels.",
+					"deprecated": true
 				},
 				"classid": {
-					"description": "The URI of the object's implementation. It can be used together with, or in place of, the data attribute."
+					"description": "The URI of the object's implementation. It can be used together with, or in place of, the data attribute.",
+					"deprecated": true
 				},
 				"codebase": {
-					"description": "The base path used to resolve relative URIs specified by classid, data, or archive. If not specified, the default is the base URI of the current document."
+					"description": "The base path used to resolve relative URIs specified by classid, data, or archive. If not specified, the default is the base URI of the current document.",
+					"deprecated": true
 				},
 				"codetype": {
-					"description": "The content type of the data specified by classid."
+					"description": "The content type of the data specified by classid.",
+					"deprecated": true
 				},
 				"data": {
 					"description": "The address of the resource as a valid URL. At least one of data and type must be defined.",
@@ -53658,7 +53703,8 @@
 					"requiredEither": ["type"]
 				},
 				"declare": {
-					"description": "The presence of this Boolean attribute makes this element a declaration only. The object must be instantiated by a subsequent <object> element. Repeat the <object> element completely each time the resource is reused."
+					"description": "The presence of this Boolean attribute makes this element a declaration only. The object must be instantiated by a subsequent <object> element. Repeat the <object> element completely each time the resource is reused.",
+					"deprecated": true
 				},
 				"form": {
 					"description": "The form element, if any, that the object element is associated with (its form owner). The value of the attribute must be an ID of a <form> element in the same document."
@@ -53671,7 +53717,8 @@
 					"type": "NavigableTargetName"
 				},
 				"standby": {
-					"description": "A message that the browser can show while loading the object's implementation and data."
+					"description": "A message that the browser can show while loading the object's implementation and data.",
+					"deprecated": true
 				},
 				"type": {
 					"description": "The content type of the resource specified by data. At least one of data and type must be defined.",
@@ -53679,7 +53726,8 @@
 					"requiredEither": ["data"]
 				},
 				"usemap": {
-					"description": "A hash-name reference to a <map> element; that is a '#' followed by the value of a name of a map element."
+					"description": "A hash-name reference to a <map> element; that is a '#' followed by the value of a name of a map element.",
+					"deprecated": true
 				},
 				"width": {
 					"description": "The width of the display resource, as in <integer> in CSS pixels."
@@ -53741,6 +53789,7 @@
 			"attributes": {
 				"compact": {
 					"description": "This Boolean attribute hints that the list should be rendered in a compact style. The interpretation of this attribute is browser-specific. Use CSS instead: to give a similar effect as the compact attribute, the CSS property line-height can be used with a value of 80%.",
+					"deprecated": true,
 					"nonStandard": true
 				},
 				"reversed": {
@@ -53791,7 +53840,7 @@
 			},
 			"attributes": {
 				"disabled": {
-					"description": "If this Boolean attribute is set, none of the items in this option group is selectable. Often browsers grey out such control and it won't receive any browsing events, like mouse clicks or focus-related ones."
+					"description": "If this Boolean attribute is set, none of the items in this option group is selectable. Often browsers gray out such control and it won't receive any browsing events, like mouse clicks or focus-related ones."
 				},
 				"label": {
 					"description": "The name of the group of options, which the browser can use when labeling the options in the user interface. This attribute is mandatory if this element is used.",
@@ -53875,7 +53924,7 @@
 			},
 			"attributes": {
 				"disabled": {
-					"description": "If this Boolean attribute is set, this option is not checkable. Often browsers grey out such control and it won't receive any browsing event, like mouse clicks or focus-related ones. If this attribute is not set, the element can still be disabled if one of its ancestors is a disabled <optgroup> element."
+					"description": "If this Boolean attribute is set, this option is not checkable. Often browsers gray out such control and it won't receive any browsing event, like mouse clicks or focus-related ones. If this attribute is not set, the element can still be disabled if one of its ancestors is a disabled <optgroup> element."
 				},
 				"label": {
 					"description": "This attribute is text for the label indicating the meaning of the option. If the label attribute isn't defined, its value is that of the element text content.",
@@ -53978,18 +54027,22 @@
 			"attributes": {
 				"name": {
 					"description": "Name of the parameter.",
+					"deprecated": true,
 					"nonStandard": true
 				},
 				"type": {
 					"description": "Only used if the valuetype is set to ref. Specifies the MIME type of values found at the URI specified by value.",
+					"deprecated": true,
 					"nonStandard": true
 				},
 				"value": {
 					"description": "Specifies the value of the parameter.",
+					"deprecated": true,
 					"nonStandard": true
 				},
 				"valuetype": {
 					"description": "Specifies the type of the value attribute. Possible values are: data: Default value. The value is passed to the object's implementation as a string. ref: The value is a URI to a resource where run-time values are stored. object: An ID of another <object> in the same document.",
+					"deprecated": true,
 					"nonStandard": true
 				}
 			}
@@ -54087,10 +54140,12 @@
 			"attributes": {
 				"width": {
 					"description": "Contains the preferred count of characters that a line should have. Though technically still implemented, this attribute has no visual effect; to achieve such an effect, use CSS width instead.",
+					"deprecated": true,
 					"nonStandard": true
 				},
 				"wrap": {
 					"description": "Is a hint indicating how the overflow must happen. In modern browser this hint is ignored and no visual effect results in its present; to achieve such an effect, use CSS white-space instead.",
+					"deprecated": true,
 					"nonStandard": true
 				}
 			}
@@ -54416,6 +54471,7 @@
 				},
 				"attributionsrc": {
 					"description": "Specifies that you want the browser to send an Attribution-Reporting-Eligible header along with the script resource request. On the server-side this is used to trigger sending an Attribution-Reporting-Register-Source or Attribution-Reporting-Register-Trigger header in the response, to register a JavaScript-based attribution source or attribution trigger, respectively. Which response header should be sent back depends on the value of the Attribution-Reporting-Eligible header that triggered the registration. Note: Alternatively, JavaScript-based attribution sources or triggers can be registered by sending a fetch() request containing the attributionReporting option (either set directly on the fetch() call or on a Request object passed into the fetch() call), or by sending an XMLHttpRequest with setAttributionReporting() invoked on the request object. There are two versions of this attribute that you can set: Boolean, i.e., just the attributionsrc name. This specifies that you want the Attribution-Reporting-Eligible header sent to the same server as the src attribute points to. This is fine when you are handling the attribution source or trigger registration on the same server. When registering an attribution trigger this property is optional, and an empty string value will be used if it is omitted. Value containing one or more URLs, for example: html<script src=\"myscript.js\" attributionsrc=\"https://a.example/register-source https://b.example/register-source\"></script> This is useful in cases where the requested resource is not on a server you control, or you just want to handle registering the attribution source on a different server. In this case, you can specify one or more URLs as the value of attributionsrc. When the resource request occurs the Attribution-Reporting-Eligible header will be sent to the URL(s) specified in attributionSrc in addition to the resource origin. These URLs can then respond with an Attribution-Reporting-Register-Source or Attribution-Reporting-Register-Trigger header as appropriate to complete registration. Note: Specifying multiple URLs means that multiple attribution sources can be registered on the same feature. You might for example have different campaigns that you are trying to measure the success of, which involve generating different reports on different data. See the Attribution Reporting API for more details.",
+					"deprecated": true,
 					"nonStandard": true
 				},
 				"blocking": {
@@ -55275,7 +55331,7 @@
 		{
 			"name": "template",
 			"cite": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/template",
-			"description": "The <template> HTML element serves as a mechanism for holding HTML fragments, which can either be used later via JavaScript or generated immediately into shadow DOM.",
+			"description": "The <template> HTML element serves as a mechanism for holding HTML fragments, which can either be used later via JavaScript, generated immediately and inserted into a shadow DOM, or used as part of out-of-order patching with <template for=\"...\">.",
 			"categories": ["#metadata", "#flow", "#phrasing", "#script-supporting"],
 			"contentModel": {
 				"contents": true
@@ -55292,6 +55348,9 @@
 				"#HTMLGlobalAttrs": true
 			},
 			"attributes": {
+				"for": {
+					"description": "The for attribute is used for out-of-order patching with <template for=\"...\">, matching an equivalent <?start id=\"...\"> or <?marker \"...\"> marker. See the out-of-order patching section and examples section."
+				},
 				"shadowrootclonable": {
 					"description": "Sets the value of the clonable property of a ShadowRoot created using this element to true. If set, a clone of the shadow host (the parent element of this <template>) created with Node.cloneNode() or Document.importNode() will include a shadow root in the copy.",
 					"type": "Boolean"
@@ -55889,10 +55948,12 @@
 			},
 			"attributes": {
 				"compact": {
-					"description": "This Boolean attribute hints that the list should be rendered in a compact style. The interpretation of this attribute is browser-specific. Use CSS instead: to give a similar effect as the compact attribute, the CSS property line-height can be used with a value of 80%."
+					"description": "This Boolean attribute hints that the list should be rendered in a compact style. The interpretation of this attribute is browser-specific. Use CSS instead: to give a similar effect as the compact attribute, the CSS property line-height can be used with a value of 80%.",
+					"deprecated": true
 				},
 				"type": {
-					"description": "This attribute sets the bullet style for the list. The values defined under HTML3.2 and the transitional version of HTML 4.0/4.01 are: circle disc square A fourth bullet type has been defined in the WebTV interface, but not all browsers support it: triangle. If not present and if no CSS list-style-type property applies to the element, the user agent selects a bullet type depending on the nesting level of the list. Warning: Do not use this attribute, as it has been deprecated; use the CSS list-style-type property instead."
+					"description": "This attribute sets the bullet style for the list. The values defined under HTML3.2 and the transitional version of HTML 4.0/4.01 are: circle disc square A fourth bullet type has been defined in the WebTV interface, but not all browsers support it: triangle. If not present and if no CSS list-style-type property applies to the element, the user agent selects a bullet type depending on the nesting level of the list. Warning: Do not use this attribute, as it has been deprecated; use the CSS list-style-type property instead.",
+					"deprecated": true
 				}
 			}
 		},
@@ -56110,6 +56171,7 @@
 				},
 				"src": {
 					"description": "The location of an external source for semantic information.",
+					"deprecated": true,
 					"type": "URL"
 				}
 			}
@@ -56150,6 +56212,7 @@
 				},
 				"src": {
 					"description": "The location of an external source for semantic information.",
+					"deprecated": true,
 					"type": "URL"
 				}
 			}
@@ -56158,7 +56221,7 @@
 			"name": "mml:maction",
 			"namespace": "http://www.w3.org/1998/Math/MathML",
 			"cite": "https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/maction",
-			"description": "The <maction> MathML element allows to bind actions to mathematical expressions. By default, only the first child is rendered but some browsers may take into account actiontype and selection attributes to implement custom behaviors. Note: Historically, this element provided a mechanism to make MathML formulas interactive. Nowadays, it is recommended to rely on JavaScript and other Web technologies to implement this use case.",
+			"description": "The <maction> MathML element allows you to bind actions to mathematical expressions. By default, only the first child is rendered but some browsers may take into account actiontype and selection attributes to implement custom behaviors. Note: Historically, this element provided a mechanism to make MathML formulas interactive. Nowadays, it is recommended to rely on JavaScript and other Web technologies to implement this use case.",
 			"categories": [],
 			"contentModel": {
 				"contents": [
@@ -56187,11 +56250,13 @@
 			"attributes": {
 				"actiontype": {
 					"description": "The action which specifies what happens for this element. Special behavior for the following values were implemented by some browsers: statusline: If there is a click on the expression or the reader moves the pointer over it, the message is sent to the browser's status line. The syntax is: <maction actiontype=\"statusline\"> expression message </maction>. toggle: When there is a click on the subexpression, the rendering alternates the display of selected subexpressions. Therefore each click increments the selection value. The syntax is: <maction actiontype=\"toggle\" selection=\"positive-integer\" > expression1 expression2 expressionN </maction>.",
+					"deprecated": true,
 					"nonStandard": true,
 					"type": "Any"
 				},
 				"selection": {
 					"description": "The child element currently visible, only taken into account for actiontype=\"toggle\" or non-standard actiontype values. The default value is 1, which is the first child element.",
+					"deprecated": true,
 					"nonStandard": true,
 					"type": "Any"
 				}
@@ -56387,6 +56452,7 @@
 			"attributes": {
 				"denomalign": {
 					"description": "The alignment of the denominator under the fraction. Possible values are: left, center (default), and right.",
+					"deprecated": true,
 					"nonStandard": true
 				},
 				"linethickness": {
@@ -56395,6 +56461,7 @@
 				},
 				"numalign": {
 					"description": "The alignment of the numerator over the fraction. Possible values are: left, center (default), and right.",
+					"deprecated": true,
 					"nonStandard": true
 				}
 			}
@@ -56464,10 +56531,12 @@
 			"attributes": {
 				"subscriptshift": {
 					"description": "A <length-percentage> indicating the minimum amount to shift the baseline of the subscript down.",
+					"deprecated": true,
 					"nonStandard": true
 				},
 				"superscriptshift": {
 					"description": "A <length-percentage> indicating the minimum amount to shift the baseline of the superscript up.",
+					"deprecated": true,
 					"nonStandard": true
 				}
 			}
@@ -56936,22 +57005,27 @@
 			"attributes": {
 				"background": {
 					"description": "Use CSS property background-color instead.",
+					"deprecated": true,
 					"nonStandard": true
 				},
 				"color": {
 					"description": "Use CSS property color instead.",
+					"deprecated": true,
 					"nonStandard": true
 				},
 				"fontsize": {
 					"description": "Use CSS property font-size instead.",
+					"deprecated": true,
 					"nonStandard": true
 				},
 				"fontstyle": {
 					"description": "Use CSS property font-style instead.",
+					"deprecated": true,
 					"nonStandard": true
 				},
 				"fontweight": {
 					"description": "Use CSS property font-weight instead.",
+					"deprecated": true,
 					"nonStandard": true
 				}
 			}
@@ -56990,6 +57064,7 @@
 			"attributes": {
 				"subscriptshift": {
 					"description": "A <length-percentage> indicating the minimum amount to shift the baseline of the subscript down.",
+					"deprecated": true,
 					"nonStandard": true
 				}
 			}
@@ -57028,10 +57103,12 @@
 			"attributes": {
 				"subscriptshift": {
 					"description": "A <length-percentage> indicating the minimum amount to shift the baseline of the subscript down.",
+					"deprecated": true,
 					"nonStandard": true
 				},
 				"superscriptshift": {
 					"description": "A <length-percentage> indicating the minimum amount to shift the baseline of the superscript up.",
+					"deprecated": true,
 					"nonStandard": true
 				}
 			}
@@ -57070,6 +57147,7 @@
 			"attributes": {
 				"superscriptshift": {
 					"description": "A <length-percentage> indicating the minimum amount to shift the baseline of the superscript up.",
+					"deprecated": true,
 					"nonStandard": true
 				}
 			}
@@ -57536,7 +57614,8 @@
 					"description": "A MIME type for the linked URL. Value type: <string>; Default value: none; Animatable: no"
 				},
 				"xlink:href": {
-					"description": "The URL or URL fragment that the hyperlink points to. May be required for backwards compatibility for older browsers. Value type: <URL>; Default value: none; Animatable: yes"
+					"description": "The URL or URL fragment that the hyperlink points to. May be required for backwards compatibility for older browsers. Value type: <URL>; Default value: none; Animatable: yes",
+					"deprecated": true
 				}
 			}
 		},
@@ -60127,7 +60206,7 @@
 			"name": "svg:fePointLight",
 			"namespace": "http://www.w3.org/2000/svg",
 			"cite": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/fePointLight",
-			"description": "The <fePointLight> SVG element defines a light source which allows to create a point light effect. It can be used within a lighting filter primitive: <feDiffuseLighting> or <feSpecularLighting>.",
+			"description": "The <fePointLight> SVG element defines a light source which allows you to create a point light effect. It can be used within a lighting filter primitive: <feDiffuseLighting> or <feSpecularLighting>.",
 			"categories": [],
 			"contentModel": {
 				"contents": [
@@ -60360,7 +60439,7 @@
 			"name": "svg:feTile",
 			"namespace": "http://www.w3.org/2000/svg",
 			"cite": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feTile",
-			"description": "The <feTile> SVG filter primitive allows to fill a target rectangle with a repeated, tiled pattern of an input image. The effect is similar to the one of a <pattern>.",
+			"description": "The <feTile> SVG filter primitive allows you to fill a target rectangle with a repeated, tiled pattern of an input image. The effect is similar to the one of a <pattern>.",
 			"categories": [],
 			"contentModel": {
 				"contents": [
@@ -61092,7 +61171,8 @@
 					"description": "Positions the image horizontally from the origin. Value type: <length> | <percentage>; Default value: 0; Animatable: yes"
 				},
 				"xlink:href": {
-					"description": "Points at a URL for the image file. Value type: <URL>; Default value: none; Animatable: no"
+					"description": "Points at a URL for the image file. Value type: <URL>; Default value: none; Animatable: no",
+					"deprecated": true
 				},
 				"y": {
 					"description": "Positions the image vertically from the origin. Value type: <length> | <percentage>; Default value: 0; Animatable: yes"
@@ -61380,7 +61460,8 @@
 					"animatable": true
 				},
 				"xlink:href": {
-					"description": "An <IRI> reference to another <linearGradient> element that will be used as a template. Value type: <IRI>; Default value: none; Animatable: yes"
+					"description": "An <IRI> reference to another <linearGradient> element that will be used as a template. Value type: <IRI>; Default value: none; Animatable: yes",
+					"deprecated": true
 				},
 				"y1": {
 					"description": "This attribute defines the y coordinate of the starting point of the vector gradient along which the linear gradient is drawn. Value type: <length>; Default value: 0%; Animatable: yes",
@@ -62062,7 +62143,8 @@
 					"description": "This attribute determines the x coordinate shift of the pattern tile. Value type: <length>; Default value: 0; Animatable: yes"
 				},
 				"xlink:href": {
-					"description": "This attribute references a template pattern that provides default values for the <pattern> attributes. Value type: <URL>; Default value: none; Animatable: yes Note: For browsers implementing href, if both href and xlink:href are set, xlink:href will be ignored and only href will be used."
+					"description": "This attribute references a template pattern that provides default values for the <pattern> attributes. Value type: <URL>; Default value: none; Animatable: yes Note: For browsers implementing href, if both href and xlink:href are set, xlink:href will be ignored and only href will be used.",
+					"deprecated": true
 				},
 				"y": {
 					"description": "This attribute determines the y coordinate shift of the pattern tile. Value type: <length>; Default value: 0; Animatable: yes"
@@ -62473,7 +62555,8 @@
 					"animatable": true
 				},
 				"xlink:href": {
-					"description": "An <IRI> reference to another <radialGradient> element that will be used as a template. Value type: <IRI>; Default value: none; Animatable: yes"
+					"description": "An <IRI> reference to another <radialGradient> element that will be used as a template. Value type: <IRI>; Default value: none; Animatable: yes",
+					"deprecated": true
 				}
 			}
 		},
@@ -62620,7 +62703,7 @@
 			"name": "svg:script",
 			"namespace": "http://www.w3.org/2000/svg",
 			"cite": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/script",
-			"description": "The <script> SVG element allows to add scripts to an SVG document. Note: While SVG's script element is equivalent to the HTML <script> element, it has some discrepancies, like it uses the href attribute instead of src and it doesn't support ECMAScript modules so far (See browser compatibility below for details)",
+			"description": "The <script> SVG element allows you to add scripts to an SVG document. Note: While SVG's script element is equivalent to the HTML <script> element, it has some discrepancies, like it uses the href attribute instead of src and it doesn't support ECMAScript modules so far (See browser compatibility below for details)",
 			"categories": [],
 			"contentModel": {
 				"contents": [
@@ -62673,7 +62756,8 @@
 					"defaultValue": "application/ecmascript"
 				},
 				"xlink:href": {
-					"description": "The URL to the script to load. Value type: <URL>; Default value: none; Animatable: no"
+					"description": "The URL to the script to load. Value type: <URL>; Default value: none; Animatable: no",
+					"deprecated": true
 				}
 			}
 		},
@@ -63877,7 +63961,8 @@
 					"description": "The x coordinate of an additional final offset transformation applied to the <use> element. Value type: <coordinate>; Default value: 0; Animatable: yes"
 				},
 				"xlink:href": {
-					"description": "An <IRI> reference to an element/fragment that needs to be duplicated. If both href and xlink:href are present, the value given by href is used. Value type: <IRI>; Default value: none; Animatable: yes Warning: Since SVG 2, the xlink:href attribute is deprecated in favor of href. See xlink:href page for more information."
+					"description": "An <IRI> reference to an element/fragment that needs to be duplicated. If both href and xlink:href are present, the value given by href is used. Value type: <IRI>; Default value: none; Animatable: yes Warning: Since SVG 2, the xlink:href attribute is deprecated in favor of href. See xlink:href page for more information.",
+					"deprecated": true
 				},
 				"y": {
 					"description": "The y coordinate of an additional final offset transformation applied to the <use> element. Value type: <coordinate>; Default value: 0; Animatable: yes"


### PR DESCRIPTION
## Summary

- MDN replaced the deprecated-attribute badge markup with a Baseline status widget (`class="icon icon-baseline discouraged"` / `class="icon icon-baseline removing"`) in place of the old `.icon.deprecated` / `.icon.icon-deprecated` classes the scraper looked for.
- A routine MDN sync (#3994) silently dropped **75 attribute-level `deprecated` flags** across 30+ elements (`marquee`, `frame`, `object`, `param`, `hr`, and others) — verified as a scraper miss, not a real MDN status change, because not a single description string changed and sibling flags scraped from the same `<dt>` (`nonStandard`, `experimental`) stayed intact throughout.
- #3995 hand-restored `deprecated: true` for the 21 elements it touched directly in `src/spec.*.jsonc`, but never regenerated `index.json`, so none of it reached the generated output.
- This PR adds the new badge classes to the attribute-level selector (`generator/scraping.ts`) and regenerates `index.json`.
- Also documents the failure mode in `html-spec/CLAUDE.md`: a regeneration that flips dozens of flags at once across unrelated elements should be treated as a scraper regression by default, with a concrete check order (BCD → MDN source macros → live badge markup) to tell it apart from a genuine MDN update.

## Verified

- Restored set is **exactly** the 75 flags that were lost — no gains, no further losses (diffed against the pre-regression baseline commit)
- `obsolete` (2), `experimental` (19), `nonStandard` (85) counts unchanged
- A second `yarn up:gen` run produces a byte-identical `index.json` (idempotency check per `html-spec/CLAUDE.md`)
- `yarn build && yarn test` — 310 files / 4566 passed / 1 skipped / 0 type errors
- `yarn lint-check` green

## Note on #3998

This PR's `up:gen` run supersedes the pending automated sync in #3998 — it captures the same live MDN description sync plus the deprecated-flag fix that #3998's run (built with the old, buggy selector) does not have. I'll comment on #3998 to close it as superseded once this merges.

## Test plan

- [x] `yarn build`
- [x] `yarn test`
- [x] `yarn lint-check`
- [x] Deprecated-flag diff verified against `e925565ce` (pre-#3989) baseline