### PR TITLE
docs: create vscode/CLAUDE.md and fix stale VS Code publishing text

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,9 @@ for the setup, command list, and the Docker / `excluded-ids.json` workflow.
 
 The npm packages are published automatically from CI (npm trusted publisher).
 The VS Code extension, in contrast, is published **manually** after the core
-packages land.
+packages land. See [`vscode/CLAUDE.md`](https://github.com/markuplint/markuplint/blob/dev/vscode/CLAUDE.md#release-policy-mandatory)
+for why stable and prerelease versions are distributed through different
+channels.
 
 ### Publisher
 
@@ -55,7 +57,7 @@ The extension is published under the `markuplint` publisher
 (Marketplace ID: `markuplint.vscode-markuplint`).
 
 The legacy `yusukehirao.vscode-markuplint` ID is deprecated from
-`v5.0.0-rc.3` onwards and no longer receives updates.
+`v5.0.0-rc.4` onwards and no longer receives updates.
 
 `yarn vscode:login` runs `vsce login markuplint`, so the Azure DevOps
 Personal Access Token you authenticate with must have rights on the
@@ -65,7 +67,7 @@ Personal Access Token you authenticate with must have rights on the
 
 All packages — including the VS Code extension — share a single version
 because Lerna is configured in non-independent mode. The extension version
-always matches the core version (e.g. `5.0.0`, `5.0.0-rc.2`).
+always matches the core version (e.g. `5.0.0`, `5.0.0-rc.4`).
 
 ### Workflow
 

--- a/vscode/CLAUDE.md
+++ b/vscode/CLAUDE.md
@@ -1,0 +1,52 @@
+# vscode
+
+## Release policy (MANDATORY)
+
+The VS Code Marketplace rejects semver prerelease suffixes (`5.0.0-rc.4` is
+literally refused on upload), and its own prerelease channel requires a
+version scheme divorced from semver (an odd/even minor split), which
+conflicts with this repo's Lerna non-independent versioning. Rather than
+maintain a divergent version mapping for the extension alone, releases are
+split by channel instead:
+
+| Release type                                  | npm     | Marketplace                | GitHub Release (`.vsix`)      |
+| --------------------------------------------- | ------- | -------------------------- | ----------------------------- |
+| Stable (`X.Y.Z`)                              | CI auto | Manual publish (see below) | Attach for archival           |
+| Prerelease (`-rc.N` / `-beta.N` / `-alpha.N`) | CI auto | **Never**                  | **Only** distribution channel |
+
+A prerelease build is therefore installable only via the `.vsix` attached to
+its GitHub Release, never via the Marketplace's own prerelease channel.
+
+## Publishing (stable only)
+
+There is no CI publish job for the extension — Marketplace publishing is a
+manual step performed after the npm packages for that version are out:
+
+```bash
+yarn vscode:package   # builds and verifies the VSIX (installable, no upload)
+yarn vscode:release   # publishes the verified VSIX to the Marketplace
+```
+
+Always run `vscode:package` first and sanity-check the resulting `.vsix`
+before `vscode:release` — there is no dry-run for the Marketplace upload
+itself.
+
+An OIDC-based publish pipeline (replacing the long-lived Marketplace PAT)
+was scoped but not adopted — there is no `vscode-marketplace` GitHub
+Environment and no Azure-related repo secret. Publishing still uses the PAT
+via `vsce`'s interactive login (`yarn vscode:login`).
+
+## Build modes
+
+`vscode/scripts/install.mjs [mode]` only accepts `package` and `release`
+(see `vscode/scripts/resolve-mode.mjs`). Prerelease modes (`pre-package` /
+`pre-release`) existed briefly during the switch to the `markuplint`
+publisher namespace and were removed once the policy above was decided —
+don't reintroduce them without revisiting that decision.
+
+## Legacy publisher
+
+The extension previously published under `yusukehirao.vscode-markuplint`.
+That listing is deprecated in favor of the `markuplint` publisher namespace
+above; its final version and migration notice are tracked separately and are
+out of scope for this file.


### PR DESCRIPTION
## Summary

- Create `vscode/CLAUDE.md`: three existing references (`vscode/scripts/install.mjs`, `resolve-mode.mjs`, the rc.4 release notes) pointed at a file that had never actually been created. Documents the split-channel release policy (npm CI-auto / Marketplace manual-stable-only / GitHub Release for prereleases) decided in #3756 during the rc.4 publisher switch.
- Fix `CONTRIBUTING.md` (and its website mirror, regenerated at build time, not tracked): legacy-publisher deprecation said "from rc.3", but the publisher switch (#3754) shipped in rc.4.
- Link `CONTRIBUTING.md`'s VS Code section to `vscode/CLAUDE.md`.
- Update #3756 to reflect reality: scope A (this cleanup) is done, scope B (Marketplace OIDC publish pipeline) is explicitly withdrawn rather than left looking merely deferred — the extension publishes far less often than npm packages, so the added Azure/Entra machinery costs more than the manual `vsce login` flow it replaces. npm's own OIDC trusted publishing is unrelated and unaffected by this.

## Test plan

- [x] `yarn build && yarn test` — 310 files / 4567 passed / 1 skipped, 0 type errors (docs-only change)
- [x] `yarn lint-check` — clean
- [x] `yarn site:build` — EN/JA build succeeds; `website/src/**` and `website/yarn.lock` reverted (prettier pass artifact of `site:prebuild`)
- [x] Confirmed no `vscode-marketplace` GitHub Environment and 0 repo secrets exist — scope B genuinely never started, not partially done

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>