### PR TITLE
ci: skip VS Code packaging test on release-only vscode/** diffs

### DIFF
--- a/.github/workflows/build-vscode.yml
+++ b/.github/workflows/build-vscode.yml
@@ -9,7 +9,37 @@ on:
             - 'vscode/**'
 
 jobs:
+    check:
+        runs-on: ubuntu-latest
+        outputs:
+            release-only: ${{ steps.check.outputs.release-only }}
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+              with:
+                  # SEE: https://github.com/lerna/lerna/issues/2542
+                  fetch-depth: '0'
+
+            - name: Check whether the vscode/** diff is release-only
+              id: check
+              run: |
+                  CHANGED=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}" -- vscode/ | sort)
+                  EXPECTED=$(printf 'vscode/CHANGELOG.md\nvscode/package.json')
+                  # A version-bump PR touches exactly these two files together —
+                  # never the extension's own source or scripts, and never just one
+                  # of the two (a real dependency bump, e.g. from Renovate, only
+                  # touches package.json). Packaging a release-only diff exercises
+                  # nothing new and, right after a tag push, can spuriously fail on
+                  # the npm-registry propagation race for a workspace package that
+                  # publish.yml is still publishing (see #4010).
+                  if [ "$CHANGED" = "$EXPECTED" ]; then
+                    echo "release-only=true" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "release-only=false" >> "$GITHUB_OUTPUT"
+                  fi
+
     build:
+        needs: check
+        if: needs.check.outputs.release-only != 'true'
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Summary

- `VS Code Extension Packaging Test` triggers on any `pull_request` touching `vscode/**`, but every release's version-bump commit touches exactly `vscode/package.json` (version field) and `vscode/CHANGELOG.md` — never the extension's own source or scripts.
- Right after a tag push, this can spuriously fail: the merge-back PR's packaging job races `publish.yml`'s npm publish, briefly seeing a workspace package (e.g. `@markuplint-dev/tsconfig`) at its new version before the registry has propagated it. Observed on #4010 — a re-run with no code change passed, confirming it was a timing race, not a real packaging bug.
- Add a `check` job that diffs the PR's `vscode/**` files against the base and skips `build` only when the changed set is *exactly* `{package.json, CHANGELOG.md}`. A real dependency bump (e.g. from Renovate) only touches `package.json` alone and still runs the real test.

## Test plan

- [x] `yarn lint` (oxlint + oxfmt + cspell + actionlint) — clean
- [x] `yarn build` — unaffected, workflow-only change
- [x] Locally simulated the skip condition against 5 cases (release diff, release diff + real src change, package.json-only bump, empty diff, CHANGELOG.md-only) — only the exact `{package.json, CHANGELOG.md}` pair skips
- [ ] Live verification will come from the next real release's merge-back PR

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>