### PR TITLE
ci: preapprove this repo's own packages for Yarn's npmMinimalAgeGate

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -9,3 +9,15 @@ nodeLinker: node-modules
 
 npmRegistryServer: "https://registry.npmjs.org"
 npmMinimalAgeGate: 7d
+
+# npmMinimalAgeGate guards against installing a recently-compromised
+# third-party package, but it also blocks this repo's own packages
+# right after every release: the isolated-env sandbox test installs a
+# packed `markuplint` tarball, whose own dependencies (@markuplint/*)
+# resolve from the real registry at whatever version was just published
+# by publish.yml moments earlier — nothing to gate here, since we
+# published it ourselves.
+npmPreapprovedPackages:
+  - "markuplint"
+  - "@markuplint/*"
+  - "@markuplint-dev/*"


### PR DESCRIPTION
## Summary

`npmMinimalAgeGate: 7d` (already set in `.yarnrc.yml`, presumably to guard against installing a recently-compromised third-party package) also blocks this repo's own packages right after every release: the isolated-env sandbox test (`.github/workflows/test.yml`) installs a packed `markuplint` tarball, and its own dependencies (`@markuplint/*`) resolve from the real registry at whatever version `publish.yml` just published moments earlier.

Observed on #4010's merge-back — all three `yarn`-based isolated-env variants failed with `@markuplint/pretenders@npm:5.0.0-rc.5: All versions satisfying "5.0.0-rc.5" are quarantined`. Unlike the vscode-packaging race on the same PR, retrying does not help here: this would keep failing for the full 7 days regardless (confirmed the `npm`/`pnpm` variants, which don't apply this gate, passed immediately).

Add `npmPreapprovedPackages` so this repo's own published packages (`markuplint`, `@markuplint/*`, `@markuplint-dev/*`) bypass the gate, without weakening it for genuine third-party dependencies. The isolated-env sandbox copies the root `.yarnrc.yml` verbatim, so this flows through automatically.

## Test plan

- [x] `yarn lint` — clean
- [x] `yarn build` — unaffected, config-only change
- [x] Verified locally: installing `@markuplint/pretenders@5.0.0-rc.5` in a throwaway project with the updated `.yarnrc.yml` now resolves instead of erroring with "are quarantined"

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>