### PR TITLE
feat: split rule-deprecation notices out of config-error

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -341,6 +341,21 @@
 							}
 						}
 					]
+				},
+				"deprecation": {
+					"description": "Severity for the built-in `rule-deprecation` channel (deprecated rule names that still work but will be removed in v6). Defaults to `warning`.",
+					"oneOf": [
+						{
+							"$ref": "https://raw.githubusercontent.com/markuplint/markuplint/main/packages/%40markuplint/ml-config/schema.json#/definitions/severity"
+						},
+						{
+							"type": "string",
+							"enum": ["off"]
+						},
+						{
+							"type": "boolean"
+						}
+					]
 				}
 			}
 		},

--- a/packages/@markuplint/ml-config/src/merge-config.spec.ts
+++ b/packages/@markuplint/ml-config/src/merge-config.spec.ts
@@ -116,6 +116,18 @@ describe('mergeConfig', () => {
 		});
 	});
 
+	test('severity shallow merge: deprecation independent of parseError', () => {
+		expect(
+			mergeConfig(
+				{ severity: { parseError: 'error' } },
+				// @ts-ignore -- test with partial config
+				{ severity: { deprecation: 'off' } },
+			),
+		).toStrictEqual({
+			severity: { parseError: 'error', deprecation: 'off' },
+		});
+	});
+
 	test('parserOptions merge', () => {
 		expect(
 			mergeConfig(

--- a/packages/@markuplint/ml-config/src/types.ts
+++ b/packages/@markuplint/ml-config/src/types.ts
@@ -147,6 +147,24 @@ export type SeverityOptions = {
 	 * ```
 	 */
 	readonly parseError?: ParseErrorSeverity | Partial<Record<MLASTParseErrorCode, ParseErrorSeverity>>;
+
+	/**
+	 * Severity for deprecated-rule-name notices, surfaced via the built-in
+	 * `rule-deprecation` channel. A deprecated name is one the v5
+	 * rule-system redesign (#3989) renamed or split; the notice reports that
+	 * the config still works today but will stop resolving in v6.
+	 *
+	 * Unlike {@link parseError}, this defaults to `'warning'` (not off) —
+	 * it carves an already-surfaced notice out of the generic `config-error`
+	 * channel rather than introducing a new one, so leaving it unset must
+	 * not silence something users already see.
+	 *
+	 * @example
+	 * ```jsonc
+	 * { "severity": { "deprecation": "off" } }
+	 * ```
+	 */
+	readonly deprecation?: Severity | 'off' | boolean;
 };
 
 /**

--- a/packages/@markuplint/ml-core/src/ml-core.ts
+++ b/packages/@markuplint/ml-core/src/ml-core.ts
@@ -9,8 +9,10 @@ import type {
 	NodeRule,
 	PlainData,
 	Pretender,
+	RuleAliasWarning,
 	RuleCommonSettings,
 	RuleConfigValue,
+	Severity,
 	SeverityOptions,
 	TextEdit,
 	Violation,
@@ -24,6 +26,22 @@ import { Document } from './ml-dom/index.js';
 import { expandNamedNodeRules, expandNamedRules } from './virtual-rule.js';
 
 const resultLog = log.extend('result');
+
+/**
+ * `ruleId` of a genuinely broken config (unresolved rule reference, plugin
+ * resolution failure, ...). Exported so consumers that need to recognize
+ * config-level violations (e.g. the CLI's per-run dedupe and failed-file
+ * counting in `packages/markuplint/src/cli/command.ts`) reference the same
+ * literal `MLCore.verify()` emits, instead of duplicating the string.
+ */
+export const CONFIG_ERROR_RULE_ID = 'config-error';
+
+/**
+ * `ruleId` of a deprecated-but-working rule name notice — see
+ * {@link CONFIG_ERROR_RULE_ID} for why this is exported rather than a
+ * private literal.
+ */
+export const RULE_DEPRECATION_RULE_ID = 'rule-deprecation';
 
 /**
  * Summary of the multi-pass fix process.
@@ -119,6 +137,13 @@ export class MLCore {
 	 */
 	#configErrors: Error[];
 	/**
+	 * Deprecated-rule-name notices, kept structured and separate from
+	 * `#configErrors` so `verify()` can report them under their own
+	 * `rule-deprecation` ruleId. Set once per construction/`update()`, same
+	 * lifecycle as `#configErrors`.
+	 */
+	#ruleDeprecations: readonly RuleAliasWarning[];
+	/**
 	 * Rule-mapping errors for the CURRENT document. Reset (not accumulated) on
 	 * every `#createDocument()` so repeated `setCode()` calls don't duplicate
 	 * them. See https://github.com/markuplint/markuplint/issues/3900.
@@ -148,6 +173,7 @@ export class MLCore {
 		filename,
 		debug,
 		configErrors,
+		ruleDeprecations,
 	}: MLCoreParams) {
 		if (debug) {
 			enableDebug();
@@ -163,6 +189,7 @@ export class MLCore {
 		this.#severity = severity;
 		this.#pretenders = [...pretenders];
 		this.#configErrors = [...(configErrors ?? [])];
+		this.#ruleDeprecations = [...(ruleDeprecations ?? [])];
 
 		// Preserve pre-expansion nodeRules for hot-reload
 		this.#originalNodeRules = ruleset.nodeRules ?? [];
@@ -214,12 +241,23 @@ export class MLCore {
 	 *
 	 * @param fabric - Partial fabric with the properties to update
 	 */
-	update({ parser, ruleset, rules, locale, schemas, parserOptions, pretenders, configErrors }: Partial<MLFabric>) {
+	update({
+		parser,
+		ruleset,
+		rules,
+		locale,
+		schemas,
+		parserOptions,
+		pretenders,
+		configErrors,
+		ruleDeprecations,
+	}: Partial<MLFabric>) {
 		this.#parser = parser ?? this.#parser;
 		this.#locale = locale ?? this.#locale;
 		this.#schemas = schemas ?? this.#schemas;
 		this.#pretenders = pretenders ? [...pretenders] : this.#pretenders;
 		this.#configErrors = [...(configErrors ?? [])];
+		this.#ruleDeprecations = [...(ruleDeprecations ?? [])];
 
 		const baseRules = rules ? [...rules] : this.#rules.filter(r => !r.baseRuleId);
 
@@ -328,7 +366,7 @@ export class MLCore {
 			}
 			if (!definedRuleName.has(setRuleName)) {
 				configViolations.push({
-					ruleId: 'config-error',
+					ruleId: CONFIG_ERROR_RULE_ID,
 					severity: 'warning',
 					message: `Rule not found: ${setRuleName}`,
 					col: 1,
@@ -340,13 +378,27 @@ export class MLCore {
 
 		for (const error of [...this.#configErrors, ...this.#mappingErrors]) {
 			configViolations.push({
-				ruleId: 'config-error',
+				ruleId: CONFIG_ERROR_RULE_ID,
 				severity: 'warning',
 				message: error.message,
 				col: 1,
 				line: 1,
 				raw: '',
 			});
+		}
+
+		const deprecationSeverity = this.#resolveDeprecationSeverity();
+		if (deprecationSeverity != null) {
+			for (const { deprecatedName, replacedBy } of this.#ruleDeprecations) {
+				configViolations.push({
+					ruleId: RULE_DEPRECATION_RULE_ID,
+					severity: deprecationSeverity,
+					message: `Rule "${deprecatedName}" is deprecated and will be removed in v6. Use ${replacedBy.join(', ')} instead.`,
+					col: 1,
+					line: 1,
+					raw: '',
+				});
+			}
 		}
 
 		violations.push(...configViolations);
@@ -536,6 +588,23 @@ export class MLCore {
 	}
 
 	/**
+	 * Resolves `severity.deprecation`, honouring its single-value form only
+	 * (unlike `severity.parseError`, there's no fixed enum of deprecated rule
+	 * names to key a per-code `Record` on).
+	 *
+	 * Unlike `#createParseError`'s parse-error channel, this defaults to
+	 * `'warning'` (not off/suppressed) when unset — the deprecation channel
+	 * is being carved out of the always-on `config-error` channel, not
+	 * introduced cold, so leaving the option unset must not silence a notice
+	 * users already see today.
+	 *
+	 * @returns the resolved severity, or `null` if suppressed.
+	 */
+	#resolveDeprecationSeverity(): Violation['severity'] | null {
+		return resolveUniformSeverity(this.#severity.deprecation, 'warning');
+	}
+
+	/**
 	 * Builds a `ruleId: 'parse-error'` violation, honouring
 	 * `severity.parseError`.
 	 *
@@ -556,34 +625,19 @@ export class MLCore {
 	): Violation | null {
 		const cfg = this.#severity.parseError;
 
-		if (cfg === false || cfg === 'off') {
+		// Fatal ParserErrors (no `code`) can't be targeted by the per-code
+		// Record form, so they fall back to `'error'` there; under the
+		// uniform form they default to `'error'` too, while non-fatal entries
+		// default to suppressed when unset — see `resolveUniformSeverity`.
+		const severity =
+			typeof cfg === 'object'
+				? code == null
+					? 'error'
+					: resolveUniformSeverity(cfg[code], null)
+				: resolveUniformSeverity(cfg, code == null ? 'error' : null);
+
+		if (severity == null) {
 			return null;
-		}
-
-		let severity: Violation['severity'];
-
-		if (typeof cfg === 'object') {
-			if (code == null) {
-				// Fatal ParserError without a code; the Record form cannot target
-				// it, so fall back to `'error'` (the channel is otherwise enabled).
-				severity = 'error';
-			} else {
-				const perCode = cfg[code];
-				if (perCode == null || perCode === false || perCode === 'off') {
-					return null;
-				}
-				severity = perCode === true ? 'error' : perCode;
-			}
-		} else if (cfg == null) {
-			// New default: non-fatal `parseErrors` entries are off; fatal
-			// `ParserError`s (no code) still emit at `'error'`.
-			if (code != null) {
-				return null;
-			}
-			severity = 'error';
-		} else {
-			// Uniform string/boolean form (legacy).
-			severity = cfg === true ? 'error' : cfg;
 		}
 
 		return {
@@ -803,6 +857,28 @@ export class MLCore {
 			}
 		}
 	}
+}
+
+/**
+ * Normalizes a single-value `Severity | 'off' | boolean | undefined` option
+ * (the shape `severity.deprecation` and `severity.parseError`'s uniform/
+ * per-code leaf values share) to a resolved severity or `null` (suppressed).
+ *
+ * Shared so the same three-way rule — `false`/`'off'` → suppressed, `true` →
+ * `'error'`, unset → `defaultWhenUnset` — isn't reimplemented at each call
+ * site as channels using this shape are added.
+ */
+function resolveUniformSeverity(
+	cfg: Severity | 'off' | boolean | undefined,
+	defaultWhenUnset: Violation['severity'] | null,
+): Violation['severity'] | null {
+	if (cfg === false || cfg === 'off') {
+		return null;
+	}
+	if (cfg == null) {
+		return defaultWhenUnset;
+	}
+	return cfg === true ? 'error' : cfg;
 }
 
 function extractDisabledNamespaces(rules: { readonly [key: string]: unknown }): readonly string[] {

--- a/packages/@markuplint/ml-core/src/types.ts
+++ b/packages/@markuplint/ml-core/src/types.ts
@@ -2,7 +2,7 @@ import type { AnyMLRule } from './ml-rule/index.js';
 import type { Ruleset } from './ruleset/index.js';
 import type { LocaleSet } from '@markuplint/i18n';
 import type { MLParser, ParserOptions } from '@markuplint/ml-ast';
-import type { Pretender, RuleCommonSettings, SeverityOptions } from '@markuplint/ml-config';
+import type { Pretender, RuleAliasWarning, RuleCommonSettings, SeverityOptions } from '@markuplint/ml-config';
 import type { ExtendedSpec, MLMLSpec } from '@markuplint/ml-spec';
 
 /**
@@ -26,4 +26,11 @@ export type MLFabric = {
 	readonly severity: SeverityOptions;
 	readonly pretenders: readonly Pretender[];
 	readonly configErrors?: readonly Readonly<Error>[];
+	/**
+	 * Deprecated-rule-name notices found while applying the rule-alias table
+	 * (v5 rule-system redesign, #3989). Kept structured, separate from
+	 * {@link configErrors}, so `MLCore.verify()` can report them under their
+	 * own `rule-deprecation` ruleId instead of `config-error`.
+	 */
+	readonly ruleDeprecations?: readonly RuleAliasWarning[];
 };

--- a/packages/@markuplint/shared/src/errors/index.ts
+++ b/packages/@markuplint/shared/src/errors/index.ts
@@ -20,6 +20,11 @@
  *   (`@markuplint/ml-core`) is the conversion boundary: these become
  *   ordinary violations (`parse-error` / `config-error`) merged into lint
  *   results, because the user can fix them like any other violation.
+ *   Deprecated-rule-name notices are a third synthetic ruleId on the same
+ *   boundary (`rule-deprecation`) — kept structured end-to-end
+ *   (`RuleAliasWarning[]` from `@markuplint/ml-config`'s `rule-aliases.ts`)
+ *   rather than as generic `Error`s, so they never collapse into
+ *   `config-error`.
  *
  * Rules for any new `catch` block in the monorepo:
  *

--- a/packages/markuplint/README.md
+++ b/packages/markuplint/README.md
@@ -87,6 +87,7 @@ Options
 	--verbose                              Output with detailed information.
 	--include-node-modules                 Include files in node_modules directory. Default: false.
 	--severity-parse-error                 Specifies the severity level of parse errors. Supports "error", "warning", and "off". Default: "error".
+	--severity-deprecation                 Specifies the severity level of deprecated rule name notices. Supports "error", "warning", and "off". Default: "warning".
 	--max-count                            Limit the number of violations shown. Default: 0 (no limit).
 	--max-warnings                         Number of warnings to trigger nonzero exit code. Default: -1 (no limit).
 	--progressive-output                   Output results immediately after processing each file. Default: false.

--- a/packages/markuplint/src/api/ml-engine.ts
+++ b/packages/markuplint/src/api/ml-engine.ts
@@ -1,7 +1,7 @@
 import type { APIOptions, MLEngineEventMap } from './types.js';
 import type { MLResultInfo } from '../types.js';
 import type { ConfigSet, MLFile, Target } from '@markuplint/file-resolver';
-import type { PlainData } from '@markuplint/ml-config';
+import type { PlainData, RuleAliasWarning } from '@markuplint/ml-config';
 import type { Ruleset, Plugin, Document, RuleConfigValue, MLFabric } from '@markuplint/ml-core';
 
 import {
@@ -43,6 +43,17 @@ export type FromCodeOptions = APIOptions &
 		/** Optional working directory for config resolution */
 		readonly dirname?: string;
 	};
+
+/**
+ * A {@link ConfigSet} widened with deprecated-rule-name notices found while
+ * applying {@link applyRuleAliasesToConfig}. Kept structured (not folded
+ * into `errs` as generic `Error`s) so `MLCore` can report them under their
+ * own `rule-deprecation` ruleId instead of `config-error` — see
+ * `packages/@markuplint/ml-core/src/ml-core.ts`'s `verify()`.
+ */
+type ResolvedConfigSet = ConfigSet & {
+	readonly ruleDeprecations: readonly RuleAliasWarning[];
+};
 
 /**
  * The main markuplint engine that orchestrates file resolution, configuration loading,
@@ -279,7 +290,7 @@ export class MLEngine extends Emitter<MLEngineEventMap> {
 	}
 
 	async #provide(cache = true): Promise<MLFabric | null> {
-		let configSet: ConfigSet;
+		let configSet: ResolvedConfigSet;
 
 		try {
 			configSet = await this.resolveConfig(cache);
@@ -290,6 +301,7 @@ export class MLEngine extends Emitter<MLEngineEventMap> {
 					plugins: [],
 					files: new Set(),
 					errs: [error],
+					ruleDeprecations: [],
 				};
 			} else {
 				throw error;
@@ -377,6 +389,7 @@ export class MLEngine extends Emitter<MLEngineEventMap> {
 			locale,
 			ruleCommonSettings,
 			configErrors: configSet.errs,
+			ruleDeprecations: configSet.ruleDeprecations,
 		};
 	}
 
@@ -396,7 +409,7 @@ export class MLEngine extends Emitter<MLEngineEventMap> {
 	 * @param cache - Whether to reuse previously loaded config files
 	 * @returns The resolved configuration set
 	 */
-	async resolveConfig(cache: boolean) {
+	async resolveConfig(cache: boolean): Promise<ResolvedConfigSet> {
 		this.emit('log', 'resolveConfig', JSON.stringify(this.#configProvider, null, 2));
 		configLog('configProvider: %s', this.#configProvider);
 
@@ -445,22 +458,14 @@ export class MLEngine extends Emitter<MLEngineEventMap> {
 			resolvedConfigSet.config,
 			ruleAliasTable,
 		);
-		const configSet: ConfigSet =
+		// Kept structured (not folded into `errs` as generic `Error`s) so
+		// `MLCore` can report these under their own `rule-deprecation` ruleId,
+		// separate from genuine config-validation failures — see
+		// `ResolvedConfigSet`'s doc comment.
+		const configSet: ResolvedConfigSet =
 			ruleAliasWarnings.length === 0
-				? resolvedConfigSet
-				: {
-						...resolvedConfigSet,
-						config: aliasedConfig,
-						errs: [
-							...resolvedConfigSet.errs,
-							...ruleAliasWarnings.map(
-								({ deprecatedName, replacedBy }) =>
-									new Error(
-										`Rule "${deprecatedName}" is deprecated and will be removed in v6. Use ${replacedBy.join(', ')} instead.`,
-									),
-							),
-						],
-					};
+				? { ...resolvedConfigSet, ruleDeprecations: [] }
+				: { ...resolvedConfigSet, config: aliasedConfig, ruleDeprecations: ruleAliasWarnings };
 
 		this.emit('config', this.#file.path, configSet);
 

--- a/packages/markuplint/src/cli/bootstrap.ts
+++ b/packages/markuplint/src/cli/bootstrap.ts
@@ -24,6 +24,7 @@ Options
 	--verbose                              Output with detailed information.
 	--include-node-modules                 Include files in node_modules directory. Default: false.
 	--severity-parse-error                 Severity for the built-in parse-error channel. Supports "error", "warning", and "off". Unset by default: fatal ParserErrors emit at "error" and non-fatal parse5 events are off (opt-in per code via config).
+	--severity-deprecation                 Severity for the built-in rule-deprecation channel (deprecated rule names). Supports "error", "warning", and "off". Default: "warning".
 	--max-count                            Limit the number of violations shown. Default: 0 (no limit).
 	--max-warnings                         Number of warnings to trigger nonzero exit code. Default: -1 (no limit).
 	--no-progressive-output                Wait until every file is processed before outputting results. Default: false (output progressively).
@@ -118,6 +119,9 @@ export const cli = meow(help, {
 			default: false,
 		},
 		severityParseError: {
+			type: 'string',
+		},
+		severityDeprecation: {
 			type: 'string',
 		},
 		maxCount: {

--- a/packages/markuplint/src/cli/command.ts
+++ b/packages/markuplint/src/cli/command.ts
@@ -8,7 +8,7 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
 import { resolveFiles } from '@markuplint/file-resolver';
-import { ViolationCollector } from '@markuplint/ml-core';
+import { CONFIG_ERROR_RULE_ID, RULE_DEPRECATION_RULE_ID, ViolationCollector } from '@markuplint/ml-core';
 import { isFatalError } from '@markuplint/shared';
 
 import { MLEngine } from '../api/index.js';
@@ -25,6 +25,33 @@ import {
 
 import { outputDryRunDiff } from './dry-run-output.js';
 import { output, outputSummary } from './output.js';
+
+/**
+ * Synthetic ruleIds produced from resolving the run's config rather than
+ * from linting a file's content (`config-error`: broken config;
+ * `rule-deprecation`: deprecated-but-working rule names). Both regenerate
+ * identically for every file in a run, so both need the same per-run dedupe
+ * and the same exclusion from per-file failure counting — see the two call
+ * sites below.
+ */
+const CONFIG_LEVEL_RULE_IDS = new Set([CONFIG_ERROR_RULE_ID, RULE_DEPRECATION_RULE_ID]);
+
+/**
+ * Validates a `--severity-*` flag's raw string value against the uniform
+ * single-value form both `--severity-parse-error` and `--severity-deprecation`
+ * accept, shared so adding another such flag doesn't mean copy-pasting this
+ * check again.
+ *
+ * @returns the validated value, or `undefined` if unset or not one of
+ * `"error"`, `"warning"`, `"off"`.
+ */
+function parseSeverityFlag(value: string | undefined): Severity | 'off' | undefined {
+	const normalized = value?.toLowerCase();
+	if (normalized != null && ['error', 'warning', 'off'].includes(normalized)) {
+		return normalized as Severity | 'off';
+	}
+	return undefined;
+}
 
 export async function command(files: readonly Readonly<Target>[], options: CLIOptions, apiOptions?: APIOptions) {
 	const fixDryRun = options.fixDryRun;
@@ -78,19 +105,20 @@ export async function command(files: readonly Readonly<Target>[], options: CLIOp
 	const collector = new ViolationCollector(options.maxCount);
 	const processedFiles: string[] = [];
 	const skippedFiles: string[] = [];
-	// `config-error` violations (deprecated rule names, unresolved rule
-	// references, ...) come from resolving this run's config, so the same
-	// message is identical across every file. Track messages already
-	// reported once so a run over many files doesn't repeat the same lines
-	// per file — the config is one thing, not N things.
+	// Config-level violations (`CONFIG_LEVEL_RULE_IDS`: unresolved rule
+	// references, deprecated rule names, ...) come from resolving this run's
+	// config, so the same message is identical across every file. Track
+	// messages already reported once so a run over many files doesn't repeat
+	// the same lines per file — the config is one thing, not N things.
 	const seenConfigMessages = new Set<string>();
 	const filesContent = new Map<string, { sourceCode: string; fixedCode: string }>();
 	const engines = new Map<string, MLEngine>();
-	const severityParseError = options.severityParseError?.toLowerCase();
-	const severity: SeverityOptions =
-		severityParseError != null && ['error', 'warning', 'off'].includes(severityParseError)
-			? { parseError: severityParseError as Severity | 'off' }
-			: {};
+	const parsedSeverityParseError = parseSeverityFlag(options.severityParseError);
+	const parsedSeverityDeprecation = parseSeverityFlag(options.severityDeprecation);
+	const severity: SeverityOptions = {
+		...(parsedSeverityParseError != null && { parseError: parsedSeverityParseError }),
+		...(parsedSeverityDeprecation != null && { deprecation: parsedSeverityDeprecation }),
+	};
 
 	// Progressive output prints each file's own violations as soon as that
 	// file is processed, ahead of the two whole-run passes that batch output
@@ -152,6 +180,7 @@ export async function command(files: readonly Readonly<Target>[], options: CLIOp
 					dependencies,
 					plugins: configSet.plugins,
 					errors: configSet.errs,
+					ruleDeprecations: configSet.ruleDeprecations,
 				};
 			} else {
 				data = configSet.config;
@@ -184,11 +213,12 @@ export async function command(files: readonly Readonly<Target>[], options: CLIOp
 			? result.violations
 			: (result.fixSummary?.finalPassViolations ?? result.violations);
 
-		// `config-error` is regenerated fresh per file (config resolution is
-		// not shared across a run), so an identical message would otherwise
-		// repeat once per file. Keep only the first occurrence across this run.
+		// Config-level violations are regenerated fresh per file (config
+		// resolution is not shared across a run), so an identical message
+		// would otherwise repeat once per file. Keep only the first
+		// occurrence across this run.
 		const reportedViolations = violationsBeforeDedupe.filter(violation => {
-			if (violation.ruleId !== 'config-error') {
+			if (!CONFIG_LEVEL_RULE_IDS.has(violation.ruleId)) {
 				return true;
 			}
 			const key = `${violation.ruleId} ${violation.message}`;
@@ -405,10 +435,11 @@ export async function command(files: readonly Readonly<Target>[], options: CLIOp
 
 	for (const filePath of processedFiles) {
 		const violations = outputViolationsByFile.get(filePath) || [];
-		// A file whose only violations are `config-error` didn't fail on its
-		// own content — the config issue is reported once for the whole run
-		// (see the dedupe above), not attributable to this particular file.
-		if (violations.some(violation => violation.ruleId !== 'config-error')) {
+		// A file whose only violations are config-level (`CONFIG_LEVEL_RULE_IDS`)
+		// didn't fail on its own content — the config issue is reported once
+		// for the whole run (see the dedupe above), not attributable to this
+		// particular file.
+		if (violations.some(violation => !CONFIG_LEVEL_RULE_IDS.has(violation.ruleId))) {
 			failedFileCount++;
 		}
 		for (const violation of violations) {

--- a/packages/markuplint/src/cli/index.spec.ts
+++ b/packages/markuplint/src/cli/index.spec.ts
@@ -213,6 +213,56 @@ describe('STDOUT Test', () => {
 		expect(stderr).toContain('(parse-error)');
 	});
 
+	test('--severity-deprecation (no specified) warns but does not fail the build (default: warning)', async () => {
+		const targetFilePath = path.resolve(import.meta.dirname, '../../test/config-error-dedupe/clean-1.html');
+		const configPath = path.resolve(import.meta.dirname, '../../test/config-error-dedupe/config.json');
+		const { exitCode, stderr } = await execa(
+			entryFilePath,
+			['--no-color', '--config', escape(configPath), '--no-search-config', escape(targetFilePath)],
+			{ reject: false },
+		);
+		expect(exitCode).toBe(0);
+		expect(stderr).toContain('(rule-deprecation)');
+	});
+
+	test('--severity-deprecation error escalates deprecation notices to build failures', async () => {
+		const targetFilePath = path.resolve(import.meta.dirname, '../../test/config-error-dedupe/clean-1.html');
+		const configPath = path.resolve(import.meta.dirname, '../../test/config-error-dedupe/config.json');
+		const { exitCode } = await execa(
+			entryFilePath,
+			[
+				'--config',
+				escape(configPath),
+				'--no-search-config',
+				'--severity-deprecation',
+				'error',
+				escape(targetFilePath),
+			],
+			{ reject: false },
+		);
+		expect(exitCode).toBe(1);
+	});
+
+	test('--severity-deprecation off suppresses deprecation notices entirely', async () => {
+		const targetFilePath = path.resolve(import.meta.dirname, '../../test/config-error-dedupe/clean-1.html');
+		const configPath = path.resolve(import.meta.dirname, '../../test/config-error-dedupe/config.json');
+		const { exitCode, stderr } = await execa(
+			entryFilePath,
+			[
+				'--no-color',
+				'--config',
+				escape(configPath),
+				'--no-search-config',
+				'--severity-deprecation',
+				'off',
+				escape(targetFilePath),
+			],
+			{ reject: false },
+		);
+		expect(exitCode).toBe(0);
+		expect(stderr).not.toContain('rule-deprecation');
+	});
+
 	test('parserOptions.documentMode "document" in .markuplintrc surfaces missing-doctype on bare <head> input', async () => {
 		// `bare-head.html` starts with `<head>` and has no `<!doctype html>`.
 		// With `documentMode: 'document'` the HTML parser is forced to treat
@@ -454,7 +504,13 @@ describe('Issues', () => {
 	});
 });
 
-describe('config-error deduplication', () => {
+describe('config-level violation deduplication', () => {
+	// `config.json` deliberately mixes both config-level channels: two
+	// deprecated-but-working rule names (`id-duplication`, `required-attr`)
+	// and one genuinely unresolved rule reference (`no-such-rule`) — so the
+	// dedupe and failed-file logic (`CONFIG_LEVEL_RULE_IDS` in `command.ts`)
+	// is exercised for `rule-deprecation` and `config-error` together, not
+	// just whichever channel happens to be under test.
 	const fixtureDir = path.resolve(import.meta.dirname, '../../test/config-error-dedupe');
 	const configPath = path.join(fixtureDir, 'config.json');
 	const targetFiles = ['clean-1.html', 'clean-2.html', 'clean-3.html'].map(name => path.join(fixtureDir, name));
@@ -467,15 +523,30 @@ describe('config-error deduplication', () => {
 		);
 
 		const violations = JSON.parse(stdout) as { ruleId: string; message: string; filePath: string }[];
-		const configErrorMessages = violations.filter(v => v.ruleId === 'config-error').map(v => v.message);
+		const deprecationMessages = violations.filter(v => v.ruleId === 'rule-deprecation').map(v => v.message);
 
 		// Two deprecated rule names in the config, three identical files: without
 		// dedupe this would be 6 (one pair per file), not 2.
-		expect(configErrorMessages).toHaveLength(2);
-		expect(new Set(configErrorMessages).size).toBe(2);
+		expect(deprecationMessages).toHaveLength(2);
+		expect(new Set(deprecationMessages).size).toBe(2);
 	});
 
-	test('a file whose only violations are config-error counts as passed, not failed', async () => {
+	test('the same genuine config-error message is reported once per run, not once per file', async () => {
+		const { stdout } = await execa(
+			entryFilePath,
+			['--config', escape(configPath), '--no-search-config', '--format', 'json', ...targetFiles.map(escape)],
+			{ reject: false },
+		);
+
+		const violations = JSON.parse(stdout) as { ruleId: string; message: string; filePath: string }[];
+		const configErrorMessages = violations.filter(v => v.ruleId === 'config-error').map(v => v.message);
+
+		// One unresolved rule reference in the config, three identical files:
+		// without dedupe this would be 3, not 1.
+		expect(configErrorMessages).toStrictEqual(['Rule not found: no-such-rule']);
+	});
+
+	test('a file whose only violations are config-level counts as passed, not failed', async () => {
 		const { stderr } = await execa(
 			entryFilePath,
 			['--config', escape(configPath), '--no-search-config', ...targetFiles.map(escape)],
@@ -483,9 +554,37 @@ describe('config-error deduplication', () => {
 		);
 
 		// All three files are clean HTML; the config-level deprecation notices
-		// are attributed to whichever file reports them first, but none of the
-		// files has a markup violation of its own.
+		// and the genuine config-error are attributed to whichever file
+		// reports them first, but none of the files has a markup violation of
+		// its own.
 		expect(stderr).toContain('3 files checked: 3 passed, 0 failed');
+	});
+
+	test('--show-config details surfaces deprecated-rule-name notices', async () => {
+		// `--show-config` resolves the config only (via `MLEngine#resolveConfig`),
+		// without resolving it against the loaded rule set — so "Rule not
+		// found" (computed later, inside `MLCore.verify()`) doesn't appear
+		// here even though `no-such-rule` triggers it at lint time (see the
+		// "genuine config-error" test above). Rule-alias expansion, in
+		// contrast, runs as part of `resolveConfig` itself, so deprecation
+		// notices ARE visible at this stage.
+		const { stdout } = await execa(
+			entryFilePath,
+			['--config', escape(configPath), '--no-search-config', '--show-config', 'details', escape(targetFiles[0]!)],
+			{ reject: false },
+		);
+
+		const data = JSON.parse(stdout) as {
+			ruleDeprecations: readonly { deprecatedName: string; replacedBy: readonly string[] }[];
+		};
+
+		expect(data.ruleDeprecations).toStrictEqual(
+			expect.arrayContaining([
+				{ deprecatedName: 'id-duplication', replacedBy: ['no-duplicate-id'] },
+				{ deprecatedName: 'required-attr', replacedBy: ['require-attr'] },
+			]),
+		);
+		expect(data.ruleDeprecations).toHaveLength(2);
 	});
 });
 

--- a/packages/markuplint/src/rule-aliases.spec.ts
+++ b/packages/markuplint/src/rule-aliases.spec.ts
@@ -18,9 +18,7 @@ describe('rule aliasing', () => {
 				'no-duplicate-id': true,
 			},
 		});
-		const deprecationNotices = violations.filter(
-			v => v.ruleId === 'config-error' && v.message.includes('is deprecated'),
-		);
+		const deprecationNotices = violations.filter(v => v.ruleId === 'rule-deprecation');
 		expect(deprecationNotices).toStrictEqual([]);
 		expect(violations.some(v => v.ruleId === 'no-duplicate-id')).toBe(true);
 	});
@@ -31,11 +29,9 @@ describe('rule aliasing', () => {
 				'id-duplication': true,
 			},
 		});
-		const deprecationNotice = violations.find(
-			v => v.ruleId === 'config-error' && v.message.includes('is deprecated'),
-		);
+		const deprecationNotice = violations.find(v => v.ruleId === 'rule-deprecation');
 		expect(deprecationNotice).toStrictEqual({
-			ruleId: 'config-error',
+			ruleId: 'rule-deprecation',
 			severity: 'warning',
 			message: 'Rule "id-duplication" is deprecated and will be removed in v6. Use no-duplicate-id instead.',
 			col: 1,
@@ -45,6 +41,31 @@ describe('rule aliasing', () => {
 		// The check itself still ran, reported under the replacement's rule ID.
 		expect(violations.some(v => v.ruleId === 'no-duplicate-id')).toBe(true);
 		expect(violations.some(v => v.ruleId === 'id-duplication')).toBe(false);
+	});
+
+	it('severity.deprecation "off" suppresses the notice; a genuine config-error is unaffected', async () => {
+		const { violations } = await mlTest('<div id="a"></div><div id="a"></div>', {
+			rules: {
+				'id-duplication': true,
+				'nonexistent-rule': true,
+			},
+			severity: { deprecation: 'off' },
+		});
+		expect(violations.some(v => v.ruleId === 'rule-deprecation')).toBe(false);
+		expect(
+			violations.some(v => v.ruleId === 'config-error' && v.message === 'Rule not found: nonexistent-rule'),
+		).toBe(true);
+	});
+
+	it('severity.deprecation "error" escalates the notice', async () => {
+		const { violations } = await mlTest('<div id="a"></div><div id="a"></div>', {
+			rules: {
+				'id-duplication': true,
+			},
+			severity: { deprecation: 'error' },
+		});
+		const deprecationNotice = violations.find(v => v.ruleId === 'rule-deprecation');
+		expect(deprecationNotice?.severity).toBe('error');
 	});
 
 	it('a deprecated boolean rule name disabled with `false` stays disabled under the replacement', async () => {

--- a/packages/markuplint/test/config-error-dedupe/config.json
+++ b/packages/markuplint/test/config-error-dedupe/config.json
@@ -1,6 +1,7 @@
 {
 	"rules": {
 		"id-duplication": true,
-		"required-attr": true
+		"required-attr": true,
+		"no-such-rule": true
 	}
 }

--- a/website/docs/configuration/properties.md
+++ b/website/docs/configuration/properties.md
@@ -327,12 +327,25 @@ Controls the severity of parse errors. Set to `"off"` or `false` to suppress par
 }
 ```
 
+#### `deprecation`
+
+Controls the severity of deprecated-rule-name notices (a rule name from before the v5 rule-system redesign that still resolves but will be removed in v6). Defaults to `"warning"`. Set to `"off"` or `false` to suppress these notices.
+
+```json class=config
+{
+  "severity": {
+    "deprecation": "off"
+  }
+}
+```
+
 #### Interface {#severity/interface}
 
 ```ts
 interface Config {
   severity?: {
     parseError?: 'error' | 'warning' | 'info' | 'off' | boolean;
+    deprecation?: 'error' | 'warning' | 'info' | 'off' | boolean;
   };
 }
 ```

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/configuration/properties.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/configuration/properties.md
@@ -302,12 +302,25 @@ interface Config {
 }
 ```
 
+#### `deprecation`
+
+非推奨のルール名に関する通知（v5 のルール体系再設計より前の名前で、現在も解決はできるが v6 で削除される予定のもの）の深刻度を制御します。デフォルトは `"warning"` です。`"off"` または `false` を設定するとこの通知を抑制できます。
+
+```json class=config
+{
+  "severity": {
+    "deprecation": "off"
+  }
+}
+```
+
 #### インターフェイス {#severity/interface}
 
 ```ts
 interface Config {
   severity?: {
     parseError?: 'error' | 'warning' | 'info' | 'off' | boolean;
+    deprecation?: 'error' | 'warning' | 'info' | 'off' | boolean;
   };
 }
 ```


### PR DESCRIPTION
## Summary

`MLCore.verify()` reported two unrelated things under the same `ruleId: 'config-error'` / `severity: 'warning'` channel: genuinely broken config (`Rule not found: X`, unresolved named-nodeRule references, ...) and deprecated-rule-name notices (config works fine, just uses a pre-v5-redesign rule name). This split them:

- Deprecated-rule-name notices now report as a distinct `ruleId: 'rule-deprecation'`, kept structured end-to-end (`RuleAliasWarning[]`) instead of being converted to generic `Error`s and folded into `config-error`.
- New `severity.deprecation` config option (default: `warning`, matching prior always-on behavior) and `--severity-deprecation` CLI flag, mirroring `severity.parseError` / `--severity-parse-error`.
- CLI per-run dedupe and failed-file counting generalized to cover both config-level ruleIds.
- `--show-config details` now also surfaces `ruleDeprecations`.
- Extracted `resolveUniformSeverity` (shared by `parseError`'s uniform form and the new `deprecation` option) and `parseSeverityFlag` (shared CLI flag validation) to avoid triplicating the same normalization logic.

Closes #4006.

## Breaking change

Violations for deprecated rule names now have `ruleId: 'rule-deprecation'` instead of `ruleId: 'config-error'`. Any consumer filtering `MLCore.verify()` output (or the markuplint CLI/API) by `ruleId === 'config-error'` to catch deprecation messages must also check for `rule-deprecation`. This repo is currently on the v5 RC track, so this ships as a normal `feat` rather than a stable-release major bump.

## Test plan

- [x] `yarn build` (all 39 packages)
- [x] `yarn test` (full suite, 4578 passed / 1 pre-existing skip, typecheck clean)
- [x] `yarn lint` / `yarn lint-check` (0 warnings)
- [x] `yarn site:build` (en + ja)
- [x] New/updated tests: `packages/markuplint/src/rule-aliases.spec.ts` (ruleId + severity.deprecation off/error), `packages/markuplint/src/cli/index.spec.ts` (`--severity-deprecation` flag, dedupe of both config-level channels, `--show-config details`), `packages/@markuplint/ml-config/src/merge-config.spec.ts` (severity shallow merge)
