### PR TITLE
ci: add timeouts to website-vrt so a hang fails fast

### DIFF
--- a/.github/workflows/website-vrt.yml
+++ b/.github/workflows/website-vrt.yml
@@ -17,6 +17,15 @@ jobs:
         # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
         if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'pull_request_target ok')
         runs-on: ubuntu-latest
+        # A healthy run completes in ~1-2 minutes on a cache hit (checkout +
+        # install + a handful of screenshots); a cold cache (yarn.lock or
+        # Playwright version bump) can push that out by several minutes for
+        # `yarn install`/`apt-get`/browser download. 30 minutes leaves ample
+        # room above either case while still cutting off the platform
+        # default of 360 minutes, which is exactly what let a hung
+        # `playwright install` step burn 6 hours per run instead of failing
+        # fast — see #4000.
+        timeout-minutes: 30
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
               with:
@@ -48,6 +57,11 @@ jobs:
                   key: playwright-${{ runner.os }}-${{ hashFiles('website/yarn.lock') }}
 
             - name: Install Playwright Browsers
+              # Step-level timeout, tighter than the job's, so a hang here
+              # specifically (the observed failure mode in #4000) is
+              # attributed to this step rather than surfacing as a generic
+              # job timeout.
+              timeout-minutes: 10
               run: cd website && npx playwright install --with-deps chromium
 
             - name: Capture screenshots


### PR DESCRIPTION
## Summary

`website-vrt.yml` had no explicit timeout, so a hung `npx playwright install --with-deps chromium` step (observed on every run since 2026-08-26) burned the platform's 360-minute (6h) default before being cancelled — exactly the symptom reported in #4000.

Historical successful runs (checked via `gh run list`) consistently complete in ~1-2 minutes on a cache hit. This PR does not fix the underlying hang (root cause unknown, unrelated to any dependency or workflow change in this repo — no `website/package.json`, `website/yarn.lock`, or workflow diff around 2026-08-26), but makes a recurrence fail fast and cheap instead of burning 6 hours of runner time:

- 30-minute job-level timeout (generous headroom above the ~1-2 min healthy case and a plausible cold-cache case)
- 10-minute step-level timeout specifically on the Playwright install step, so a future hang is attributed to that exact step rather than a generic job timeout

Note: the acute problem of this hang blocking **every `dev` push** was already fixed by #4001 (dropped the `push` trigger from this workflow; VRT now only runs on labeled PRs). This PR is the "worth doing regardless" defensive follow-up #4000 also asked for.

## Test plan

- [x] `yarn lint` (includes `actionlint`) — 0 issues
- [x] `yarn lint-check`
- Not applicable: `yarn build` / `yarn test` (workflow-only change, no package code touched)
