### PR TITLE
perf: share ConfigProvider across a run's files, fix latent overrides caching bug

### DIFF
--- a/packages/@markuplint/file-resolver/src/config-provider.spec.ts
+++ b/packages/@markuplint/file-resolver/src/config-provider.spec.ts
@@ -297,3 +297,81 @@ test('Overrides with OverrideMode', async () => {
 		bar: true,
 	});
 });
+
+test('Overrides remain per-file correct when sharing one ConfigProvider across files (#3997)', async () => {
+	const testDir = path.resolve(import.meta.dirname, '..', 'test', 'fixtures');
+	const resetKey = path.resolve(testDir, '011', '.markuplintrc.reset.json');
+	const htmlFile = getFile(path.resolve(testDir, '011', 'target.html'));
+	const vueFile = getFile(path.resolve(testDir, '011', 'target.vue'));
+
+	// Same ConfigProvider, same `names` (`resetKey`) for both files — the base
+	// config is cached once, but each file's `overrides` match must still be
+	// evaluated independently on every call.
+	const sharedProvider = new ConfigProvider();
+
+	// .vue resolves first, populating the shared base cache after resolving
+	// an overrides-eligible target.
+	const vueResult = await sharedProvider.resolve(vueFile, [resetKey]);
+	expect(vueResult.config.rules).toStrictEqual({ foo: false });
+
+	// .html resolves second, same `names` — must NOT inherit .vue's override.
+	const htmlResult = await sharedProvider.resolve(htmlFile, [resetKey]);
+	expect(htmlResult.config.rules).toStrictEqual({ foo: true, bar: true });
+});
+
+test('Overrides remain per-file correct when sharing one ConfigProvider, opposite resolve order (#3997)', async () => {
+	const testDir = path.resolve(import.meta.dirname, '..', 'test', 'fixtures');
+	const resetKey = path.resolve(testDir, '011', '.markuplintrc.reset.json');
+	const htmlFile = getFile(path.resolve(testDir, '011', 'target.html'));
+	const vueFile = getFile(path.resolve(testDir, '011', 'target.vue'));
+
+	const sharedProvider = new ConfigProvider();
+
+	// .html resolves first, populating the shared base cache after resolving
+	// a target with no override match.
+	const htmlResult = await sharedProvider.resolve(htmlFile, [resetKey]);
+	expect(htmlResult.config.rules).toStrictEqual({ foo: true, bar: true });
+
+	// .vue resolves second, same `names` — must still get its own override.
+	const vueResult = await sharedProvider.resolve(vueFile, [resetKey]);
+	expect(vueResult.config.rules).toStrictEqual({ foo: false });
+});
+
+test('Base config resolution is cached and reused across files sharing one ConfigProvider (#3997)', async () => {
+	const testDir = path.resolve(import.meta.dirname, '..', 'test', 'fixtures');
+	const resetKey = path.resolve(testDir, '011', '.markuplintrc.reset.json');
+	const htmlFile = getFile(path.resolve(testDir, '011', 'target.html'));
+	const vueFile = getFile(path.resolve(testDir, '011', 'target.vue'));
+
+	const sharedProvider = new ConfigProvider();
+	const htmlResult = await sharedProvider.resolve(htmlFile, [resetKey]);
+	const vueResult = await sharedProvider.resolve(vueFile, [resetKey]);
+
+	// Both calls resolve the same `names`; `files`/`plugins` must be the SAME
+	// object across both results — proof the second call reused the cached
+	// base config instead of redoing merge/validate/plugin-resolution.
+	expect(vueResult.files).toBe(htmlResult.files);
+	expect(vueResult.plugins).toBe(htmlResult.plugins);
+});
+
+test('set() reuses the same key for the same config object identity (#3997)', () => {
+	const provider = new ConfigProvider();
+	const inlineConfig = { rules: { foo: true } };
+
+	const key1 = provider.set(inlineConfig);
+	const key2 = provider.set(inlineConfig);
+	expect(key2).toBe(key1);
+
+	// A different object, even with identical content, still gets its own key.
+	const key3 = provider.set({ rules: { foo: true } });
+	expect(key3).not.toBe(key1);
+});
+
+test('set() with an explicit identity stabilizes the key across differently-merged values (#3997)', () => {
+	const provider = new ConfigProvider();
+	const identity = { rules: { foo: true } };
+
+	const key1 = provider.set({ rules: { foo: true }, extends: ['a'] }, undefined, identity);
+	const key2 = provider.set({ rules: { foo: true }, extends: ['b'] }, undefined, identity);
+	expect(key2).toBe(key1);
+});

--- a/packages/@markuplint/file-resolver/src/config-provider.ts
+++ b/packages/@markuplint/file-resolver/src/config-provider.ts
@@ -30,12 +30,30 @@ const KEY_SEPARATOR = '__ML_CONFIG_MERGE__';
  *
  * Handles `extends` chains, plugins, presets, overrides, and circular reference detection.
  * Configuration files are searched via cosmiconfig and cached by file path.
+ *
+ * Designed to be shared across every target file in a run (see
+ * `MLEngineOptions.configProvider` in `packages/markuplint/src/api/ml-engine.ts`):
+ * {@link resolve}'s cache is keyed by the resolved config's `names`, not by
+ * target file, so one instance reused across many files avoids redoing
+ * merge/validate/plugin-resolution once per file that shares the same
+ * config — see #3997.
  */
 export class ConfigProvider {
 	#cache = new Map<string, ConfigSet>();
 	#held = new Set<string>();
 	#recursiveLoadKeyAndDepth = new Map<string, number>();
 	#store = new Map<string, Config | ConfigLoadError>();
+	/**
+	 * Stabilizes {@link set}'s auto-generated key for an inline config object
+	 * across repeated calls with the *same* object reference (e.g. one caller
+	 * sharing one `ConfigProvider` — and one `options.config`/`defaultConfig`
+	 * object — across many target files). Without this, `set()` would mint a
+	 * fresh UUID per call even for identical content, so `resolve()`'s cache
+	 * (keyed on that UUID) would never hit for inline (non-file-path) config.
+	 * Keyed on object identity, not content, so it costs nothing to check and
+	 * needs no hashing of arbitrary config shapes.
+	 */
+	#autoKeys = new WeakMap<object, string>();
 
 	/**
 	 * Recursively loads a configuration and all its `extends` dependencies.
@@ -102,6 +120,15 @@ export class ConfigProvider {
 	 * Resolves the full configuration for a target file by merging all named configs,
 	 * resolving plugins, and applying file-specific overrides.
 	 *
+	 * Split into a cacheable "base" phase (`#resolveBase`: merge/validate/plugin
+	 * resolution/plugin-provided `extends`) and a per-call `overrides` phase, because
+	 * `overrides` matching depends on `targetFile` while everything else in `names`
+	 * resolution does not. Only the base result is cached (keyed on `names`, not on
+	 * `targetFile`) — callers sharing one `ConfigProvider` across many target files
+	 * (see #3997) get that work done once, while `overrides` are always re-evaluated
+	 * per call so a `.vue`-only override never leaks into a `.html` file's result (or
+	 * vice versa) just because they resolve the same `names`.
+	 *
 	 * @param targetFile - The file being linted
 	 * @param names - Config file paths or module names to merge
 	 * @param cache - Whether to use cached results
@@ -111,21 +138,34 @@ export class ConfigProvider {
 		if (!cache) {
 			this.#store.clear();
 			this.#cache.clear();
+			this.#autoKeys = new WeakMap();
 			cacheClear();
 		}
 
 		const keys = names.filter(nonNullableFilter);
 		const key = keys.join(KEY_SEPARATOR);
-		const currentConfig = this.#cache.get(key);
-		if (currentConfig) {
-			return currentConfig;
+
+		let baseConfigSet = this.#cache.get(key);
+		if (!baseConfigSet) {
+			baseConfigSet = await this.#resolveBase(keys, cache, targetFile.path);
+			this.#cache.set(key, baseConfigSet);
 		}
-		let configSet = await this.#mergeConfigs(keys, cache, targetFile.path);
+
+		return this.#applyOverrides(baseConfigSet, targetFile);
+	}
+
+	/**
+	 * The `names`-dependent, `targetFile`-independent part of {@link resolve}:
+	 * merges all named configs, validates, resolves plugins, and expands
+	 * plugin-provided `extends`. Safe to cache under a `names`-only key.
+	 */
+	async #resolveBase(keys: readonly string[], cache: boolean, referrer: string): Promise<ConfigSet> {
+		let configSet = await this.#mergeConfigs(keys, cache, referrer);
 
 		const filePath = [...configSet.files].toReversed()[0];
 		if (!filePath) {
 			throw new ConfigParserError('Config file not found', {
-				filePath: targetFile.path,
+				filePath: referrer,
 			});
 		}
 		const errors = this.#validateConfig(configSet.config, filePath);
@@ -151,40 +191,36 @@ export class ConfigProvider {
 				}
 			}
 
-			configSet = await this.#mergeConfigs([...keys, ...extendHelds], cache, targetFile.path);
+			configSet = await this.#mergeConfigs([...keys, ...extendHelds], cache, referrer);
 
 			this.#held.clear();
 		}
 
-		// Resolves `overrides`
-		if (configSet.config.overrides) {
-			const overrides = configSet.config.overrides;
-			const globs = Object.keys(overrides);
-			for (const glob of globs) {
-				const isMatched = targetFile.matches(glob);
-				const config = overrides[glob];
-				if (isMatched && config) {
-					switch (configSet.config.overrideMode) {
-						case 'merge': {
-							configSet.config = mergeConfig(configSet.config, config);
-							break;
-						}
-						default: /* or "reset" */ {
-							configSet.config = config;
-							break;
-						}
-					}
-				}
-			}
-		}
-
-		const result = {
+		return {
 			...configSet,
 			plugins,
 		};
+	}
 
-		this.#cache.set(key, result);
-		return result;
+	/**
+	 * The `targetFile`-dependent part of {@link resolve}: matches `config.overrides`
+	 * globs against `targetFile` and applies whichever match, per `overrideMode`.
+	 * Never mutates `baseConfigSet` — returns it unchanged (same reference) when no
+	 * override matches, or a shallow copy with a freshly computed `config` otherwise,
+	 * so the cached base entry stays valid for the next target file.
+	 */
+	#applyOverrides(baseConfigSet: ConfigSet, targetFile: Readonly<MLFile>): ConfigSet {
+		let config = baseConfigSet.config;
+		if (config.overrides) {
+			const overrides = config.overrides;
+			for (const glob of Object.keys(overrides)) {
+				const overrideConfig = overrides[glob];
+				if (targetFile.matches(glob) && overrideConfig) {
+					config = config.overrideMode === 'merge' ? mergeConfig(config, overrideConfig) : overrideConfig;
+				}
+			}
+		}
+		return config === baseConfigSet.config ? baseConfigSet : { ...baseConfigSet, config };
 	}
 
 	/**
@@ -223,12 +259,39 @@ export class ConfigProvider {
 	 *
 	 * @param config - The optimized configuration to store
 	 * @param key - An optional key to store the config under; auto-generated if omitted
+	 * @param identity - Object identity to auto-key on when `key` is omitted (e.g. the
+	 * caller's original, pre-merge config object). Repeated calls with the same
+	 * `identity` reuse the same generated key instead of minting a fresh UUID each
+	 * time, so `resolve()`'s base cache can hit for inline (non-file-path) config
+	 * shared across multiple target files — see #3997. Falls back to `config` itself
+	 * (which is rebuilt fresh by every caller today, so this is a no-op unless a
+	 * caller passes a stable `identity`).
+	 *
+	 * **Invariant**: an `identity` must correspond to `config` content that is
+	 * effectively immutable for as long as that identity is reused — a second
+	 * call with the same `identity` but *different* `config` content returns
+	 * the *first* call's key/content, silently discarding the new content. Not
+	 * reachable via `MLEngine`'s call sites today (they hold `options.config`/
+	 * `defaultConfig` as one unchanged reference per run); a future caller
+	 * passing a reused identity for genuinely different content would hit this.
 	 * @returns The key under which the config was stored
 	 */
-	set(config: OptimizedConfig, key?: string) {
-		key = key ?? uuid();
-		this.#store.set(key, config);
-		return key;
+	set(config: OptimizedConfig, key?: string, identity?: object) {
+		if (key != null) {
+			this.#store.set(key, config);
+			return key;
+		}
+
+		const identityKey = identity ?? config;
+		const existingKey = this.#autoKeys.get(identityKey);
+		if (existingKey != null) {
+			return existingKey;
+		}
+
+		const newKey = uuid();
+		this.#store.set(newKey, config);
+		this.#autoKeys.set(identityKey, newKey);
+		return newKey;
 	}
 
 	async #load(filePath: string, cache: boolean, referrer: string) {

--- a/packages/markuplint/src/api/lint.spec.ts
+++ b/packages/markuplint/src/api/lint.spec.ts
@@ -1,0 +1,80 @@
+import { describe, test, expect } from 'vitest';
+
+import { lint } from './lint.js';
+
+describe('lint() (#3997)', () => {
+	test('lints multiple files sharing one config independently', async () => {
+		const results = await lint(
+			[
+				{ sourceCode: '<div id="a"></div><div id="a"></div>', name: 'a.html' },
+				{ sourceCode: '<p>ok</p>', name: 'b.html' },
+			],
+			{ config: { rules: { 'no-duplicate-id': true } } },
+		);
+
+		expect(results).toHaveLength(2);
+		const [a, b] = results;
+		expect(a?.violations.some(v => v.ruleId === 'no-duplicate-id')).toBe(true);
+		expect(b?.violations.some(v => v.ruleId === 'no-duplicate-id')).toBe(false);
+	});
+
+	test('deduplicates a repeated rule-deprecation notice across files sharing one config', async () => {
+		const results = await lint(
+			[
+				{ sourceCode: '<div id="a"></div><div id="a"></div>', name: 'a.html' },
+				{ sourceCode: '<div id="b"></div><div id="b"></div>', name: 'b.html' },
+			],
+			{ config: { rules: { 'id-duplication': true } } },
+		);
+
+		expect(results).toHaveLength(2);
+		const [a, b] = results;
+		// The deprecation notice is kept only in the first file's result...
+		expect(a?.violations.some(v => v.ruleId === 'rule-deprecation')).toBe(true);
+		expect(b?.violations.some(v => v.ruleId === 'rule-deprecation')).toBe(false);
+		// ...but the check itself still ran independently for both files.
+		expect(a?.violations.some(v => v.ruleId === 'no-duplicate-id')).toBe(true);
+		expect(b?.violations.some(v => v.ruleId === 'no-duplicate-id')).toBe(true);
+	});
+
+	test('a genuine config-error is also deduplicated across files, independent of rule-deprecation', async () => {
+		const results = await lint(
+			[
+				{ sourceCode: '<p>ok</p>', name: 'a.html' },
+				{ sourceCode: '<p>ok</p>', name: 'b.html' },
+			],
+			{ config: { rules: { 'nonexistent-rule': true } } },
+		);
+
+		expect(results).toHaveLength(2);
+		const [a, b] = results;
+		expect(a?.violations.filter(v => v.ruleId === 'config-error')).toHaveLength(1);
+		expect(b?.violations.filter(v => v.ruleId === 'config-error')).toHaveLength(0);
+	});
+
+	test('dedupes config-level violations in fixSummary.finalPassViolations too, when fix mode applies fixes', async () => {
+		// `attr-value-quotes` has an auto-fixer, so fix mode produces a
+		// `fixSummary` for both files; `id-duplication` (deprecated) has none,
+		// so its notice only ever appears via the config-level channel, never
+		// as something fixed. `finalPassViolations` must be deduped the same
+		// way `violations` is — not just the first-pass array.
+		const results = await lint(
+			[
+				{ sourceCode: '<html lang=en></html>', name: 'a.html' },
+				{ sourceCode: '<html lang=en></html>', name: 'b.html' },
+			],
+			{ config: { rules: { 'id-duplication': true, 'attr-value-quotes': true } }, fix: true },
+		);
+
+		expect(results).toHaveLength(2);
+		const [a, b] = results;
+		// File a's OWN `violations` (first pass) and `fixSummary.finalPassViolations`
+		// (post-fix) both keep the notice — they describe the same file, so
+		// this isn't a cross-file repeat worth suppressing.
+		expect(a?.violations.some(v => v.ruleId === 'rule-deprecation')).toBe(true);
+		expect(a?.fixSummary?.finalPassViolations?.some(v => v.ruleId === 'rule-deprecation')).toBe(true);
+		// File b is the actual repeat: suppressed in both of its arrays.
+		expect(b?.violations.some(v => v.ruleId === 'rule-deprecation')).toBe(false);
+		expect(b?.fixSummary?.finalPassViolations?.some(v => v.ruleId === 'rule-deprecation')).toBe(false);
+	});
+});

--- a/packages/markuplint/src/api/lint.ts
+++ b/packages/markuplint/src/api/lint.ts
@@ -2,12 +2,18 @@ import type { APIOptions } from './types.js';
 import type { MLResultInfo } from '../types.js';
 import type { Target } from '@markuplint/file-resolver';
 
-import { resolveFiles } from '@markuplint/file-resolver';
+import { ConfigProvider, resolveFiles } from '@markuplint/file-resolver';
 
+import { dedupeConfigLevelViolations } from '../dedupe-config-violations.js';
 import { MLEngine } from './ml-engine.js';
 
 /**
  * Lints multiple targets (files or inline sources) and returns results for each.
+ *
+ * Config-level violations (broken config, deprecated rule names) are deduped
+ * per call the same way the CLI dedupes them per run: a message identical
+ * across every file sharing one config is kept only in the first file's
+ * result, not repeated in every file's `violations` array. See #3997.
  *
  * @param targetList - An array of file paths/globs or inline source code targets
  * @param options - API options for configuration, locale, rules, and behavior
@@ -16,16 +22,48 @@ import { MLEngine } from './ml-engine.js';
 export async function lint(targetList: readonly Readonly<Target>[], options?: APIOptions) {
 	const res: MLResultInfo[] = [];
 	const files = await resolveFiles(targetList);
+	// Shared across every file so `MLEngine`'s config cache — keyed by
+	// resolved config `names`, not by target file — actually helps: see
+	// `ConfigProvider.resolve`'s doc comment and #3997.
+	const configProvider = new ConfigProvider();
+	const seenConfigMessages = new Set<string>();
 
 	for (const file of files) {
-		const engine = new MLEngine(file, options);
+		const engine = new MLEngine(file, { ...options, configProvider });
 		const result = await engine.exec();
 
 		if (!result) {
 			continue;
 		}
 
-		res.push(result);
+		// Dedupe both views a caller might read: the first-pass `violations`,
+		// and — when fix mode found fixes — `fixSummary.finalPassViolations`
+		// (the post-fix re-verification `command.ts` prefers when reporting
+		// fixed results). Both arrays describe the SAME file, so they always
+		// carry the same config-level messages — that's not a repeat worth
+		// suppressing. Only a *later file* repeating a message already kept
+		// (in either array) is. So both arrays are deduped against the same
+		// pre-file snapshot of `seenConfigMessages` (not against each other),
+		// and only after both are done are their combined discoveries folded
+		// back into `seenConfigMessages` for the next file. The snapshot is
+		// only taken when there's a second array to protect against — most
+		// files (no fix mode, or fix mode with nothing to fix) have none.
+		let finalPassViolations = result.fixSummary?.finalPassViolations;
+		const seenBeforeThisFile = finalPassViolations ? new Set(seenConfigMessages) : undefined;
+		const violations = dedupeConfigLevelViolations(result.violations, seenConfigMessages);
+		if (finalPassViolations && seenBeforeThisFile) {
+			const seenForFinalPass = new Set(seenBeforeThisFile);
+			finalPassViolations = dedupeConfigLevelViolations(finalPassViolations, seenForFinalPass);
+			for (const key of seenForFinalPass) {
+				seenConfigMessages.add(key);
+			}
+		}
+
+		res.push({
+			...result,
+			violations,
+			fixSummary: result.fixSummary && { ...result.fixSummary, finalPassViolations },
+		});
 	}
 
 	return res;

--- a/packages/markuplint/src/api/ml-engine.spec.ts
+++ b/packages/markuplint/src/api/ml-engine.spec.ts
@@ -5,6 +5,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
+import { ConfigProvider } from '@markuplint/file-resolver';
 import { describe, it, expect } from 'vitest';
 
 import { MLEngine } from './ml-engine.js';
@@ -466,5 +467,39 @@ describe('Parse Error Severity', () => {
 
 		const boolFalse = await new MLEngine(file!, { config: options.config, severity: { parseError: false } }).exec();
 		expect(boolFalse?.violations?.[0]?.severity).toBeUndefined();
+	});
+});
+
+describe('configProvider option (#3997)', () => {
+	it('shares config resolution across engines given the same configProvider', async () => {
+		const configProvider = new ConfigProvider();
+		const config = { rules: { 'no-duplicate-id': true } };
+
+		const fileA = await MLEngine.toMLFile({ sourceCode: '<p>a</p>', name: 'a.html' });
+		const fileB = await MLEngine.toMLFile({ sourceCode: '<p>b</p>', name: 'b.html' });
+
+		const configSetA = await new MLEngine(fileA!, { config, configProvider }).resolveConfig(true);
+		const configSetB = await new MLEngine(fileB!, { config, configProvider }).resolveConfig(true);
+
+		// Same inline `config` object, same shared provider — the base config
+		// resolution (files/plugins) must be reused, not redone per engine.
+		expect(configSetB.files).toBe(configSetA.files);
+		expect(configSetB.plugins).toBe(configSetA.plugins);
+	});
+
+	it('does not share config resolution across engines without an explicit configProvider', async () => {
+		const config = { rules: { 'no-duplicate-id': true } };
+
+		const fileA = await MLEngine.toMLFile({ sourceCode: '<p>a</p>', name: 'a.html' });
+		const fileB = await MLEngine.toMLFile({ sourceCode: '<p>b</p>', name: 'b.html' });
+
+		const configSetA = await new MLEngine(fileA!, { config }).resolveConfig(true);
+		const configSetB = await new MLEngine(fileB!, { config }).resolveConfig(true);
+
+		// No shared provider (today's default): each engine resolves its own
+		// config independently, so the underlying objects are NOT the same
+		// reference, even though their content is equal.
+		expect(configSetB.files).not.toBe(configSetA.files);
+		expect(configSetB.config).toStrictEqual(configSetA.config);
 	});
 });

--- a/packages/markuplint/src/api/ml-engine.ts
+++ b/packages/markuplint/src/api/ml-engine.ts
@@ -31,7 +31,43 @@ const configLog = log.extend('config');
 type MLEngineOptions = {
 	readonly debug?: boolean;
 	readonly watch?: boolean;
+	/**
+	 * A pre-built {@link ConfigProvider} to resolve config through, instead of
+	 * the one this instance would otherwise create for itself.
+	 *
+	 * `ConfigProvider` caches by the resolved config's `names` (file paths),
+	 * not by target file — so a caller looping over many files (the CLI, or
+	 * the `lint()` API) that constructs one `MLEngine` per file should share
+	 * a single `ConfigProvider` across that loop; every file whose config
+	 * resolves to the same `names` then reuses the same cached base config
+	 * (merge/validate/plugin-resolution) instead of redoing that work once
+	 * per file. See #3997.
+	 *
+	 * Optional and additive: omitted, each `MLEngine` still creates its own
+	 * provider exactly as before.
+	 *
+	 * **Caveat — `watch: true`**: `ConfigProvider.resolve`'s cache-busting
+	 * (`cache: false`, used internally on every watch-triggered re-resolve)
+	 * clears the *entire* shared provider, not anything scoped to one engine
+	 * or file. Sharing one `configProvider` across multiple engines that also
+	 * have `watch: true` risks one engine's re-resolve silently invalidating
+	 * another's in-flight or just-cached config. Neither the CLI (which
+	 * doesn't support `--watch`) nor `lint()` (which never sets `watch`)
+	 * create this combination — it only arises if a direct API consumer
+	 * builds it deliberately.
+	 */
+	readonly configProvider?: ConfigProvider;
 };
+
+/**
+ * The config passed to {@link ConfigProvider.set} when no config was
+ * discovered, requested, or provided by the caller. A module-level constant
+ * (not rebuilt per call) so its object identity is stable — letting
+ * `ConfigProvider.set`'s auto-key cache (keyed by identity) recognize repeat
+ * calls across every file in a run sharing one `ConfigProvider`, the same
+ * way a stable `options.config`/`defaultConfig` reference does. See #3997.
+ */
+const RECOMMENDED_CONFIG = { extends: ['markuplint:recommended'] };
 
 /**
  * Options for creating an {@link MLEngine} from inline source code.
@@ -116,7 +152,7 @@ export class MLEngine extends Emitter<MLEngineEventMap> {
 
 		this.#file = file;
 		this.#options = options;
-		this.#configProvider = new ConfigProvider();
+		this.#configProvider = options?.configProvider ?? new ConfigProvider();
 		this.watchMode(!!this.#options?.watch);
 
 		log('[MLEngine] Initialized: %s', this.#file.path);
@@ -414,7 +450,8 @@ export class MLEngine extends Emitter<MLEngineEventMap> {
 		configLog('configProvider: %s', this.#configProvider);
 
 		const defaultConfigKey =
-			this.#options?.defaultConfig && this.#configProvider.set(mergeConfig(this.#options?.defaultConfig));
+			this.#options?.defaultConfig &&
+			this.#configProvider.set(mergeConfig(this.#options.defaultConfig), undefined, this.#options.defaultConfig);
 		configLog('defaultConfigKey: %s', defaultConfigKey ?? 'N/A');
 		this.emit('log', 'defaultConfigKey', defaultConfigKey ?? 'N/A');
 
@@ -428,7 +465,9 @@ export class MLEngine extends Emitter<MLEngineEventMap> {
 		configLog('configFilePathsFromTarget: %s', configFilePathsFromTarget ?? 'N/A');
 		this.emit('log', 'configFilePathsFromTarget', configFilePathsFromTarget ?? 'N/A');
 
-		const configKey = this.#options?.config && this.#configProvider.set(mergeConfig(this.#options.config));
+		const configKey =
+			this.#options?.config &&
+			this.#configProvider.set(mergeConfig(this.#options.config), undefined, this.#options.config);
 		configLog('option.config: %s', configKey ?? 'N/A');
 		this.emit('log', 'option.config', configFilePathsFromTarget ?? 'N/A');
 
@@ -436,7 +475,7 @@ export class MLEngine extends Emitter<MLEngineEventMap> {
 		if (!defaultConfigKey && !configFilePathsFromTarget && !configKey && !this.#options?.configFile) {
 			// No configured
 			// Default: set recommended
-			defaultRecommended = this.#configProvider.set({ extends: ['markuplint:recommended'] });
+			defaultRecommended = this.#configProvider.set(RECOMMENDED_CONFIG);
 		}
 		configLog('defaultRecommended: %s', defaultRecommended ?? 'N/A');
 		this.emit('log', 'defaultRecommended', defaultRecommended ?? 'N/A');

--- a/packages/markuplint/src/cli/command.ts
+++ b/packages/markuplint/src/cli/command.ts
@@ -7,8 +7,8 @@ import type { Severity, SeverityOptions, Violation } from '@markuplint/ml-config
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
-import { resolveFiles } from '@markuplint/file-resolver';
-import { CONFIG_ERROR_RULE_ID, RULE_DEPRECATION_RULE_ID, ViolationCollector } from '@markuplint/ml-core';
+import { ConfigProvider, resolveFiles } from '@markuplint/file-resolver';
+import { ViolationCollector } from '@markuplint/ml-core';
 import { isFatalError } from '@markuplint/shared';
 
 import { MLEngine } from '../api/index.js';
@@ -22,19 +22,10 @@ import {
 	resolveSuppressionsPath,
 	writeSuppressionsFile,
 } from '../suppressions/index.js';
+import { CONFIG_LEVEL_RULE_IDS, dedupeConfigLevelViolations } from '../dedupe-config-violations.js';
 
 import { outputDryRunDiff } from './dry-run-output.js';
 import { output, outputSummary } from './output.js';
-
-/**
- * Synthetic ruleIds produced from resolving the run's config rather than
- * from linting a file's content (`config-error`: broken config;
- * `rule-deprecation`: deprecated-but-working rule names). Both regenerate
- * identically for every file in a run, so both need the same per-run dedupe
- * and the same exclusion from per-file failure counting — see the two call
- * sites below.
- */
-const CONFIG_LEVEL_RULE_IDS = new Set([CONFIG_ERROR_RULE_ID, RULE_DEPRECATION_RULE_ID]);
 
 /**
  * Validates a `--severity-*` flag's raw string value against the uniform
@@ -105,14 +96,16 @@ export async function command(files: readonly Readonly<Target>[], options: CLIOp
 	const collector = new ViolationCollector(options.maxCount);
 	const processedFiles: string[] = [];
 	const skippedFiles: string[] = [];
-	// Config-level violations (`CONFIG_LEVEL_RULE_IDS`: unresolved rule
-	// references, deprecated rule names, ...) come from resolving this run's
-	// config, so the same message is identical across every file. Track
-	// messages already reported once so a run over many files doesn't repeat
-	// the same lines per file — the config is one thing, not N things.
+	// See `dedupeConfigLevelViolations` for why this Set needs to persist
+	// across the whole run (not per file).
 	const seenConfigMessages = new Set<string>();
 	const filesContent = new Map<string, { sourceCode: string; fixedCode: string }>();
 	const engines = new Map<string, MLEngine>();
+	// Shared across every file in this run so its config cache — keyed by
+	// resolved config `names`, not by target file — actually helps: config
+	// loading/merging/plugin-resolution is done once per distinct config,
+	// not once per file. See #3997.
+	const configProvider = new ConfigProvider();
 	const parsedSeverityParseError = parseSeverityFlag(options.severityParseError);
 	const parsedSeverityDeprecation = parseSeverityFlag(options.severityDeprecation);
 	const severity: SeverityOptions = {
@@ -164,6 +157,7 @@ export async function command(files: readonly Readonly<Target>[], options: CLIOp
 			debug: verbose,
 			severity,
 			...apiOptions,
+			configProvider,
 		});
 
 		if (options.showConfig != null) {
@@ -213,21 +207,7 @@ export async function command(files: readonly Readonly<Target>[], options: CLIOp
 			? result.violations
 			: (result.fixSummary?.finalPassViolations ?? result.violations);
 
-		// Config-level violations are regenerated fresh per file (config
-		// resolution is not shared across a run), so an identical message
-		// would otherwise repeat once per file. Keep only the first
-		// occurrence across this run.
-		const reportedViolations = violationsBeforeDedupe.filter(violation => {
-			if (!CONFIG_LEVEL_RULE_IDS.has(violation.ruleId)) {
-				return true;
-			}
-			const key = `${violation.ruleId} ${violation.message}`;
-			if (seenConfigMessages.has(key)) {
-				return false;
-			}
-			seenConfigMessages.add(key);
-			return true;
-		});
+		const reportedViolations = dedupeConfigLevelViolations(violationsBeforeDedupe, seenConfigMessages);
 
 		// Progressive出力が有効でJSON形式でない場合
 		if (progressiveOutput && format !== 'json') {

--- a/packages/markuplint/src/dedupe-config-violations.ts
+++ b/packages/markuplint/src/dedupe-config-violations.ts
@@ -1,0 +1,45 @@
+import type { Violation } from '@markuplint/ml-config';
+
+import { CONFIG_ERROR_RULE_ID, RULE_DEPRECATION_RULE_ID } from '@markuplint/ml-core';
+
+/**
+ * Synthetic ruleIds produced from resolving a run's config rather than from
+ * linting a file's content (`config-error`: broken config; `rule-deprecation`:
+ * deprecated-but-working rule names). Both regenerate identically for every
+ * file that shares the same config, so both need the same per-run dedupe —
+ * see {@link dedupeConfigLevelViolations} — and the same exclusion from
+ * per-file failure counting (`packages/markuplint/src/cli/command.ts`).
+ */
+export const CONFIG_LEVEL_RULE_IDS = new Set([CONFIG_ERROR_RULE_ID, RULE_DEPRECATION_RULE_ID]);
+
+/**
+ * Filters `violations` down to the first occurrence of each distinct
+ * config-level ({@link CONFIG_LEVEL_RULE_IDS}) message, tracked in `seen`
+ * across calls. Non-config-level violations always pass through unchanged.
+ *
+ * Even with config resolution now shared across a run (see
+ * `ConfigProvider`, #3997), each file's `MLCore.verify()` still builds its
+ * own `violations` array independently from that shared config data — so a
+ * config-level message would otherwise still repeat once per file that
+ * shares the config. The config is one thing, not N things. `seen` is
+ * caller-owned (a plain `Set<string>`) so both the CLI (per run) and the
+ * `lint()` API (per call) can each keep their own dedupe scope without
+ * sharing state between unrelated runs.
+ *
+ * @param violations - Violations to filter, in file-processing order
+ * @param seen - Accumulates `${ruleId} ${message}` keys already kept; mutated in place
+ * @returns `violations` with repeat config-level entries removed
+ */
+export function dedupeConfigLevelViolations(violations: readonly Violation[], seen: Set<string>): readonly Violation[] {
+	return violations.filter(violation => {
+		if (!CONFIG_LEVEL_RULE_IDS.has(violation.ruleId)) {
+			return true;
+		}
+		const key = `${violation.ruleId} ${violation.message}`;
+		if (seen.has(key)) {
+			return false;
+		}
+		seen.add(key);
+		return true;
+	});
+}


### PR DESCRIPTION
## Summary

`ConfigProvider` caches resolved config by the set of config file paths (`names`), not by target file — so the cache is designed to be per-config, shareable across every file that resolves to the same config. But `ConfigProvider` was instantiated fresh inside `MLEngine`'s constructor, and both the CLI (`command.ts`) and the `lint()` API construct one `MLEngine` per target file — so the cache never actually spanned more than one file. Loading, merging, validating the config, and resolving plugins was redone from scratch for every linted file.

Worse, a latent correctness bug: `ConfigProvider.resolve()` cached its **final** result — after applying `overrides` for the calling target file — under that file-independent key. Harmless while every file got its own fresh provider, but a real bug waiting to happen for any future caller sharing one provider across files: whichever file's overrides applied first would be served, wrongly, to every other file resolving the same `names`.

## Changes

- `ConfigProvider.resolve()` split into a cacheable **base** phase (merge/validate/plugin-resolution/plugin-provided `extends` — genuinely target-file-independent) and a per-call **overrides** phase (never cached under the shared key, always re-evaluated against the calling target file).
- `ConfigProvider.set()` gains an optional `identity` parameter, so an inline (non-file-path) config object registered under an auto-generated key is recognized across repeated calls with the same object reference — otherwise the base cache above could never hit for inline `config`/`defaultConfig` shared across a run.
- `MLEngineOptions` gains an optional `configProvider` field (defaults to a fresh instance, as before — additive, non-breaking).
- `command.ts` and `lint()` each create one `ConfigProvider` before their per-file loop and pass it to every `MLEngine` they construct.
- `lint()` also gains the same per-run dedupe for config-level violations (`config-error`, `rule-deprecation`) the CLI already had, extracted into a shared `dedupeConfigLevelViolations()` helper — a message identical across every file sharing one config is kept only where it first appears, in both `violations` and (when fix mode found fixes) `fixSummary.finalPassViolations`.

## Not in scope

- A separate, pre-existing bug was discovered while testing this (`resolveConfig(false)` + inline `config` crashes with `TypeError: N is not an absolute path`, reproducible on `dev` HEAD independent of this change) — filed as #4015, not fixed here.
- Watch-mode (`{ watch: true }`) combined with a shared `configProvider` across multiple engines has a documented caveat (JSDoc on `MLEngineOptions.configProvider`): `resolve(cache: false)`'s cache-busting clears the *entire* shared provider, which could race with another engine's in-flight resolution. Neither the CLI (no `--watch` support) nor `lint()` (never sets `watch`) create this combination — it's a caveat for direct API consumers who deliberately combine both, not a bug in any call site this PR wires up.

## Test plan

- [x] `yarn build` (all 39 packages)
- [x] `yarn test` (full suite, 4589 passed / 1 pre-existing skip, typecheck clean)
- [x] `yarn lint` / `yarn lint-check` (0 warnings)
- [x] New regression tests in `config-provider.spec.ts`: overrides stay per-file-correct in both resolve orders when sharing one provider; base config resolution is proven cached/reused (`files`/`plugins` reference equality); `set()`'s identity stabilization. Verified via git-stash-against-old-code that each fails without the fix.
- [x] New tests in `ml-engine.spec.ts`: `configProvider` option actually shares resolution; omitting it keeps engines isolated (today's default, unchanged).
- [x] New `lint.spec.ts`: multi-file dedupe for `rule-deprecation` and `config-error`, including the `fixSummary.finalPassViolations` case (an issue found and fixed during review — see commit history).
