### PR TITLE
fix: resolveConfig(false) crashes with inline config (not a file path)

### DIFF
--- a/packages/@markuplint/file-resolver/src/config-provider.spec.ts
+++ b/packages/@markuplint/file-resolver/src/config-provider.spec.ts
@@ -375,3 +375,70 @@ test('set() with an explicit identity stabilizes the key across differently-merg
 	const key2 = provider.set({ rules: { foo: true }, extends: ['b'] }, undefined, identity);
 	expect(key2).toBe(key1);
 });
+
+test('resolve(cache: false) no longer clears entries registered via set() before the call (#4015)', async () => {
+	const provider = new ConfigProvider();
+	const testDir = path.resolve(import.meta.dirname, '..', 'test', 'fixtures');
+	const file = getFile(path.resolve(testDir, '002', 'target.html'));
+
+	// Mirrors `MLEngine#resolveConfig()`'s pattern: `set()` an inline config,
+	// then immediately `resolve()` referencing that key with `cache: false`.
+	const key = provider.set({ rules: { foo: true } });
+	const configSet = await provider.resolve(file, [key], false);
+
+	expect(configSet.config.rules).toStrictEqual({ foo: true });
+});
+
+test('invalidate() clears entries registered via set() (#4015)', async () => {
+	const provider = new ConfigProvider();
+	const testDir = path.resolve(import.meta.dirname, '..', 'test', 'fixtures');
+	const file = getFile(path.resolve(testDir, '002', 'target.html'));
+
+	const key = provider.set({ rules: { foo: true } });
+	provider.invalidate();
+
+	// The key only ever lived in the store; once cleared, resolving it falls
+	// through to `#load()`, which treats it as a file path/module name.
+	await expect(provider.resolve(file, [key], false)).rejects.toThrow(/is not an absolute path/);
+});
+
+test('runExclusive() serializes overlapping calls, deferring a later call until an earlier one settles (#4015)', async () => {
+	// `MLEngine#resolveConfig()` wraps its whole invalidate → set → search →
+	// resolve sequence in `runExclusive()` so that an overlapping call on the
+	// same (possibly shared) provider can't run its own `invalidate()` in the
+	// middle of another call's `set()`/`resolve()` sequence. This exercises
+	// `runExclusive()`'s serialization directly, with the interleaving under
+	// the test's own control instead of relying on incidental async timing.
+	const provider = new ConfigProvider();
+	const order: string[] = [];
+
+	let releaseFirst: () => void = () => {};
+	const firstGate = new Promise<void>(resolve => {
+		releaseFirst = resolve;
+	});
+
+	const first = provider.runExclusive(async () => {
+		order.push('first-start');
+		await firstGate;
+		order.push('first-end');
+	});
+
+	const second = provider.runExclusive(() => {
+		order.push('second-start');
+		order.push('second-end');
+		return Promise.resolve();
+	});
+
+	releaseFirst();
+	await Promise.all([first, second]);
+
+	// If `runExclusive()` let the two calls run concurrently instead of
+	// queueing, `second`'s callback (no internal `await`) would complete
+	// before `first`'s gated one resumes, producing
+	// ['first-start', 'second-start', 'second-end', 'first-end'] instead.
+	// Asserting only on this final, fully-settled order (not on intermediate
+	// state after N microtask ticks) keeps the assertion independent of a
+	// runtime's exact `await` scheduling — relevant since this repo also
+	// tests under Bun and Deno, not just Node/V8.
+	expect(order).toStrictEqual(['first-start', 'first-end', 'second-start', 'second-end']);
+});

--- a/packages/@markuplint/file-resolver/src/config-provider.ts
+++ b/packages/@markuplint/file-resolver/src/config-provider.ts
@@ -10,7 +10,7 @@ import { ConfigParserError } from '@markuplint/parser-utils';
 import { InvalidSelectorError, createSelector } from '@markuplint/selector';
 import { nonNullableFilter, toNoEmptyStringArrayFromStringOrArray, ConfigLoadError } from '@markuplint/shared';
 
-import { load as loadConfig, search } from './cosmiconfig.js';
+import { load as loadConfig, search, clearExplorerCache } from './cosmiconfig.js';
 import { log } from './debug.js';
 import { generalImport } from './general-import.js';
 import { getPreset } from './get-preset.js';
@@ -54,6 +54,67 @@ export class ConfigProvider {
 	 * needs no hashing of arbitrary config shapes.
 	 */
 	#autoKeys = new WeakMap<object, string>();
+
+	/**
+	 * Serializes {@link runExclusive} calls on this instance.
+	 */
+	#queue: Promise<void> = Promise.resolve();
+
+	/**
+	 * Clears every cached and stored config entry: the base-config cache
+	 * (`#cache`), the loaded/registered config store (`#store`), `set()`'s
+	 * identity→key stabilization (`#autoKeys`), `resolve-plugins.ts`'s own
+	 * module-level plugin-resolution cache, and the shared `cosmiconfig`
+	 * explorer's own search/load caches (so {@link search}, called right
+	 * after this, re-reads the current file content instead of a stale
+	 * cosmiconfig-level cache).
+	 *
+	 * The `cosmiconfig` explorer and the `resolve-plugins.ts` cache are
+	 * module-level singletons shared by every `ConfigProvider` instance in
+	 * the process — clearing them here affects other instances too, not just
+	 * this one. Harmless (they just re-search/re-load), but worth knowing
+	 * when reasoning about a cache-busting re-resolve's blast radius.
+	 *
+	 * Callers doing a cache-busting re-resolve (e.g. watch mode after a file
+	 * change) must call this **before** registering any inline config via
+	 * {@link set}, and before {@link search}, for that same resolve —
+	 * `resolve()` itself no longer clears anything, so a `set()`/`search()`
+	 * call made after `invalidate()` survives through to `resolve()`. Wrap
+	 * the whole `invalidate()` → `set()`/`search()` → `resolve()` sequence in
+	 * {@link runExclusive} so an overlapping call on the same instance can't
+	 * interleave its own `invalidate()` in the middle of it. See #4015.
+	 */
+	invalidate() {
+		this.#store.clear();
+		this.#cache.clear();
+		this.#autoKeys = new WeakMap();
+		cacheClear();
+		clearExplorerCache();
+	}
+
+	/**
+	 * Runs `fn` exclusively with respect to every other `runExclusive` call on
+	 * this instance: queued calls wait for earlier ones to settle before
+	 * starting, so two overlapping cache-busting re-resolves (e.g. two
+	 * watch-triggered `MLEngine#resolveConfig(false)` calls close together,
+	 * whether from one engine's own provider or several engines sharing one)
+	 * can't interleave — one call's {@link invalidate} can no longer wipe the
+	 * `set()`/`search()` entries another call registered a moment earlier but
+	 * hasn't yet consumed. See #4015.
+	 */
+	async runExclusive<T>(fn: () => Promise<T>): Promise<T> {
+		const previous = this.#queue;
+		let release: () => void;
+		this.#queue = new Promise(resolve => {
+			release = resolve;
+		});
+		await previous;
+		try {
+			return await fn();
+		} finally {
+			release!();
+		}
+	}
 
 	/**
 	 * Recursively loads a configuration and all its `extends` dependencies.
@@ -129,19 +190,21 @@ export class ConfigProvider {
 	 * per call so a `.vue`-only override never leaks into a `.html` file's result (or
 	 * vice versa) just because they resolve the same `names`.
 	 *
+	 * Does NOT clear the provider's store/cache itself — call {@link invalidate}
+	 * first if a fresh re-read is needed (e.g. a watch-triggered re-resolve).
+	 * `cache` only controls whether an already-loaded `names` entry (this call's
+	 * base-config cache, and — deeper still — cosmiconfig's own per-file cache in
+	 * `#load`) is reused; it used to also wipe the store/cache up front, which
+	 * discarded any `set()` call the caller had just made for this same resolve
+	 * (e.g. `MLEngine#resolveConfig()` registering inline `config`/`defaultConfig`
+	 * right before calling this) — see #4015.
+	 *
 	 * @param targetFile - The file being linted
 	 * @param names - Config file paths or module names to merge
-	 * @param cache - Whether to use cached results
+	 * @param cache - Whether to reuse already-loaded/cached entries
 	 * @returns The fully resolved configuration set including plugins and errors
 	 */
 	async resolve(targetFile: Readonly<MLFile>, names: readonly Nullable<string>[], cache = true): Promise<ConfigSet> {
-		if (!cache) {
-			this.#store.clear();
-			this.#cache.clear();
-			this.#autoKeys = new WeakMap();
-			cacheClear();
-		}
-
 		const keys = names.filter(nonNullableFilter);
 		const key = keys.join(KEY_SEPARATOR);
 

--- a/packages/@markuplint/file-resolver/src/cosmiconfig.ts
+++ b/packages/@markuplint/file-resolver/src/cosmiconfig.ts
@@ -49,6 +49,18 @@ const explorer = cosmiconfig('markuplint', {
 
 type CosmiConfig = ReturnType<LoaderSync>;
 
+/**
+ * Clears the shared `cosmiconfig` explorer's own internal search/load caches.
+ * Distinct from this module's `cacheClear` parameters (which clear the same
+ * caches but only as a side effect of one `search`/`load` call) — this lets a
+ * caller (see `ConfigProvider#invalidate`) clear them up front, before any
+ * `search`/`load` call, so a subsequent `search` reads the current file
+ * content instead of the explorer's stale cache. See #4015.
+ */
+export function clearExplorerCache() {
+	explorer.clearCaches();
+}
+
 export async function search<T = CosmiConfig>(filePath: string, cacheClear: boolean) {
 	if (cacheClear) {
 		explorer.clearCaches();

--- a/packages/markuplint/src/api/ml-engine.spec.ts
+++ b/packages/markuplint/src/api/ml-engine.spec.ts
@@ -503,3 +503,34 @@ describe('configProvider option (#3997)', () => {
 		expect(configSetB.config).toStrictEqual(configSetA.config);
 	});
 });
+
+describe('resolveConfig(false) with inline config (#4015)', () => {
+	it('does not throw for an inline `config` option', async () => {
+		const file = await MLEngine.toMLFile({ sourceCode: '<p>a</p>', name: 'a.html' });
+		const engine = new MLEngine(file!, { config: { rules: { 'no-duplicate-id': true } } });
+
+		const configSet = await engine.resolveConfig(false);
+
+		expect(configSet.config.rules).toStrictEqual({ 'no-duplicate-id': true });
+	});
+
+	it('does not throw for an inline `defaultConfig` option', async () => {
+		const file = await MLEngine.toMLFile({ sourceCode: '<p>a</p>', name: 'a.html' });
+		const engine = new MLEngine(file!, { defaultConfig: { rules: { 'no-duplicate-id': true } } });
+
+		const configSet = await engine.resolveConfig(false);
+
+		expect(configSet.config.rules).toStrictEqual({ 'no-duplicate-id': true });
+	});
+
+	it('re-resolving twice with cache: false still works (watch-mode-like repeated re-resolve)', async () => {
+		const file = await MLEngine.toMLFile({ sourceCode: '<p>a</p>', name: 'a.html' });
+		const engine = new MLEngine(file!, { config: { rules: { 'no-duplicate-id': true } } });
+
+		const first = await engine.resolveConfig(false);
+		const second = await engine.resolveConfig(false);
+
+		expect(first.config.rules).toStrictEqual({ 'no-duplicate-id': true });
+		expect(second.config.rules).toStrictEqual({ 'no-duplicate-id': true });
+	});
+});

--- a/packages/markuplint/src/api/ml-engine.ts
+++ b/packages/markuplint/src/api/ml-engine.ts
@@ -46,15 +46,20 @@ type MLEngineOptions = {
 	 * Optional and additive: omitted, each `MLEngine` still creates its own
 	 * provider exactly as before.
 	 *
-	 * **Caveat — `watch: true`**: `ConfigProvider.resolve`'s cache-busting
+	 * **Caveat — `watch: true`**: `resolveConfig()`'s cache-busting
 	 * (`cache: false`, used internally on every watch-triggered re-resolve)
-	 * clears the *entire* shared provider, not anything scoped to one engine
-	 * or file. Sharing one `configProvider` across multiple engines that also
-	 * have `watch: true` risks one engine's re-resolve silently invalidating
-	 * another's in-flight or just-cached config. Neither the CLI (which
-	 * doesn't support `--watch`) nor `lint()` (which never sets `watch`)
-	 * create this combination — it only arises if a direct API consumer
-	 * builds it deliberately.
+	 * calls `ConfigProvider#invalidate()`, which clears the *entire* shared
+	 * provider, not anything scoped to one engine or file. `resolveConfig()`
+	 * runs through `ConfigProvider#runExclusive()`, so an overlapping call
+	 * from another engine can no longer interleave with — and corrupt — this
+	 * one's in-flight resolve (see #4015); it can only run *before* or
+	 * *after* it. Sharing one `configProvider` across multiple engines that
+	 * also have `watch: true` still risks one engine's re-resolve evicting
+	 * another's already-cached config, forcing an avoidable re-resolve on
+	 * that engine's next lookup. Neither the CLI (which doesn't support
+	 * `--watch`) nor `lint()` (which never sets `watch`) create this
+	 * combination — it only arises if a direct API consumer builds it
+	 * deliberately.
 	 */
 	readonly configProvider?: ConfigProvider;
 };
@@ -449,42 +454,63 @@ export class MLEngine extends Emitter<MLEngineEventMap> {
 		this.emit('log', 'resolveConfig', JSON.stringify(this.#configProvider, null, 2));
 		configLog('configProvider: %s', this.#configProvider);
 
-		const defaultConfigKey =
-			this.#options?.defaultConfig &&
-			this.#configProvider.set(mergeConfig(this.#options.defaultConfig), undefined, this.#options.defaultConfig);
-		configLog('defaultConfigKey: %s', defaultConfigKey ?? 'N/A');
-		this.emit('log', 'defaultConfigKey', defaultConfigKey ?? 'N/A');
+		// Runs the whole invalidate → set → search → resolve sequence as one
+		// exclusive unit on the provider — an overlapping call on the same
+		// (possibly shared, e.g. two watch-triggered re-resolves close
+		// together) `ConfigProvider` must not interleave its own `invalidate()`
+		// in the middle of this one's `set()`/`search()` calls, which would
+		// wipe the keys just registered below before `resolve()` gets to use
+		// them. See #4015.
+		const resolvedConfigSet = await this.#configProvider.runExclusive(async () => {
+			if (!cache) {
+				// Must run before any `set()` call below — `ConfigProvider#resolve()`
+				// no longer clears its own store on `cache: false`, so invalidating
+				// after registering this call's inline config would discard it
+				// again immediately. See #4015.
+				this.#configProvider.invalidate();
+			}
 
-		const targetConfig = await this.#configProvider.search(this.#file);
-		this.emit('log', 'targetConfig', targetConfig ?? 'N/A');
+			const defaultConfigKey =
+				this.#options?.defaultConfig &&
+				this.#configProvider.set(
+					mergeConfig(this.#options.defaultConfig),
+					undefined,
+					this.#options.defaultConfig,
+				);
+			configLog('defaultConfigKey: %s', defaultConfigKey ?? 'N/A');
+			this.emit('log', 'defaultConfigKey', defaultConfigKey ?? 'N/A');
 
-		const configFilePathsFromTarget =
-			this.#options?.noSearchConfig || this.#options?.configFile
-				? (defaultConfigKey ?? null)
-				: (targetConfig ?? defaultConfigKey);
-		configLog('configFilePathsFromTarget: %s', configFilePathsFromTarget ?? 'N/A');
-		this.emit('log', 'configFilePathsFromTarget', configFilePathsFromTarget ?? 'N/A');
+			const targetConfig = await this.#configProvider.search(this.#file);
+			this.emit('log', 'targetConfig', targetConfig ?? 'N/A');
 
-		const configKey =
-			this.#options?.config &&
-			this.#configProvider.set(mergeConfig(this.#options.config), undefined, this.#options.config);
-		configLog('option.config: %s', configKey ?? 'N/A');
-		this.emit('log', 'option.config', configFilePathsFromTarget ?? 'N/A');
+			const configFilePathsFromTarget =
+				this.#options?.noSearchConfig || this.#options?.configFile
+					? (defaultConfigKey ?? null)
+					: (targetConfig ?? defaultConfigKey);
+			configLog('configFilePathsFromTarget: %s', configFilePathsFromTarget ?? 'N/A');
+			this.emit('log', 'configFilePathsFromTarget', configFilePathsFromTarget ?? 'N/A');
 
-		let defaultRecommended: string | null = null;
-		if (!defaultConfigKey && !configFilePathsFromTarget && !configKey && !this.#options?.configFile) {
-			// No configured
-			// Default: set recommended
-			defaultRecommended = this.#configProvider.set(RECOMMENDED_CONFIG);
-		}
-		configLog('defaultRecommended: %s', defaultRecommended ?? 'N/A');
-		this.emit('log', 'defaultRecommended', defaultRecommended ?? 'N/A');
+			const configKey =
+				this.#options?.config &&
+				this.#configProvider.set(mergeConfig(this.#options.config), undefined, this.#options.config);
+			configLog('option.config: %s', configKey ?? 'N/A');
+			this.emit('log', 'option.config', configFilePathsFromTarget ?? 'N/A');
 
-		const resolvedConfigSet = await this.#configProvider.resolve(
-			this.#file,
-			[configFilePathsFromTarget, this.#options?.configFile, configKey, defaultRecommended],
-			cache,
-		);
+			let defaultRecommended: string | null = null;
+			if (!defaultConfigKey && !configFilePathsFromTarget && !configKey && !this.#options?.configFile) {
+				// No configured
+				// Default: set recommended
+				defaultRecommended = this.#configProvider.set(RECOMMENDED_CONFIG);
+			}
+			configLog('defaultRecommended: %s', defaultRecommended ?? 'N/A');
+			this.emit('log', 'defaultRecommended', defaultRecommended ?? 'N/A');
+
+			return this.#configProvider.resolve(
+				this.#file,
+				[configFilePathsFromTarget, this.#options?.configFile, configKey, defaultRecommended],
+				cache,
+			);
+		});
 
 		// Rewrite deprecated rule names (v5 rule-system redesign, #3989) to
 		// their current replacement(s) so old configurations keep working.


### PR DESCRIPTION
## Summary

- `MLEngine#resolveConfig(cache: false)` — used internally on every watch-triggered re-resolve, and by the CLI's `--show-config` — crashed with `TypeError: <N> is not an absolute path` whenever the engine was built with an inline `config`/`defaultConfig` object instead of a config file path.
- Root cause: `resolveConfig()` registers inline config via `ConfigProvider#set()`, then immediately calls `ConfigProvider#resolve(..., false)`, which used to wipe the entire store/cache up front — discarding the key it had just registered a moment earlier.
- Fix: `ConfigProvider#resolve()` no longer clears anything by itself; a new `ConfigProvider#invalidate()` does that, and `resolveConfig()` now calls it **before** registering inline config, not after. `invalidate()` also clears cosmiconfig's own explorer cache (previously cleared transitively through `resolve()`'s old auto-clear) so watch-mode's file-based re-reads stay correct.
- Also serializes `resolveConfig()`'s whole invalidate → set → search → resolve sequence via a new `ConfigProvider#runExclusive()` mutex, so two overlapping cache-busting re-resolves on the same (possibly shared) provider can't interleave one call's `invalidate()` into another's in-flight sequence — found during review as a narrower, timing-dependent variant of the same class of bug.

## Breaking change

`ConfigProvider#resolve(targetFile, names, false)` no longer clears the provider's store/cache/plugin-resolution caches by itself. Callers that relied on `cache: false` alone to force a fresh re-read must now call the new `ConfigProvider#invalidate()` first. `ConfigProvider` is a public export of `@markuplint/file-resolver`, and reachable via `MLEngineOptions.configProvider` in `markuplint`'s API — see the `fix(file-resolver)!` commit's `BREAKING CHANGE:` footer.

Fixes #4015.

## Test plan

- [x] `yarn build`
- [x] `yarn lint-check`
- [x] `yarn test` (full suite incl. type-checking)
- New regression tests:
  - `config-provider.spec.ts`: `resolve(cache: false)` no longer clears entries just registered via `set()`; `invalidate()` does clear them; `runExclusive()` actually serializes overlapping calls (verified to fail without the fix by temporarily disabling the mutex)
  - `ml-engine.spec.ts`: `resolveConfig(false)` no longer throws for inline `config`/`defaultConfig`, and repeated `cache: false` calls keep working
- Existing `Watcher > updates config` test (file-based config, real chokidar round-trip) still passes, confirming no regression to watch mode's file-based reload path
