### PR TITLE
fix(rules): exempt no-unclosed-element-at-eof for never-close-tag parsers

### DIFF
--- a/packages/@markuplint/rules/src/no-unclosed-element-at-eof/index.spec.ts
+++ b/packages/@markuplint/rules/src/no-unclosed-element-at-eof/index.spec.ts
@@ -53,3 +53,25 @@ test('[no-unclosed-element-at-eof-valid-003] void elements are never flagged', a
 test('[no-unclosed-element-at-eof-valid-004] an element autoclosed mid-document by a sibling is not an EOF case', async () => {
 	expect((await mlRuleTest(rule, '<p>one<div>two</div>')).violations).toStrictEqual([]);
 });
+
+test('[no-unclosed-element-at-eof-issue-4022-001] a parser that never emits close tags (Pug) is exempt entirely', async () => {
+	expect(
+		(
+			await mlRuleTest(
+				rule,
+				`doctype html
+html(lang="ja")
+	head
+		title Sample
+		meta(charset="UTF-8")
+	body
+		div Hello`,
+				{
+					parser: {
+						'.*': '@markuplint/pug-parser',
+					},
+				},
+			)
+		).violations,
+	).toStrictEqual([]);
+});

--- a/packages/@markuplint/rules/src/no-unclosed-element-at-eof/index.ts
+++ b/packages/@markuplint/rules/src/no-unclosed-element-at-eof/index.ts
@@ -72,6 +72,17 @@ function deepEndOffset(node: EndAnchored): number {
 export default createRule<boolean>({
 	meta: meta,
 	async verify({ document, report, t }) {
+		/**
+		 * A parser with `endTagType: 'never'` (e.g. `@markuplint/pug-parser`)
+		 * structurally never records a close tag for any element, so
+		 * `el.closeTag == null` carries no signal about whether the source is
+		 * actually malformed — see `require-end-tag`'s identical guard for the
+		 * same rationale.
+		 */
+		if (document.endTag === 'never') {
+			return;
+		}
+
 		const eof = document.raw.length;
 
 		await document.walkOn('Element', el => {


### PR DESCRIPTION
## Summary

- `no-unclosed-element-at-eof` reported a false positive on the last non-exempt element in documents parsed by a parser that structurally never records close tags (`endTagType: 'never'`, currently only `@markuplint/pug-parser`), since `closeTag == null` carries no signal about malformed source for such parsers.
- Add the same `document.endTag === 'never'` early-return guard already used by `require-end-tag` for the identical reason.

## Test plan

- [x] Added regression test `[no-unclosed-element-at-eof-issue-4022-001]` reproducing the issue's exact Pug sample, asserting zero violations.
- [x] `yarn lint`
- [x] `yarn build`
- [x] `yarn test` (4602 passed, 1 skipped)

Fixes #4022
