### PR TITLE
fix: named rule group disable propagation and validation (#4023)

### DIFF
--- a/packages/@markuplint/ml-config/src/merge-config.spec.ts
+++ b/packages/@markuplint/ml-config/src/merge-config.spec.ts
@@ -982,6 +982,68 @@ describe('Named rule group merging', () => {
 		expect(result.rules?.['a11y/id-duplication']).toBe(false);
 	});
 
+	describe('knownNamedRuleGroupKeys (issue #4023)', () => {
+		test('records a key that was a genuine NamedRuleGroup before being disabled by false', () => {
+			const result = mergeConfig(
+				{
+					rules: {
+						'html-standard/no-unclosed-element-at-eof': {
+							specConformance: 'normative',
+							rules: { 'no-unclosed-element-at-eof': true },
+						},
+					},
+				},
+				{
+					rules: {
+						'html-standard/no-unclosed-element-at-eof': false,
+					},
+				},
+			);
+			expect(result.knownNamedRuleGroupKeys).toStrictEqual(['html-standard/no-unclosed-element-at-eof']);
+		});
+
+		test('does not record a key that was never a NamedRuleGroup, even when disabled by false', () => {
+			const result = mergeConfig(
+				{},
+				{
+					rules: {
+						'totally/nonexistent': false,
+					},
+				},
+			);
+			expect(result.knownNamedRuleGroupKeys).toBeUndefined();
+		});
+
+		test('is absent from configs that never touch a named rule group', () => {
+			const result = mergeConfig({ rules: { 'no-duplicate-id': true } }, { rules: { 'require-attr': false } });
+			expect(result.knownNamedRuleGroupKeys).toBeUndefined();
+		});
+
+		test('carries over across an unrelated later merge step', () => {
+			const disabledStep = mergeConfig(
+				{
+					rules: {
+						'html-standard/no-unclosed-element-at-eof': {
+							rules: { 'no-unclosed-element-at-eof': true },
+						},
+					},
+				},
+				{
+					rules: {
+						'html-standard/no-unclosed-element-at-eof': false,
+					},
+				},
+			);
+			// A further merge step (e.g. user overrides) that never touches the
+			// already-collapsed `false` key must still carry the known-group record.
+			const final = mergeConfig(disabledStep, {
+				rules: { 'no-duplicate-id': true },
+			});
+			expect(final.rules?.['html-standard/no-unclosed-element-at-eof']).toBe(false);
+			expect(final.knownNamedRuleGroupKeys).toStrictEqual(['html-standard/no-unclosed-element-at-eof']);
+		});
+	});
+
 	test('named rule group severity overridden by object', () => {
 		const result = mergeConfig(
 			{

--- a/packages/@markuplint/ml-config/src/merge-config.ts
+++ b/packages/@markuplint/ml-config/src/merge-config.ts
@@ -38,6 +38,12 @@ import { deleteUndefProp, cleanOptions, isRuleConfigValue, isNamedRuleGroup } fr
 export function mergeConfig(a: Config, b?: Config): OptimizedConfig {
 	const deleteExtendsProp = !!b;
 	b = b ?? {};
+	const mergedRules = mergeRules(
+		// Shallow merge: rule-level options are replaced entirely by the overriding config.
+		// Deep merging individual rule options would require schema-aware merging logic.
+		a.rules,
+		b.rules,
+	);
 	const config: OptimizedConfig = {
 		...a,
 		...b,
@@ -56,11 +62,11 @@ export function mergeConfig(a: Config, b?: Config): OptimizedConfig {
 		excludeFiles: concatArray(a.excludeFiles, b.excludeFiles, true),
 		severity: mergeObject(a.severity, b.severity),
 		pretenders: mergePretenders(a.pretenders, b.pretenders),
-		rules: mergeRules(
-			// Shallow merge: rule-level options are replaced entirely by the overriding config.
-			// Deep merging individual rule options would require schema-aware merging logic.
-			a.rules,
-			b.rules,
+		rules: mergedRules.rules,
+		knownNamedRuleGroupKeys: mergeKnownNamedRuleGroupKeys(
+			a.knownNamedRuleGroupKeys,
+			b.knownNamedRuleGroupKeys,
+			mergedRules.knownNamedRuleGroupKeys,
 		),
 		nodeRules: concatArray(a.nodeRules, b.nodeRules, true, 'name'),
 		childNodeRules: concatArray(a.childNodeRules, b.childNodeRules, true, 'name'),
@@ -287,12 +293,19 @@ function getName(item: any, comparePropName: string) {
 	return null;
 }
 
-function mergeRules(a?: Rules, b?: Rules): Rules | undefined {
+type MergeRulesResult = {
+	readonly rules: Rules | undefined;
+	/** See {@link mergeConfig}'s `knownNamedRuleGroupKeys` handling. */
+	readonly knownNamedRuleGroupKeys: readonly string[] | undefined;
+};
+
+function mergeRules(a?: Rules, b?: Rules): MergeRulesResult {
+	const knownNamedRuleGroupKeys = collectNamedRuleGroupKeys(a, b);
 	if (a == null) {
-		return b && optimizeRules(b);
+		return { rules: b && optimizeRules(b), knownNamedRuleGroupKeys };
 	}
 	if (b == null) {
-		return optimizeRules(a);
+		return { rules: optimizeRules(a), knownNamedRuleGroupKeys };
 	}
 	const res = optimizeRules(a);
 	for (const [key, rule] of Object.entries(b)) {
@@ -307,7 +320,51 @@ function mergeRules(a?: Rules, b?: Rules): Rules | undefined {
 		}
 	}
 	deleteUndefProp(res);
-	return Object.freeze(res);
+	return { rules: Object.freeze(res), knownNamedRuleGroupKeys };
+}
+
+/**
+ * Collects `rules` keys that are a genuine {@link NamedRuleGroup} in either
+ * operand, before {@link mergeNamedRuleGroupEntry}'s `false`-collapse erases
+ * that shape. See `Config.knownNamedRuleGroupKeys` for why this must be
+ * tracked separately from the merged `rules` value.
+ */
+function collectNamedRuleGroupKeys(a?: Rules, b?: Rules): readonly string[] | undefined {
+	let known: Set<string> | undefined;
+	for (const rules of [a, b]) {
+		if (!rules) {
+			continue;
+		}
+		for (const [key, value] of Object.entries(rules)) {
+			if (key.includes('/') && isNamedRuleGroup(value)) {
+				known ??= new Set();
+				known.add(key);
+			}
+		}
+	}
+	return known && [...known];
+}
+
+/**
+ * Unions `knownNamedRuleGroupKeys` carried over from each side of a merge
+ * with the keys freshly detected at this merge step, returning `undefined`
+ * (not an empty array) when there's nothing to carry — so `deleteUndefProp`
+ * keeps the field absent from configs that never touch named rule groups.
+ */
+function mergeKnownNamedRuleGroupKeys(
+	...groups: readonly (readonly string[] | undefined)[]
+): readonly string[] | undefined {
+	let known: Set<string> | undefined;
+	for (const group of groups) {
+		if (!group) {
+			continue;
+		}
+		for (const key of group) {
+			known ??= new Set();
+			known.add(key);
+		}
+	}
+	return known && [...known];
 }
 
 function mergeNamedRuleGroupEntry(

--- a/packages/@markuplint/ml-config/src/types.ts
+++ b/packages/@markuplint/ml-config/src/types.ts
@@ -27,6 +27,18 @@ export type Config = {
 	readonly childNodeRules?: readonly ChildNodeRule[];
 	readonly overrideMode?: 'merge' | 'reset';
 	readonly overrides?: Readonly<Record<string, OverrideConfig>>;
+	/**
+	 * Computed by {@link mergeConfig} — never authored in a config file. Tracks
+	 * `rules` keys that were a genuine {@link NamedRuleGroup} in some layer of the
+	 * `extends`/override chain, even where the final merged value collapsed to
+	 * `false` (a whole-group disable erases which base rule(s) it wrapped — see
+	 * `mergeNamedRuleGroupEntry`). Consumers (`@markuplint/ml-core`) use this to
+	 * tell an intentional named-group disable apart from a typo'd/nonexistent
+	 * rule name that also happens to be set to `false` with a `/` in its key —
+	 * both collapse to the same `rules[key] === false` shape after merging, but
+	 * only the former should be exempt from "Rule not found" validation.
+	 */
+	readonly knownNamedRuleGroupKeys?: readonly string[];
 };
 
 /**

--- a/packages/@markuplint/ml-core/src/ml-core.ts
+++ b/packages/@markuplint/ml-core/src/ml-core.ts
@@ -208,6 +208,11 @@ export class MLCore {
 			nodeRules: nodeRuleResult.transformedNodeRules,
 			childNodeRules: childNodeRuleResult.transformedNodeRules,
 			baseRuleToVirtualNames: buildBaseRuleToVirtualNames(namedRulesResult.virtualRules),
+			baseRuleToScopedVirtualNames: buildBaseRuleToVirtualNames([
+				...nodeRuleResult.virtualRules,
+				...childNodeRuleResult.virtualRules,
+			]),
+			knownNamedRuleGroupKeys: ruleset.knownNamedRuleGroupKeys ?? new Set(),
 			mappingErrors: [],
 		};
 		this.#disabledNamespaces = extractDisabledNamespaces(resolvedRules);
@@ -285,6 +290,11 @@ export class MLCore {
 			nodeRules: nodeRuleResult.transformedNodeRules,
 			childNodeRules: childNodeRuleResult.transformedNodeRules,
 			baseRuleToVirtualNames: buildBaseRuleToVirtualNames(namedRulesResult.virtualRules),
+			baseRuleToScopedVirtualNames: buildBaseRuleToVirtualNames([
+				...nodeRuleResult.virtualRules,
+				...childNodeRuleResult.virtualRules,
+			]),
+			knownNamedRuleGroupKeys: ruleset?.knownNamedRuleGroupKeys ?? this.#ruleset.knownNamedRuleGroupKeys,
 			mappingErrors: [],
 		};
 		this.#disabledNamespaces = extractDisabledNamespaces(resolvedRules);
@@ -362,6 +372,15 @@ export class MLCore {
 		for (const setRuleName of setRuleNames) {
 			// Skip wildcard patterns (e.g., "a11y/*") — they are namespace disable entries, not rule references
 			if (setRuleName.endsWith('/*')) {
+				continue;
+			}
+			// Skip a named rule group disabled via top-level `rules` (e.g. "html-standard/foo": false).
+			// `expandNamedRules` intentionally doesn't instantiate a virtual rule when the merged value
+			// already resolved to `false` (there's nothing to run), so it never appears in `definedRuleName`.
+			// `knownNamedRuleGroupKeys` (threaded from config merge — see its JSDoc) tells a genuine
+			// named-group disable apart from a typo'd/nonexistent rule name that also happens to be
+			// set to `false` with a `/` in its key; only the former is exempt from this check.
+			if (this.#ruleset.rules[setRuleName] === false && this.#ruleset.knownNamedRuleGroupKeys.has(setRuleName)) {
 				continue;
 			}
 			if (!definedRuleName.has(setRuleName)) {

--- a/packages/@markuplint/ml-core/src/ml-dom/node/document.ts
+++ b/packages/@markuplint/ml-core/src/ml-dom/node/document.ts
@@ -3546,7 +3546,9 @@ export class MLDocument<T extends RuleConfigValue, O extends PlainData = undefin
 						rule: mergedRule,
 					});
 
-					// Propagate to virtual rules that wrap this base rule
+					// Propagate to top-level-group virtual rules that wrap this base rule. These
+					// wrappers have no selector scope of their own (they mirror the base rule
+					// globally), so any matched value is safe to forward.
 					const virtualNames = ruleset.baseRuleToVirtualNames.get(ruleName);
 					if (virtualNames) {
 						for (const vName of virtualNames) {
@@ -3558,6 +3560,27 @@ export class MLDocument<T extends RuleConfigValue, O extends PlainData = undefin
 								specificity: matches.specificity,
 								rule: vMergedRule,
 							});
+						}
+					}
+
+					// Propagate a disable to selector-scoped (nodeRules/childNodeRules-named) virtual
+					// rules that wrap this base rule. Limited to `false`: unlike the top-level-group
+					// case above, these wrappers DO have their own selector scope, so forwarding a
+					// non-false value would apply their semantics (e.g. a required attribute name) to
+					// every node this (unrelated) nodeRule matches, even where the virtual rule's own
+					// selector never matched — see issue #4023's fix history for the regression this caused.
+					if (convertedRule === false) {
+						const scopedVirtualNames = ruleset.baseRuleToScopedVirtualNames.get(ruleName);
+						if (scopedVirtualNames) {
+							for (const vName of scopedVirtualNames) {
+								// No merge needed: mergeRule(_, false) always returns false, so the
+								// disable is unconditional regardless of any global config for vName.
+								ruleMapper.set(node, vName, {
+									from: 'nodeRules',
+									specificity: matches.specificity,
+									rule: false,
+								});
+							}
 						}
 					}
 				}
@@ -3647,7 +3670,8 @@ export class MLDocument<T extends RuleConfigValue, O extends PlainData = undefin
 							});
 						}
 
-						// Propagate to virtual rules that wrap this base rule
+						// Propagate to top-level-group virtual rules — see the matching nodeRules
+						// propagation above for why any value is safe to forward here.
 						const virtualNames = ruleset.baseRuleToVirtualNames.get(ruleName);
 						if (virtualNames) {
 							for (const vName of virtualNames) {
@@ -3660,6 +3684,26 @@ export class MLDocument<T extends RuleConfigValue, O extends PlainData = undefin
 										specificity: matches.specificity,
 										rule: vMergedRule,
 									});
+								}
+							}
+						}
+
+						// Propagate a disable to selector-scoped virtual rules. Limited to `false` —
+						// see the matching nodeRules propagation above for why a non-false value must
+						// not be forwarded to a virtual rule whose own selector didn't match.
+						if (convertedRule === false) {
+							const scopedVirtualNames = ruleset.baseRuleToScopedVirtualNames.get(ruleName);
+							if (scopedVirtualNames) {
+								for (const vName of scopedVirtualNames) {
+									// No merge needed: mergeRule(_, false) always returns false, so the
+									// disable is unconditional regardless of any global config for vName.
+									for (const descendant of targetDescendants) {
+										ruleMapper.set(descendant, vName, {
+											from: 'childNodeRules',
+											specificity: matches.specificity,
+											rule: false,
+										});
+									}
 								}
 							}
 						}

--- a/packages/@markuplint/ml-core/src/ruleset/index.ts
+++ b/packages/@markuplint/ml-core/src/ruleset/index.ts
@@ -6,14 +6,31 @@ import type { ChildNodeRule, Config, NodeRule, Rules } from '@markuplint/ml-conf
  */
 export class Ruleset {
 	/**
-	 * Maps base rule names to their virtual rule names created by NamedRuleGroups.
-	 * For example, if `a11y/landmark-roles` wraps `no-nested-top-level-landmark`, this maps
-	 * `"no-nested-top-level-landmark"` → `["a11y/landmark-roles"]`.
-	 * Used by nodeRules/childNodeRules to propagate settings to virtual rules.
+	 * Maps base rule names to the virtual rule names created by top-level `rules`
+	 * NamedRuleGroups (e.g. `"a11y/landmark-roles": { rules: { "no-nested-top-level-landmark": true } }`).
+	 * These wrappers have no selector scope of their own — they mirror the base rule
+	 * globally — so nodeRules/childNodeRules may propagate *any* matched value to them,
+	 * not just a disable.
 	 */
 	readonly baseRuleToVirtualNames: ReadonlyMap<string, readonly string[]>;
+	/**
+	 * Maps base rule names to the virtual rule names created by `nodeRules[].name` /
+	 * `childNodeRules[].name` (selector-scoped named groups), as opposed to
+	 * {@link baseRuleToVirtualNames}'s top-level `rules` groups. Because these wrappers
+	 * DO have their own selector scope, only a disable (`false`) may be propagated to
+	 * them from an unrelated nodeRules/childNodeRules entry — forwarding a non-false
+	 * value would apply the wrapper's semantics to nodes its own selector never matched
+	 * (see issue #4023's fix history).
+	 */
+	readonly baseRuleToScopedVirtualNames: ReadonlyMap<string, readonly string[]>;
 	/** Rule overrides that apply to child nodes matching specific selectors */
 	readonly childNodeRules: readonly ChildNodeRule[];
+	/**
+	 * `rules` keys that are a genuine NamedRuleGroup in some layer of the
+	 * `extends`/override chain, carried over from {@link Config.knownNamedRuleGroupKeys}
+	 * even where the final merged value collapsed to `false`. See that field's JSDoc.
+	 */
+	readonly knownNamedRuleGroupKeys: ReadonlySet<string>;
 	/**
 	 * Errors collected during rule mapping (e.g., invalid wildcard usage).
 	 * Consumed by MLCore and reported as config-error violations.
@@ -26,12 +43,19 @@ export class Ruleset {
 
 	/**
 	 * @param config - The markuplint configuration to extract rules from
-	 * @param baseRuleToVirtualNames - Mapping from base rule names to virtual rule names
+	 * @param baseRuleToVirtualNames - Mapping from base rule names to top-level-group virtual rule names
+	 * @param baseRuleToScopedVirtualNames - Mapping from base rule names to selector-scoped (nodeRules/childNodeRules) virtual rule names
 	 */
-	constructor(config: Config, baseRuleToVirtualNames?: ReadonlyMap<string, readonly string[]>) {
+	constructor(
+		config: Config,
+		baseRuleToVirtualNames?: ReadonlyMap<string, readonly string[]>,
+		baseRuleToScopedVirtualNames?: ReadonlyMap<string, readonly string[]>,
+	) {
 		this.rules = config.rules ?? {};
 		this.nodeRules = config.nodeRules ?? [];
 		this.childNodeRules = config.childNodeRules ?? [];
 		this.baseRuleToVirtualNames = baseRuleToVirtualNames ?? new Map();
+		this.baseRuleToScopedVirtualNames = baseRuleToScopedVirtualNames ?? new Map();
+		this.knownNamedRuleGroupKeys = new Set(config.knownNamedRuleGroupKeys);
 	}
 }

--- a/packages/markuplint/src/named-noderules.spec.ts
+++ b/packages/markuplint/src/named-noderules.spec.ts
@@ -815,6 +815,33 @@ describe('Named nodeRules integration', () => {
 			);
 			expect(violations.find(v => v.name === 'custom/li-data')).toBeUndefined();
 		});
+
+		it('a non-false override of a shared base rule does not leak to an unrelated named childNodeRule virtual rule (issue #4023)', async () => {
+			// Same guard as the nodeRules case above, for the childNodeRules propagation path.
+			// 'custom/li-data' only targets descendants of :where(ul); the div childNodeRule below
+			// overrides the shared base rule 'require-attr' with an unrelated value ('role') for
+			// descendants of :where(div) instead.
+			const { violations } = await mlTest(
+				'<!doctype html><html lang="en"><head><meta charset="UTF-8"></head><body><div><li>outside</li></div><ul><li>inside</li></ul></body></html>',
+				{
+					childNodeRules: [
+						{
+							name: 'custom/li-data',
+							selector: ':where(ul)',
+							rules: { 'require-attr': ['data-index'] },
+						},
+						{
+							selector: ':where(div)',
+							rules: { 'require-attr': 'role' },
+						},
+					],
+				},
+			);
+			// Exactly one violation: the <li> inside <ul> missing data-index. A leak would
+			// additionally misapply 'custom/li-data' to the <li> inside <div>, doubling this count.
+			const liDataViolations = violations.filter(v => v.name === 'custom/li-data');
+			expect(liDataViolations).toHaveLength(1);
+		});
 	});
 
 	describe('config error: nonexistent virtual rule reference', () => {
@@ -1284,6 +1311,76 @@ describe('Named nodeRules integration', () => {
 			// Both a11y/id-duplication and html-standard/id-duplication should be disabled on div
 			const idViolations = violations.filter(v => v.ruleId === 'no-duplicate-id');
 			expect(idViolations).toHaveLength(0);
+		});
+	});
+
+	describe('later unnamed nodeRules override propagates to an earlier named nodeRule group (issue #4023)', () => {
+		it('base rule disable from a later unnamed nodeRules entry disables the earlier named virtual rule', async () => {
+			const { violations } = await mlTest('<a data-disabled="true">no href</a>', {
+				nodeRules: [
+					{
+						name: 'custom/a-href-required',
+						selector: 'a',
+						rules: { 'require-attr': { value: 'href' } },
+					},
+					{
+						selector: 'a',
+						rules: { 'require-attr': false },
+					},
+				],
+			});
+			expect(violations.find(v => v.name === 'custom/a-href-required')).toBeUndefined();
+		});
+
+		it('a non-false override of a shared base rule does not leak to an unrelated named nodeRule virtual rule', async () => {
+			// Regression guard: propagating a *disable* from an unrelated nodeRules entry to a
+			// selector-scoped virtual rule is safe, but propagating a non-false value is not — it
+			// would apply the virtual rule's semantics to nodes its own selector never matched.
+			// 'custom/html-lang' only targets :where(html); the img nodeRule below overrides the
+			// shared base rule 'require-attr' with an unrelated value ('alt') at <img> instead.
+			const { violations } = await mlTest(
+				'<!doctype html><html><head><meta charset="UTF-8"></head><body><img src="x.png"></body></html>',
+				{
+					nodeRules: [
+						{
+							name: 'custom/html-lang',
+							selector: ':where(html)',
+							rules: { 'require-attr': ['lang'] },
+						},
+						{
+							selector: 'img',
+							rules: { 'require-attr': 'alt' },
+						},
+					],
+				},
+			);
+			// Exactly one violation: <html> missing lang. A leak would additionally misapply
+			// 'custom/html-lang' (requiring "lang") at the unrelated <img> node, doubling this count.
+			const customViolations = violations.filter(v => v.name === 'custom/html-lang');
+			expect(customViolations).toHaveLength(1);
+			expect(customViolations[0]!.raw).toBe('<html>');
+		});
+	});
+
+	describe('preset named rule group disabled via top-level rules (issue #4023)', () => {
+		it('disabling a preset named rule group by its alias name does not report "Rule not found"', async () => {
+			const { violations } = await mlTest('<picture><img src="x" alt="">', {
+				extends: ['markuplint:html-standard'],
+				rules: {
+					'html-standard/no-unclosed-element-at-eof': false,
+				},
+			});
+			expect(violations.find(v => v.ruleId === 'config-error')).toBeUndefined();
+		});
+
+		it('disabling a preset named rule group by its alias name also suppresses the underlying violation', async () => {
+			const { violations } = await mlTest('<picture><img src="x" alt="">', {
+				extends: ['markuplint:html-standard'],
+				rules: {
+					'html-standard/no-unclosed-element-at-eof': false,
+				},
+			});
+			expect(violations.find(v => v.ruleId === 'no-unclosed-element-at-eof')).toBeUndefined();
 		});
 	});
 


### PR DESCRIPTION
## Summary

Fixes two related bugs from #4023, both stemming from asymmetric handling of "a named rule group's virtual rule disabled via `false`" in `@markuplint/ml-core`:

- A base rule disabled via a **later, unnamed `nodeRules`/`childNodeRules` entry** did not propagate to a virtual rule created by an **earlier, user-defined `nodeRules[].name` entry** — the override appeared to have no effect.
- Disabling a **preset-provided named rule group** (e.g. `html-standard/no-unclosed-element-at-eof`) via top-level `rules` with `false` threw a `Rule not found` config-error, even though disabling the same rule by its real (non-namespaced) name worked fine.

## Changes

- `@markuplint/ml-config`: `mergeConfig` now tracks `knownNamedRuleGroupKeys` — `rules` keys that were a genuine `NamedRuleGroup` in some layer of the `extends`/override chain, even where the final merged value collapsed to `false` (a whole-group disable erases which base rule(s) it wrapped). This survives the full merge chain via carry-over across pairwise merge steps.
- `@markuplint/ml-core`:
  - The rule-existence validation in `verify()` now skips a `setRuleName` that resolves to `false` **and** is a known named rule group, instead of reporting a spurious `config-error`.
  - `baseRuleToVirtualNames` now has a selector-scoped counterpart, `baseRuleToScopedVirtualNames`, built from `nodeRules[].name`/`childNodeRules[].name`-defined groups. `document.ts`'s nodeRules/childNodeRules propagation logic forwards *any* matched value to top-level-group virtual rules (they have no selector scope of their own — safe), but only forwards a **disable** (`false`) to selector-scoped virtual rules, since forwarding an arbitrary value to those would misapply their semantics to nodes their own selector never matched.

## Test plan

- [x] `yarn build`
- [x] `yarn lint-check`
- [x] `yarn test` (full suite, incl. `--typecheck`) — 4611 passed, 0 failures
- [x] New unit tests in `@markuplint/ml-config`'s `merge-config.spec.ts` covering `knownNamedRuleGroupKeys` (positive/negative/absence/carry-over cases)
- [x] New integration tests in `packages/markuplint/src/named-noderules.spec.ts`:
  - Both bugs reproduced end-to-end and fixed
  - Regression guards (nodeRules + childNodeRules) proving the propagation fix stays disable-only for selector-scoped virtual rules — a broader "propagate any value" fix was tried first and caught by these tests plus the existing `007.html` fixture snapshot in `packages/markuplint/src/index.spec.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
