### PR TITLE
docs: fill v4-to-v5 migration gaps around overrides and wai-aria

### DIFF
--- a/packages/@markuplint/file-resolver/src/config-provider.spec.ts
+++ b/packages/@markuplint/file-resolver/src/config-provider.spec.ts
@@ -298,6 +298,57 @@ test('Overrides with OverrideMode', async () => {
 	});
 });
 
+test('Overrides: multiple matching globs (reset mode) — last match replaces every earlier one outright', async () => {
+	const testDir = path.resolve(import.meta.dirname, '..', 'test', 'fixtures');
+	const key = path.resolve(testDir, '012', '.markuplintrc.multi-reset.json');
+	const file = getFile(path.resolve(testDir, '012', 'target.html'));
+	const configSet = await configProvider.resolve(file, [key]);
+	// `./target.*` matched after `./*.html`, so under the default `reset` mode
+	// its config entirely replaces the first match's — `foo`/`bar` are gone.
+	expect(configSet.config).toStrictEqual({
+		rules: {
+			baz: true,
+		},
+	});
+	expect(configSet.appliedOverrides).toStrictEqual([
+		path.resolve(testDir, '012', '*.html'),
+		path.resolve(testDir, '012', 'target.*'),
+	]);
+});
+
+test('Overrides: multiple matching globs (merge mode) — appliedOverrides records match order', async () => {
+	const testDir = path.resolve(import.meta.dirname, '..', 'test', 'fixtures');
+	const key = path.resolve(testDir, '012', '.markuplintrc.multi-merge.json');
+	const file = getFile(path.resolve(testDir, '012', 'target.html'));
+	const configSet = await configProvider.resolve(file, [key]);
+	expect(configSet.config.rules).toStrictEqual({
+		foo: false,
+		bar: true,
+		baz: true,
+	});
+	expect(configSet.appliedOverrides).toStrictEqual([
+		path.resolve(testDir, '012', '*.html'),
+		path.resolve(testDir, '012', 'target.*'),
+	]);
+});
+
+test('appliedOverrides is absent when the config has no overrides at all', async () => {
+	const testDir = path.resolve(import.meta.dirname, '..', 'test', 'fixtures');
+	const key = path.resolve(testDir, '001', '.markuplintrc');
+	const file = getFile(path.resolve(testDir, '001', 'target.html'));
+	const configSet = await configProvider.resolve(file, [key]);
+	expect(configSet.appliedOverrides).toBeUndefined();
+});
+
+test('appliedOverrides is absent when overrides exist but none match the target file', async () => {
+	const testDir = path.resolve(import.meta.dirname, '..', 'test', 'fixtures');
+	const key = path.resolve(testDir, '012', '.markuplintrc.no-match.json');
+	const file = getFile(path.resolve(testDir, '012', 'target.html'));
+	const configSet = await configProvider.resolve(file, [key]);
+	expect(configSet.config.rules).toStrictEqual({ foo: true });
+	expect(configSet.appliedOverrides).toBeUndefined();
+});
+
 test('Overrides remain per-file correct when sharing one ConfigProvider across files (#3997)', async () => {
 	const testDir = path.resolve(import.meta.dirname, '..', 'test', 'fixtures');
 	const resetKey = path.resolve(testDir, '011', '.markuplintrc.reset.json');

--- a/packages/@markuplint/file-resolver/src/config-provider.ts
+++ b/packages/@markuplint/file-resolver/src/config-provider.ts
@@ -271,19 +271,29 @@ export class ConfigProvider {
 	 * Never mutates `baseConfigSet` — returns it unchanged (same reference) when no
 	 * override matches, or a shallow copy with a freshly computed `config` otherwise,
 	 * so the cached base entry stays valid for the next target file.
+	 *
+	 * Matches are applied in `Object.keys(overrides)` order (config-key insertion
+	 * order), each round re-assigning `config` rather than accumulating — so under
+	 * the default `overrideMode: 'reset'`, the last-matching glob's config entirely
+	 * replaces every earlier match, not just the base config. `appliedOverrides`
+	 * records that match order for `--show-config=details` to surface, since this
+	 * "last match wins outright" behavior is easy to mistake for a bug (see #4023).
 	 */
 	#applyOverrides(baseConfigSet: ConfigSet, targetFile: Readonly<MLFile>): ConfigSet {
 		let config = baseConfigSet.config;
+		const appliedOverrides: string[] = [];
 		if (config.overrides) {
 			const overrides = config.overrides;
 			for (const glob of Object.keys(overrides)) {
 				const overrideConfig = overrides[glob];
 				if (targetFile.matches(glob) && overrideConfig) {
 					config = config.overrideMode === 'merge' ? mergeConfig(config, overrideConfig) : overrideConfig;
+					appliedOverrides.push(glob);
 				}
 			}
+			return config === baseConfigSet.config ? baseConfigSet : { ...baseConfigSet, config, appliedOverrides };
 		}
-		return config === baseConfigSet.config ? baseConfigSet : { ...baseConfigSet, config };
+		return baseConfigSet;
 	}
 
 	/**

--- a/packages/@markuplint/file-resolver/src/types.ts
+++ b/packages/@markuplint/file-resolver/src/types.ts
@@ -14,6 +14,15 @@ export interface ConfigSet {
 	readonly files: ReadonlySet<string>;
 	/** Errors encountered during config loading or resolution */
 	readonly errs: readonly Readonly<Error>[];
+	/**
+	 * `overrides` keys (resolved to absolute globs by `OptimizedConfig`) that
+	 * matched the target file, in the order they were applied — config-key
+	 * order, so later entries win under `overrideMode: 'reset'`, the default.
+	 * Absent — never an empty array — when no override matched this target
+	 * file, whether because the config has no `overrides` at all or none of
+	 * its globs matched.
+	 */
+	readonly appliedOverrides?: readonly string[];
 }
 
 /**

--- a/packages/@markuplint/file-resolver/test/fixtures/012/.markuplintrc.multi-merge.json
+++ b/packages/@markuplint/file-resolver/test/fixtures/012/.markuplintrc.multi-merge.json
@@ -1,0 +1,19 @@
+{
+	"rules": {
+		"foo": true,
+		"bar": true
+	},
+	"overrideMode": "merge",
+	"overrides": {
+		"./*.html": {
+			"rules": {
+				"foo": false
+			}
+		},
+		"./target.*": {
+			"rules": {
+				"baz": true
+			}
+		}
+	}
+}

--- a/packages/@markuplint/file-resolver/test/fixtures/012/.markuplintrc.multi-reset.json
+++ b/packages/@markuplint/file-resolver/test/fixtures/012/.markuplintrc.multi-reset.json
@@ -1,0 +1,18 @@
+{
+	"rules": {
+		"foo": true,
+		"bar": true
+	},
+	"overrides": {
+		"./*.html": {
+			"rules": {
+				"foo": false
+			}
+		},
+		"./target.*": {
+			"rules": {
+				"baz": true
+			}
+		}
+	}
+}

--- a/packages/@markuplint/file-resolver/test/fixtures/012/.markuplintrc.no-match.json
+++ b/packages/@markuplint/file-resolver/test/fixtures/012/.markuplintrc.no-match.json
@@ -1,0 +1,12 @@
+{
+	"rules": {
+		"foo": true
+	},
+	"overrides": {
+		"./*.vue": {
+			"rules": {
+				"foo": false
+			}
+		}
+	}
+}

--- a/packages/markuplint/src/cli/command.ts
+++ b/packages/markuplint/src/cli/command.ts
@@ -175,6 +175,7 @@ export async function command(files: readonly Readonly<Target>[], options: CLIOp
 					plugins: configSet.plugins,
 					errors: configSet.errs,
 					ruleDeprecations: configSet.ruleDeprecations,
+					appliedOverrides: configSet.appliedOverrides ?? [],
 				};
 			} else {
 				data = configSet.config;

--- a/packages/markuplint/src/cli/index.spec.ts
+++ b/packages/markuplint/src/cli/index.spec.ts
@@ -586,6 +586,29 @@ describe('config-level violation deduplication', () => {
 		);
 		expect(data.ruleDeprecations).toHaveLength(2);
 	});
+
+	test('--show-config details surfaces which overrides glob(s) matched the target file', async () => {
+		const fixtureDir = path.resolve(import.meta.dirname, '../../test/show-config-overrides');
+		const overridesConfigPath = path.join(fixtureDir, 'config.json');
+		const overridesTargetFile = path.join(fixtureDir, 'target.html');
+
+		const { stdout } = await execa(
+			entryFilePath,
+			[
+				'--config',
+				escape(overridesConfigPath),
+				'--no-search-config',
+				'--show-config',
+				'details',
+				escape(overridesTargetFile),
+			],
+			{ reject: false },
+		);
+
+		const data = JSON.parse(stdout) as { appliedOverrides: readonly string[] };
+
+		expect(data.appliedOverrides).toStrictEqual([path.join(fixtureDir, 'target.*')]);
+	});
 });
 
 describe('--max-warnings option', () => {

--- a/packages/markuplint/test/show-config-overrides/config.json
+++ b/packages/markuplint/test/show-config-overrides/config.json
@@ -1,0 +1,12 @@
+{
+	"rules": {
+		"id-duplication": true
+	},
+	"overrides": {
+		"./target.*": {
+			"rules": {
+				"required-attr": true
+			}
+		}
+	}
+}

--- a/packages/markuplint/test/show-config-overrides/target.html
+++ b/packages/markuplint/test/show-config-overrides/target.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<title>ok</title>

--- a/website/docs/configuration/properties.md
+++ b/website/docs/configuration/properties.md
@@ -1301,6 +1301,38 @@ It can override the following properties:
 - [`childNodeRules`](#childnoderules)
 - [`pretenders`](#pretenders)
 
+#### When more than one glob matches the same file
+
+Entries are evaluated in the order they're written. Each matching entry is applied on top of the
+previous result, so with the default [`overrideMode`](#overridemode) (`reset`), **the last-matching
+entry replaces every earlier match outright** — not just the base configuration:
+
+```json class=config
+{
+  "rules": {
+    "any-rule": true,
+    "another-rule": true
+  },
+  "overrides": {
+    "./src/**/*": {
+      "rules": { "any-rule": false }
+    },
+    "./src/legacy/**/*": {
+      "rules": { "another-rule": false }
+    }
+  }
+}
+```
+
+For a file under `./src/legacy/`, both entries match. Under `reset` mode, the second entry's
+`{ "rules": { "another-rule": false } }` becomes the entire configuration — `any-rule: false` from
+the first match is discarded along with everything else from the base config, since the second
+entry is applied to the _first entry's result_, and `reset` replaces its input wholesale. Reorder
+the entries, or switch [`overrideMode`](#overridemode) to `merge`, to combine both instead.
+
+Run `markuplint --show-config=details` on the target file to see which `overrides` entries matched
+and in what order (`appliedOverrides` in the output).
+
 #### Interface {#overrides/interface}
 
 ```ts

--- a/website/docs/migration/v4-to-v5/aria.md
+++ b/website/docs/migration/v4-to-v5/aria.md
@@ -105,6 +105,72 @@ v4 always ran (no option): `#ARIAAttrs: false` → `no-aria-on-unsupported-eleme
 
 v4 `wai-aria` **did not** implement `require-parent-role` or `tab-requires-tabpanel`. The alias and `markuplint:a11y` still enable them.
 
+### All 21 successor rules
+
+If you extend `markuplint:a11y` (or `markuplint:recommended`), you don't need this list at all:
+`"a11y/wai-aria/*": false` disables every one of them at once (see
+[Named rules in presets](/docs/guides/presets#named-rules)).
+
+The list below is for a **raw `wai-aria: true` config with no preset** — there, each of the 21
+current rule names must be disabled individually. It's also the bare-rule-name column if you're
+disabling one check by name rather than by preset group (see
+[base rule name disables reach every named group](/docs/configuration/properties#disable-by-base-rule-name)):
+
+| Rule name                            | `markuplint:a11y` group name               |
+| ------------------------------------ | ------------------------------------------ |
+| `no-aria-on-unsupported-element`     | `a11y/wai-aria/unsupported-element`        |
+| `no-unknown-role`                    | `a11y/wai-aria/non-existent-role`          |
+| `no-abstract-role`                   | `a11y/wai-aria/abstract-role`              |
+| `require-parent-role`                | `a11y/wai-aria/required-parent-role`       |
+| `require-aria-prop`                  | `a11y/wai-aria/required-props`             |
+| `no-deprecated-role`                 | `a11y/wai-aria/deprecated-role`            |
+| `no-redundant-role`                  | `a11y/wai-aria/implicit-role`              |
+| `permitted-roles`                    | `a11y/wai-aria/permitted-roles`            |
+| `no-prohibited-naming`               | `a11y/wai-aria/prohibited-naming`          |
+| `element-supports-aria-prop`         | `a11y/wai-aria/element-supports-aria-prop` |
+| `role-supports-aria-prop`            | `a11y/wai-aria/disallowed-props`           |
+| `no-deprecated-aria-prop`            | `a11y/wai-aria/deprecated-props`           |
+| `no-redundant-aria-prop`             | `a11y/wai-aria/implicit-props`             |
+| `no-contradictory-aria-prop`         | `a11y/wai-aria/contradictory-props`        |
+| `no-invalid-aria-prop-value`         | `a11y/wai-aria/value`                      |
+| `no-default-aria-value`              | `a11y/wai-aria/default-value`              |
+| `aria-prop-requires-role`            | `a11y/wai-aria/no-global-prop`             |
+| `require-owned-elements`             | `a11y/wai-aria/required-owned-elements`    |
+| `no-aria-on-presentational-children` | `a11y/wai-aria/presentational-children`    |
+| `no-focusable-in-aria-hidden`        | `a11y/wai-aria/interaction-in-hidden`      |
+| `tab-requires-tabpanel`              | `a11y/wai-aria/tab-requires-tabpanel`      |
+
+```json
+{
+  "rules": {
+    "no-aria-on-unsupported-element": false,
+    "no-unknown-role": false,
+    "no-abstract-role": false,
+    "require-parent-role": false,
+    "require-aria-prop": false,
+    "no-deprecated-role": false,
+    "no-redundant-role": false,
+    "permitted-roles": false,
+    "no-prohibited-naming": false,
+    "element-supports-aria-prop": false,
+    "role-supports-aria-prop": false,
+    "no-deprecated-aria-prop": false,
+    "no-redundant-aria-prop": false,
+    "no-contradictory-aria-prop": false,
+    "no-invalid-aria-prop-value": false,
+    "no-default-aria-value": false,
+    "aria-prop-requires-role": false,
+    "require-owned-elements": false,
+    "no-aria-on-presentational-children": false,
+    "no-focusable-in-aria-hidden": false,
+    "tab-requires-tabpanel": false
+  }
+}
+```
+
+`no-aria-hidden-on-hidden-until-found` (`a11y/wai-aria/hidden-until-found`) is a related, but
+separate, new-in-v5 check — the `wai-aria` alias does **not** expand to it, so it isn't in this list.
+
 ### Extra reports vs v4 defaults
 
 Because toggles are dropped, `wai-aria: true` (and `markuplint:a11y`) now also run:

--- a/website/docs/migration/v4-to-v5/cli.md
+++ b/website/docs/migration/v4-to-v5/cli.md
@@ -52,3 +52,28 @@ markuplint "**/*.html"
 ```
 
 JSON output (`--format json`) is unaffected, and always uses batch mode.
+
+## Diagnosing config drift with `--show-config=details`
+
+If a rule you expected to run silently doesn't fire — or a rename/split alias doesn't seem to
+apply — run `--show-config=details` on the target file before assuming a bug:
+
+```bash
+markuplint --show-config=details path/to/file.html
+```
+
+It prints the fully computed configuration for that file as JSON, including:
+
+- `computedConfig` — the final merged config actually used to lint the file
+- `configurationFile` / `dependencies` — every config file that contributed, in load order. Useful
+  when more than one `.markuplintrc` / `markuplint.config.*` exists in the project and it's unclear
+  which one (or which combination) applies to a given file
+- `ruleDeprecations` — old rule names found in the resolved config and what they expanded to (see
+  [Renames and Splits](/docs/migration/v4-to-v5/rules/rule-names))
+- `appliedOverrides` — which [`overrides`](/docs/configuration/properties#overrides) glob(s)
+  matched this file, in the order they were applied. See
+  [When more than one glob matches the same file](/docs/configuration/properties#when-more-than-one-glob-matches-the-same-file)
+  if more than one appears here — the last one can replace everything before it.
+
+This resolves the config only; it does not run rule resolution, so a `Rule not found` config error
+won't appear here even if the same config would produce one at lint time.

--- a/website/docs/migration/v4-to-v5/config.md
+++ b/website/docs/migration/v4-to-v5/config.md
@@ -19,6 +19,7 @@ Most additions are opt-in. Merge changes under `extends` are breaking.
 | Pretenders ignored on standard HTML/SVG tags          | Configs that pretended built-in tags         |
 | `--config` loads only the given file                  | CLI; see [CLI](/docs/migration/v4-to-v5/cli) |
 | `:closest()` deprecated                               | Selectors in nodeRules                       |
+| Multiple `overrides` globs matching one file          | Config authors using `overrides`             |
 
 ## `ruleCommonSettings` {#rulecommonsettings}
 
@@ -67,6 +68,11 @@ Presets attach a `name` (for example `a11y/html-lang`) to a `nodeRules` entry so
 
 Violations expose `ruleId` (base rule) and `name` (group). `specConformance` is metadata only (`normative` / `non-normative`); it does not change severity.
 
+You don't have to spell out every named group to disable a check everywhere it's wrapped: setting
+the **base rule name** to `false` (e.g. `"no-broken-fragment-link": false`) disables it inside
+every named group that wraps it, in addition to any bare use. See
+[Disabling by base rule name](/docs/configuration/properties#disable-by-base-rule-name).
+
 ## Merge behavior
 
 **Named nodeRules:** same `name` is replaced by the child config. Unnamed entries still concatenate.
@@ -84,6 +90,17 @@ Per HTML LS / Selectors L4, attribute names are ASCII case-insensitive when the 
 ## Pretenders on standard tags {#pretenders-no-longer-apply-to-standard-html-tags}
 
 A pretender whose selector is a recognized HTML/SVG element is ignored ([issue #3740](https://github.com/markuplint/markuplint/issues/3740)). Use per-rule disable/severity to silence a built-in tag; do not masquerade it as another element.
+
+## `overrides` with multiple matching globs
+
+Not a v5 change, but worth checking while you're touching config during migration: if more than
+one [`overrides`](/docs/configuration/properties#overrides) glob matches the same file, the
+last-matching entry replaces every earlier match outright under the default `overrideMode: 'reset'`
+— it isn't merged with them. See
+[When more than one glob matches the same file](/docs/configuration/properties#when-more-than-one-glob-matches-the-same-file).
+
+Run `--show-config=details` (see [CLI](/docs/migration/v4-to-v5/cli#diagnosing-config-drift-with---show-configdetails))
+to see exactly which globs matched a given file, in order, before assuming a v5 regression.
 
 ## `:closest()` deprecated
 

--- a/website/docs/migration/v4-to-v5/index.md
+++ b/website/docs/migration/v4-to-v5/index.md
@@ -42,6 +42,8 @@ Use no-table-cell-overlap, no-table-span-overflow, no-empty-table-track, consist
 
 Rewrite from those lines. That does not cover the silent gaps above; check [Renames and Splits](/docs/migration/v4-to-v5/rules/rule-names#known-migration-gap) by hand.
 
+If a rule doesn't behave the way you expect after rewriting, run `markuplint --show-config=details` on the target file before assuming a regression — see [CLI](/docs/migration/v4-to-v5/cli#diagnosing-config-drift-with---show-configdetails).
+
 5. If CI treated warnings as failures, add `--no-allow-warnings`. See [CLI](/docs/migration/v4-to-v5/cli).
 6. If you used `--config`, confirm it no longer merges with `.markuplintrc`.
 7. If you used `extends` with array rule values or nested `options`, see [Config](/docs/migration/v4-to-v5/config).
@@ -57,14 +59,14 @@ npx skills add markuplint/markuplint@migrations/v4-v5
 
 ## For users
 
-| Area                                            | Summary                                                                                                                                              | Who's affected         |
-| ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
-| [Node.js](/docs/migration/v4-to-v5/nodejs)      | Minimum version v24.0.0 (v4 documented v18.18.0). TypeScript target ES2022.                                                                          | Everyone               |
-| [CLI](/docs/migration/v4-to-v5/cli)             | `--fix-dry-run`. Warnings allowed by default (`--no-allow-warnings` restores v4). `--config` does not merge.                                         | CLI, CI                |
-| [Config](/docs/migration/v4-to-v5/config)       | `ruleCommonSettings`, named nodeRules, array override, shallow option merge, pretender restrictions, `:closest()` deprecated.                        | Config authors         |
-| [ARIA](/docs/migration/v4-to-v5/aria)           | Default ARIA 1.3. `wai-aria` expands to 21 rules; some checks that were off or absent in v4 now run.                                                 | Everyone               |
-| [Framework](/docs/migration/v4-to-v5/framework) | `@markuplint/htmx-parser` removed. Alpine spec is `@markuplint/alpine-spec`.                                                                         | htmx / Alpine.js       |
-| [AST](/docs/migration/v4-to-v5/ast)             | Bundled parsers (html, vue, ejs, astro, mdx, jsx, svelte) now keep `/` in unquoted attribute values instead of splitting on it. `pug` is unaffected. | Users of those parsers |
+| Area                                            | Summary                                                                                                                                                           | Who's affected         |
+| ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| [Node.js](/docs/migration/v4-to-v5/nodejs)      | Minimum version v24.0.0 (v4 documented v18.18.0). TypeScript target ES2022.                                                                                       | Everyone               |
+| [CLI](/docs/migration/v4-to-v5/cli)             | `--fix-dry-run`. Warnings allowed by default (`--no-allow-warnings` restores v4). `--config` does not merge. `--show-config=details` for diagnosing config drift. | CLI, CI                |
+| [Config](/docs/migration/v4-to-v5/config)       | `ruleCommonSettings`, named nodeRules, array override, shallow option merge, pretender restrictions, `:closest()` deprecated, `overrides` multi-match order.      | Config authors         |
+| [ARIA](/docs/migration/v4-to-v5/aria)           | Default ARIA 1.3. `wai-aria` expands to 21 rules; some checks that were off or absent in v4 now run.                                                              | Everyone               |
+| [Framework](/docs/migration/v4-to-v5/framework) | `@markuplint/htmx-parser` removed. Alpine spec is `@markuplint/alpine-spec`.                                                                                      | htmx / Alpine.js       |
+| [AST](/docs/migration/v4-to-v5/ast)             | Bundled parsers (html, vue, ejs, astro, mdx, jsx, svelte) now keep `/` in unquoted attribute values instead of splitting on it. `pug` is unaffected.              | Users of those parsers |
 
 ### Rules
 


### PR DESCRIPTION
## Summary

Fills documentation and diagnostic-tooling gaps identified while migrating a real project from v4
to v5 — issues that weren't bugs, but forced a source read or were briefly mistaken for a
regression:

- **`overrides` multi-match behavior was undocumented anywhere.** Under the default
  `overrideMode: 'reset'`, when more than one `overrides` glob matches the same file, the
  last-matching entry replaces every earlier match outright (not just the base config) — this is
  easy to mistake for a bug (see #4023). Documented in `configuration/properties.md` and linked
  from the migration guide.
- **No way to see which `overrides` glob(s) actually matched a file.** Added
  `ConfigSet#appliedOverrides` (`@markuplint/file-resolver`) and wired it into the CLI's
  `--show-config=details` JSON output (`markuplint`), so this is now inspectable instead of
  requiring a source read or a controlled repro.
- **The 21 `wai-aria` successor rules had no single, copy-pasteable list.** Added a table in the
  migration guide mapping each rule name to its `markuplint:a11y` named-group equivalent — while
  also documenting that preset users don't need the list at all (`"a11y/wai-aria/*": false`
  disables all 21 at once).
- **`--show-config=details` wasn't mentioned as a migration diagnostic.** It already surfaces
  `ruleDeprecations` and config file provenance; the migration guide now points to it explicitly
  for diagnosing config drift.
- **Named rule group "disable everywhere" mechanism wasn't linked from the migration guide.**
  Setting a base rule name to `false` already disables it inside every named group that wraps it;
  the migration guide's config page now links to that instead of implying per-group enumeration is
  required.

None of the `overrides`/named-group behavior changed — this is documentation plus one small,
additive diagnostic field. No breaking changes.

## Changes

- `@markuplint/file-resolver`: `ConfigSet.appliedOverrides` (new, optional field)
- `markuplint`: `--show-config=details` output includes `appliedOverrides`
- `website`: `configuration/properties.md`, `migration/v4-to-v5/{index,cli,config,aria}.md`

## Test plan

- [x] `yarn lint-check` passes
- [x] `yarn build` passes
- [x] `yarn test` passes (4616 tests, full suite)
- [x] `yarn site:build` passes
- [x] New unit tests for `appliedOverrides` in `@markuplint/file-resolver` (multi-match reset/merge
      order, absent-when-no-match, absent-when-no-overrides)
- [x] New CLI test verifying `--show-config=details` surfaces `appliedOverrides`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
