### PR TITLE
fix(rules): add role predefined group to attr-order

### DIFF
--- a/packages/@markuplint/rules/src/attr-order/README.ja.md
+++ b/packages/@markuplint/rules/src/attr-order/README.ja.md
@@ -4,7 +4,7 @@ description: 要素の属性の順序を統一します。
 
 # `attr-order`
 
-要素の**属性**の順序を統一します。デフォルトではアルファベット順にソートされます。優先度リスト、定義済みグループ（`global`、`event`、`aria`、`data`、`spread`）、カスタムパターンを使って順序を指定できます。
+要素の**属性**の順序を統一します。デフォルトではアルファベット順にソートされます。優先度リスト、定義済みグループ（`global`、`event`、`aria`、`role`、`data`、`spread`）、カスタムパターンを使って順序を指定できます。
 
 :::info
 
@@ -42,7 +42,13 @@ description: 要素の属性の順序を統一します。
 
 ```json
 {
-  "attr-order": [{ "group": "global" }, { "group": "aria" }, { "group": "event" }, { "group": "data" }]
+  "attr-order": [
+    { "group": "global" },
+    { "group": "role" },
+    { "group": "aria" },
+    { "group": "event" },
+    { "group": "data" }
+  ]
 }
 ```
 
@@ -51,6 +57,7 @@ description: 要素の属性の順序を統一します。
 | `global` | HTMLグローバル属性（`id`、`class`、`style` など）  |
 | `event`  | イベントハンドラ属性（`onclick`、`onchange` など） |
 | `aria`   | ARIA属性（`aria-label`、`aria-hidden` など）       |
+| `role`   | `role` 属性                                        |
 | `data`   | カスタムデータ属性（`data-*`）                     |
 | `spread` | スプレッド属性（JSXの `{...props}`）               |
 

--- a/packages/@markuplint/rules/src/attr-order/README.md
+++ b/packages/@markuplint/rules/src/attr-order/README.md
@@ -5,7 +5,7 @@ description: Enforces a consistent order of attributes on elements.
 
 # `attr-order`
 
-Enforces a consistent order of **attributes** on elements. By default, attributes are sorted alphabetically. You can configure priority lists, predefined groups (`global`, `event`, `aria`, `data`, `spread`), and custom patterns to define the desired order.
+Enforces a consistent order of **attributes** on elements. By default, attributes are sorted alphabetically. You can configure priority lists, predefined groups (`global`, `event`, `aria`, `role`, `data`, `spread`), and custom patterns to define the desired order.
 
 :::info
 
@@ -41,7 +41,13 @@ Attributes matching the list are placed first in the specified order. Unmatched 
 
 ```json
 {
-  "attr-order": [{ "group": "global" }, { "group": "aria" }, { "group": "event" }, { "group": "data" }]
+  "attr-order": [
+    { "group": "global" },
+    { "group": "role" },
+    { "group": "aria" },
+    { "group": "event" },
+    { "group": "data" }
+  ]
 }
 ```
 
@@ -50,6 +56,7 @@ Attributes matching the list are placed first in the specified order. Unmatched 
 | `global` | HTML global attributes (`id`, `class`, `style`, etc.)  |
 | `event`  | Event handler attributes (`onclick`, `onchange`, etc.) |
 | `aria`   | ARIA attributes (`aria-label`, `aria-hidden`, etc.)    |
+| `role`   | The `role` attribute                                   |
 | `data`   | Custom data attributes (`data-*`)                      |
 | `spread` | Spread attributes (JSX `{...props}`)                   |
 

--- a/packages/@markuplint/rules/src/attr-order/index.spec.ts
+++ b/packages/@markuplint/rules/src/attr-order/index.spec.ts
@@ -135,6 +135,68 @@ describe('group matching', () => {
 	});
 });
 
+describe('role group', () => {
+	test('[attr-order-invalid-021] role group - role should be before aria group', async () => {
+		const { violations } = await mlRuleTest(rule, '<ul aria-label="x" role="radiogroup"></ul>', {
+			rule: { value: [{ group: 'global' }, { group: 'role' }, { group: 'aria' }] },
+		});
+		expect(violations).toStrictEqual([
+			{
+				severity: 'warning',
+				line: 1,
+				col: 20,
+				raw: 'role',
+				message: '"role" should be before "aria-label"',
+			},
+		]);
+	});
+
+	test('[attr-order-valid-019] no violation - role before aria matches configured order', async () => {
+		const { violations } = await mlRuleTest(rule, '<ul role="radiogroup" aria-label="x"></ul>', {
+			rule: { value: [{ group: 'global' }, { group: 'role' }, { group: 'aria' }] },
+		});
+		expect(violations.length).toBe(0);
+	});
+
+	test('[attr-order-valid-020] no violation - aria before role matches configured order', async () => {
+		const { violations } = await mlRuleTest(rule, '<ul aria-label="x" role="radiogroup"></ul>', {
+			rule: { value: [{ group: 'aria' }, { group: 'role' }] },
+		});
+		expect(violations.length).toBe(0);
+	});
+
+	test('[attr-order-valid-021] role group does not match aria-* attributes with similar names', async () => {
+		const { violations } = await mlRuleTest(rule, '<div aria-roledescription="x" role="y"></div>', {
+			rule: { value: [{ group: 'aria' }, { group: 'role' }] },
+		});
+		// "aria-roledescription" must stay matched by the aria group (entry 0), not "role" (entry 1)
+		expect(violations.length).toBe(0);
+	});
+
+	test('[attr-order-fix-013] fix: role group placed before aria group', async () => {
+		const { fixedCode } = await mlRuleTest(
+			rule,
+			'<ul aria-label="x" role="radiogroup"></ul>',
+			{ rule: { value: [{ group: 'role' }, { group: 'aria' }] } },
+			true,
+		);
+		expect(fixedCode).toBe('<ul role="radiogroup" aria-label="x"></ul>');
+	});
+
+	test('[attr-order-issue-4033-001] role placed before aria-* via an explicit role group', async () => {
+		const { violations } = await mlRuleTest(rule, '<ul role="radiogroup" aria-label="XXX"></ul>', {
+			rule: {
+				value: [
+					{ group: 'global', order: 'source-order' },
+					{ group: 'role', order: 'source-order' },
+					{ group: 'aria', order: 'source-order' },
+				],
+			},
+		});
+		expect(violations.length).toBe(0);
+	});
+});
+
 describe('pattern matching', () => {
 	test('[attr-order-invalid-010] data- pattern first', async () => {
 		const { violations } = await mlRuleTest(rule, '<div class="a" data-x="1"></div>', {

--- a/packages/@markuplint/rules/src/attr-order/index.ts
+++ b/packages/@markuplint/rules/src/attr-order/index.ts
@@ -4,7 +4,7 @@ import { createRule } from '@markuplint/ml-core';
 
 import meta from './meta.js';
 
-type PredefinedGroup = 'global' | 'event' | 'aria' | 'data' | 'spread';
+type PredefinedGroup = 'global' | 'event' | 'aria' | 'role' | 'data' | 'spread';
 
 type SortOrder = 'alphabetical' | 'source-order' | string[];
 
@@ -170,6 +170,13 @@ function compileEntries(
 						entryIndex,
 						order: groupOrder,
 						match: (name: string) => /^aria-.+$/.test(name),
+					};
+				}
+				case 'role': {
+					return {
+						entryIndex,
+						order: groupOrder,
+						match: (name: string) => name === 'role',
 					};
 				}
 				case 'data': {

--- a/packages/@markuplint/rules/src/attr-order/schema.json
+++ b/packages/@markuplint/rules/src/attr-order/schema.json
@@ -34,7 +34,7 @@
 						},
 						"group": {
 							"type": "string",
-							"enum": ["global", "event", "aria", "data", "spread"],
+							"enum": ["global", "event", "aria", "role", "data", "spread"],
 							"description": "A predefined group of attributes."
 						},
 						"order": {


### PR DESCRIPTION
## Summary

- Add an independent `role` predefined group to the `attr-order` rule, so the `role` attribute's position relative to `aria`, `global`, and other groups is configurable — previously `role` matched no predefined group and always sorted after every configured group
- Sync `README.md` / `README.ja.md` with the new group

Fixes #4033

## Test plan

- [x] Added failing tests first, then implemented (`role` group config, both orderings relative to `aria`, no accidental match on similar names like `aria-roledescription`, autofix, and an issue-4033 regression case)
- [x] `yarn lint-check`
- [x] `yarn build`
- [x] `yarn test` (312 files / 4622 tests passed, 1 skipped, no type errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
