### PR TITLE
fix(vscode): rename extension package to avoid Marketplace name collision

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ channels.
 ### Publisher
 
 The extension is published under the `markuplint` publisher
-(Marketplace ID: `markuplint.vscode-markuplint`).
+(Marketplace ID: `markuplint.markuplint-vscode`).
 
 The legacy `yusukehirao.vscode-markuplint` ID is deprecated from
 `v5.0.0-rc.4` onwards and no longer receives updates.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 
 ## Editor Extensions
 
-- [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=markuplint.vscode-markuplint)
+- [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=markuplint.markuplint-vscode)
 
 ## License
 

--- a/packages/markuplint/README.md
+++ b/packages/markuplint/README.md
@@ -159,7 +159,7 @@ See [ESLint's Bulk Suppressions](https://eslint.org/docs/latest/use/suppressions
 
 ## Editor Extensions
 
-- [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=markuplint.vscode-markuplint)
+- [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=markuplint.markuplint-vscode)
 
 ## License
 

--- a/vscode/CLAUDE.md
+++ b/vscode/CLAUDE.md
@@ -50,3 +50,27 @@ The extension previously published under `yusukehirao.vscode-markuplint`.
 That listing is deprecated in favor of the `markuplint` publisher namespace
 above; its final version and migration notice are tracked separately and are
 out of scope for this file.
+
+## Package `name` differs from the npm/legacy convention
+
+`package.json`'s `name` is `markuplint-vscode`, not `vscode-markuplint` — the
+extension identity is therefore `markuplint.markuplint-vscode`, not
+`markuplint.vscode-markuplint`. This is not a stylistic choice:
+
+- On the first publish attempt to the new `markuplint` publisher (v5.0.0),
+  the Marketplace rejected `name: "vscode-markuplint"` with `ERROR The
+extension 'vscode-markuplint' already exists in the Marketplace` — its
+  name-uniqueness check apparently applies to the raw extension `name`
+  across _all_ publishers, not the full `publisher.name` identity, so the
+  string `vscode-markuplint` already in use by the legacy `yusukehirao`
+  listing blocked reuse under `markuplint` too.
+- `name: "markuplint"` (matching the npm CLI package) was tried next and
+  rejected locally before publishing: it collides with
+  `packages/markuplint`'s own `name: "markuplint"` in the same Yarn
+  workspace (`vscode` is a workspace member — see root `package.json`
+  `workspaces`), which breaks Nx/Lerna project-graph construction
+  (`lerna ERR!` duplicate project name) as soon as both are installed
+  together.
+
+Don't rename `name` back to `vscode-markuplint` or to `markuplint` without
+confirming both constraints above no longer apply.

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -1,4 +1,4 @@
-# vscode-markuplint
+# Markuplint for VS Code
 
 [Markuplint](https://markuplint.dev) for Visual Studio Code
 
@@ -82,4 +82,4 @@ If not set, markuplint uses the parent directory of each file as the working dir
 
 ## Release
 
-[Changelog](https://marketplace.visualstudio.com/items/markuplint.vscode-markuplint/changelog)
+[Changelog](https://marketplace.visualstudio.com/items/markuplint.markuplint-vscode/changelog)

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "vscode-markuplint",
+	"name": "markuplint-vscode",
 	"displayName": "Markuplint",
 	"description": "Markuplint for VS Code",
 	"version": "5.0.0",

--- a/vscode/test/extension.spec.ts
+++ b/vscode/test/extension.spec.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert';
 import { suite, suiteSetup, test } from 'mocha';
 import * as vscode from 'vscode';
 
-const EXTENSION_ID = 'markuplint.vscode-markuplint';
+const EXTENSION_ID = 'markuplint.markuplint-vscode';
 
 async function waitForExtension(timeout = 5000): Promise<vscode.Extension<unknown>> {
 	const start = Date.now();

--- a/website/docs/guides/faq.md
+++ b/website/docs/guides/faq.md
@@ -4,7 +4,7 @@
 
 ### I am a beginner. Is it OK to use it?
 
-Absolutely. With VS Code, you can start immediately — just install [the extension](https://marketplace.visualstudio.com/items?itemName=markuplint.vscode-markuplint) and open an HTML file. No Node.js or command line knowledge is needed. You can also try it on the [Playground](https://playground.markuplint.dev) without installing anything.
+Absolutely. With VS Code, you can start immediately — just install [the extension](https://marketplace.visualstudio.com/items?itemName=markuplint.markuplint-vscode) and open an HTML file. No Node.js or command line knowledge is needed. You can also try it on the [Playground](https://playground.markuplint.dev) without installing anything.
 
 ### Can I use it with React?
 

--- a/website/docs/guides/index.md
+++ b/website/docs/guides/index.md
@@ -4,7 +4,7 @@
 
 ### The quickest way: VS Code extension
 
-Install the [Markuplint extension](https://marketplace.visualstudio.com/items?itemName=markuplint.vscode-markuplint) from the Visual Studio Marketplace, or search "markuplint" in the VS Code extensions panel.
+Install the [Markuplint extension](https://marketplace.visualstudio.com/items?itemName=markuplint.markuplint-vscode) from the Visual Studio Marketplace, or search "markuplint" in the VS Code extensions panel.
 
 ![VS Code extensions panel: searching "markuplint" shows the Markuplint extension by Yusuke Hirao](/img/guides/vscode-search.png)
 

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/faq.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/faq.md
@@ -6,7 +6,7 @@
 
 ### 初心者ですが使っても大丈夫ですか？
 
-大丈夫です。VS Codeであれば[拡張機能](https://marketplace.visualstudio.com/items?itemName=markuplint.vscode-markuplint)をインストールするだけですぐに利用できます。Node.jsやコマンドラインの知識は不要です。また、[プレイグラウンドサイト](https://playground.markuplint.dev)でインストールなしに試すこともできます。
+大丈夫です。VS Codeであれば[拡張機能](https://marketplace.visualstudio.com/items?itemName=markuplint.markuplint-vscode)をインストールするだけですぐに利用できます。Node.jsやコマンドラインの知識は不要です。また、[プレイグラウンドサイト](https://playground.markuplint.dev)でインストールなしに試すこともできます。
 
 ### Reactで使えますか？
 

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/index.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/guides/index.md
@@ -4,7 +4,7 @@
 
 ### もっとも簡単な方法: VS Code 拡張 {#the-quickest-way-vs-code-extension}
 
-[Markuplint拡張](https://marketplace.visualstudio.com/items?itemName=markuplint.vscode-markuplint)をVisual Studio Marketplaceからインストールするか、VS Codeの拡張機能パネルで「markuplint」と検索してください。
+[Markuplint拡張](https://marketplace.visualstudio.com/items?itemName=markuplint.markuplint-vscode)をVisual Studio Marketplaceからインストールするか、VS Codeの拡張機能パネルで「markuplint」と検索してください。
 
 ![VS Codeの拡張機能パネル: 「markuplint」で検索するとYusuke Hirao作のMarkuplint拡張が表示される](/img/guides/vscode-search.png)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 9
+  version: 10
   cacheKey: 10c0
 
 "@apidevtools/json-schema-ref-parser@npm:^11.5.5":
@@ -11607,6 +11607,33 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"markuplint-vscode@workspace:vscode":
+  version: 0.0.0-use.local
+  resolution: "markuplint-vscode@workspace:vscode"
+  dependencies:
+    "@markuplint-dev/tsconfig": "npm:5.0.0"
+    "@markuplint/file-resolver": "npm:5.0.0"
+    "@markuplint/i18n": "npm:5.0.0"
+    "@markuplint/ml-spec": "npm:5.0.0"
+    "@types/mocha": "npm:10.0.10"
+    "@types/node": "npm:22.17.0"
+    "@types/semver": "npm:7.7.1"
+    "@types/vscode": "npm:1.99.1"
+    "@vscode/test-electron": "npm:2.5.2"
+    "@vscode/vsce": "npm:3.9.1"
+    debug: "npm:4.4.3"
+    esbuild: "npm:0.28.1"
+    glob: "npm:13.0.6"
+    markuplint: "npm:5.0.0"
+    mocha: "npm:11.7.5"
+    semver: "npm:7.7.4"
+    typescript: "npm:6.0.3"
+    vscode-languageclient: "npm:9.0.1"
+    vscode-languageserver: "npm:9.0.1"
+    vscode-languageserver-textdocument: "npm:1.0.12"
+  languageName: unknown
+  linkType: soft
+
 "markuplint@workspace:*, markuplint@workspace:packages/markuplint":
   version: 0.0.0-use.local
   resolution: "markuplint@workspace:packages/markuplint"
@@ -15202,14 +15229,14 @@ __metadata:
 
 "resolve@patch:resolve@npm%3A^1.10.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.17.0#optional!builtin<compat/resolve>":
   version: 1.22.11
-  resolution: "resolve@patch:resolve@npm%3A1.22.11#optional!builtin<compat/resolve>::version=1.22.11&hash=c3c19d"
+  resolution: "resolve@patch:resolve@npm%3A1.22.11#optional!builtin<compat/resolve>::version=1.22.11&hash=9bd1a5"
   dependencies:
     is-core-module: "npm:^2.16.1"
     path-parse: "npm:^1.0.7"
     supports-preserve-symlinks-flag: "npm:^1.0.0"
   bin:
     resolve: bin/resolve
-  checksum: 10c0/ee5b182f2e37cb1165465e58c6abc797fec0a80b5ba3231607beb4677db0c9291ac010c47cf092b6daa2b7f518d69a0e21888e7e2b633f68d501a874212a8c63
+  checksum: 10c0/55f7a298977b1aacf6dbec6dcfc81100ba98675bced193b57d3ac58ced65acc40c3a38927853cea86b7f75edb3c20e1f099a09d48b0d8ceccc25d466993eec47
   languageName: node
   linkType: hard
 
@@ -17981,33 +18008,6 @@ __metadata:
   checksum: 10c0/8a0838d77c98a211c76e54bd3a6249fc877e4e1a73322673fb0e921168d8e91de4f170f1d4ff7e8b6289d0698207afc6aba6662d4c1cd8e4bd7cae96afd6b0c2
   languageName: node
   linkType: hard
-
-"vscode-markuplint@workspace:vscode":
-  version: 0.0.0-use.local
-  resolution: "vscode-markuplint@workspace:vscode"
-  dependencies:
-    "@markuplint-dev/tsconfig": "npm:5.0.0"
-    "@markuplint/file-resolver": "npm:5.0.0"
-    "@markuplint/i18n": "npm:5.0.0"
-    "@markuplint/ml-spec": "npm:5.0.0"
-    "@types/mocha": "npm:10.0.10"
-    "@types/node": "npm:22.17.0"
-    "@types/semver": "npm:7.7.1"
-    "@types/vscode": "npm:1.99.1"
-    "@vscode/test-electron": "npm:2.5.2"
-    "@vscode/vsce": "npm:3.9.1"
-    debug: "npm:4.4.3"
-    esbuild: "npm:0.28.1"
-    glob: "npm:13.0.6"
-    markuplint: "npm:5.0.0"
-    mocha: "npm:11.7.5"
-    semver: "npm:7.7.4"
-    typescript: "npm:6.0.3"
-    vscode-languageclient: "npm:9.0.1"
-    vscode-languageserver: "npm:9.0.1"
-    vscode-languageserver-textdocument: "npm:1.0.12"
-  languageName: unknown
-  linkType: soft
 
 "vscode-uri@npm:^3.1.0":
   version: 3.1.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 10
+  version: 9
   cacheKey: 10c0
 
 "@apidevtools/json-schema-ref-parser@npm:^11.5.5":
@@ -15229,14 +15229,14 @@ __metadata:
 
 "resolve@patch:resolve@npm%3A^1.10.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.17.0#optional!builtin<compat/resolve>":
   version: 1.22.11
-  resolution: "resolve@patch:resolve@npm%3A1.22.11#optional!builtin<compat/resolve>::version=1.22.11&hash=9bd1a5"
+  resolution: "resolve@patch:resolve@npm%3A1.22.11#optional!builtin<compat/resolve>::version=1.22.11&hash=c3c19d"
   dependencies:
     is-core-module: "npm:^2.16.1"
     path-parse: "npm:^1.0.7"
     supports-preserve-symlinks-flag: "npm:^1.0.0"
   bin:
     resolve: bin/resolve
-  checksum: 10c0/55f7a298977b1aacf6dbec6dcfc81100ba98675bced193b57d3ac58ced65acc40c3a38927853cea86b7f75edb3c20e1f099a09d48b0d8ceccc25d466993eec47
+  checksum: 10c0/ee5b182f2e37cb1165465e58c6abc797fec0a80b5ba3231607beb4677db0c9291ac010c47cf092b6daa2b7f518d69a0e21888e7e2b633f68d501a874212a8c63
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- The v5.0.0 VS Code extension publish under the new `markuplint` publisher was rejected by the Marketplace: `ERROR The extension 'vscode-markuplint' already exists in the Marketplace` — the legacy `yusukehirao.vscode-markuplint` listing already registered that raw `name`, and the Marketplace's uniqueness check apparently isn't scoped to the full `publisher.name` identity.
- Renamed `vscode/package.json`'s `name` to `markuplint-vscode` (identity `markuplint.markuplint-vscode`), confirmed unused on the Marketplace beforehand.
- `name: "markuplint"` was tried first but rejected locally: it collides with `packages/markuplint`'s workspace package name and breaks Nx/Lerna project-graph construction.
- Updated every Marketplace link (root README, packages/markuplint README, CONTRIBUTING.md, website docs EN/JA) and the extension's own `EXTENSION_ID` test constant to match.
- Documented both rejected names and the reasoning in `vscode/CLAUDE.md` so this isn't rediscovered the hard way next release.

## Test plan
- [x] `yarn lint-check` passes
- [x] `yarn build` passes
- [x] Rebuilt the `.vsix` locally (`yarn vscode:package`) and installed it via `code --install-extension` — confirmed `markuplint.markuplint-vscode@5.0.0` installs correctly
- [x] Confirmed `markuplint.markuplint-vscode` is unregistered on the Marketplace (404) before this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)