### PR TITLE
fix(vscode): rename displayName to avoid Marketplace collision

### DIFF
--- a/vscode/CLAUDE.md
+++ b/vscode/CLAUDE.md
@@ -74,3 +74,14 @@ extension 'vscode-markuplint' already exists in the Marketplace` — its
 
 Don't rename `name` back to `vscode-markuplint` or to `markuplint` without
 confirming both constraints above no longer apply.
+
+## `displayName` is also globally unique, not just `name`
+
+After fixing the `name` collision above, the v5.0.0 publish hit a second
+Marketplace rejection: `ERROR This extension display name is taken` for
+`displayName: "Markuplint"` — the same legacy `yusukehirao.vscode-markuplint`
+listing already uses that display name, and this check also isn't scoped to
+the publisher. `displayName` was changed to `"Markuplint for VS Code"` to
+resolve it. Don't revert to plain `"Markuplint"` without first freeing the
+name (e.g. renaming the legacy listing's `displayName`) or confirming the
+Marketplace behavior has changed.

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "markuplint-vscode",
-	"displayName": "Markuplint",
+	"displayName": "Markuplint for VS Code",
 	"description": "Markuplint for VS Code",
 	"version": "5.0.0",
 	"publisher": "markuplint",


### PR DESCRIPTION
## Summary
- After fixing the `name` collision in #4040, the v5.0.0 publish hit a second Marketplace rejection: `ERROR This extension display name is taken` for `displayName: "Markuplint"` — the legacy `yusukehirao.vscode-markuplint` listing already uses that display name, and this check isn't scoped to the publisher either.
- Renamed `displayName` to `"Markuplint for VS Code"`.
- Documented the finding in `vscode/CLAUDE.md`.

## Test plan
- [x] `yarn lint-check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)